### PR TITLE
Generate RestResponse overloads

### DIFF
--- a/src/azure/Model/MethodJva.cs
+++ b/src/azure/Model/MethodJva.cs
@@ -509,44 +509,6 @@ namespace AutoRest.Java.Azure.Model
         }
 
         [JsonIgnore]
-        public override string ServiceFutureFactoryMethod
-        {
-            get
-            {
-                if (this.IsPagingOperation || this.IsPagingNextOperation)
-                {
-                    if (ReturnType.Headers == null)
-                    {
-                        return "fromPageResponse";
-                    }
-                    else
-                    {
-                        return "fromHeaderPageResponse";
-                    }
-                }
-                else
-                {
-                    return base.ServiceFutureFactoryMethod;
-                }
-            }
-        }
-
-        [JsonIgnore]
-        public override string CallbackDocumentation
-        {
-            get
-            {
-                IndentedStringBuilder builder = new IndentedStringBuilder();
-                if (this.IsPagingNextOperation)
-                {
-                    builder.AppendLine(" * @param serviceFuture the ServiceFuture object tracking the Retrofit calls");
-                }
-                builder.Append(" * @param serviceCallback the async ServiceCallback to handle successful and failed responses.");
-                return builder.ToString();
-            }
-        }
-
-        [JsonIgnore]
         public string NextUrlConstruction
         {
             get

--- a/src/azure/Model/ResponseJva.cs
+++ b/src/azure/Model/ResponseJva.cs
@@ -85,7 +85,7 @@ namespace AutoRest.Java.Azure.Model
         }
 
         [JsonIgnore]
-        public string ServiceResponseConcreteTypeParameterString
+        public override string ServiceResponseConcreteParameterString
         {
             get
             {

--- a/src/azure/Model/ResponseJva.cs
+++ b/src/azure/Model/ResponseJva.cs
@@ -76,7 +76,7 @@ namespace AutoRest.Java.Azure.Model
             get
             {
                 var bodySequenceType = base.BodyClientType as SequenceTypeJva;
-                if (bodySequenceType != null && IsPagedResponse)
+                if (bodySequenceType != null && (IsPagedResponse || Parent.SimulateAsPagingOperation))
                 {
                     return string.Format(CultureInfo.InvariantCulture, "Page<{0}>", bodySequenceType.ElementType.Name);
                 }

--- a/src/azure/Templates/AzureMethodGroupRetrofitTemplate.cshtml
+++ b/src/azure/Templates/AzureMethodGroupRetrofitTemplate.cshtml
@@ -31,7 +31,7 @@ if (method.IsLongRunningOperation)
 }
 else
 {
-@:    Single<@(method.RestResponseTypeName)> @(method.Name)(@method.MethodParameterApiDeclaration);
+@:    Single<@(method.RestResponseConcreteTypeName)> @(method.Name)(@method.MethodParameterApiDeclaration);
 }
 @EmptyLine
 }

--- a/src/azure/Templates/AzureMethodGroupRetrofitTemplate.cshtml
+++ b/src/azure/Templates/AzureMethodGroupRetrofitTemplate.cshtml
@@ -31,7 +31,7 @@ if (method.IsLongRunningOperation)
 }
 else
 {
-@:    Single<@(method.ReturnTypeJva.ServiceResponseConcreteTypeParameterString)> @(method.Name)(@method.MethodParameterApiDeclaration);
+@:    Single<@(method.RestResponseTypeName)> @(method.Name)(@method.MethodParameterApiDeclaration);
 }
 @EmptyLine
 }

--- a/src/azure/Templates/AzureMethodInterfaceTemplate.cshtml
+++ b/src/azure/Templates/AzureMethodInterfaceTemplate.cshtml
@@ -93,8 +93,40 @@ else
 }
  */
 @(Model.AsyncClientReturnTypeString) @(Model.Name)Async(@Model.MethodRequiredParameterDeclaration);
+
+
+@* --------------------------------------------- *@
+@* Observable, RestResponse, required parameters *@
+@* --------------------------------------------- *@
+/**
+@if (!string.IsNullOrEmpty(Model.Summary))
+{
+@: * @Model.Summary.EscapeXmlComment().Period()
+}
+@if (!string.IsNullOrEmpty(Model.Description))
+{
+@: * @Model.Description.EscapeXmlComment().Period()
+}
+ *
+@foreach (var param in Model.LocalParameters.Where(p => !p.IsConstant && p.IsRequired))
+{
+@: * @@param @param.Name @((param.Documentation.IsNullOrEmpty() ? "the " + param.ModelType.Name + " value" : param.Documentation.ToString()).EscapeXmlComment().Trim())
+}
+ * @@throws IllegalArgumentException thrown if parameters fail the validation
+@if (Model.ReturnTypeResponseName.Else("void") != "void")
+{
+@: * @@return the observable to the @Model.ReturnTypeResponseName.EscapeXmlComment() object
+}
+else
+{
+@: * @@return the {@@link @Model.RestResponseAbstractTypeName} object if successful.
+}
+ */
+@(Model.RestResponseAbstractTypeName) @(Model.Name)WithRestResponseAsync(@Model.MethodRequiredParameterDeclaration);
+}
 </text>
 }
+
 
 
 @* ------------------------------- *@
@@ -184,4 +216,36 @@ else
 }
  */
 @(Model.AsyncClientReturnTypeString) @(Model.Name)Async(@Model.MethodParameterDeclaration);
+@EmptyLine
+
+
+
+@* ---------------------------------------- *@
+@* Observable, RestResponse, all parameters *@
+@* ---------------------------------------- *@
+/**
+@if (!string.IsNullOrEmpty(Model.Summary))
+{
+@: * @Model.Summary.EscapeXmlComment().Period()
+}
+@if (!string.IsNullOrEmpty(Model.Description))
+{
+@: * @Model.Description.EscapeXmlComment().Period()
+}
+ *
+@foreach (var param in Model.LocalParameters.Where(p => !p.IsConstant))
+{
+@: * @@param @param.Name @((param.Documentation.IsNullOrEmpty() ? "the " + param.ModelType.Name + " value" : param.Documentation.ToString()).EscapeXmlComment().Trim())
+}
+ * @@throws IllegalArgumentException thrown if parameters fail the validation
+@if (Model.ReturnTypeResponseName.Else("void") != "void")
+{
+@: * @@return the observable to the @Model.ReturnTypeResponseName.EscapeXmlComment() object
+}
+else
+{
+@: * @@return the {@@link @Model.RestResponseAbstractTypeName} object if successful.
+}
+ */
+@(Model.RestResponseAbstractTypeName) @(Model.Name)WithRestResponseAsync(@Model.MethodParameterDeclaration);
 @EmptyLine

--- a/src/azure/Templates/PagingMethodTemplate.cshtml
+++ b/src/azure/Templates/PagingMethodTemplate.cshtml
@@ -148,10 +148,10 @@ public Single<@Model.ReturnTypeJva.ServiceResponseGenericParameterString> @(Mode
 {
 @:    String nextUrl = @(Model.NextUrlConstruction);
 }
-    return service.@(Model.Name)(@Model.MethodParameterApiInvocation).map(new Func1<@(Model.ReturnTypeJva.ServiceResponseConcreteTypeParameterString), @(Model.ReturnTypeJva.ServiceResponseGenericParameterString)>() {
+    return service.@(Model.Name)(@Model.MethodParameterApiInvocation).map(new Func1<@(Model.RestResponseConcreteTypeName), @(Model.ReturnTypeJva.ServiceResponseGenericParameterString)>() {
             @@Override
-            public @(Model.ReturnTypeJva.ServiceResponseGenericParameterString) call(@(Model.ReturnTypeJva.ServiceResponseConcreteTypeParameterString) productPage) {
-                return productPage;
+            public @(Model.ReturnTypeJva.ServiceResponseGenericParameterString) call(@(Model.RestResponseConcreteTypeName) response) {
+                return response.body();
             }
         });
 }
@@ -295,10 +295,10 @@ public Single<@Model.ReturnTypeJva.ServiceResponseGenericParameterString> @(Mode
 {
 @:    String nextUrl = @(Model.NextUrlConstruction);
 }
-    return service.@(Model.Name)(@Model.MethodParameterApiInvocation).map(new Func1<@(Model.ReturnTypeJva.ServiceResponseConcreteTypeParameterString), @(Model.ReturnTypeJva.ServiceResponseGenericParameterString)>() {
+    return service.@(Model.Name)(@Model.MethodParameterApiInvocation).map(new Func1<@(Model.RestResponseConcreteTypeName), @(Model.ReturnTypeJva.ServiceResponseGenericParameterString)>() {
             @@Override
-            public @(Model.ReturnTypeJva.ServiceResponseGenericParameterString) call(@(Model.ReturnTypeJva.ServiceResponseConcreteTypeParameterString) productPage) {
-                return productPage;
+            public @(Model.ReturnTypeJva.ServiceResponseGenericParameterString) call(@(Model.RestResponseConcreteTypeName) response) {
+                return response.body();
             }
         });
 }

--- a/src/azure/Templates/PagingMethodTemplate.cshtml
+++ b/src/azure/Templates/PagingMethodTemplate.cshtml
@@ -258,7 +258,7 @@ public Observable<@Model.ReturnTypeJva.ServiceResponseGenericParameterString> @(
  *
 @foreach (var param in Model.LocalParameters.Where(p => !p.IsConstant))
 {
-    @Model.ReturnTypeJva.GenericBodyWireTypeStringWrapped
+    @Model.ReturnTypeJva.GenericBodyWireTypeString
 @: * @@param @param.Name @(param.Documentation.Else("the " + param.ModelType.Name + " value").EscapeXmlComment().Trim())
 }
  * @@throws IllegalArgumentException thrown if parameters fail the validation

--- a/src/azure/Templates/SimulatedPageMethodTemplate.cshtml
+++ b/src/azure/Templates/SimulatedPageMethodTemplate.cshtml
@@ -96,9 +96,9 @@ public Observable<Page<@Model.ReturnTypeJv.SequenceElementTypeString>> @(Model.N
 }
     @Model.BuildInputMappings(true)
     @Model.ParameterConversion
-    return service.@(Model.Name)(@Model.MethodParameterApiInvocation).map(new Func1<@(Model.ReturnTypeJva.ServiceResponseConcreteTypeParameterString), Page<@(Model.ReturnTypeJv.SequenceElementTypeString)>>() {
+    return service.@(Model.Name)(@Model.MethodParameterApiInvocation).map(new Func1<@(Model.ReturnTypeJva.ServiceResponseConcreteParameterString), Page<@(Model.ReturnTypeJv.SequenceElementTypeString)>>() {
         @@Override
-        public Page<@Model.ReturnTypeJv.SequenceElementTypeString> call(@(Model.ReturnTypeJva.ServiceResponseConcreteTypeParameterString) page) {
+        public Page<@Model.ReturnTypeJv.SequenceElementTypeString> call(@(Model.ReturnTypeJva.ServiceResponseConcreteParameterString) page) {
             return page;
         }
     }).toObservable();
@@ -190,9 +190,9 @@ public Observable<Page<@Model.ReturnTypeJv.SequenceElementTypeString>> @(Model.N
 }
     @Model.BuildInputMappings()
     @Model.ParameterConversion
-    return service.@(Model.Name)(@Model.MethodParameterApiInvocation).map(new Func1<@(Model.ReturnTypeJva.ServiceResponseConcreteTypeParameterString), Page<@(Model.ReturnTypeJv.SequenceElementTypeString)>>() {
+    return service.@(Model.Name)(@Model.MethodParameterApiInvocation).map(new Func1<@(Model.ReturnTypeJva.ServiceResponseConcreteParameterString), Page<@(Model.ReturnTypeJv.SequenceElementTypeString)>>() {
         @@Override
-        public Page<@Model.ReturnTypeJv.SequenceElementTypeString> call(@(Model.ReturnTypeJva.ServiceResponseConcreteTypeParameterString) page) {
+        public Page<@Model.ReturnTypeJv.SequenceElementTypeString> call(@(Model.ReturnTypeJva.ServiceResponseConcreteParameterString) page) {
             return page;
         }
     }).toObservable();

--- a/src/azure/Templates/SimulatedPageMethodTemplate.cshtml
+++ b/src/azure/Templates/SimulatedPageMethodTemplate.cshtml
@@ -96,11 +96,11 @@ public Observable<Page<@Model.ReturnTypeJv.SequenceElementTypeString>> @(Model.N
 }
     @Model.BuildInputMappings(true)
     @Model.ParameterConversion
-    return service.@(Model.Name)(@Model.MethodParameterApiInvocation).map(new Func1<@(Model.ReturnTypeJva.ServiceResponseConcreteParameterString), Page<@(Model.ReturnTypeJv.SequenceElementTypeString)>>() {
-        @@Override
-        public Page<@Model.ReturnTypeJv.SequenceElementTypeString> call(@(Model.ReturnTypeJva.ServiceResponseConcreteParameterString) page) {
-            return page;
-        }
+    return service.@(Model.Name)(@Model.MethodParameterApiInvocation).map(new Func1<@(Model.RestResponseConcreteTypeName), @(Model.ReturnTypeJva.ServiceResponseGenericParameterString)>() {
+            @@Override
+            public @(Model.ReturnTypeJva.ServiceResponseGenericParameterString) call(@(Model.RestResponseConcreteTypeName) response) {
+                return response.body();
+            }
     }).toObservable();
 }
 @EmptyLine
@@ -190,11 +190,11 @@ public Observable<Page<@Model.ReturnTypeJv.SequenceElementTypeString>> @(Model.N
 }
     @Model.BuildInputMappings()
     @Model.ParameterConversion
-    return service.@(Model.Name)(@Model.MethodParameterApiInvocation).map(new Func1<@(Model.ReturnTypeJva.ServiceResponseConcreteParameterString), Page<@(Model.ReturnTypeJv.SequenceElementTypeString)>>() {
-        @@Override
-        public Page<@Model.ReturnTypeJv.SequenceElementTypeString> call(@(Model.ReturnTypeJva.ServiceResponseConcreteParameterString) page) {
-            return page;
-        }
+    return service.@(Model.Name)(@Model.MethodParameterApiInvocation).map(new Func1<@(Model.RestResponseConcreteTypeName), @(Model.ReturnTypeJva.ServiceResponseGenericParameterString)>() {
+            @@Override
+            public @(Model.ReturnTypeJva.ServiceResponseGenericParameterString) call(@(Model.RestResponseConcreteTypeName) response) {
+                return response.body();
+            }
     }).toObservable();
 }
 @EmptyLine

--- a/src/azurefluent/CodeGeneratorJvaf.cs
+++ b/src/azurefluent/CodeGeneratorJvaf.cs
@@ -92,7 +92,7 @@ namespace AutoRest.Java.Azure.Fluent
             }
 
             //XML wrappers
-            if (codeModel.ShouldGenerateXmlSerialization)
+            if (codeModel.ShouldGenerateXmlSerializationCached)
             {
                 // Every sequence type used as a parameter to a service method.
                 var parameterSequenceTypes = cm.Operations

--- a/src/vanilla/Model/CodeModelJv.cs
+++ b/src/vanilla/Model/CodeModelJv.cs
@@ -35,6 +35,19 @@ namespace AutoRest.Java.Model
         [JsonIgnore]
         public bool IsCustomBaseUri => Extensions.ContainsKey(SwaggerExtensions.ParameterizedHostExtension);
 
+        private bool? shouldGenerateXmlSerializationCached = null;
+        public bool ShouldGenerateXmlSerializationCached
+        {
+            get
+            {
+                if (!shouldGenerateXmlSerializationCached.HasValue)
+                {
+                    shouldGenerateXmlSerializationCached = ShouldGenerateXmlSerialization;
+                }
+                return shouldGenerateXmlSerializationCached.Value;
+            }
+        }
+
         [JsonIgnore]
         public string ServiceClientServiceType
         {

--- a/src/vanilla/Model/CodeModelJv.cs
+++ b/src/vanilla/Model/CodeModelJv.cs
@@ -73,6 +73,7 @@ namespace AutoRest.Java.Model
                 }
                 classes.AddRange(new[]{
                         "com.microsoft.rest.RestProxy",
+                        "com.microsoft.rest.RestResponse",
                         "com.microsoft.rest.ServiceClient",
                         "com.microsoft.rest.RestClient",
                         "rx.Single"

--- a/src/vanilla/Model/MethodGroupJv.cs
+++ b/src/vanilla/Model/MethodGroupJv.cs
@@ -116,6 +116,7 @@ namespace AutoRest.Java.Model
             {
                 var imports = new List<string>();
                 imports.Add("com.microsoft.rest.RestProxy");
+                imports.Add("com.microsoft.rest.RestResponse");
                 if (MethodGroupTypeString == TypeName)
                 {
                     imports.Add(MethodGroupFullType);

--- a/src/vanilla/Model/MethodJv.cs
+++ b/src/vanilla/Model/MethodJv.cs
@@ -800,6 +800,7 @@ namespace AutoRest.Java.Model
                 imports.Add("rx.Single");
                 imports.Add("com.microsoft.rest.ServiceFuture");
                 imports.Add("com.microsoft.rest.ServiceCallback");
+                imports.Add("com.microsoft.rest.RestResponse");
                 // parameter types
                 this.Parameters.OfType<ParameterJv>().ForEach(p => imports.AddRange(p.InterfaceImports));
                 // return type

--- a/src/vanilla/Model/ResponseJv.cs
+++ b/src/vanilla/Model/ResponseJv.cs
@@ -206,9 +206,6 @@ namespace AutoRest.Java.Model
         public virtual string GenericBodyWireTypeString => BodyWireType.Name;
 
         [JsonIgnore]
-        public string GenericBodyWireTypeStringWrapped => GenericBodyWireTypeString;
-
-        [JsonIgnore]
         public virtual string GenericHeaderWireTypeString => HeaderWireType.Name;
 
         [JsonIgnore]

--- a/src/vanilla/Model/ResponseJv.cs
+++ b/src/vanilla/Model/ResponseJv.cs
@@ -153,13 +153,8 @@ namespace AutoRest.Java.Model
         #region template strings
 
         [JsonIgnore]
-        public string ClientResponseTypeString
-        {
-            get
-            {
-                return GenericBodyClientTypeString;
-            }
-        }
+        [Obsolete]
+        public string ClientResponseTypeString => GenericBodyClientTypeString;
 
         [JsonIgnore]
         public virtual string ClientCallbackTypeString
@@ -184,71 +179,37 @@ namespace AutoRest.Java.Model
             }
         }
 
+        // The virtual properties below seem redundant in vanilla, but they are needed to allow fine-grained distinctions when generating paging methods in Azure.
+
+        /// <summary>
+        /// The generic type argument to a method overload with a ServiceFuture return type.
+        /// </summary>
         [JsonIgnore]
-        [Obsolete("Use GenericBodyClientTypeString")]
-        public virtual string ServiceFutureGenericParameterString
-        {
-            get
-            {
-                return GenericBodyClientTypeString;
-            }
-        }
+        public virtual string ServiceFutureGenericParameterString => GenericBodyClientTypeString;
+
+        /// <summary>
+        /// The generic type argument to a method overload with an Observable or Single return type.
+        /// </summary>
+        [JsonIgnore]
+        public virtual string ServiceResponseGenericParameterString => GenericBodyClientTypeString;
+
+        /// <summary>
+        /// The generic type argument to a service interface method, which uses concrete types for serialization.
+        /// </summary>
+        [JsonIgnore]
+        public virtual string ServiceResponseConcreteParameterString => GenericBodyClientTypeString;
 
         [JsonIgnore]
-
-        [Obsolete("Use GenericBodyClientTypeString")]
-        public virtual string ServiceResponseGenericParameterString
-        {
-            get
-            {
-                return ServiceFutureGenericParameterString;
-            }
-        }
+        public virtual string GenericHeaderClientTypeString => HeaderClientType.ResponseVariant.Name;
 
         [JsonIgnore]
-        public string XmlWrapperGenericParameterString
-        {
-            get
-            {
-                return Body.XmlName + "Wrapper";
-            }
-        }
+        public virtual string GenericBodyWireTypeString => BodyWireType.Name;
 
         [JsonIgnore]
-        public virtual string GenericHeaderClientTypeString
-        {
-            get
-            {
-                return HeaderClientType.ResponseVariant.Name;
-            }
-        }
+        public string GenericBodyWireTypeStringWrapped => GenericBodyWireTypeString;
 
         [JsonIgnore]
-        public virtual string GenericBodyWireTypeString
-        {
-            get
-            {
-                return BodyWireType.Name;
-            }
-        }
-
-        [JsonIgnore]
-        public string GenericBodyWireTypeStringWrapped
-        {
-            get
-            {
-                return GenericBodyWireTypeString;
-            }
-        }
-
-        [JsonIgnore]
-        public virtual string GenericHeaderWireTypeString
-        {
-            get
-            {
-                return HeaderWireType.Name;
-            }
-        }
+        public virtual string GenericHeaderWireTypeString => HeaderWireType.Name;
 
         [JsonIgnore]
         public virtual string SequenceElementTypeString

--- a/src/vanilla/Model/ResponseJv.cs
+++ b/src/vanilla/Model/ResponseJv.cs
@@ -185,6 +185,7 @@ namespace AutoRest.Java.Model
         }
 
         [JsonIgnore]
+        [Obsolete("Use GenericBodyClientTypeString")]
         public virtual string ServiceFutureGenericParameterString
         {
             get
@@ -194,6 +195,8 @@ namespace AutoRest.Java.Model
         }
 
         [JsonIgnore]
+
+        [Obsolete("Use GenericBodyClientTypeString")]
         public virtual string ServiceResponseGenericParameterString
         {
             get

--- a/src/vanilla/Templates/MethodGroupRetrofitTemplate.cshtml
+++ b/src/vanilla/Templates/MethodGroupRetrofitTemplate.cshtml
@@ -33,7 +33,7 @@ if (method.DefaultResponse.Body != null)
 {
 @:    @@UnexpectedResponseExceptionType(@(method.OperationExceptionTypeString).class)
 }
-@:    Single<@(method.ReturnTypeJv.GenericBodyClientTypeString)> @(method.Name)(@method.MethodParameterApiDeclaration);
+@:    Single<@(method.RestResponseTypeName)> @(method.Name)(@method.MethodParameterApiDeclaration);
 @EmptyLine
 }
 }

--- a/src/vanilla/Templates/MethodGroupRetrofitTemplate.cshtml
+++ b/src/vanilla/Templates/MethodGroupRetrofitTemplate.cshtml
@@ -33,7 +33,7 @@ if (method.DefaultResponse.Body != null)
 {
 @:    @@UnexpectedResponseExceptionType(@(method.OperationExceptionTypeString).class)
 }
-@:    Single<@(method.RestResponseTypeName)> @(method.Name)(@method.MethodParameterApiDeclaration);
+@:    Single<@(method.RestResponseConcreteTypeName)> @(method.Name)(@method.MethodParameterApiDeclaration);
 @EmptyLine
 }
 }

--- a/src/vanilla/Templates/MethodInterfaceTemplate.cshtml
+++ b/src/vanilla/Templates/MethodInterfaceTemplate.cshtml
@@ -75,6 +75,35 @@ else
 }
  */
 Single<@Model.ReturnTypeJv.ServiceResponseGenericParameterString> @(Model.Name)Async(@Model.MethodRequiredParameterDeclaration);
+ 
+ 
+@EmptyLine
+/**
+@if (!string.IsNullOrEmpty(Model.Summary))
+{
+@: * @Model.Summary.EscapeXmlComment().Period()
+}
+@if (!string.IsNullOrEmpty(Model.Description))
+{
+@: * @Model.Description.EscapeXmlComment().Period()
+}
+ *
+@foreach (var param in Model.LocalParameters.Where(p => !p.IsConstant && p.IsRequired))
+{
+@: * @@param @param.Name @((param.Documentation.IsNullOrEmpty() ? "the " + param.ModelType.Name + " value" : param.Documentation.ToString()).EscapeXmlComment().Trim())
+}
+ * @@throws IllegalArgumentException thrown if parameters fail the validation
+@if (Model.ReturnTypeResponseName.Else("void") != "void")
+{
+@: * @@return the observable to the @Model.ReturnTypeResponseName object
+}
+else
+{
+@: * @@return the {@@link Single<@Model.ReturnTypeJv.ServiceResponseGenericParameterString>} object if successful.
+}
+ */
+Single<@Model.RestResponseConcreteBodyName> @(Model.Name)WithRestResponseAsync(@Model.MethodRequiredParameterDeclaration);
+ 
 </text>
 }
 /**
@@ -146,4 +175,30 @@ else
 }
  */
 Single<@Model.ReturnTypeJv.ServiceResponseGenericParameterString> @(Model.Name)Async(@Model.MethodParameterDeclaration);
+
+/**
+@if (!string.IsNullOrEmpty(Model.Summary))
+{
+@: * @Model.Summary.EscapeXmlComment().Period()
+}
+@if (!string.IsNullOrEmpty(Model.Description))
+{
+@: * @Model.Description.EscapeXmlComment().Period()
+}
+ *
+@foreach (var param in Model.LocalParameters.Where(p => !p.IsConstant))
+{
+@: * @@param @param.Name @((param.Documentation.IsNullOrEmpty() ? "the " + param.ModelType.Name + " value" : param.Documentation.ToString()).EscapeXmlComment().Trim())
+}
+ * @@throws IllegalArgumentException thrown if parameters fail the validation
+@if (Model.ReturnTypeResponseName.Else("void") != "void")
+{
+@: * @@return the observable to the @Model.ReturnTypeResponseName.EscapeXmlComment() object
+}
+else
+{
+@: * @@return the {@@link Single<@Model.ReturnTypeJv.ServiceResponseGenericParameterString>} object if successful.
+}
+ */
+Single<@Model.RestResponseConcreteTypeName> @(Model.Name)WithRestResponseAsync(@Model.MethodParameterDeclaration);
 @EmptyLine

--- a/src/vanilla/Templates/MethodInterfaceTemplate.cshtml
+++ b/src/vanilla/Templates/MethodInterfaceTemplate.cshtml
@@ -102,7 +102,7 @@ else
 @: * @@return the {@@link Single<@Model.ReturnTypeJv.ServiceResponseGenericParameterString>} object if successful.
 }
  */
-Single<@Model.RestResponseConcreteBodyName> @(Model.Name)WithRestResponseAsync(@Model.MethodRequiredParameterDeclaration);
+Single<@Model.RestResponseAbstractTypeName> @(Model.Name)WithRestResponseAsync(@Model.MethodRequiredParameterDeclaration);
  
 </text>
 }
@@ -200,5 +200,5 @@ else
 @: * @@return the {@@link Single<@Model.ReturnTypeJv.ServiceResponseGenericParameterString>} object if successful.
 }
  */
-Single<@Model.RestResponseConcreteTypeName> @(Model.Name)WithRestResponseAsync(@Model.MethodParameterDeclaration);
+Single<@Model.RestResponseAbstractTypeName> @(Model.Name)WithRestResponseAsync(@Model.MethodParameterDeclaration);
 @EmptyLine

--- a/src/vanilla/Templates/MethodTemplate.cshtml
+++ b/src/vanilla/Templates/MethodTemplate.cshtml
@@ -14,17 +14,17 @@
 @if (parameterVariants.HasOptionalParameters)
 {
 <text>
-@* ---------------------------------------------- *@
-@* Synchronous, RestResponse, required parameters *@
-@* ---------------------------------------------- *@
+@* -------------------------------------- *@
+@* Synchronous, Body, required parameters *@
+@* -------------------------------------- *@
 @Model.Javadoc(parameterVariants.RequiredParameters, Model.SyncExceptionDocumentation, Model.SyncReturnDocumentation)
 @Model.SyncImpl(parameterVariants.RequiredParameters)
 @EmptyLine
 
 
-@* ------------------------------------------- *@
-@* Callback, RestResponse, required parameters *@
-@* ------------------------------------------- *@
+@* ----------------------------------- *@
+@* Callback, Body, required parameters *@
+@* ----------------------------------- *@
 @Model.Javadoc(parameterVariants.RequiredParameters.ConcatSingleItem(callbackParam), Model.AsyncExceptionDocumentation, Model.CallbackReturnDocumentation)
 @Model.CallbackImpl(parameterVariants.RequiredParameters, callbackParam)
 @EmptyLine
@@ -38,23 +38,6 @@
 @EmptyLine
 
 
-
-@* -------------------------------------- *@
-@* Synchronous, Body, required parameters *@
-@* -------------------------------------- *@
-@*@Model.Javadoc(parameterVariants.RequiredParameters, Model.SyncExceptionDocumentation, Model.SyncReturnDocumentation)
-@Model.SyncImpl(parameterVariants.RequiredParameters)
-@EmptyLine*@
-
-
-@* ----------------------------------- *@
-@* Callback, Body, required parameters *@
-@* ----------------------------------- *@
-@*@Model.Javadoc(parameterVariants.RequiredParameters.ConcatSingleItem(callbackParam), Model.AsyncExceptionDocumentation, Model.CallbackReturnDocumentation)
-@Model.CallbackImpl(parameterVariants.RequiredParameters, callbackParam)
-@EmptyLine*@
-
-
 @* ------------------------------------- *@
 @* Observable, Body, required parameters *@
 @* ------------------------------------- *@
@@ -66,17 +49,17 @@
 }
 
 
-@* ----------------------------------------- *@
-@* Synchronous, RestResponse, all parameters *@
-@* ----------------------------------------- *@
+@* --------------------------------- *@
+@* Synchronous, Body, all parameters *@
+@* --------------------------------- *@
 @Model.Javadoc(parameterVariants.AllParameters, Model.SyncExceptionDocumentation, Model.SyncReturnDocumentation)
 @Model.SyncImpl(parameterVariants.AllParameters)
 @EmptyLine
 
 
-@* -------------------------------------- *@
-@* Callback, RestResponse, all parameters *@
-@* -------------------------------------- *@
+@* ------------------------------ *@
+@* Callback, Body, all parameters *@
+@* ------------------------------ *@
 @Model.Javadoc(parameterVariants.AllParameters.ConcatSingleItem(callbackParam), Model.AsyncExceptionDocumentation, Model.CallbackReturnDocumentation)
 @Model.CallbackImpl(parameterVariants.AllParameters, callbackParam)
 @EmptyLine
@@ -88,23 +71,6 @@
 @Model.Javadoc(parameterVariants.AllParameters, Model.AsyncExceptionDocumentation, Model.ObservableReturnDocumentation)
 @Model.ObservableRestResponseImpl(parameterVariants.AllParameters, takeOnlyRequiredParameters: false)
 @EmptyLine
-
-
-
-@* --------------------------------- *@
-@* Synchronous, Body, all parameters *@
-@* --------------------------------- *@
-@*@Model.Javadoc(parameterVariants.AllParameters, Model.SyncExceptionDocumentation, Model.SyncReturnDocumentation)
-@Model.SyncImpl(parameterVariants.AllParameters)
-@EmptyLine*@
-
-
-@* ------------------------------ *@
-@* Callback, Body, all parameters *@
-@* ------------------------------ *@
-@*@Model.Javadoc(parameterVariants.AllParameters.ConcatSingleItem(callbackParam), Model.AsyncExceptionDocumentation, Model.CallbackReturnDocumentation)
-@Model.CallbackImpl(parameterVariants.AllParameters, callbackParam)
-@EmptyLine*@
 
 
 @* -------------------------------- *@

--- a/src/vanilla/Templates/MethodTemplate.cshtml
+++ b/src/vanilla/Templates/MethodTemplate.cshtml
@@ -69,17 +69,17 @@
 @* ----------------------------------------- *@
 @* Synchronous, RestResponse, all parameters *@
 @* ----------------------------------------- *@
-@*@Model.Javadoc(parameterVariants.AllParameters, Model.SyncExceptionDocumentation, Model.SyncReturnDocumentation)
+@Model.Javadoc(parameterVariants.AllParameters, Model.SyncExceptionDocumentation, Model.SyncReturnDocumentation)
 @Model.SyncImpl(parameterVariants.AllParameters)
-@EmptyLine*@
+@EmptyLine
 
 
 @* -------------------------------------- *@
 @* Callback, RestResponse, all parameters *@
 @* -------------------------------------- *@
-@*@Model.Javadoc(parameterVariants.AllParameters.ConcatSingleItem(callbackParam), Model.AsyncExceptionDocumentation, Model.CallbackReturnDocumentation)
+@Model.Javadoc(parameterVariants.AllParameters.ConcatSingleItem(callbackParam), Model.AsyncExceptionDocumentation, Model.CallbackReturnDocumentation)
 @Model.CallbackImpl(parameterVariants.AllParameters, callbackParam)
-@EmptyLine*@
+@EmptyLine
 
 
 @* ---------------------------------------- *@
@@ -88,6 +88,8 @@
 @Model.Javadoc(parameterVariants.AllParameters, Model.AsyncExceptionDocumentation, Model.ObservableReturnDocumentation)
 @Model.ObservableRestResponseImpl(parameterVariants.AllParameters, takeOnlyRequiredParameters: false)
 @EmptyLine
+
+
 
 @* --------------------------------- *@
 @* Synchronous, Body, all parameters *@

--- a/src/vanilla/Templates/MethodTemplate.cshtml
+++ b/src/vanilla/Templates/MethodTemplate.cshtml
@@ -14,51 +14,100 @@
 @if (parameterVariants.HasOptionalParameters)
 {
 <text>
-@* ------------------------------------ *@
-@* Synchronous with required parameters *@
-@* ------------------------------------ *@
+@* ---------------------------------------------- *@
+@* Synchronous, RestResponse, required parameters *@
+@* ---------------------------------------------- *@
 @Model.Javadoc(parameterVariants.RequiredParameters, Model.SyncExceptionDocumentation, Model.SyncReturnDocumentation)
 @Model.SyncImpl(parameterVariants.RequiredParameters)
 @EmptyLine
 
 
-@* --------------------------------- *@
-@* Callback with required parameters *@
-@* --------------------------------- *@
-@Model.Javadoc(parameterVariants.RequiredParameters.ConcatSingleItem(callbackParam), Model.SyncExceptionDocumentation, Model.CallbackReturnDocumentation)
+@* ------------------------------------------- *@
+@* Callback, RestResponse, required parameters *@
+@* ------------------------------------------- *@
+@Model.Javadoc(parameterVariants.RequiredParameters.ConcatSingleItem(callbackParam), Model.AsyncExceptionDocumentation, Model.CallbackReturnDocumentation)
 @Model.CallbackImpl(parameterVariants.RequiredParameters, callbackParam)
 @EmptyLine
 
 
-@* ----------------------------------- *@
-@* Observable with required parameters *@
-@* ----------------------------------- *@
+@* --------------------------------------------- *@
+@* Observable, RestResponse, required parameters *@
+@* --------------------------------------------- *@
 @Model.Javadoc(parameterVariants.RequiredParameters, Model.AsyncExceptionDocumentation, Model.ObservableReturnDocumentation)
-@Model.ObservableRestResponseImpl(parameterVariants.RequiredParameters, filterRequired: true)
+@Model.ObservableRestResponseImpl(parameterVariants.RequiredParameters, takeOnlyRequiredParameters: true)
 @EmptyLine
+
+
+
+@* -------------------------------------- *@
+@* Synchronous, Body, required parameters *@
+@* -------------------------------------- *@
+@*@Model.Javadoc(parameterVariants.RequiredParameters, Model.SyncExceptionDocumentation, Model.SyncReturnDocumentation)
+@Model.SyncImpl(parameterVariants.RequiredParameters)
+@EmptyLine*@
+
+
+@* ----------------------------------- *@
+@* Callback, Body, required parameters *@
+@* ----------------------------------- *@
+@*@Model.Javadoc(parameterVariants.RequiredParameters.ConcatSingleItem(callbackParam), Model.AsyncExceptionDocumentation, Model.CallbackReturnDocumentation)
+@Model.CallbackImpl(parameterVariants.RequiredParameters, callbackParam)
+@EmptyLine*@
+
+
+@* ------------------------------------- *@
+@* Observable, Body, required parameters *@
+@* ------------------------------------- *@
+@Model.Javadoc(parameterVariants.RequiredParameters, Model.AsyncExceptionDocumentation, Model.ObservableReturnDocumentation)
+@Model.ObservableImpl(parameterVariants.RequiredParameters)
+@EmptyLine
+
 </text>
 }
 
 
-@* ------------------------------- *@
-@* Synchronous with all parameters *@
-@* ------------------------------- *@
-@Model.Javadoc(parameterVariants.AllParameters, Model.SyncExceptionDocumentation, Model.SyncReturnDocumentation)
+@* ----------------------------------------- *@
+@* Synchronous, RestResponse, all parameters *@
+@* ----------------------------------------- *@
+@*@Model.Javadoc(parameterVariants.AllParameters, Model.SyncExceptionDocumentation, Model.SyncReturnDocumentation)
 @Model.SyncImpl(parameterVariants.AllParameters)
-@EmptyLine
+@EmptyLine*@
 
 
-@* ---------------------------- *@
-@* Callback with all parameters *@
-@* ---------------------------- *@
-@Model.Javadoc(parameterVariants.AllParameters.ConcatSingleItem(callbackParam), Model.AsyncExceptionDocumentation, Model.CallbackReturnDocumentation)
+@* -------------------------------------- *@
+@* Callback, RestResponse, all parameters *@
+@* -------------------------------------- *@
+@*@Model.Javadoc(parameterVariants.AllParameters.ConcatSingleItem(callbackParam), Model.AsyncExceptionDocumentation, Model.CallbackReturnDocumentation)
 @Model.CallbackImpl(parameterVariants.AllParameters, callbackParam)
+@EmptyLine*@
+
+
+@* ---------------------------------------- *@
+@* Observable, RestResponse, all parameters *@
+@* ---------------------------------------- *@
+@Model.Javadoc(parameterVariants.AllParameters, Model.AsyncExceptionDocumentation, Model.ObservableReturnDocumentation)
+@Model.ObservableRestResponseImpl(parameterVariants.AllParameters, takeOnlyRequiredParameters: false)
 @EmptyLine
 
+@* --------------------------------- *@
+@* Synchronous, Body, all parameters *@
+@* --------------------------------- *@
+@*@Model.Javadoc(parameterVariants.AllParameters, Model.SyncExceptionDocumentation, Model.SyncReturnDocumentation)
+@Model.SyncImpl(parameterVariants.AllParameters)
+@EmptyLine*@
+
 
 @* ------------------------------ *@
-@* Observable with all parameters *@
+@* Callback, Body, all parameters *@
 @* ------------------------------ *@
+@*@Model.Javadoc(parameterVariants.AllParameters.ConcatSingleItem(callbackParam), Model.AsyncExceptionDocumentation, Model.CallbackReturnDocumentation)
+@Model.CallbackImpl(parameterVariants.AllParameters, callbackParam)
+@EmptyLine*@
+
+
+@* -------------------------------- *@
+@* Observable, Body, all parameters *@
+@* -------------------------------- *@
 @Model.Javadoc(parameterVariants.AllParameters, Model.AsyncExceptionDocumentation, Model.ObservableReturnDocumentation)
-@Model.ObservableRestResponseImpl(parameterVariants.AllParameters, filterRequired: false)
+@Model.ObservableImpl(parameterVariants.AllParameters)
 @EmptyLine

--- a/src/vanilla/Templates/MethodTemplate.cshtml
+++ b/src/vanilla/Templates/MethodTemplate.cshtml
@@ -1,131 +1,40 @@
 ﻿@using System.Linq;
+@using AutoRest.Core.Utilities.Collections;
 @using AutoRest.Core.Model
 @using AutoRest.Core.Utilities
 @using AutoRest.Java
 @using AutoRest.Java.Model
 @inherits AutoRest.Core.Template<AutoRest.Java.Model.MethodJv>
-@if (Model.LocalParameters.Any(p => !p.IsConstant && !p.IsRequired))
+
+@{
+    var parameterVariants = Model.ParameterVariants;
+    var callbackParam = Model.CallbackParam;
+}
+
+@if (parameterVariants.HasOptionalParameters)
 {
 <text>
 @* ------------------------------------ *@
 @* Synchronous with required parameters *@
 @* ------------------------------------ *@
-/**
-@if (!string.IsNullOrEmpty(Model.Summary))
-{
-@: * @Model.Summary.EscapeXmlComment().Period()
-}
-@if (!string.IsNullOrEmpty(Model.Description))
-{
-@: * @Model.Description.EscapeXmlComment().Period()
-}
- *
-@foreach (var param in Model.LocalParameters.Where(p => !p.IsConstant && p.IsRequired))
-{
-@: * @@param @param.Name @(param.Documentation.Else("the " + param.ModelType.Name + " value").EscapeXmlComment().Trim())
-}
- * @@throws IllegalArgumentException thrown if parameters fail the validation
- * @@throws @Model.OperationExceptionTypeString thrown if the request is rejected by server
- * @@throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
-@if (Model.ReturnType.Body != null)
-{
-@: * @@return the @Model.ReturnTypeResponseName.EscapeXmlComment() object if successful.
-}
- */
-public @Model.ReturnTypeResponseName @(Model.Name)(@Model.MethodRequiredParameterDeclaration) {
-@if (@Model.ReturnTypeResponseName == "void")
-{
-@:    @(Model.Name)Async(@Model.MethodRequiredParameterInvocation).toBlocking().value();
-}
-else
-{
-@:    return @(Model.Name)Async(@Model.MethodRequiredParameterInvocation).toBlocking().value();
-}
-}
+@Model.Javadoc(parameterVariants.RequiredParameters, Model.SyncExceptionDocumentation, Model.SyncReturnDocumentation)
+@Model.SyncImpl(parameterVariants.RequiredParameters)
 @EmptyLine
 
 
 @* --------------------------------- *@
 @* Callback with required parameters *@
 @* --------------------------------- *@
-/**
-@if (!string.IsNullOrEmpty(Model.Summary))
-{
-@: * @Model.Summary.EscapeXmlComment().Period()
-}
-@if (!string.IsNullOrEmpty(Model.Description))
-{
-@: * @Model.Description.EscapeXmlComment().Period()
-}
- *
-@foreach (var param in Model.LocalParameters.Where(p => !p.IsConstant && p.IsRequired))
-{
-@: * @@param @param.Name @(param.Documentation.Else("the " + param.ModelType.Name + " value").EscapeXmlComment().Trim())
-}
-@Model.CallbackDocumentation
- * @@throws IllegalArgumentException thrown if parameters fail the validation
- * @@return the {@@link ServiceFuture} object
- */
-public ServiceFuture<@Model.ReturnTypeJv.ServiceFutureGenericParameterString> @(Model.Name)Async(@Model.MethodRequiredParameterDeclarationWithCallback) {
-    return ServiceFuture.@(Model.ServiceFutureFactoryMethod)(@(Model.Name)Async(@Model.MethodRequiredParameterInvocation), serviceCallback);
-}
+@Model.Javadoc(parameterVariants.RequiredParameters.ConcatSingleItem(callbackParam), Model.SyncExceptionDocumentation, Model.CallbackReturnDocumentation)
+@Model.CallbackImpl(parameterVariants.RequiredParameters, callbackParam)
 @EmptyLine
 
 
 @* ----------------------------------- *@
 @* Observable with required parameters *@
 @* ----------------------------------- *@
-/**
-@if (!string.IsNullOrEmpty(Model.Summary))
-{
-@: * @Model.Summary.EscapeXmlComment().Period()
-}
-@if (!string.IsNullOrEmpty(Model.Description))
-{
-@: * @Model.Description.EscapeXmlComment().Period()
-}
- *
-@foreach (var param in Model.LocalParameters.Where(p => !p.IsConstant && p.IsRequired))
-{
-@: * @@param @param.Name @(param.Documentation.Else("the " + param.ModelType.Name + " value").EscapeXmlComment().Trim())
-}
- * @@throws IllegalArgumentException thrown if parameters fail the validation
-@if (Model.ReturnType.Body != null)
-{
-@: * @@return the observable to the @Model.ReturnTypeJv.GenericBodyClientTypeString.EscapeXmlComment() object
-}
-else
-{
-@: * @@return the {@@link @(Model.ReturnTypeJv.GenericBodyClientTypeString)} object if successful.
-}
- */
-public Single<@Model.ReturnTypeJv.ClientResponseTypeString> @(Model.Name)Async(@Model.MethodRequiredParameterDeclaration) {
-@foreach (var param in Model.RequiredNullableParameters)
-{
-@:    if (@param.Name == null) {
-@:        throw new IllegalArgumentException("Parameter @param.Name is required and cannot be null.");
-@:    }
-}
-@foreach (var param in Model.ParametersToValidate.Where(p => p.IsRequired))
-{
-@:    Validator.validate(@(param.Name));
-}
-@foreach (ParameterJv parameter in Model.LocalParameters)
-{
-    if (!parameter.IsRequired)
-    {
-@:    final @(parameter.ClientType.Name) @(parameter.Name) = @(parameter.ClientType.GetDefaultValue(Model) ?? "null");
-    }
-    if (parameter.IsConstant)
-    {
-@:    final @(parameter.ClientType.Name) @(parameter.Name) = @(parameter.DefaultValue ?? "null");
-
-    }
-}
-    @Model.BuildInputMappings(true)
-    @Model.ParameterConversion
-    return service.@(Model.Name)(@Model.MethodParameterApiInvocation);
-}
+@Model.Javadoc(parameterVariants.RequiredParameters, Model.AsyncExceptionDocumentation, Model.ObservableReturnDocumentation)
+@Model.ObservableRestResponseImpl(parameterVariants.RequiredParameters, filterRequired: true)
 @EmptyLine
 </text>
 }
@@ -134,88 +43,22 @@ public Single<@Model.ReturnTypeJv.ClientResponseTypeString> @(Model.Name)Async(@
 @* ------------------------------- *@
 @* Synchronous with all parameters *@
 @* ------------------------------- *@
-@{ 
-    var allParams = Model.LocalParameters.Where(p => !p.IsConstant).ToList();
-}
-@Model.Javadoc(allParams)
-@Model.SyncImpl(allParams)
+@Model.Javadoc(parameterVariants.AllParameters, Model.SyncExceptionDocumentation, Model.SyncReturnDocumentation)
+@Model.SyncImpl(parameterVariants.AllParameters)
 @EmptyLine
 
-    
+
 @* ---------------------------- *@
 @* Callback with all parameters *@
 @* ---------------------------- *@
-/**
-@if (!string.IsNullOrEmpty(Model.Summary))
-{
-@: * @Model.Summary.EscapeXmlComment().Period()
-}
-@if (!string.IsNullOrEmpty(Model.Description))
-{
-@: * @Model.Description.EscapeXmlComment().Period()
-}
- *
-@foreach (var param in Model.LocalParameters.Where(p => !p.IsConstant))
-{
-@: * @@param @param.Name @(param.Documentation.Else("the " + param.ModelType.Name + " value").EscapeXmlComment().Trim())
-}
-@Model.CallbackDocumentation
- * @@throws IllegalArgumentException thrown if parameters fail the validation
- * @@return the {@@link ServiceFuture} object
- */
-public ServiceFuture<@Model.ReturnTypeJv.ServiceFutureGenericParameterString> @(Model.Name)Async(@Model.MethodParameterDeclarationWithCallback) {
-    return ServiceFuture.@(Model.ServiceFutureFactoryMethod)(@(Model.Name)Async(@Model.MethodParameterInvocation), serviceCallback);
-}
+@Model.Javadoc(parameterVariants.AllParameters.ConcatSingleItem(callbackParam), Model.AsyncExceptionDocumentation, Model.CallbackReturnDocumentation)
+@Model.CallbackImpl(parameterVariants.AllParameters, callbackParam)
 @EmptyLine
 
-    
-@* ----------------------------------- *@
-@* Observable with required parameters *@
-@* ----------------------------------- *@
-/**
-@if (!string.IsNullOrEmpty(Model.Summary))
-{
-@: * @Model.Summary.EscapeXmlComment().Period()
-}
-@if (!string.IsNullOrEmpty(Model.Description))
-{
-@: * @Model.Description.EscapeXmlComment().Period()
-}
- *
-@foreach (var param in Model.LocalParameters.Where(p => !p.IsConstant))
-{
-@: * @@param @param.Name @(param.Documentation.Else("the " + param.ModelType.Name + " value").EscapeXmlComment().Trim())
-}
- * @@throws IllegalArgumentException thrown if parameters fail the validation
-@if (Model.ReturnType.Body != null)
-{
-@: * @@return the observable to the @Model.ReturnTypeJv.GenericBodyClientTypeString.EscapeXmlComment() object
-}
-else
-{
-@: * @@return the {@@link Single<@Model.ReturnTypeJv.GenericBodyClientTypeString>} object if successful.
-}
- */
-public Single<@(Model.ReturnTypeJv.GenericBodyClientTypeString)> @(Model.Name)Async(@Model.MethodParameterDeclaration) {
-@foreach (var param in Model.RequiredNullableParameters)
-{
-@:    if (@param.Name == null) {
-@:        throw new IllegalArgumentException("Parameter @param.Name is required and cannot be null.");
-@:    }
-}
-@foreach (var param in Model.ParametersToValidate)
-{
-@:    Validator.validate(@(param.Name));
-}
-@foreach (ParameterJv parameter in Model.LocalParameters)
-{
-    if (parameter.IsConstant)
-    {
-@:    final @(parameter.ModelType.Name) @(parameter.Name) = @(parameter.DefaultValue ?? "null");
-    }
-}
-    @Model.BuildInputMappings()
-    @Model.ParameterConversion
-    return service.@(Model.Name)(@Model.MethodParameterApiInvocation);
-}
+
+@* ------------------------------ *@
+@* Observable with all parameters *@
+@* ------------------------------ *@
+@Model.Javadoc(parameterVariants.AllParameters, Model.AsyncExceptionDocumentation, Model.ObservableReturnDocumentation)
+@Model.ObservableRestResponseImpl(parameterVariants.AllParameters, filterRequired: false)
 @EmptyLine

--- a/src/vanilla/Templates/MethodTemplate.cshtml
+++ b/src/vanilla/Templates/MethodTemplate.cshtml
@@ -134,38 +134,11 @@ public Single<@Model.ReturnTypeJv.ClientResponseTypeString> @(Model.Name)Async(@
 @* ------------------------------- *@
 @* Synchronous with all parameters *@
 @* ------------------------------- *@
-/**
-@if (!string.IsNullOrEmpty(Model.Summary))
-{
-@: * @Model.Summary.EscapeXmlComment().Period()
+@{ 
+    var allParams = Model.LocalParameters.Where(p => !p.IsConstant).ToList();
 }
-@if (!string.IsNullOrEmpty(Model.Description))
-{
-@: * @Model.Description.EscapeXmlComment().Period()
-}
- *
-@foreach (var param in Model.LocalParameters.Where(p => !p.IsConstant))
-{
-@: * @@param @param.Name @(param.Documentation.Else("the " + param.ModelType.Name + " value").EscapeXmlComment().Trim())
-}
- * @@throws IllegalArgumentException thrown if parameters fail the validation
- * @@throws @Model.OperationExceptionTypeString thrown if the request is rejected by server
- * @@throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
-@if (Model.ReturnType.Body != null)
-{
-@: * @@return the @Model.ReturnTypeResponseName.EscapeXmlComment() object if successful.
-}
- */
-public @Model.ReturnTypeResponseName @(Model.Name)(@Model.MethodParameterDeclaration) {
-@if (@Model.ReturnTypeResponseName == "void")
-{
-@:    @(Model.Name)Async(@Model.MethodParameterInvocation).toBlocking().value();
-}
-else
-{
-@:    return @(Model.Name)Async(@Model.MethodParameterInvocation).toBlocking().value();
-}
-}
+@Model.Javadoc(allParams)
+@Model.SyncImpl(allParams)
 @EmptyLine
 
     

--- a/src/vanilla/Templates/ServiceClientRetrofitTemplate.cshtml
+++ b/src/vanilla/Templates/ServiceClientRetrofitTemplate.cshtml
@@ -29,7 +29,7 @@ if (method.DefaultResponse.Body != null)
 {
 @:    @@UnexpectedResponseExceptionType(@(method.OperationExceptionTypeString).class)
 }
-@:    Single<@(method.ReturnTypeJv.GenericBodyClientTypeString)> @(method.Name)(@method.MethodParameterApiDeclaration);
+@:    Single<@(method.RestResponseTypeName)> @(method.Name)(@method.MethodParameterApiDeclaration);
 @EmptyLine
 }
 }

--- a/src/vanilla/Templates/ServiceClientRetrofitTemplate.cshtml
+++ b/src/vanilla/Templates/ServiceClientRetrofitTemplate.cshtml
@@ -29,7 +29,7 @@ if (method.DefaultResponse.Body != null)
 {
 @:    @@UnexpectedResponseExceptionType(@(method.OperationExceptionTypeString).class)
 }
-@:    Single<@(method.RestResponseTypeName)> @(method.Name)(@method.MethodParameterApiDeclaration);
+@:    Single<@(method.RestResponseConcreteTypeName)> @(method.Name)(@method.MethodParameterApiDeclaration);
 @EmptyLine
 }
 }

--- a/test/azure/src/main/java/fixtures/azureparametergrouping/ParameterGroupings.java
+++ b/test/azure/src/main/java/fixtures/azureparametergrouping/ParameterGroupings.java
@@ -10,6 +10,7 @@
 
 package fixtures.azureparametergrouping;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.azureparametergrouping.models.ErrorException;
@@ -55,6 +56,15 @@ public interface ParameterGroupings {
      */
     Single<Void> postRequiredAsync(ParameterGroupingPostRequiredParameters parameterGroupingPostRequiredParameters);
 
+    /**
+     * Post a bunch of required parameters grouped.
+     *
+     * @param parameterGroupingPostRequiredParameters Additional parameters for the operation
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> postRequiredWithRestResponseAsync(ParameterGroupingPostRequiredParameters parameterGroupingPostRequiredParameters);
+
 
     /**
      * Post a bunch of optional parameters grouped.
@@ -84,6 +94,14 @@ public interface ParameterGroupings {
     /**
      * Post a bunch of optional parameters grouped.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> postOptionalWithRestResponseAsync();
+    }
+    /**
+     * Post a bunch of optional parameters grouped.
+     *
      * @param parameterGroupingPostOptionalParameters Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
@@ -109,6 +127,15 @@ public interface ParameterGroupings {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postOptionalAsync(ParameterGroupingPostOptionalParameters parameterGroupingPostOptionalParameters);
+
+    /**
+     * Post a bunch of optional parameters grouped.
+     *
+     * @param parameterGroupingPostOptionalParameters Additional parameters for the operation
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> postOptionalWithRestResponseAsync(ParameterGroupingPostOptionalParameters parameterGroupingPostOptionalParameters);
 
 
     /**
@@ -136,6 +163,14 @@ public interface ParameterGroupings {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postMultiParamGroupsAsync();
+    /**
+     * Post parameters from multiple different parameter groups.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> postMultiParamGroupsWithRestResponseAsync();
+    }
     /**
      * Post parameters from multiple different parameter groups.
      *
@@ -168,6 +203,16 @@ public interface ParameterGroupings {
      */
     Single<Void> postMultiParamGroupsAsync(FirstParameterGroup firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroup parameterGroupingPostMultiParamGroupsSecondParamGroup);
 
+    /**
+     * Post parameters from multiple different parameter groups.
+     *
+     * @param firstParameterGroup Additional parameters for the operation
+     * @param parameterGroupingPostMultiParamGroupsSecondParamGroup Additional parameters for the operation
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> postMultiParamGroupsWithRestResponseAsync(FirstParameterGroup firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroup parameterGroupingPostMultiParamGroupsSecondParamGroup);
+
 
     /**
      * Post parameters with a shared parameter group object.
@@ -197,6 +242,14 @@ public interface ParameterGroupings {
     /**
      * Post parameters with a shared parameter group object.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> postSharedParameterGroupObjectWithRestResponseAsync();
+    }
+    /**
+     * Post parameters with a shared parameter group object.
+     *
      * @param firstParameterGroup Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
@@ -222,6 +275,15 @@ public interface ParameterGroupings {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postSharedParameterGroupObjectAsync(FirstParameterGroup firstParameterGroup);
+
+    /**
+     * Post parameters with a shared parameter group object.
+     *
+     * @param firstParameterGroup Additional parameters for the operation
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> postSharedParameterGroupObjectWithRestResponseAsync(FirstParameterGroup firstParameterGroup);
 
 
 }

--- a/test/azure/src/main/java/fixtures/azureparametergrouping/implementation/AutoRestParameterGroupingTestServiceImpl.java
+++ b/test/azure/src/main/java/fixtures/azureparametergrouping/implementation/AutoRestParameterGroupingTestServiceImpl.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.AzureProxy;
 import com.microsoft.azure.AzureServiceClient;
 import com.microsoft.rest.credentials.ServiceClientCredentials;
 import com.microsoft.rest.RestClient;
+import com.microsoft.rest.RestResponse;
 import fixtures.azureparametergrouping.AutoRestParameterGroupingTestService;
 import fixtures.azureparametergrouping.ParameterGroupings;
 import rx.Single;

--- a/test/azure/src/main/java/fixtures/azureparametergrouping/implementation/ParameterGroupingsImpl.java
+++ b/test/azure/src/main/java/fixtures/azureparametergrouping/implementation/ParameterGroupingsImpl.java
@@ -10,6 +10,7 @@
 
 package fixtures.azureparametergrouping.implementation;
 
+import com.microsoft.rest.RestResponse;
 import fixtures.azureparametergrouping.ParameterGroupings;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.BodyParam;
@@ -66,25 +67,25 @@ public class ParameterGroupingsImpl implements ParameterGroupings {
         @POST("parameterGrouping/postRequired/{path}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postRequired(@PathParam("path") String path, @HeaderParam("accept-language") String acceptLanguage, @BodyParam("application/json; charset=utf-8") int body, @HeaderParam("customHeader") String customHeader, @QueryParam("query") Integer query, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> postRequired(@PathParam("path") String path, @HeaderParam("accept-language") String acceptLanguage, @BodyParam("application/json; charset=utf-8") int body, @HeaderParam("customHeader") String customHeader, @QueryParam("query") Integer query, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azureparametergrouping.ParameterGroupings postOptional" })
         @POST("parameterGrouping/postOptional")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postOptional(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("customHeader") String customHeader, @QueryParam("query") Integer query, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> postOptional(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("customHeader") String customHeader, @QueryParam("query") Integer query, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azureparametergrouping.ParameterGroupings postMultiParamGroups" })
         @POST("parameterGrouping/postMultipleParameterGroups")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postMultiParamGroups(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("header-one") String headerOne, @QueryParam("query-one") Integer queryOne, @HeaderParam("header-two") String headerTwo, @QueryParam("query-two") Integer queryTwo, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> postMultiParamGroups(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("header-one") String headerOne, @QueryParam("query-one") Integer queryOne, @HeaderParam("header-two") String headerTwo, @QueryParam("query-two") Integer queryTwo, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azureparametergrouping.ParameterGroupings postSharedParameterGroupObject" })
         @POST("parameterGrouping/sharedParameterGroupObject")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postSharedParameterGroupObject(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("header-one") String headerOne, @QueryParam("query-one") Integer queryOne, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> postSharedParameterGroupObject(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("header-one") String headerOne, @QueryParam("query-one") Integer queryOne, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -95,6 +96,7 @@ public class ParameterGroupingsImpl implements ParameterGroupings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postRequired(ParameterGroupingPostRequiredParameters parameterGroupingPostRequiredParameters) {
         postRequiredAsync(parameterGroupingPostRequiredParameters).toBlocking().value();
@@ -108,7 +110,7 @@ public class ParameterGroupingsImpl implements ParameterGroupings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postRequiredAsync(ParameterGroupingPostRequiredParameters parameterGroupingPostRequiredParameters, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postRequiredAsync(ParameterGroupingPostRequiredParameters parameterGroupingPostRequiredParameters, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postRequiredAsync(parameterGroupingPostRequiredParameters), serviceCallback);
     }
 
@@ -117,19 +119,31 @@ public class ParameterGroupingsImpl implements ParameterGroupings {
      *
      * @param parameterGroupingPostRequiredParameters Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postRequiredAsync(ParameterGroupingPostRequiredParameters parameterGroupingPostRequiredParameters) {
+    public Single<RestResponse<Void, Void>> postRequiredWithRestResponseAsync(ParameterGroupingPostRequiredParameters parameterGroupingPostRequiredParameters) {
         if (parameterGroupingPostRequiredParameters == null) {
             throw new IllegalArgumentException("Parameter parameterGroupingPostRequiredParameters is required and cannot be null.");
         }
         Validator.validate(parameterGroupingPostRequiredParameters);
-        int body = parameterGroupingPostRequiredParameters.body();
-        String customHeader = parameterGroupingPostRequiredParameters.customHeader();
-        Integer query = parameterGroupingPostRequiredParameters.query();
-        String path = parameterGroupingPostRequiredParameters.path();
+    int body = parameterGroupingPostRequiredParameters.body();
+    String customHeader = parameterGroupingPostRequiredParameters.customHeader();
+    Integer query = parameterGroupingPostRequiredParameters.query();
+    String path = parameterGroupingPostRequiredParameters.path();
         return service.postRequired(path, this.client.acceptLanguage(), body, customHeader, query, this.client.userAgent());
     }
+
+    /**
+     * Post a bunch of required parameters grouped.
+     *
+     * @param parameterGroupingPostRequiredParameters Additional parameters for the operation
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postRequiredAsync(ParameterGroupingPostRequiredParameters parameterGroupingPostRequiredParameters) {
+        return postRequiredWithRestResponseAsync(parameterGroupingPostRequiredParameters)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -138,6 +152,7 @@ public class ParameterGroupingsImpl implements ParameterGroupings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postOptional() {
         postOptionalAsync().toBlocking().value();
@@ -150,7 +165,7 @@ public class ParameterGroupingsImpl implements ParameterGroupings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postOptionalAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postOptionalAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postOptionalAsync(), serviceCallback);
     }
 
@@ -158,14 +173,26 @@ public class ParameterGroupingsImpl implements ParameterGroupings {
      * Post a bunch of optional parameters grouped.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postOptionalAsync() {
+    public Single<RestResponse<Void, Void>> postOptionalWithRestResponseAsync() {
         final ParameterGroupingPostOptionalParameters parameterGroupingPostOptionalParameters = null;
-        String customHeader = null;
-        Integer query = null;
+        Validator.validate(parameterGroupingPostOptionalParameters);
+    String customHeader = null;
+    Integer query = null;
         return service.postOptional(this.client.acceptLanguage(), customHeader, query, this.client.userAgent());
     }
+
+    /**
+     * Post a bunch of optional parameters grouped.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postOptionalAsync() {
+        return postOptionalWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Post a bunch of optional parameters grouped.
@@ -174,6 +201,7 @@ public class ParameterGroupingsImpl implements ParameterGroupings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postOptional(ParameterGroupingPostOptionalParameters parameterGroupingPostOptionalParameters) {
         postOptionalAsync(parameterGroupingPostOptionalParameters).toBlocking().value();
@@ -187,7 +215,7 @@ public class ParameterGroupingsImpl implements ParameterGroupings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postOptionalAsync(ParameterGroupingPostOptionalParameters parameterGroupingPostOptionalParameters, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postOptionalAsync(ParameterGroupingPostOptionalParameters parameterGroupingPostOptionalParameters, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postOptionalAsync(parameterGroupingPostOptionalParameters), serviceCallback);
     }
 
@@ -196,20 +224,32 @@ public class ParameterGroupingsImpl implements ParameterGroupings {
      *
      * @param parameterGroupingPostOptionalParameters Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postOptionalAsync(ParameterGroupingPostOptionalParameters parameterGroupingPostOptionalParameters) {
+    public Single<RestResponse<Void, Void>> postOptionalWithRestResponseAsync(ParameterGroupingPostOptionalParameters parameterGroupingPostOptionalParameters) {
         Validator.validate(parameterGroupingPostOptionalParameters);
-        String customHeader = null;
-        if (parameterGroupingPostOptionalParameters != null) {
-            customHeader = parameterGroupingPostOptionalParameters.customHeader();
-        }
-        Integer query = null;
-        if (parameterGroupingPostOptionalParameters != null) {
-            query = parameterGroupingPostOptionalParameters.query();
-        }
+    String customHeader = null;
+    if (parameterGroupingPostOptionalParameters != null) {
+        customHeader = parameterGroupingPostOptionalParameters.customHeader();
+    }
+    Integer query = null;
+    if (parameterGroupingPostOptionalParameters != null) {
+        query = parameterGroupingPostOptionalParameters.query();
+    }
         return service.postOptional(this.client.acceptLanguage(), customHeader, query, this.client.userAgent());
     }
+
+    /**
+     * Post a bunch of optional parameters grouped.
+     *
+     * @param parameterGroupingPostOptionalParameters Additional parameters for the operation
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postOptionalAsync(ParameterGroupingPostOptionalParameters parameterGroupingPostOptionalParameters) {
+        return postOptionalWithRestResponseAsync(parameterGroupingPostOptionalParameters)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -218,6 +258,7 @@ public class ParameterGroupingsImpl implements ParameterGroupings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postMultiParamGroups() {
         postMultiParamGroupsAsync().toBlocking().value();
@@ -230,7 +271,7 @@ public class ParameterGroupingsImpl implements ParameterGroupings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postMultiParamGroupsAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postMultiParamGroupsAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postMultiParamGroupsAsync(), serviceCallback);
     }
 
@@ -238,17 +279,30 @@ public class ParameterGroupingsImpl implements ParameterGroupings {
      * Post parameters from multiple different parameter groups.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postMultiParamGroupsAsync() {
+    public Single<RestResponse<Void, Void>> postMultiParamGroupsWithRestResponseAsync() {
         final FirstParameterGroup firstParameterGroup = null;
         final ParameterGroupingPostMultiParamGroupsSecondParamGroup parameterGroupingPostMultiParamGroupsSecondParamGroup = null;
-        String headerOne = null;
-        Integer queryOne = null;
-        String headerTwo = null;
-        Integer queryTwo = null;
+        Validator.validate(firstParameterGroup);
+        Validator.validate(parameterGroupingPostMultiParamGroupsSecondParamGroup);
+    String headerOne = null;
+    Integer queryOne = null;
+    String headerTwo = null;
+    Integer queryTwo = null;
         return service.postMultiParamGroups(this.client.acceptLanguage(), headerOne, queryOne, headerTwo, queryTwo, this.client.userAgent());
     }
+
+    /**
+     * Post parameters from multiple different parameter groups.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postMultiParamGroupsAsync() {
+        return postMultiParamGroupsWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Post parameters from multiple different parameter groups.
@@ -258,6 +312,7 @@ public class ParameterGroupingsImpl implements ParameterGroupings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postMultiParamGroups(FirstParameterGroup firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroup parameterGroupingPostMultiParamGroupsSecondParamGroup) {
         postMultiParamGroupsAsync(firstParameterGroup, parameterGroupingPostMultiParamGroupsSecondParamGroup).toBlocking().value();
@@ -272,7 +327,7 @@ public class ParameterGroupingsImpl implements ParameterGroupings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postMultiParamGroupsAsync(FirstParameterGroup firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroup parameterGroupingPostMultiParamGroupsSecondParamGroup, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postMultiParamGroupsAsync(FirstParameterGroup firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroup parameterGroupingPostMultiParamGroupsSecondParamGroup, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postMultiParamGroupsAsync(firstParameterGroup, parameterGroupingPostMultiParamGroupsSecondParamGroup), serviceCallback);
     }
 
@@ -282,29 +337,42 @@ public class ParameterGroupingsImpl implements ParameterGroupings {
      * @param firstParameterGroup Additional parameters for the operation
      * @param parameterGroupingPostMultiParamGroupsSecondParamGroup Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postMultiParamGroupsAsync(FirstParameterGroup firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroup parameterGroupingPostMultiParamGroupsSecondParamGroup) {
+    public Single<RestResponse<Void, Void>> postMultiParamGroupsWithRestResponseAsync(FirstParameterGroup firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroup parameterGroupingPostMultiParamGroupsSecondParamGroup) {
         Validator.validate(firstParameterGroup);
         Validator.validate(parameterGroupingPostMultiParamGroupsSecondParamGroup);
-        String headerOne = null;
-        if (firstParameterGroup != null) {
-            headerOne = firstParameterGroup.headerOne();
-        }
-        Integer queryOne = null;
-        if (firstParameterGroup != null) {
-            queryOne = firstParameterGroup.queryOne();
-        }
-        String headerTwo = null;
-        if (parameterGroupingPostMultiParamGroupsSecondParamGroup != null) {
-            headerTwo = parameterGroupingPostMultiParamGroupsSecondParamGroup.headerTwo();
-        }
-        Integer queryTwo = null;
-        if (parameterGroupingPostMultiParamGroupsSecondParamGroup != null) {
-            queryTwo = parameterGroupingPostMultiParamGroupsSecondParamGroup.queryTwo();
-        }
+    String headerOne = null;
+    if (firstParameterGroup != null) {
+        headerOne = firstParameterGroup.headerOne();
+    }
+    Integer queryOne = null;
+    if (firstParameterGroup != null) {
+        queryOne = firstParameterGroup.queryOne();
+    }
+    String headerTwo = null;
+    if (parameterGroupingPostMultiParamGroupsSecondParamGroup != null) {
+        headerTwo = parameterGroupingPostMultiParamGroupsSecondParamGroup.headerTwo();
+    }
+    Integer queryTwo = null;
+    if (parameterGroupingPostMultiParamGroupsSecondParamGroup != null) {
+        queryTwo = parameterGroupingPostMultiParamGroupsSecondParamGroup.queryTwo();
+    }
         return service.postMultiParamGroups(this.client.acceptLanguage(), headerOne, queryOne, headerTwo, queryTwo, this.client.userAgent());
     }
+
+    /**
+     * Post parameters from multiple different parameter groups.
+     *
+     * @param firstParameterGroup Additional parameters for the operation
+     * @param parameterGroupingPostMultiParamGroupsSecondParamGroup Additional parameters for the operation
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postMultiParamGroupsAsync(FirstParameterGroup firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroup parameterGroupingPostMultiParamGroupsSecondParamGroup) {
+        return postMultiParamGroupsWithRestResponseAsync(firstParameterGroup, parameterGroupingPostMultiParamGroupsSecondParamGroup)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -313,6 +381,7 @@ public class ParameterGroupingsImpl implements ParameterGroupings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postSharedParameterGroupObject() {
         postSharedParameterGroupObjectAsync().toBlocking().value();
@@ -325,7 +394,7 @@ public class ParameterGroupingsImpl implements ParameterGroupings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postSharedParameterGroupObjectAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postSharedParameterGroupObjectAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postSharedParameterGroupObjectAsync(), serviceCallback);
     }
 
@@ -333,14 +402,26 @@ public class ParameterGroupingsImpl implements ParameterGroupings {
      * Post parameters with a shared parameter group object.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postSharedParameterGroupObjectAsync() {
+    public Single<RestResponse<Void, Void>> postSharedParameterGroupObjectWithRestResponseAsync() {
         final FirstParameterGroup firstParameterGroup = null;
-        String headerOne = null;
-        Integer queryOne = null;
+        Validator.validate(firstParameterGroup);
+    String headerOne = null;
+    Integer queryOne = null;
         return service.postSharedParameterGroupObject(this.client.acceptLanguage(), headerOne, queryOne, this.client.userAgent());
     }
+
+    /**
+     * Post parameters with a shared parameter group object.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postSharedParameterGroupObjectAsync() {
+        return postSharedParameterGroupObjectWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Post parameters with a shared parameter group object.
@@ -349,6 +430,7 @@ public class ParameterGroupingsImpl implements ParameterGroupings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postSharedParameterGroupObject(FirstParameterGroup firstParameterGroup) {
         postSharedParameterGroupObjectAsync(firstParameterGroup).toBlocking().value();
@@ -362,7 +444,7 @@ public class ParameterGroupingsImpl implements ParameterGroupings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postSharedParameterGroupObjectAsync(FirstParameterGroup firstParameterGroup, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postSharedParameterGroupObjectAsync(FirstParameterGroup firstParameterGroup, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postSharedParameterGroupObjectAsync(firstParameterGroup), serviceCallback);
     }
 
@@ -371,20 +453,32 @@ public class ParameterGroupingsImpl implements ParameterGroupings {
      *
      * @param firstParameterGroup Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postSharedParameterGroupObjectAsync(FirstParameterGroup firstParameterGroup) {
+    public Single<RestResponse<Void, Void>> postSharedParameterGroupObjectWithRestResponseAsync(FirstParameterGroup firstParameterGroup) {
         Validator.validate(firstParameterGroup);
-        String headerOne = null;
-        if (firstParameterGroup != null) {
-            headerOne = firstParameterGroup.headerOne();
-        }
-        Integer queryOne = null;
-        if (firstParameterGroup != null) {
-            queryOne = firstParameterGroup.queryOne();
-        }
+    String headerOne = null;
+    if (firstParameterGroup != null) {
+        headerOne = firstParameterGroup.headerOne();
+    }
+    Integer queryOne = null;
+    if (firstParameterGroup != null) {
+        queryOne = firstParameterGroup.queryOne();
+    }
         return service.postSharedParameterGroupObject(this.client.acceptLanguage(), headerOne, queryOne, this.client.userAgent());
     }
+
+    /**
+     * Post parameters with a shared parameter group object.
+     *
+     * @param firstParameterGroup Additional parameters for the operation
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postSharedParameterGroupObjectAsync(FirstParameterGroup firstParameterGroup) {
+        return postSharedParameterGroupObjectWithRestResponseAsync(firstParameterGroup)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azure/src/main/java/fixtures/azurereport/AutoRestReportServiceForAzure.java
+++ b/test/azure/src/main/java/fixtures/azurereport/AutoRestReportServiceForAzure.java
@@ -11,6 +11,7 @@
 package fixtures.azurereport;
 
 import com.microsoft.rest.RestClient;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.azurereport.models.ErrorException;
@@ -108,6 +109,13 @@ public interface AutoRestReportServiceForAzure {
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
     Single<Map<String, Integer>> getReportAsync();
+    /**
+     * Get test coverage report.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, Integer&gt; object
+     */
+    Single<RestResponse<Void, Map<String, Integer>>> getReportWithRestResponseAsync();
 
 
 }

--- a/test/azure/src/main/java/fixtures/azurereport/implementation/AutoRestReportServiceForAzureImpl.java
+++ b/test/azure/src/main/java/fixtures/azurereport/implementation/AutoRestReportServiceForAzureImpl.java
@@ -22,6 +22,7 @@ import com.microsoft.rest.annotations.UnexpectedResponseExceptionType;
 import com.microsoft.rest.credentials.ServiceClientCredentials;
 import com.microsoft.rest.http.HttpClient;
 import com.microsoft.rest.RestClient;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.azurereport.AutoRestReportServiceForAzure;
@@ -170,7 +171,7 @@ public class AutoRestReportServiceForAzureImpl extends AzureServiceClient implem
         @GET("report/azure")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, Integer>> getReport(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Map<String, Integer>>> getReport(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -193,7 +194,7 @@ public class AutoRestReportServiceForAzureImpl extends AzureServiceClient implem
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, Integer>> getReportAsync(final ServiceCallback<Map<String, Integer>> serviceCallback) {
+    public ServiceFuture<Map<String, Integer>> getReportAsync(ServiceCallback<Map<String, Integer>> serviceCallback) {
         return ServiceFuture.fromBody(getReportAsync(), serviceCallback);
     }
 
@@ -201,11 +202,22 @@ public class AutoRestReportServiceForAzureImpl extends AzureServiceClient implem
      * Get test coverage report.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, Integer&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Integer>> object
      */
-    public Single<Map<String, Integer>> getReportAsync() {
+    public Single<RestResponse<Void, Map<String, Integer>>> getReportWithRestResponseAsync() {
         return service.getReport(this.acceptLanguage(), this.userAgent());
     }
+
+    /**
+     * Get test coverage report.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Integer>> object
+     */
+    public Single<Map<String, Integer>> getReportAsync() {
+        return getReportWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, Integer>>, Map<String, Integer>>() { public Map<String, Integer> call(RestResponse<Void, Map<String, Integer>> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azure/src/main/java/fixtures/azureresource/AutoRestResourceFlatteningTestService.java
+++ b/test/azure/src/main/java/fixtures/azureresource/AutoRestResourceFlatteningTestService.java
@@ -12,6 +12,7 @@ package fixtures.azureresource;
 
 import com.microsoft.azure.Resource;
 import com.microsoft.rest.RestClient;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.azureresource.models.ErrorException;
@@ -111,6 +112,14 @@ public interface AutoRestResourceFlatteningTestService {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putArrayAsync();
+
+    /**
+     * Put External Resource as an Array.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putArrayWithRestResponseAsync();
     /**
      * Put External Resource as an Array.
      *
@@ -139,6 +148,14 @@ public interface AutoRestResourceFlatteningTestService {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putArrayAsync(List<Resource> resourceArray);
+    /**
+     * Put External Resource as an Array.
+     *
+     * @param resourceArray External Resource as an Array to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putArrayWithRestResponseAsync(List<Resource> resourceArray);
 
 
     /**
@@ -167,6 +184,13 @@ public interface AutoRestResourceFlatteningTestService {
      * @return the observable to the List&lt;FlattenedProduct&gt; object
      */
     Single<List<FlattenedProduct>> getArrayAsync();
+    /**
+     * Get External Resource as an Array.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;FlattenedProduct&gt; object
+     */
+    Single<RestResponse<Void, List<FlattenedProduct>>> getArrayWithRestResponseAsync();
 
 
     /**
@@ -194,6 +218,14 @@ public interface AutoRestResourceFlatteningTestService {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putDictionaryAsync();
+
+    /**
+     * Put External Resource as a Dictionary.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putDictionaryWithRestResponseAsync();
     /**
      * Put External Resource as a Dictionary.
      *
@@ -222,6 +254,14 @@ public interface AutoRestResourceFlatteningTestService {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putDictionaryAsync(Map<String, FlattenedProduct> resourceDictionary);
+    /**
+     * Put External Resource as a Dictionary.
+     *
+     * @param resourceDictionary External Resource as a Dictionary to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putDictionaryWithRestResponseAsync(Map<String, FlattenedProduct> resourceDictionary);
 
 
     /**
@@ -250,6 +290,13 @@ public interface AutoRestResourceFlatteningTestService {
      * @return the observable to the Map&lt;String, FlattenedProduct&gt; object
      */
     Single<Map<String, FlattenedProduct>> getDictionaryAsync();
+    /**
+     * Get External Resource as a Dictionary.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, FlattenedProduct&gt; object
+     */
+    Single<RestResponse<Void, Map<String, FlattenedProduct>>> getDictionaryWithRestResponseAsync();
 
 
     /**
@@ -277,6 +324,14 @@ public interface AutoRestResourceFlatteningTestService {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putResourceCollectionAsync();
+
+    /**
+     * Put External Resource as a ResourceCollection.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putResourceCollectionWithRestResponseAsync();
     /**
      * Put External Resource as a ResourceCollection.
      *
@@ -305,6 +360,14 @@ public interface AutoRestResourceFlatteningTestService {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putResourceCollectionAsync(ResourceCollection resourceComplexObject);
+    /**
+     * Put External Resource as a ResourceCollection.
+     *
+     * @param resourceComplexObject External Resource as a ResourceCollection to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putResourceCollectionWithRestResponseAsync(ResourceCollection resourceComplexObject);
 
 
     /**
@@ -333,6 +396,13 @@ public interface AutoRestResourceFlatteningTestService {
      * @return the observable to the ResourceCollection object
      */
     Single<ResourceCollection> getResourceCollectionAsync();
+    /**
+     * Get External Resource as a ResourceCollection.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the ResourceCollection object
+     */
+    Single<RestResponse<Void, ResourceCollection>> getResourceCollectionWithRestResponseAsync();
 
 
 }

--- a/test/azure/src/main/java/fixtures/azureresource/implementation/AutoRestResourceFlatteningTestServiceImpl.java
+++ b/test/azure/src/main/java/fixtures/azureresource/implementation/AutoRestResourceFlatteningTestServiceImpl.java
@@ -25,6 +25,7 @@ import com.microsoft.rest.annotations.UnexpectedResponseExceptionType;
 import com.microsoft.rest.credentials.ServiceClientCredentials;
 import com.microsoft.rest.http.HttpClient;
 import com.microsoft.rest.RestClient;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import com.microsoft.rest.Validator;
@@ -177,37 +178,37 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
         @PUT("azure/resource-flatten/array")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putArray(@BodyParam("application/json; charset=utf-8") List<Resource> resourceArray, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> putArray(@BodyParam("application/json; charset=utf-8") List<Resource> resourceArray, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azureresource.AutoRestResourceFlatteningTestService getArray" })
         @GET("azure/resource-flatten/array")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<FlattenedProduct>> getArray(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, List<FlattenedProduct>>> getArray(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azureresource.AutoRestResourceFlatteningTestService putDictionary" })
         @PUT("azure/resource-flatten/dictionary")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putDictionary(@BodyParam("application/json; charset=utf-8") Map<String, FlattenedProduct> resourceDictionary, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> putDictionary(@BodyParam("application/json; charset=utf-8") Map<String, FlattenedProduct> resourceDictionary, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azureresource.AutoRestResourceFlatteningTestService getDictionary" })
         @GET("azure/resource-flatten/dictionary")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, FlattenedProduct>> getDictionary(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Map<String, FlattenedProduct>>> getDictionary(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azureresource.AutoRestResourceFlatteningTestService putResourceCollection" })
         @PUT("azure/resource-flatten/resourcecollection")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putResourceCollection(@BodyParam("application/json; charset=utf-8") ResourceCollection resourceComplexObject, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> putResourceCollection(@BodyParam("application/json; charset=utf-8") ResourceCollection resourceComplexObject, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azureresource.AutoRestResourceFlatteningTestService getResourceCollection" })
         @GET("azure/resource-flatten/resourcecollection")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<ResourceCollection> getResourceCollection(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, ResourceCollection>> getResourceCollection(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -217,6 +218,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putArray() {
         putArrayAsync().toBlocking().value();
@@ -229,7 +231,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putArrayAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putArrayAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putArrayAsync(), serviceCallback);
     }
 
@@ -237,12 +239,24 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * Put External Resource as an Array.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putArrayAsync() {
+    public Single<RestResponse<Void, Void>> putArrayWithRestResponseAsync() {
         final List<Resource> resourceArray = null;
+        Validator.validate(resourceArray);
         return service.putArray(resourceArray, this.acceptLanguage(), this.userAgent());
     }
+
+    /**
+     * Put External Resource as an Array.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putArrayAsync() {
+        return putArrayWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Put External Resource as an Array.
@@ -251,6 +265,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putArray(List<Resource> resourceArray) {
         putArrayAsync(resourceArray).toBlocking().value();
@@ -264,7 +279,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putArrayAsync(List<Resource> resourceArray, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putArrayAsync(List<Resource> resourceArray, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putArrayAsync(resourceArray), serviceCallback);
     }
 
@@ -273,12 +288,24 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      *
      * @param resourceArray External Resource as an Array to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putArrayAsync(List<Resource> resourceArray) {
+    public Single<RestResponse<Void, Void>> putArrayWithRestResponseAsync(List<Resource> resourceArray) {
         Validator.validate(resourceArray);
         return service.putArray(resourceArray, this.acceptLanguage(), this.userAgent());
     }
+
+    /**
+     * Put External Resource as an Array.
+     *
+     * @param resourceArray External Resource as an Array to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putArrayAsync(List<Resource> resourceArray) {
+        return putArrayWithRestResponseAsync(resourceArray)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -300,7 +327,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<FlattenedProduct>> getArrayAsync(final ServiceCallback<List<FlattenedProduct>> serviceCallback) {
+    public ServiceFuture<List<FlattenedProduct>> getArrayAsync(ServiceCallback<List<FlattenedProduct>> serviceCallback) {
         return ServiceFuture.fromBody(getArrayAsync(), serviceCallback);
     }
 
@@ -308,11 +335,22 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * Get External Resource as an Array.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;FlattenedProduct&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<FlattenedProduct>> object
      */
-    public Single<List<FlattenedProduct>> getArrayAsync() {
+    public Single<RestResponse<Void, List<FlattenedProduct>>> getArrayWithRestResponseAsync() {
         return service.getArray(this.acceptLanguage(), this.userAgent());
     }
+
+    /**
+     * Get External Resource as an Array.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<FlattenedProduct>> object
+     */
+    public Single<List<FlattenedProduct>> getArrayAsync() {
+        return getArrayWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<FlattenedProduct>>, List<FlattenedProduct>>() { public List<FlattenedProduct> call(RestResponse<Void, List<FlattenedProduct>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -321,6 +359,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putDictionary() {
         putDictionaryAsync().toBlocking().value();
@@ -333,7 +372,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putDictionaryAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putDictionaryAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putDictionaryAsync(), serviceCallback);
     }
 
@@ -341,12 +380,24 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * Put External Resource as a Dictionary.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putDictionaryAsync() {
+    public Single<RestResponse<Void, Void>> putDictionaryWithRestResponseAsync() {
         final Map<String, FlattenedProduct> resourceDictionary = null;
+        Validator.validate(resourceDictionary);
         return service.putDictionary(resourceDictionary, this.acceptLanguage(), this.userAgent());
     }
+
+    /**
+     * Put External Resource as a Dictionary.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putDictionaryAsync() {
+        return putDictionaryWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Put External Resource as a Dictionary.
@@ -355,6 +406,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putDictionary(Map<String, FlattenedProduct> resourceDictionary) {
         putDictionaryAsync(resourceDictionary).toBlocking().value();
@@ -368,7 +420,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putDictionaryAsync(Map<String, FlattenedProduct> resourceDictionary, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putDictionaryAsync(Map<String, FlattenedProduct> resourceDictionary, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putDictionaryAsync(resourceDictionary), serviceCallback);
     }
 
@@ -377,12 +429,24 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      *
      * @param resourceDictionary External Resource as a Dictionary to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putDictionaryAsync(Map<String, FlattenedProduct> resourceDictionary) {
+    public Single<RestResponse<Void, Void>> putDictionaryWithRestResponseAsync(Map<String, FlattenedProduct> resourceDictionary) {
         Validator.validate(resourceDictionary);
         return service.putDictionary(resourceDictionary, this.acceptLanguage(), this.userAgent());
     }
+
+    /**
+     * Put External Resource as a Dictionary.
+     *
+     * @param resourceDictionary External Resource as a Dictionary to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putDictionaryAsync(Map<String, FlattenedProduct> resourceDictionary) {
+        return putDictionaryWithRestResponseAsync(resourceDictionary)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -404,7 +468,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, FlattenedProduct>> getDictionaryAsync(final ServiceCallback<Map<String, FlattenedProduct>> serviceCallback) {
+    public ServiceFuture<Map<String, FlattenedProduct>> getDictionaryAsync(ServiceCallback<Map<String, FlattenedProduct>> serviceCallback) {
         return ServiceFuture.fromBody(getDictionaryAsync(), serviceCallback);
     }
 
@@ -412,11 +476,22 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * Get External Resource as a Dictionary.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, FlattenedProduct&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, FlattenedProduct>> object
      */
-    public Single<Map<String, FlattenedProduct>> getDictionaryAsync() {
+    public Single<RestResponse<Void, Map<String, FlattenedProduct>>> getDictionaryWithRestResponseAsync() {
         return service.getDictionary(this.acceptLanguage(), this.userAgent());
     }
+
+    /**
+     * Get External Resource as a Dictionary.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, FlattenedProduct>> object
+     */
+    public Single<Map<String, FlattenedProduct>> getDictionaryAsync() {
+        return getDictionaryWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, FlattenedProduct>>, Map<String, FlattenedProduct>>() { public Map<String, FlattenedProduct> call(RestResponse<Void, Map<String, FlattenedProduct>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -425,6 +500,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putResourceCollection() {
         putResourceCollectionAsync().toBlocking().value();
@@ -437,7 +513,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putResourceCollectionAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putResourceCollectionAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putResourceCollectionAsync(), serviceCallback);
     }
 
@@ -445,12 +521,24 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * Put External Resource as a ResourceCollection.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putResourceCollectionAsync() {
+    public Single<RestResponse<Void, Void>> putResourceCollectionWithRestResponseAsync() {
         final ResourceCollection resourceComplexObject = null;
+        Validator.validate(resourceComplexObject);
         return service.putResourceCollection(resourceComplexObject, this.acceptLanguage(), this.userAgent());
     }
+
+    /**
+     * Put External Resource as a ResourceCollection.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putResourceCollectionAsync() {
+        return putResourceCollectionWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Put External Resource as a ResourceCollection.
@@ -459,6 +547,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putResourceCollection(ResourceCollection resourceComplexObject) {
         putResourceCollectionAsync(resourceComplexObject).toBlocking().value();
@@ -472,7 +561,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putResourceCollectionAsync(ResourceCollection resourceComplexObject, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putResourceCollectionAsync(ResourceCollection resourceComplexObject, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putResourceCollectionAsync(resourceComplexObject), serviceCallback);
     }
 
@@ -481,12 +570,24 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      *
      * @param resourceComplexObject External Resource as a ResourceCollection to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putResourceCollectionAsync(ResourceCollection resourceComplexObject) {
+    public Single<RestResponse<Void, Void>> putResourceCollectionWithRestResponseAsync(ResourceCollection resourceComplexObject) {
         Validator.validate(resourceComplexObject);
         return service.putResourceCollection(resourceComplexObject, this.acceptLanguage(), this.userAgent());
     }
+
+    /**
+     * Put External Resource as a ResourceCollection.
+     *
+     * @param resourceComplexObject External Resource as a ResourceCollection to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putResourceCollectionAsync(ResourceCollection resourceComplexObject) {
+        return putResourceCollectionWithRestResponseAsync(resourceComplexObject)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -508,7 +609,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ResourceCollection> getResourceCollectionAsync(final ServiceCallback<ResourceCollection> serviceCallback) {
+    public ServiceFuture<ResourceCollection> getResourceCollectionAsync(ServiceCallback<ResourceCollection> serviceCallback) {
         return ServiceFuture.fromBody(getResourceCollectionAsync(), serviceCallback);
     }
 
@@ -516,11 +617,22 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * Get External Resource as a ResourceCollection.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ResourceCollection object
+     * @return a {@link Single} emitting the RestResponse<Void, ResourceCollection> object
      */
-    public Single<ResourceCollection> getResourceCollectionAsync() {
+    public Single<RestResponse<Void, ResourceCollection>> getResourceCollectionWithRestResponseAsync() {
         return service.getResourceCollection(this.acceptLanguage(), this.userAgent());
     }
+
+    /**
+     * Get External Resource as a ResourceCollection.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ResourceCollection> object
+     */
+    public Single<ResourceCollection> getResourceCollectionAsync() {
+        return getResourceCollectionWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, ResourceCollection>, ResourceCollection>() { public ResourceCollection call(RestResponse<Void, ResourceCollection> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azure/src/main/java/fixtures/azurespecials/ApiVersionDefaults.java
+++ b/test/azure/src/main/java/fixtures/azurespecials/ApiVersionDefaults.java
@@ -10,6 +10,7 @@
 
 package fixtures.azurespecials;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.azurespecials.models.ErrorException;
@@ -48,6 +49,14 @@ public interface ApiVersionDefaults {
      */
     Single<Void> getMethodGlobalValidAsync();
 
+    /**
+     * GET method with api-version modeled in global settings.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> getMethodGlobalValidWithRestResponseAsync();
+
 
     /**
      * GET method with api-version modeled in global settings.
@@ -74,6 +83,14 @@ public interface ApiVersionDefaults {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getMethodGlobalNotProvidedValidAsync();
+
+    /**
+     * GET method with api-version modeled in global settings.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> getMethodGlobalNotProvidedValidWithRestResponseAsync();
 
 
     /**
@@ -102,6 +119,14 @@ public interface ApiVersionDefaults {
      */
     Single<Void> getPathGlobalValidAsync();
 
+    /**
+     * GET method with api-version modeled in global settings.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> getPathGlobalValidWithRestResponseAsync();
+
 
     /**
      * GET method with api-version modeled in global settings.
@@ -128,6 +153,14 @@ public interface ApiVersionDefaults {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getSwaggerGlobalValidAsync();
+
+    /**
+     * GET method with api-version modeled in global settings.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> getSwaggerGlobalValidWithRestResponseAsync();
 
 
 }

--- a/test/azure/src/main/java/fixtures/azurespecials/ApiVersionLocals.java
+++ b/test/azure/src/main/java/fixtures/azurespecials/ApiVersionLocals.java
@@ -10,6 +10,7 @@
 
 package fixtures.azurespecials;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.azurespecials.models.ErrorException;
@@ -48,6 +49,14 @@ public interface ApiVersionLocals {
      */
     Single<Void> getMethodLocalValidAsync();
 
+    /**
+     * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> getMethodLocalValidWithRestResponseAsync();
+
 
     /**
      * Get method with api-version modeled in the method.  pass in api-version = null to succeed.
@@ -77,6 +86,14 @@ public interface ApiVersionLocals {
     /**
      * Get method with api-version modeled in the method.  pass in api-version = null to succeed.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> getMethodLocalNullWithRestResponseAsync();
+    }
+    /**
+     * Get method with api-version modeled in the method.  pass in api-version = null to succeed.
+     *
      * @param apiVersion This should appear as a method parameter, use value null, this should result in no serialized parameter
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
@@ -102,6 +119,15 @@ public interface ApiVersionLocals {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getMethodLocalNullAsync(String apiVersion);
+
+    /**
+     * Get method with api-version modeled in the method.  pass in api-version = null to succeed.
+     *
+     * @param apiVersion This should appear as a method parameter, use value null, this should result in no serialized parameter
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> getMethodLocalNullWithRestResponseAsync(String apiVersion);
 
 
     /**
@@ -130,6 +156,14 @@ public interface ApiVersionLocals {
      */
     Single<Void> getPathLocalValidAsync();
 
+    /**
+     * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> getPathLocalValidWithRestResponseAsync();
+
 
     /**
      * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed.
@@ -156,6 +190,14 @@ public interface ApiVersionLocals {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getSwaggerLocalValidAsync();
+
+    /**
+     * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> getSwaggerLocalValidWithRestResponseAsync();
 
 
 }

--- a/test/azure/src/main/java/fixtures/azurespecials/Headers.java
+++ b/test/azure/src/main/java/fixtures/azurespecials/Headers.java
@@ -10,6 +10,7 @@
 
 package fixtures.azurespecials;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.azurespecials.models.ErrorException;
@@ -55,6 +56,15 @@ public interface Headers {
      */
     Single<Void> customNamedRequestIdAsync(String fooClientRequestId);
 
+    /**
+     * Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request.
+     *
+     * @param fooClientRequestId The fooRequestId
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<HeaderCustomNamedRequestIdHeaders, Void>} object if successful.
+     */
+    RestResponse<HeaderCustomNamedRequestIdHeaders, Void> customNamedRequestIdWithRestResponseAsync(String fooClientRequestId);
+
 
     /**
      * Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request, via a parameter group.
@@ -84,6 +94,15 @@ public interface Headers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> customNamedRequestIdParamGroupingAsync(HeaderCustomNamedRequestIdParamGroupingParameters headerCustomNamedRequestIdParamGroupingParameters);
+
+    /**
+     * Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request, via a parameter group.
+     *
+     * @param headerCustomNamedRequestIdParamGroupingParameters Additional parameters for the operation
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<HeaderCustomNamedRequestIdParamGroupingHeaders, Void>} object if successful.
+     */
+    RestResponse<HeaderCustomNamedRequestIdParamGroupingHeaders, Void> customNamedRequestIdParamGroupingWithRestResponseAsync(HeaderCustomNamedRequestIdParamGroupingParameters headerCustomNamedRequestIdParamGroupingParameters);
 
 
     /**
@@ -115,6 +134,15 @@ public interface Headers {
      * @return the observable to the boolean object
      */
     Single<Boolean> customNamedRequestIdHeadAsync(String fooClientRequestId);
+
+    /**
+     * Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request.
+     *
+     * @param fooClientRequestId The fooRequestId
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the boolean object
+     */
+    RestResponse<HeaderCustomNamedRequestIdHeadHeaders, Boolean> customNamedRequestIdHeadWithRestResponseAsync(String fooClientRequestId);
 
 
 }

--- a/test/azure/src/main/java/fixtures/azurespecials/Odatas.java
+++ b/test/azure/src/main/java/fixtures/azurespecials/Odatas.java
@@ -10,6 +10,7 @@
 
 package fixtures.azurespecials;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.azurespecials.models.ErrorException;
@@ -50,6 +51,14 @@ public interface Odatas {
     /**
      * Specify filter parameter with value '$filter=id gt 5 and name eq 'foo'&amp;$orderby=id&amp;$top=10'.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> getWithFilterWithRestResponseAsync();
+    }
+    /**
+     * Specify filter parameter with value '$filter=id gt 5 and name eq 'foo'&amp;$orderby=id&amp;$top=10'.
+     *
      * @param filter The filter parameter with value '$filter=id gt 5 and name eq 'foo''.
      * @param top The top parameter with value 10.
      * @param orderby The orderby parameter with value id.
@@ -81,6 +90,17 @@ public interface Odatas {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getWithFilterAsync(String filter, Integer top, String orderby);
+
+    /**
+     * Specify filter parameter with value '$filter=id gt 5 and name eq 'foo'&amp;$orderby=id&amp;$top=10'.
+     *
+     * @param filter The filter parameter with value '$filter=id gt 5 and name eq 'foo''.
+     * @param top The top parameter with value 10.
+     * @param orderby The orderby parameter with value id.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> getWithFilterWithRestResponseAsync(String filter, Integer top, String orderby);
 
 
 }

--- a/test/azure/src/main/java/fixtures/azurespecials/SkipUrlEncodings.java
+++ b/test/azure/src/main/java/fixtures/azurespecials/SkipUrlEncodings.java
@@ -10,6 +10,7 @@
 
 package fixtures.azurespecials;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.azurespecials.models.ErrorException;
@@ -51,6 +52,15 @@ public interface SkipUrlEncodings {
      */
     Single<Void> getMethodPathValidAsync(String unencodedPathParam);
 
+    /**
+     * Get method with unencoded path parameter with value 'path1/path2/path3'.
+     *
+     * @param unencodedPathParam Unencoded path parameter with value 'path1/path2/path3'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> getMethodPathValidWithRestResponseAsync(String unencodedPathParam);
+
 
     /**
      * Get method with unencoded path parameter with value 'path1/path2/path3'.
@@ -81,6 +91,15 @@ public interface SkipUrlEncodings {
      */
     Single<Void> getPathPathValidAsync(String unencodedPathParam);
 
+    /**
+     * Get method with unencoded path parameter with value 'path1/path2/path3'.
+     *
+     * @param unencodedPathParam Unencoded path parameter with value 'path1/path2/path3'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> getPathPathValidWithRestResponseAsync(String unencodedPathParam);
+
 
     /**
      * Get method with unencoded path parameter with value 'path1/path2/path3'.
@@ -107,6 +126,14 @@ public interface SkipUrlEncodings {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getSwaggerPathValidAsync();
+
+    /**
+     * Get method with unencoded path parameter with value 'path1/path2/path3'.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> getSwaggerPathValidWithRestResponseAsync();
 
 
     /**
@@ -138,6 +165,15 @@ public interface SkipUrlEncodings {
      */
     Single<Void> getMethodQueryValidAsync(String q1);
 
+    /**
+     * Get method with unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'.
+     *
+     * @param q1 Unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> getMethodQueryValidWithRestResponseAsync(String q1);
+
 
     /**
      * Get method with unencoded query parameter with value null.
@@ -167,6 +203,14 @@ public interface SkipUrlEncodings {
     /**
      * Get method with unencoded query parameter with value null.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> getMethodQueryNullWithRestResponseAsync();
+    }
+    /**
+     * Get method with unencoded query parameter with value null.
+     *
      * @param q1 Unencoded query parameter with value null
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
@@ -192,6 +236,15 @@ public interface SkipUrlEncodings {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getMethodQueryNullAsync(String q1);
+
+    /**
+     * Get method with unencoded query parameter with value null.
+     *
+     * @param q1 Unencoded query parameter with value null
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> getMethodQueryNullWithRestResponseAsync(String q1);
 
 
     /**
@@ -223,6 +276,15 @@ public interface SkipUrlEncodings {
      */
     Single<Void> getPathQueryValidAsync(String q1);
 
+    /**
+     * Get method with unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'.
+     *
+     * @param q1 Unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> getPathQueryValidWithRestResponseAsync(String q1);
+
 
     /**
      * Get method with unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'.
@@ -249,6 +311,14 @@ public interface SkipUrlEncodings {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getSwaggerQueryValidAsync();
+
+    /**
+     * Get method with unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> getSwaggerQueryValidWithRestResponseAsync();
 
 
 }

--- a/test/azure/src/main/java/fixtures/azurespecials/SubscriptionInCredentials.java
+++ b/test/azure/src/main/java/fixtures/azurespecials/SubscriptionInCredentials.java
@@ -10,6 +10,7 @@
 
 package fixtures.azurespecials;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.azurespecials.models.ErrorException;
@@ -48,6 +49,14 @@ public interface SubscriptionInCredentials {
      */
     Single<Void> postMethodGlobalValidAsync();
 
+    /**
+     * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> postMethodGlobalValidWithRestResponseAsync();
+
 
     /**
      * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to null, and client-side validation should prevent you from making this call.
@@ -74,6 +83,14 @@ public interface SubscriptionInCredentials {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postMethodGlobalNullAsync();
+
+    /**
+     * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to null, and client-side validation should prevent you from making this call.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> postMethodGlobalNullWithRestResponseAsync();
 
 
     /**
@@ -102,6 +119,14 @@ public interface SubscriptionInCredentials {
      */
     Single<Void> postMethodGlobalNotProvidedValidAsync();
 
+    /**
+     * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> postMethodGlobalNotProvidedValidWithRestResponseAsync();
+
 
     /**
      * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
@@ -129,6 +154,14 @@ public interface SubscriptionInCredentials {
      */
     Single<Void> postPathGlobalValidAsync();
 
+    /**
+     * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> postPathGlobalValidWithRestResponseAsync();
+
 
     /**
      * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
@@ -155,6 +188,14 @@ public interface SubscriptionInCredentials {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postSwaggerGlobalValidAsync();
+
+    /**
+     * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> postSwaggerGlobalValidWithRestResponseAsync();
 
 
 }

--- a/test/azure/src/main/java/fixtures/azurespecials/SubscriptionInMethods.java
+++ b/test/azure/src/main/java/fixtures/azurespecials/SubscriptionInMethods.java
@@ -10,6 +10,7 @@
 
 package fixtures.azurespecials;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.azurespecials.models.ErrorException;
@@ -51,6 +52,15 @@ public interface SubscriptionInMethods {
      */
     Single<Void> postMethodLocalValidAsync(String subscriptionId);
 
+    /**
+     * POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed.
+     *
+     * @param subscriptionId This should appear as a method parameter, use value '1234-5678-9012-3456'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> postMethodLocalValidWithRestResponseAsync(String subscriptionId);
+
 
     /**
      * POST method with subscriptionId modeled in the method.  pass in subscription id = null, client-side validation should prevent you from making this call.
@@ -80,6 +90,15 @@ public interface SubscriptionInMethods {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postMethodLocalNullAsync(String subscriptionId);
+
+    /**
+     * POST method with subscriptionId modeled in the method.  pass in subscription id = null, client-side validation should prevent you from making this call.
+     *
+     * @param subscriptionId This should appear as a method parameter, use value null, client-side validation should prvenet the call
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> postMethodLocalNullWithRestResponseAsync(String subscriptionId);
 
 
     /**
@@ -111,6 +130,15 @@ public interface SubscriptionInMethods {
      */
     Single<Void> postPathLocalValidAsync(String subscriptionId);
 
+    /**
+     * POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed.
+     *
+     * @param subscriptionId Should appear as a method parameter -use value '1234-5678-9012-3456'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> postPathLocalValidWithRestResponseAsync(String subscriptionId);
+
 
     /**
      * POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed.
@@ -140,6 +168,15 @@ public interface SubscriptionInMethods {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postSwaggerLocalValidAsync(String subscriptionId);
+
+    /**
+     * POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed.
+     *
+     * @param subscriptionId The subscriptionId, which appears in the path, the value is always '1234-5678-9012-3456'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> postSwaggerLocalValidWithRestResponseAsync(String subscriptionId);
 
 
 }

--- a/test/azure/src/main/java/fixtures/azurespecials/XMsClientRequestIds.java
+++ b/test/azure/src/main/java/fixtures/azurespecials/XMsClientRequestIds.java
@@ -11,6 +11,7 @@
 package fixtures.azurespecials;
 
 import com.microsoft.azure.CloudException;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.azurespecials.models.ErrorException;
@@ -49,6 +50,14 @@ public interface XMsClientRequestIds {
      */
     Single<Void> getAsync();
 
+    /**
+     * Get method that overwrites x-ms-client-request header with value 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> getWithRestResponseAsync();
+
 
     /**
      * Get method that overwrites x-ms-client-request header with value 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -78,6 +87,15 @@ public interface XMsClientRequestIds {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> paramGetAsync(String xMsClientRequestId);
+
+    /**
+     * Get method that overwrites x-ms-client-request header with value 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+     *
+     * @param xMsClientRequestId This should appear as a method parameter, use value '9C4D50EE-2D56-4CD3-8152-34347DC9F2B0'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> paramGetWithRestResponseAsync(String xMsClientRequestId);
 
 
 }

--- a/test/azure/src/main/java/fixtures/azurespecials/implementation/ApiVersionDefaultsImpl.java
+++ b/test/azure/src/main/java/fixtures/azurespecials/implementation/ApiVersionDefaultsImpl.java
@@ -10,6 +10,7 @@
 
 package fixtures.azurespecials.implementation;
 
+import com.microsoft.rest.RestResponse;
 import fixtures.azurespecials.ApiVersionDefaults;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.ExpectedResponses;
@@ -59,25 +60,25 @@ public class ApiVersionDefaultsImpl implements ApiVersionDefaults {
         @GET("azurespecials/apiVersion/method/string/none/query/global/2015-07-01-preview")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getMethodGlobalValid(@QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> getMethodGlobalValid(@QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.ApiVersionDefaults getMethodGlobalNotProvidedValid" })
         @GET("azurespecials/apiVersion/method/string/none/query/globalNotProvided/2015-07-01-preview")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getMethodGlobalNotProvidedValid(@QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> getMethodGlobalNotProvidedValid(@QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.ApiVersionDefaults getPathGlobalValid" })
         @GET("azurespecials/apiVersion/path/string/none/query/global/2015-07-01-preview")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getPathGlobalValid(@QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> getPathGlobalValid(@QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.ApiVersionDefaults getSwaggerGlobalValid" })
         @GET("azurespecials/apiVersion/swagger/string/none/query/global/2015-07-01-preview")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getSwaggerGlobalValid(@QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> getSwaggerGlobalValid(@QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -87,6 +88,7 @@ public class ApiVersionDefaultsImpl implements ApiVersionDefaults {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getMethodGlobalValid() {
         getMethodGlobalValidAsync().toBlocking().value();
@@ -99,7 +101,7 @@ public class ApiVersionDefaultsImpl implements ApiVersionDefaults {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getMethodGlobalValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getMethodGlobalValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getMethodGlobalValidAsync(), serviceCallback);
     }
 
@@ -107,14 +109,25 @@ public class ApiVersionDefaultsImpl implements ApiVersionDefaults {
      * GET method with api-version modeled in global settings.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getMethodGlobalValidAsync() {
+    public Single<RestResponse<Void, Void>> getMethodGlobalValidWithRestResponseAsync() {
         if (this.client.apiVersion() == null) {
             throw new IllegalArgumentException("Parameter this.client.apiVersion() is required and cannot be null.");
         }
         return service.getMethodGlobalValid(this.client.apiVersion(), this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * GET method with api-version modeled in global settings.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getMethodGlobalValidAsync() {
+        return getMethodGlobalValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -123,6 +136,7 @@ public class ApiVersionDefaultsImpl implements ApiVersionDefaults {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getMethodGlobalNotProvidedValid() {
         getMethodGlobalNotProvidedValidAsync().toBlocking().value();
@@ -135,7 +149,7 @@ public class ApiVersionDefaultsImpl implements ApiVersionDefaults {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getMethodGlobalNotProvidedValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getMethodGlobalNotProvidedValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getMethodGlobalNotProvidedValidAsync(), serviceCallback);
     }
 
@@ -143,14 +157,25 @@ public class ApiVersionDefaultsImpl implements ApiVersionDefaults {
      * GET method with api-version modeled in global settings.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getMethodGlobalNotProvidedValidAsync() {
+    public Single<RestResponse<Void, Void>> getMethodGlobalNotProvidedValidWithRestResponseAsync() {
         if (this.client.apiVersion() == null) {
             throw new IllegalArgumentException("Parameter this.client.apiVersion() is required and cannot be null.");
         }
         return service.getMethodGlobalNotProvidedValid(this.client.apiVersion(), this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * GET method with api-version modeled in global settings.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getMethodGlobalNotProvidedValidAsync() {
+        return getMethodGlobalNotProvidedValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -159,6 +184,7 @@ public class ApiVersionDefaultsImpl implements ApiVersionDefaults {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getPathGlobalValid() {
         getPathGlobalValidAsync().toBlocking().value();
@@ -171,7 +197,7 @@ public class ApiVersionDefaultsImpl implements ApiVersionDefaults {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getPathGlobalValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getPathGlobalValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getPathGlobalValidAsync(), serviceCallback);
     }
 
@@ -179,14 +205,25 @@ public class ApiVersionDefaultsImpl implements ApiVersionDefaults {
      * GET method with api-version modeled in global settings.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getPathGlobalValidAsync() {
+    public Single<RestResponse<Void, Void>> getPathGlobalValidWithRestResponseAsync() {
         if (this.client.apiVersion() == null) {
             throw new IllegalArgumentException("Parameter this.client.apiVersion() is required and cannot be null.");
         }
         return service.getPathGlobalValid(this.client.apiVersion(), this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * GET method with api-version modeled in global settings.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getPathGlobalValidAsync() {
+        return getPathGlobalValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -195,6 +232,7 @@ public class ApiVersionDefaultsImpl implements ApiVersionDefaults {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getSwaggerGlobalValid() {
         getSwaggerGlobalValidAsync().toBlocking().value();
@@ -207,7 +245,7 @@ public class ApiVersionDefaultsImpl implements ApiVersionDefaults {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getSwaggerGlobalValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getSwaggerGlobalValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getSwaggerGlobalValidAsync(), serviceCallback);
     }
 
@@ -215,14 +253,25 @@ public class ApiVersionDefaultsImpl implements ApiVersionDefaults {
      * GET method with api-version modeled in global settings.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getSwaggerGlobalValidAsync() {
+    public Single<RestResponse<Void, Void>> getSwaggerGlobalValidWithRestResponseAsync() {
         if (this.client.apiVersion() == null) {
             throw new IllegalArgumentException("Parameter this.client.apiVersion() is required and cannot be null.");
         }
         return service.getSwaggerGlobalValid(this.client.apiVersion(), this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * GET method with api-version modeled in global settings.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getSwaggerGlobalValidAsync() {
+        return getSwaggerGlobalValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azure/src/main/java/fixtures/azurespecials/implementation/ApiVersionLocalsImpl.java
+++ b/test/azure/src/main/java/fixtures/azurespecials/implementation/ApiVersionLocalsImpl.java
@@ -10,6 +10,7 @@
 
 package fixtures.azurespecials.implementation;
 
+import com.microsoft.rest.RestResponse;
 import fixtures.azurespecials.ApiVersionLocals;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.ExpectedResponses;
@@ -59,25 +60,25 @@ public class ApiVersionLocalsImpl implements ApiVersionLocals {
         @GET("azurespecials/apiVersion/method/string/none/query/local/2.0")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getMethodLocalValid(@QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> getMethodLocalValid(@QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.ApiVersionLocals getMethodLocalNull" })
         @GET("azurespecials/apiVersion/method/string/none/query/local/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getMethodLocalNull(@QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> getMethodLocalNull(@QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.ApiVersionLocals getPathLocalValid" })
         @GET("azurespecials/apiVersion/path/string/none/query/local/2.0")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getPathLocalValid(@QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> getPathLocalValid(@QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.ApiVersionLocals getSwaggerLocalValid" })
         @GET("azurespecials/apiVersion/swagger/string/none/query/local/2.0")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getSwaggerLocalValid(@QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> getSwaggerLocalValid(@QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -87,6 +88,7 @@ public class ApiVersionLocalsImpl implements ApiVersionLocals {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getMethodLocalValid() {
         getMethodLocalValidAsync().toBlocking().value();
@@ -99,7 +101,7 @@ public class ApiVersionLocalsImpl implements ApiVersionLocals {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getMethodLocalValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getMethodLocalValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getMethodLocalValidAsync(), serviceCallback);
     }
 
@@ -107,12 +109,23 @@ public class ApiVersionLocalsImpl implements ApiVersionLocals {
      * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getMethodLocalValidAsync() {
+    public Single<RestResponse<Void, Void>> getMethodLocalValidWithRestResponseAsync() {
         final String apiVersion = "2.0";
         return service.getMethodLocalValid(apiVersion, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getMethodLocalValidAsync() {
+        return getMethodLocalValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -121,6 +134,7 @@ public class ApiVersionLocalsImpl implements ApiVersionLocals {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getMethodLocalNull() {
         getMethodLocalNullAsync().toBlocking().value();
@@ -133,7 +147,7 @@ public class ApiVersionLocalsImpl implements ApiVersionLocals {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getMethodLocalNullAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getMethodLocalNullAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getMethodLocalNullAsync(), serviceCallback);
     }
 
@@ -141,12 +155,23 @@ public class ApiVersionLocalsImpl implements ApiVersionLocals {
      * Get method with api-version modeled in the method.  pass in api-version = null to succeed.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getMethodLocalNullAsync() {
+    public Single<RestResponse<Void, Void>> getMethodLocalNullWithRestResponseAsync() {
         final String apiVersion = null;
         return service.getMethodLocalNull(apiVersion, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Get method with api-version modeled in the method.  pass in api-version = null to succeed.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getMethodLocalNullAsync() {
+        return getMethodLocalNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Get method with api-version modeled in the method.  pass in api-version = null to succeed.
@@ -155,6 +180,7 @@ public class ApiVersionLocalsImpl implements ApiVersionLocals {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getMethodLocalNull(String apiVersion) {
         getMethodLocalNullAsync(apiVersion).toBlocking().value();
@@ -168,7 +194,7 @@ public class ApiVersionLocalsImpl implements ApiVersionLocals {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getMethodLocalNullAsync(String apiVersion, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getMethodLocalNullAsync(String apiVersion, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getMethodLocalNullAsync(apiVersion), serviceCallback);
     }
 
@@ -177,11 +203,23 @@ public class ApiVersionLocalsImpl implements ApiVersionLocals {
      *
      * @param apiVersion This should appear as a method parameter, use value null, this should result in no serialized parameter
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getMethodLocalNullAsync(String apiVersion) {
+    public Single<RestResponse<Void, Void>> getMethodLocalNullWithRestResponseAsync(String apiVersion) {
         return service.getMethodLocalNull(apiVersion, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Get method with api-version modeled in the method.  pass in api-version = null to succeed.
+     *
+     * @param apiVersion This should appear as a method parameter, use value null, this should result in no serialized parameter
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getMethodLocalNullAsync(String apiVersion) {
+        return getMethodLocalNullWithRestResponseAsync(apiVersion)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -190,6 +228,7 @@ public class ApiVersionLocalsImpl implements ApiVersionLocals {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getPathLocalValid() {
         getPathLocalValidAsync().toBlocking().value();
@@ -202,7 +241,7 @@ public class ApiVersionLocalsImpl implements ApiVersionLocals {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getPathLocalValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getPathLocalValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getPathLocalValidAsync(), serviceCallback);
     }
 
@@ -210,12 +249,23 @@ public class ApiVersionLocalsImpl implements ApiVersionLocals {
      * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getPathLocalValidAsync() {
+    public Single<RestResponse<Void, Void>> getPathLocalValidWithRestResponseAsync() {
         final String apiVersion = "2.0";
         return service.getPathLocalValid(apiVersion, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getPathLocalValidAsync() {
+        return getPathLocalValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -224,6 +274,7 @@ public class ApiVersionLocalsImpl implements ApiVersionLocals {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getSwaggerLocalValid() {
         getSwaggerLocalValidAsync().toBlocking().value();
@@ -236,7 +287,7 @@ public class ApiVersionLocalsImpl implements ApiVersionLocals {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getSwaggerLocalValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getSwaggerLocalValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getSwaggerLocalValidAsync(), serviceCallback);
     }
 
@@ -244,12 +295,23 @@ public class ApiVersionLocalsImpl implements ApiVersionLocals {
      * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getSwaggerLocalValidAsync() {
+    public Single<RestResponse<Void, Void>> getSwaggerLocalValidWithRestResponseAsync() {
         final String apiVersion = "2.0";
         return service.getSwaggerLocalValid(apiVersion, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getSwaggerLocalValidAsync() {
+        return getSwaggerLocalValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azure/src/main/java/fixtures/azurespecials/implementation/AutoRestAzureSpecialParametersTestClientImpl.java
+++ b/test/azure/src/main/java/fixtures/azurespecials/implementation/AutoRestAzureSpecialParametersTestClientImpl.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.AzureProxy;
 import com.microsoft.azure.AzureServiceClient;
 import com.microsoft.rest.credentials.ServiceClientCredentials;
 import com.microsoft.rest.RestClient;
+import com.microsoft.rest.RestResponse;
 import fixtures.azurespecials.ApiVersionDefaults;
 import fixtures.azurespecials.ApiVersionLocals;
 import fixtures.azurespecials.AutoRestAzureSpecialParametersTestClient;

--- a/test/azure/src/main/java/fixtures/azurespecials/implementation/HeadersImpl.java
+++ b/test/azure/src/main/java/fixtures/azurespecials/implementation/HeadersImpl.java
@@ -10,6 +10,7 @@
 
 package fixtures.azurespecials.implementation;
 
+import com.microsoft.rest.RestResponse;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.ExpectedResponses;
 import com.microsoft.rest.annotations.HEAD;
@@ -63,19 +64,19 @@ public class HeadersImpl implements fixtures.azurespecials.Headers {
         @POST("azurespecials/customNamedRequestId")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> customNamedRequestId(@HeaderParam("foo-client-request-id") String fooClientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<HeaderCustomNamedRequestIdHeaders, Void>> customNamedRequestId(@HeaderParam("foo-client-request-id") String fooClientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.Headers customNamedRequestIdParamGrouping" })
         @POST("azurespecials/customNamedRequestIdParamGrouping")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> customNamedRequestIdParamGrouping(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("foo-client-request-id") String fooClientRequestId, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<HeaderCustomNamedRequestIdParamGroupingHeaders, Void>> customNamedRequestIdParamGrouping(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("foo-client-request-id") String fooClientRequestId, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.Headers customNamedRequestIdHead" })
         @HEAD("azurespecials/customNamedRequestIdHead")
         @ExpectedResponses({200, 404})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Boolean> customNamedRequestIdHead(@HeaderParam("foo-client-request-id") String fooClientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<HeaderCustomNamedRequestIdHeadHeaders, Boolean>> customNamedRequestIdHead(@HeaderParam("foo-client-request-id") String fooClientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -86,6 +87,7 @@ public class HeadersImpl implements fixtures.azurespecials.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void customNamedRequestId(String fooClientRequestId) {
         customNamedRequestIdAsync(fooClientRequestId).toBlocking().value();
@@ -99,8 +101,8 @@ public class HeadersImpl implements fixtures.azurespecials.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> customNamedRequestIdAsync(String fooClientRequestId, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(customNamedRequestIdAsync(fooClientRequestId), serviceCallback);
+    public ServiceFuture<Void> customNamedRequestIdAsync(String fooClientRequestId, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(customNamedRequestIdAsync(fooClientRequestId), serviceCallback);
     }
 
     /**
@@ -108,14 +110,26 @@ public class HeadersImpl implements fixtures.azurespecials.Headers {
      *
      * @param fooClientRequestId The fooRequestId
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HeaderCustomNamedRequestIdHeaders, Void> object
      */
-    public Single<Void> customNamedRequestIdAsync(String fooClientRequestId) {
+    public Single<RestResponse<HeaderCustomNamedRequestIdHeaders, Void>> customNamedRequestIdWithRestResponseAsync(String fooClientRequestId) {
         if (fooClientRequestId == null) {
             throw new IllegalArgumentException("Parameter fooClientRequestId is required and cannot be null.");
         }
         return service.customNamedRequestId(fooClientRequestId, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request.
+     *
+     * @param fooClientRequestId The fooRequestId
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HeaderCustomNamedRequestIdHeaders, Void> object
+     */
+    public Single<Void> customNamedRequestIdAsync(String fooClientRequestId) {
+        return customNamedRequestIdWithRestResponseAsync(fooClientRequestId)
+            .map(new Func1<RestResponse<HeaderCustomNamedRequestIdHeaders, Void>, Void>() { public Void call(RestResponse<HeaderCustomNamedRequestIdHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -125,6 +139,7 @@ public class HeadersImpl implements fixtures.azurespecials.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void customNamedRequestIdParamGrouping(HeaderCustomNamedRequestIdParamGroupingParameters headerCustomNamedRequestIdParamGroupingParameters) {
         customNamedRequestIdParamGroupingAsync(headerCustomNamedRequestIdParamGroupingParameters).toBlocking().value();
@@ -138,8 +153,8 @@ public class HeadersImpl implements fixtures.azurespecials.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> customNamedRequestIdParamGroupingAsync(HeaderCustomNamedRequestIdParamGroupingParameters headerCustomNamedRequestIdParamGroupingParameters, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(customNamedRequestIdParamGroupingAsync(headerCustomNamedRequestIdParamGroupingParameters), serviceCallback);
+    public ServiceFuture<Void> customNamedRequestIdParamGroupingAsync(HeaderCustomNamedRequestIdParamGroupingParameters headerCustomNamedRequestIdParamGroupingParameters, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(customNamedRequestIdParamGroupingAsync(headerCustomNamedRequestIdParamGroupingParameters), serviceCallback);
     }
 
     /**
@@ -147,16 +162,28 @@ public class HeadersImpl implements fixtures.azurespecials.Headers {
      *
      * @param headerCustomNamedRequestIdParamGroupingParameters Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HeaderCustomNamedRequestIdParamGroupingHeaders, Void> object
      */
-    public Single<Void> customNamedRequestIdParamGroupingAsync(HeaderCustomNamedRequestIdParamGroupingParameters headerCustomNamedRequestIdParamGroupingParameters) {
+    public Single<RestResponse<HeaderCustomNamedRequestIdParamGroupingHeaders, Void>> customNamedRequestIdParamGroupingWithRestResponseAsync(HeaderCustomNamedRequestIdParamGroupingParameters headerCustomNamedRequestIdParamGroupingParameters) {
         if (headerCustomNamedRequestIdParamGroupingParameters == null) {
             throw new IllegalArgumentException("Parameter headerCustomNamedRequestIdParamGroupingParameters is required and cannot be null.");
         }
         Validator.validate(headerCustomNamedRequestIdParamGroupingParameters);
-        String fooClientRequestId = headerCustomNamedRequestIdParamGroupingParameters.fooClientRequestId();
+    String fooClientRequestId = headerCustomNamedRequestIdParamGroupingParameters.fooClientRequestId();
         return service.customNamedRequestIdParamGrouping(this.client.acceptLanguage(), fooClientRequestId, this.client.userAgent());
     }
+
+    /**
+     * Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request, via a parameter group.
+     *
+     * @param headerCustomNamedRequestIdParamGroupingParameters Additional parameters for the operation
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HeaderCustomNamedRequestIdParamGroupingHeaders, Void> object
+     */
+    public Single<Void> customNamedRequestIdParamGroupingAsync(HeaderCustomNamedRequestIdParamGroupingParameters headerCustomNamedRequestIdParamGroupingParameters) {
+        return customNamedRequestIdParamGroupingWithRestResponseAsync(headerCustomNamedRequestIdParamGroupingParameters)
+            .map(new Func1<RestResponse<HeaderCustomNamedRequestIdParamGroupingHeaders, Void>, Void>() { public Void call(RestResponse<HeaderCustomNamedRequestIdParamGroupingHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -180,8 +207,8 @@ public class HeadersImpl implements fixtures.azurespecials.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Boolean> customNamedRequestIdHeadAsync(String fooClientRequestId, final ServiceCallback<Boolean> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(customNamedRequestIdHeadAsync(fooClientRequestId), serviceCallback);
+    public ServiceFuture<Boolean> customNamedRequestIdHeadAsync(String fooClientRequestId, ServiceCallback<Boolean> serviceCallback) {
+        return ServiceFuture.fromBody(customNamedRequestIdHeadAsync(fooClientRequestId), serviceCallback);
     }
 
     /**
@@ -189,14 +216,26 @@ public class HeadersImpl implements fixtures.azurespecials.Headers {
      *
      * @param fooClientRequestId The fooRequestId
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Boolean object
+     * @return a {@link Single} emitting the RestResponse<HeaderCustomNamedRequestIdHeadHeaders, Boolean> object
      */
-    public Single<Boolean> customNamedRequestIdHeadAsync(String fooClientRequestId) {
+    public Single<RestResponse<HeaderCustomNamedRequestIdHeadHeaders, Boolean>> customNamedRequestIdHeadWithRestResponseAsync(String fooClientRequestId) {
         if (fooClientRequestId == null) {
             throw new IllegalArgumentException("Parameter fooClientRequestId is required and cannot be null.");
         }
         return service.customNamedRequestIdHead(fooClientRequestId, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request.
+     *
+     * @param fooClientRequestId The fooRequestId
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HeaderCustomNamedRequestIdHeadHeaders, Boolean> object
+     */
+    public Single<Boolean> customNamedRequestIdHeadAsync(String fooClientRequestId) {
+        return customNamedRequestIdHeadWithRestResponseAsync(fooClientRequestId)
+            .map(new Func1<RestResponse<HeaderCustomNamedRequestIdHeadHeaders, Boolean>, Boolean>() { public Boolean call(RestResponse<HeaderCustomNamedRequestIdHeadHeaders, Boolean> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azure/src/main/java/fixtures/azurespecials/implementation/OdatasImpl.java
+++ b/test/azure/src/main/java/fixtures/azurespecials/implementation/OdatasImpl.java
@@ -10,6 +10,7 @@
 
 package fixtures.azurespecials.implementation;
 
+import com.microsoft.rest.RestResponse;
 import fixtures.azurespecials.Odatas;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.ExpectedResponses;
@@ -59,7 +60,7 @@ public class OdatasImpl implements Odatas {
         @GET("azurespecials/odata/filter")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getWithFilter(@QueryParam("$filter") String filter, @QueryParam("$top") Integer top, @QueryParam("$orderby") String orderby, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> getWithFilter(@QueryParam("$filter") String filter, @QueryParam("$top") Integer top, @QueryParam("$orderby") String orderby, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -69,6 +70,7 @@ public class OdatasImpl implements Odatas {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getWithFilter() {
         getWithFilterAsync().toBlocking().value();
@@ -81,7 +83,7 @@ public class OdatasImpl implements Odatas {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getWithFilterAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getWithFilterAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getWithFilterAsync(), serviceCallback);
     }
 
@@ -89,14 +91,25 @@ public class OdatasImpl implements Odatas {
      * Specify filter parameter with value '$filter=id gt 5 and name eq 'foo'&amp;$orderby=id&amp;$top=10'.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getWithFilterAsync() {
+    public Single<RestResponse<Void, Void>> getWithFilterWithRestResponseAsync() {
         final String filter = null;
         final Integer top = null;
         final String orderby = null;
         return service.getWithFilter(filter, top, orderby, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Specify filter parameter with value '$filter=id gt 5 and name eq 'foo'&amp;$orderby=id&amp;$top=10'.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getWithFilterAsync() {
+        return getWithFilterWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Specify filter parameter with value '$filter=id gt 5 and name eq 'foo'&amp;$orderby=id&amp;$top=10'.
@@ -107,6 +120,7 @@ public class OdatasImpl implements Odatas {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getWithFilter(String filter, Integer top, String orderby) {
         getWithFilterAsync(filter, top, orderby).toBlocking().value();
@@ -122,7 +136,7 @@ public class OdatasImpl implements Odatas {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getWithFilterAsync(String filter, Integer top, String orderby, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getWithFilterAsync(String filter, Integer top, String orderby, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getWithFilterAsync(filter, top, orderby), serviceCallback);
     }
 
@@ -133,11 +147,25 @@ public class OdatasImpl implements Odatas {
      * @param top The top parameter with value 10.
      * @param orderby The orderby parameter with value id.
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getWithFilterAsync(String filter, Integer top, String orderby) {
+    public Single<RestResponse<Void, Void>> getWithFilterWithRestResponseAsync(String filter, Integer top, String orderby) {
         return service.getWithFilter(filter, top, orderby, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Specify filter parameter with value '$filter=id gt 5 and name eq 'foo'&amp;$orderby=id&amp;$top=10'.
+     *
+     * @param filter The filter parameter with value '$filter=id gt 5 and name eq 'foo''.
+     * @param top The top parameter with value 10.
+     * @param orderby The orderby parameter with value id.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getWithFilterAsync(String filter, Integer top, String orderby) {
+        return getWithFilterWithRestResponseAsync(filter, top, orderby)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azure/src/main/java/fixtures/azurespecials/implementation/SkipUrlEncodingsImpl.java
+++ b/test/azure/src/main/java/fixtures/azurespecials/implementation/SkipUrlEncodingsImpl.java
@@ -10,6 +10,7 @@
 
 package fixtures.azurespecials.implementation;
 
+import com.microsoft.rest.RestResponse;
 import fixtures.azurespecials.SkipUrlEncodings;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.ExpectedResponses;
@@ -60,43 +61,43 @@ public class SkipUrlEncodingsImpl implements SkipUrlEncodings {
         @GET("azurespecials/skipUrlEncoding/method/path/valid/{unencodedPathParam}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getMethodPathValid(@PathParam(value = "unencodedPathParam", encoded = true) String unencodedPathParam, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> getMethodPathValid(@PathParam(value = "unencodedPathParam", encoded = true) String unencodedPathParam, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.SkipUrlEncodings getPathPathValid" })
         @GET("azurespecials/skipUrlEncoding/path/path/valid/{unencodedPathParam}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getPathPathValid(@PathParam(value = "unencodedPathParam", encoded = true) String unencodedPathParam, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> getPathPathValid(@PathParam(value = "unencodedPathParam", encoded = true) String unencodedPathParam, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.SkipUrlEncodings getSwaggerPathValid" })
         @GET("azurespecials/skipUrlEncoding/swagger/path/valid/{unencodedPathParam}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getSwaggerPathValid(@PathParam(value = "unencodedPathParam", encoded = true) String unencodedPathParam, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> getSwaggerPathValid(@PathParam(value = "unencodedPathParam", encoded = true) String unencodedPathParam, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.SkipUrlEncodings getMethodQueryValid" })
         @GET("azurespecials/skipUrlEncoding/method/query/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getMethodQueryValid(@QueryParam(value = "q1", encoded = true) String q1, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> getMethodQueryValid(@QueryParam(value = "q1", encoded = true) String q1, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.SkipUrlEncodings getMethodQueryNull" })
         @GET("azurespecials/skipUrlEncoding/method/query/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getMethodQueryNull(@QueryParam(value = "q1", encoded = true) String q1, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> getMethodQueryNull(@QueryParam(value = "q1", encoded = true) String q1, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.SkipUrlEncodings getPathQueryValid" })
         @GET("azurespecials/skipUrlEncoding/path/query/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getPathQueryValid(@QueryParam(value = "q1", encoded = true) String q1, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> getPathQueryValid(@QueryParam(value = "q1", encoded = true) String q1, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.SkipUrlEncodings getSwaggerQueryValid" })
         @GET("azurespecials/skipUrlEncoding/swagger/query/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getSwaggerQueryValid(@QueryParam(value = "q1", encoded = true) String q1, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> getSwaggerQueryValid(@QueryParam(value = "q1", encoded = true) String q1, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -107,6 +108,7 @@ public class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getMethodPathValid(String unencodedPathParam) {
         getMethodPathValidAsync(unencodedPathParam).toBlocking().value();
@@ -120,7 +122,7 @@ public class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getMethodPathValidAsync(String unencodedPathParam, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getMethodPathValidAsync(String unencodedPathParam, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getMethodPathValidAsync(unencodedPathParam), serviceCallback);
     }
 
@@ -129,14 +131,26 @@ public class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      *
      * @param unencodedPathParam Unencoded path parameter with value 'path1/path2/path3'
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getMethodPathValidAsync(String unencodedPathParam) {
+    public Single<RestResponse<Void, Void>> getMethodPathValidWithRestResponseAsync(String unencodedPathParam) {
         if (unencodedPathParam == null) {
             throw new IllegalArgumentException("Parameter unencodedPathParam is required and cannot be null.");
         }
         return service.getMethodPathValid(unencodedPathParam, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Get method with unencoded path parameter with value 'path1/path2/path3'.
+     *
+     * @param unencodedPathParam Unencoded path parameter with value 'path1/path2/path3'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getMethodPathValidAsync(String unencodedPathParam) {
+        return getMethodPathValidWithRestResponseAsync(unencodedPathParam)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -146,6 +160,7 @@ public class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getPathPathValid(String unencodedPathParam) {
         getPathPathValidAsync(unencodedPathParam).toBlocking().value();
@@ -159,7 +174,7 @@ public class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getPathPathValidAsync(String unencodedPathParam, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getPathPathValidAsync(String unencodedPathParam, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getPathPathValidAsync(unencodedPathParam), serviceCallback);
     }
 
@@ -168,14 +183,26 @@ public class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      *
      * @param unencodedPathParam Unencoded path parameter with value 'path1/path2/path3'
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getPathPathValidAsync(String unencodedPathParam) {
+    public Single<RestResponse<Void, Void>> getPathPathValidWithRestResponseAsync(String unencodedPathParam) {
         if (unencodedPathParam == null) {
             throw new IllegalArgumentException("Parameter unencodedPathParam is required and cannot be null.");
         }
         return service.getPathPathValid(unencodedPathParam, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Get method with unencoded path parameter with value 'path1/path2/path3'.
+     *
+     * @param unencodedPathParam Unencoded path parameter with value 'path1/path2/path3'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getPathPathValidAsync(String unencodedPathParam) {
+        return getPathPathValidWithRestResponseAsync(unencodedPathParam)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -184,6 +211,7 @@ public class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getSwaggerPathValid() {
         getSwaggerPathValidAsync().toBlocking().value();
@@ -196,7 +224,7 @@ public class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getSwaggerPathValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getSwaggerPathValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getSwaggerPathValidAsync(), serviceCallback);
     }
 
@@ -204,12 +232,23 @@ public class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * Get method with unencoded path parameter with value 'path1/path2/path3'.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getSwaggerPathValidAsync() {
+    public Single<RestResponse<Void, Void>> getSwaggerPathValidWithRestResponseAsync() {
         final String unencodedPathParam = "path1/path2/path3";
         return service.getSwaggerPathValid(unencodedPathParam, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Get method with unencoded path parameter with value 'path1/path2/path3'.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getSwaggerPathValidAsync() {
+        return getSwaggerPathValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -219,6 +258,7 @@ public class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getMethodQueryValid(String q1) {
         getMethodQueryValidAsync(q1).toBlocking().value();
@@ -232,7 +272,7 @@ public class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getMethodQueryValidAsync(String q1, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getMethodQueryValidAsync(String q1, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getMethodQueryValidAsync(q1), serviceCallback);
     }
 
@@ -241,14 +281,26 @@ public class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      *
      * @param q1 Unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getMethodQueryValidAsync(String q1) {
+    public Single<RestResponse<Void, Void>> getMethodQueryValidWithRestResponseAsync(String q1) {
         if (q1 == null) {
             throw new IllegalArgumentException("Parameter q1 is required and cannot be null.");
         }
         return service.getMethodQueryValid(q1, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Get method with unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'.
+     *
+     * @param q1 Unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getMethodQueryValidAsync(String q1) {
+        return getMethodQueryValidWithRestResponseAsync(q1)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -257,6 +309,7 @@ public class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getMethodQueryNull() {
         getMethodQueryNullAsync().toBlocking().value();
@@ -269,7 +322,7 @@ public class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getMethodQueryNullAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getMethodQueryNullAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getMethodQueryNullAsync(), serviceCallback);
     }
 
@@ -277,12 +330,23 @@ public class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * Get method with unencoded query parameter with value null.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getMethodQueryNullAsync() {
+    public Single<RestResponse<Void, Void>> getMethodQueryNullWithRestResponseAsync() {
         final String q1 = null;
         return service.getMethodQueryNull(q1, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Get method with unencoded query parameter with value null.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getMethodQueryNullAsync() {
+        return getMethodQueryNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Get method with unencoded query parameter with value null.
@@ -291,6 +355,7 @@ public class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getMethodQueryNull(String q1) {
         getMethodQueryNullAsync(q1).toBlocking().value();
@@ -304,7 +369,7 @@ public class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getMethodQueryNullAsync(String q1, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getMethodQueryNullAsync(String q1, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getMethodQueryNullAsync(q1), serviceCallback);
     }
 
@@ -313,11 +378,23 @@ public class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      *
      * @param q1 Unencoded query parameter with value null
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getMethodQueryNullAsync(String q1) {
+    public Single<RestResponse<Void, Void>> getMethodQueryNullWithRestResponseAsync(String q1) {
         return service.getMethodQueryNull(q1, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Get method with unencoded query parameter with value null.
+     *
+     * @param q1 Unencoded query parameter with value null
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getMethodQueryNullAsync(String q1) {
+        return getMethodQueryNullWithRestResponseAsync(q1)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -327,6 +404,7 @@ public class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getPathQueryValid(String q1) {
         getPathQueryValidAsync(q1).toBlocking().value();
@@ -340,7 +418,7 @@ public class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getPathQueryValidAsync(String q1, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getPathQueryValidAsync(String q1, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getPathQueryValidAsync(q1), serviceCallback);
     }
 
@@ -349,14 +427,26 @@ public class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      *
      * @param q1 Unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getPathQueryValidAsync(String q1) {
+    public Single<RestResponse<Void, Void>> getPathQueryValidWithRestResponseAsync(String q1) {
         if (q1 == null) {
             throw new IllegalArgumentException("Parameter q1 is required and cannot be null.");
         }
         return service.getPathQueryValid(q1, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Get method with unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'.
+     *
+     * @param q1 Unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getPathQueryValidAsync(String q1) {
+        return getPathQueryValidWithRestResponseAsync(q1)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -365,6 +455,7 @@ public class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getSwaggerQueryValid() {
         getSwaggerQueryValidAsync().toBlocking().value();
@@ -377,7 +468,7 @@ public class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getSwaggerQueryValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getSwaggerQueryValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getSwaggerQueryValidAsync(), serviceCallback);
     }
 
@@ -385,12 +476,23 @@ public class SkipUrlEncodingsImpl implements SkipUrlEncodings {
      * Get method with unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getSwaggerQueryValidAsync() {
+    public Single<RestResponse<Void, Void>> getSwaggerQueryValidWithRestResponseAsync() {
         final String q1 = "value1&q2=value2&q3=value3";
         return service.getSwaggerQueryValid(q1, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Get method with unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getSwaggerQueryValidAsync() {
+        return getSwaggerQueryValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azure/src/main/java/fixtures/azurespecials/implementation/SubscriptionInCredentialsImpl.java
+++ b/test/azure/src/main/java/fixtures/azurespecials/implementation/SubscriptionInCredentialsImpl.java
@@ -10,6 +10,7 @@
 
 package fixtures.azurespecials.implementation;
 
+import com.microsoft.rest.RestResponse;
 import fixtures.azurespecials.SubscriptionInCredentials;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.ExpectedResponses;
@@ -60,31 +61,31 @@ public class SubscriptionInCredentialsImpl implements SubscriptionInCredentials 
         @POST("azurespecials/subscriptionId/method/string/none/path/global/1234-5678-9012-3456/{subscriptionId}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postMethodGlobalValid(@PathParam("subscriptionId") String subscriptionId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> postMethodGlobalValid(@PathParam("subscriptionId") String subscriptionId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.SubscriptionInCredentials postMethodGlobalNull" })
         @POST("azurespecials/subscriptionId/method/string/none/path/global/null/{subscriptionId}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postMethodGlobalNull(@PathParam("subscriptionId") String subscriptionId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> postMethodGlobalNull(@PathParam("subscriptionId") String subscriptionId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.SubscriptionInCredentials postMethodGlobalNotProvidedValid" })
         @POST("azurespecials/subscriptionId/method/string/none/path/globalNotProvided/1234-5678-9012-3456/{subscriptionId}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postMethodGlobalNotProvidedValid(@PathParam("subscriptionId") String subscriptionId, @QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> postMethodGlobalNotProvidedValid(@PathParam("subscriptionId") String subscriptionId, @QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.SubscriptionInCredentials postPathGlobalValid" })
         @POST("azurespecials/subscriptionId/path/string/none/path/global/1234-5678-9012-3456/{subscriptionId}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postPathGlobalValid(@PathParam("subscriptionId") String subscriptionId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> postPathGlobalValid(@PathParam("subscriptionId") String subscriptionId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.SubscriptionInCredentials postSwaggerGlobalValid" })
         @POST("azurespecials/subscriptionId/swagger/string/none/path/global/1234-5678-9012-3456/{subscriptionId}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postSwaggerGlobalValid(@PathParam("subscriptionId") String subscriptionId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> postSwaggerGlobalValid(@PathParam("subscriptionId") String subscriptionId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -94,6 +95,7 @@ public class SubscriptionInCredentialsImpl implements SubscriptionInCredentials 
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postMethodGlobalValid() {
         postMethodGlobalValidAsync().toBlocking().value();
@@ -106,7 +108,7 @@ public class SubscriptionInCredentialsImpl implements SubscriptionInCredentials 
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postMethodGlobalValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postMethodGlobalValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postMethodGlobalValidAsync(), serviceCallback);
     }
 
@@ -114,14 +116,25 @@ public class SubscriptionInCredentialsImpl implements SubscriptionInCredentials 
      * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postMethodGlobalValidAsync() {
+    public Single<RestResponse<Void, Void>> postMethodGlobalValidWithRestResponseAsync() {
         if (this.client.subscriptionId() == null) {
             throw new IllegalArgumentException("Parameter this.client.subscriptionId() is required and cannot be null.");
         }
         return service.postMethodGlobalValid(this.client.subscriptionId(), this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postMethodGlobalValidAsync() {
+        return postMethodGlobalValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -130,6 +143,7 @@ public class SubscriptionInCredentialsImpl implements SubscriptionInCredentials 
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postMethodGlobalNull() {
         postMethodGlobalNullAsync().toBlocking().value();
@@ -142,7 +156,7 @@ public class SubscriptionInCredentialsImpl implements SubscriptionInCredentials 
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postMethodGlobalNullAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postMethodGlobalNullAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postMethodGlobalNullAsync(), serviceCallback);
     }
 
@@ -150,14 +164,25 @@ public class SubscriptionInCredentialsImpl implements SubscriptionInCredentials 
      * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to null, and client-side validation should prevent you from making this call.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postMethodGlobalNullAsync() {
+    public Single<RestResponse<Void, Void>> postMethodGlobalNullWithRestResponseAsync() {
         if (this.client.subscriptionId() == null) {
             throw new IllegalArgumentException("Parameter this.client.subscriptionId() is required and cannot be null.");
         }
         return service.postMethodGlobalNull(this.client.subscriptionId(), this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to null, and client-side validation should prevent you from making this call.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postMethodGlobalNullAsync() {
+        return postMethodGlobalNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -166,6 +191,7 @@ public class SubscriptionInCredentialsImpl implements SubscriptionInCredentials 
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postMethodGlobalNotProvidedValid() {
         postMethodGlobalNotProvidedValidAsync().toBlocking().value();
@@ -178,7 +204,7 @@ public class SubscriptionInCredentialsImpl implements SubscriptionInCredentials 
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postMethodGlobalNotProvidedValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postMethodGlobalNotProvidedValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postMethodGlobalNotProvidedValidAsync(), serviceCallback);
     }
 
@@ -186,9 +212,9 @@ public class SubscriptionInCredentialsImpl implements SubscriptionInCredentials 
      * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postMethodGlobalNotProvidedValidAsync() {
+    public Single<RestResponse<Void, Void>> postMethodGlobalNotProvidedValidWithRestResponseAsync() {
         if (this.client.subscriptionId() == null) {
             throw new IllegalArgumentException("Parameter this.client.subscriptionId() is required and cannot be null.");
         }
@@ -198,6 +224,17 @@ public class SubscriptionInCredentialsImpl implements SubscriptionInCredentials 
         return service.postMethodGlobalNotProvidedValid(this.client.subscriptionId(), this.client.apiVersion(), this.client.acceptLanguage(), this.client.userAgent());
     }
 
+    /**
+     * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postMethodGlobalNotProvidedValidAsync() {
+        return postMethodGlobalNotProvidedValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
+
 
     /**
      * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
@@ -205,6 +242,7 @@ public class SubscriptionInCredentialsImpl implements SubscriptionInCredentials 
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postPathGlobalValid() {
         postPathGlobalValidAsync().toBlocking().value();
@@ -217,7 +255,7 @@ public class SubscriptionInCredentialsImpl implements SubscriptionInCredentials 
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postPathGlobalValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postPathGlobalValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postPathGlobalValidAsync(), serviceCallback);
     }
 
@@ -225,14 +263,25 @@ public class SubscriptionInCredentialsImpl implements SubscriptionInCredentials 
      * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postPathGlobalValidAsync() {
+    public Single<RestResponse<Void, Void>> postPathGlobalValidWithRestResponseAsync() {
         if (this.client.subscriptionId() == null) {
             throw new IllegalArgumentException("Parameter this.client.subscriptionId() is required and cannot be null.");
         }
         return service.postPathGlobalValid(this.client.subscriptionId(), this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postPathGlobalValidAsync() {
+        return postPathGlobalValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -241,6 +290,7 @@ public class SubscriptionInCredentialsImpl implements SubscriptionInCredentials 
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postSwaggerGlobalValid() {
         postSwaggerGlobalValidAsync().toBlocking().value();
@@ -253,7 +303,7 @@ public class SubscriptionInCredentialsImpl implements SubscriptionInCredentials 
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postSwaggerGlobalValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postSwaggerGlobalValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postSwaggerGlobalValidAsync(), serviceCallback);
     }
 
@@ -261,14 +311,25 @@ public class SubscriptionInCredentialsImpl implements SubscriptionInCredentials 
      * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postSwaggerGlobalValidAsync() {
+    public Single<RestResponse<Void, Void>> postSwaggerGlobalValidWithRestResponseAsync() {
         if (this.client.subscriptionId() == null) {
             throw new IllegalArgumentException("Parameter this.client.subscriptionId() is required and cannot be null.");
         }
         return service.postSwaggerGlobalValid(this.client.subscriptionId(), this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postSwaggerGlobalValidAsync() {
+        return postSwaggerGlobalValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azure/src/main/java/fixtures/azurespecials/implementation/SubscriptionInMethodsImpl.java
+++ b/test/azure/src/main/java/fixtures/azurespecials/implementation/SubscriptionInMethodsImpl.java
@@ -10,6 +10,7 @@
 
 package fixtures.azurespecials.implementation;
 
+import com.microsoft.rest.RestResponse;
 import fixtures.azurespecials.SubscriptionInMethods;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.ExpectedResponses;
@@ -59,25 +60,25 @@ public class SubscriptionInMethodsImpl implements SubscriptionInMethods {
         @POST("azurespecials/subscriptionId/method/string/none/path/local/1234-5678-9012-3456/{subscriptionId}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postMethodLocalValid(@PathParam("subscriptionId") String subscriptionId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> postMethodLocalValid(@PathParam("subscriptionId") String subscriptionId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.SubscriptionInMethods postMethodLocalNull" })
         @POST("azurespecials/subscriptionId/method/string/none/path/local/null/{subscriptionId}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postMethodLocalNull(@PathParam("subscriptionId") String subscriptionId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> postMethodLocalNull(@PathParam("subscriptionId") String subscriptionId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.SubscriptionInMethods postPathLocalValid" })
         @POST("azurespecials/subscriptionId/path/string/none/path/local/1234-5678-9012-3456/{subscriptionId}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postPathLocalValid(@PathParam("subscriptionId") String subscriptionId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> postPathLocalValid(@PathParam("subscriptionId") String subscriptionId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.SubscriptionInMethods postSwaggerLocalValid" })
         @POST("azurespecials/subscriptionId/swagger/string/none/path/local/1234-5678-9012-3456/{subscriptionId}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postSwaggerLocalValid(@PathParam("subscriptionId") String subscriptionId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> postSwaggerLocalValid(@PathParam("subscriptionId") String subscriptionId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -88,6 +89,7 @@ public class SubscriptionInMethodsImpl implements SubscriptionInMethods {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postMethodLocalValid(String subscriptionId) {
         postMethodLocalValidAsync(subscriptionId).toBlocking().value();
@@ -101,7 +103,7 @@ public class SubscriptionInMethodsImpl implements SubscriptionInMethods {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postMethodLocalValidAsync(String subscriptionId, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postMethodLocalValidAsync(String subscriptionId, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postMethodLocalValidAsync(subscriptionId), serviceCallback);
     }
 
@@ -110,14 +112,26 @@ public class SubscriptionInMethodsImpl implements SubscriptionInMethods {
      *
      * @param subscriptionId This should appear as a method parameter, use value '1234-5678-9012-3456'
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postMethodLocalValidAsync(String subscriptionId) {
+    public Single<RestResponse<Void, Void>> postMethodLocalValidWithRestResponseAsync(String subscriptionId) {
         if (subscriptionId == null) {
             throw new IllegalArgumentException("Parameter subscriptionId is required and cannot be null.");
         }
         return service.postMethodLocalValid(subscriptionId, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed.
+     *
+     * @param subscriptionId This should appear as a method parameter, use value '1234-5678-9012-3456'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postMethodLocalValidAsync(String subscriptionId) {
+        return postMethodLocalValidWithRestResponseAsync(subscriptionId)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -127,6 +141,7 @@ public class SubscriptionInMethodsImpl implements SubscriptionInMethods {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postMethodLocalNull(String subscriptionId) {
         postMethodLocalNullAsync(subscriptionId).toBlocking().value();
@@ -140,7 +155,7 @@ public class SubscriptionInMethodsImpl implements SubscriptionInMethods {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postMethodLocalNullAsync(String subscriptionId, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postMethodLocalNullAsync(String subscriptionId, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postMethodLocalNullAsync(subscriptionId), serviceCallback);
     }
 
@@ -149,14 +164,26 @@ public class SubscriptionInMethodsImpl implements SubscriptionInMethods {
      *
      * @param subscriptionId This should appear as a method parameter, use value null, client-side validation should prvenet the call
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postMethodLocalNullAsync(String subscriptionId) {
+    public Single<RestResponse<Void, Void>> postMethodLocalNullWithRestResponseAsync(String subscriptionId) {
         if (subscriptionId == null) {
             throw new IllegalArgumentException("Parameter subscriptionId is required and cannot be null.");
         }
         return service.postMethodLocalNull(subscriptionId, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * POST method with subscriptionId modeled in the method.  pass in subscription id = null, client-side validation should prevent you from making this call.
+     *
+     * @param subscriptionId This should appear as a method parameter, use value null, client-side validation should prvenet the call
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postMethodLocalNullAsync(String subscriptionId) {
+        return postMethodLocalNullWithRestResponseAsync(subscriptionId)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -166,6 +193,7 @@ public class SubscriptionInMethodsImpl implements SubscriptionInMethods {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postPathLocalValid(String subscriptionId) {
         postPathLocalValidAsync(subscriptionId).toBlocking().value();
@@ -179,7 +207,7 @@ public class SubscriptionInMethodsImpl implements SubscriptionInMethods {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postPathLocalValidAsync(String subscriptionId, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postPathLocalValidAsync(String subscriptionId, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postPathLocalValidAsync(subscriptionId), serviceCallback);
     }
 
@@ -188,14 +216,26 @@ public class SubscriptionInMethodsImpl implements SubscriptionInMethods {
      *
      * @param subscriptionId Should appear as a method parameter -use value '1234-5678-9012-3456'
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postPathLocalValidAsync(String subscriptionId) {
+    public Single<RestResponse<Void, Void>> postPathLocalValidWithRestResponseAsync(String subscriptionId) {
         if (subscriptionId == null) {
             throw new IllegalArgumentException("Parameter subscriptionId is required and cannot be null.");
         }
         return service.postPathLocalValid(subscriptionId, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed.
+     *
+     * @param subscriptionId Should appear as a method parameter -use value '1234-5678-9012-3456'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postPathLocalValidAsync(String subscriptionId) {
+        return postPathLocalValidWithRestResponseAsync(subscriptionId)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -205,6 +245,7 @@ public class SubscriptionInMethodsImpl implements SubscriptionInMethods {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postSwaggerLocalValid(String subscriptionId) {
         postSwaggerLocalValidAsync(subscriptionId).toBlocking().value();
@@ -218,7 +259,7 @@ public class SubscriptionInMethodsImpl implements SubscriptionInMethods {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postSwaggerLocalValidAsync(String subscriptionId, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postSwaggerLocalValidAsync(String subscriptionId, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postSwaggerLocalValidAsync(subscriptionId), serviceCallback);
     }
 
@@ -227,14 +268,26 @@ public class SubscriptionInMethodsImpl implements SubscriptionInMethods {
      *
      * @param subscriptionId The subscriptionId, which appears in the path, the value is always '1234-5678-9012-3456'
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postSwaggerLocalValidAsync(String subscriptionId) {
+    public Single<RestResponse<Void, Void>> postSwaggerLocalValidWithRestResponseAsync(String subscriptionId) {
         if (subscriptionId == null) {
             throw new IllegalArgumentException("Parameter subscriptionId is required and cannot be null.");
         }
         return service.postSwaggerLocalValid(subscriptionId, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed.
+     *
+     * @param subscriptionId The subscriptionId, which appears in the path, the value is always '1234-5678-9012-3456'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postSwaggerLocalValidAsync(String subscriptionId) {
+        return postSwaggerLocalValidWithRestResponseAsync(subscriptionId)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azure/src/main/java/fixtures/azurespecials/implementation/XMsClientRequestIdsImpl.java
+++ b/test/azure/src/main/java/fixtures/azurespecials/implementation/XMsClientRequestIdsImpl.java
@@ -10,6 +10,7 @@
 
 package fixtures.azurespecials.implementation;
 
+import com.microsoft.rest.RestResponse;
 import fixtures.azurespecials.XMsClientRequestIds;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.CloudException;
@@ -59,13 +60,13 @@ public class XMsClientRequestIdsImpl implements XMsClientRequestIds {
         @GET("azurespecials/overwrite/x-ms-client-request-id/method/")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> get(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> get(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.XMsClientRequestIds paramGet" })
         @GET("azurespecials/overwrite/x-ms-client-request-id/via-param/method/")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> paramGet(@HeaderParam("x-ms-client-request-id") String xMsClientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> paramGet(@HeaderParam("x-ms-client-request-id") String xMsClientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -75,6 +76,7 @@ public class XMsClientRequestIdsImpl implements XMsClientRequestIds {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void get() {
         getAsync().toBlocking().value();
@@ -87,7 +89,7 @@ public class XMsClientRequestIdsImpl implements XMsClientRequestIds {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getAsync(), serviceCallback);
     }
 
@@ -95,11 +97,22 @@ public class XMsClientRequestIdsImpl implements XMsClientRequestIds {
      * Get method that overwrites x-ms-client-request header with value 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getAsync() {
+    public Single<RestResponse<Void, Void>> getWithRestResponseAsync() {
         return service.get(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Get method that overwrites x-ms-client-request header with value 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getAsync() {
+        return getWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -109,6 +122,7 @@ public class XMsClientRequestIdsImpl implements XMsClientRequestIds {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void paramGet(String xMsClientRequestId) {
         paramGetAsync(xMsClientRequestId).toBlocking().value();
@@ -122,7 +136,7 @@ public class XMsClientRequestIdsImpl implements XMsClientRequestIds {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> paramGetAsync(String xMsClientRequestId, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> paramGetAsync(String xMsClientRequestId, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(paramGetAsync(xMsClientRequestId), serviceCallback);
     }
 
@@ -131,14 +145,26 @@ public class XMsClientRequestIdsImpl implements XMsClientRequestIds {
      *
      * @param xMsClientRequestId This should appear as a method parameter, use value '9C4D50EE-2D56-4CD3-8152-34347DC9F2B0'
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> paramGetAsync(String xMsClientRequestId) {
+    public Single<RestResponse<Void, Void>> paramGetWithRestResponseAsync(String xMsClientRequestId) {
         if (xMsClientRequestId == null) {
             throw new IllegalArgumentException("Parameter xMsClientRequestId is required and cannot be null.");
         }
         return service.paramGet(xMsClientRequestId, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Get method that overwrites x-ms-client-request header with value 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+     *
+     * @param xMsClientRequestId This should appear as a method parameter, use value '9C4D50EE-2D56-4CD3-8152-34347DC9F2B0'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> paramGetAsync(String xMsClientRequestId) {
+        return paramGetWithRestResponseAsync(xMsClientRequestId)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azure/src/main/java/fixtures/custombaseuri/Paths.java
+++ b/test/azure/src/main/java/fixtures/custombaseuri/Paths.java
@@ -10,6 +10,7 @@
 
 package fixtures.custombaseuri;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.custombaseuri.models.ErrorException;
@@ -50,6 +51,15 @@ public interface Paths {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getEmptyAsync(String accountName);
+
+    /**
+     * Get a 200 to test a valid base uri.
+     *
+     * @param accountName Account Name
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> getEmptyWithRestResponseAsync(String accountName);
 
 
 }

--- a/test/azure/src/main/java/fixtures/custombaseuri/implementation/AutoRestParameterizedHostTestClientImpl.java
+++ b/test/azure/src/main/java/fixtures/custombaseuri/implementation/AutoRestParameterizedHostTestClientImpl.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.AzureProxy;
 import com.microsoft.azure.AzureServiceClient;
 import com.microsoft.rest.credentials.ServiceClientCredentials;
 import com.microsoft.rest.RestClient;
+import com.microsoft.rest.RestResponse;
 import fixtures.custombaseuri.AutoRestParameterizedHostTestClient;
 import fixtures.custombaseuri.Paths;
 import rx.Single;

--- a/test/azure/src/main/java/fixtures/custombaseuri/implementation/PathsImpl.java
+++ b/test/azure/src/main/java/fixtures/custombaseuri/implementation/PathsImpl.java
@@ -10,6 +10,7 @@
 
 package fixtures.custombaseuri.implementation;
 
+import com.microsoft.rest.RestResponse;
 import fixtures.custombaseuri.Paths;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.ExpectedResponses;
@@ -60,7 +61,7 @@ public class PathsImpl implements Paths {
         @GET("customuri")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getEmpty(@HostParam("accountName") String accountName, @HostParam("host") String host, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> getEmpty(@HostParam("accountName") String accountName, @HostParam("host") String host, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -71,6 +72,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getEmpty(String accountName) {
         getEmptyAsync(accountName).toBlocking().value();
@@ -84,7 +86,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getEmptyAsync(String accountName, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getEmptyAsync(String accountName, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getEmptyAsync(accountName), serviceCallback);
     }
 
@@ -93,9 +95,9 @@ public class PathsImpl implements Paths {
      *
      * @param accountName Account Name
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getEmptyAsync(String accountName) {
+    public Single<RestResponse<Void, Void>> getEmptyWithRestResponseAsync(String accountName) {
         if (accountName == null) {
             throw new IllegalArgumentException("Parameter accountName is required and cannot be null.");
         }
@@ -104,6 +106,18 @@ public class PathsImpl implements Paths {
         }
         return service.getEmpty(accountName, this.client.host(), this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Get a 200 to test a valid base uri.
+     *
+     * @param accountName Account Name
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getEmptyAsync(String accountName) {
+        return getEmptyWithRestResponseAsync(accountName)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azure/src/main/java/fixtures/head/HttpSuccess.java
+++ b/test/azure/src/main/java/fixtures/head/HttpSuccess.java
@@ -11,6 +11,7 @@
 package fixtures.head;
 
 import com.microsoft.azure.CloudException;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import java.io.IOException;
@@ -49,6 +50,14 @@ public interface HttpSuccess {
      */
     Single<Boolean> head200Async();
 
+    /**
+     * Return 200 status code if successful.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the boolean object
+     */
+    RestResponse<Void, Boolean> head200WithRestResponseAsync();
+
 
     /**
      * Return 204 status code if successful.
@@ -77,6 +86,14 @@ public interface HttpSuccess {
      */
     Single<Boolean> head204Async();
 
+    /**
+     * Return 204 status code if successful.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the boolean object
+     */
+    RestResponse<Void, Boolean> head204WithRestResponseAsync();
+
 
     /**
      * Return 404 status code if successful.
@@ -104,6 +121,14 @@ public interface HttpSuccess {
      * @return the observable to the boolean object
      */
     Single<Boolean> head404Async();
+
+    /**
+     * Return 404 status code if successful.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the boolean object
+     */
+    RestResponse<Void, Boolean> head404WithRestResponseAsync();
 
 
 }

--- a/test/azure/src/main/java/fixtures/head/implementation/AutoRestHeadTestServiceImpl.java
+++ b/test/azure/src/main/java/fixtures/head/implementation/AutoRestHeadTestServiceImpl.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.AzureProxy;
 import com.microsoft.azure.AzureServiceClient;
 import com.microsoft.rest.credentials.ServiceClientCredentials;
 import com.microsoft.rest.RestClient;
+import com.microsoft.rest.RestResponse;
 import fixtures.head.AutoRestHeadTestService;
 import fixtures.head.HttpSuccess;
 import rx.Single;

--- a/test/azure/src/main/java/fixtures/head/implementation/HttpSuccessImpl.java
+++ b/test/azure/src/main/java/fixtures/head/implementation/HttpSuccessImpl.java
@@ -10,6 +10,7 @@
 
 package fixtures.head.implementation;
 
+import com.microsoft.rest.RestResponse;
 import fixtures.head.HttpSuccess;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.CloudException;
@@ -58,19 +59,19 @@ public class HttpSuccessImpl implements HttpSuccess {
         @HEAD("http/success/200")
         @ExpectedResponses({200, 404})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Boolean> head200(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Boolean>> head200(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.head.HttpSuccess head204" })
         @HEAD("http/success/204")
         @ExpectedResponses({204, 404})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Boolean> head204(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Boolean>> head204(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.head.HttpSuccess head404" })
         @HEAD("http/success/404")
         @ExpectedResponses({204, 404})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Boolean> head404(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Boolean>> head404(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -93,7 +94,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Boolean> head200Async(final ServiceCallback<Boolean> serviceCallback) {
+    public ServiceFuture<Boolean> head200Async(ServiceCallback<Boolean> serviceCallback) {
         return ServiceFuture.fromBody(head200Async(), serviceCallback);
     }
 
@@ -101,11 +102,22 @@ public class HttpSuccessImpl implements HttpSuccess {
      * Return 200 status code if successful.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Boolean object
+     * @return a {@link Single} emitting the RestResponse<Void, Boolean> object
      */
-    public Single<Boolean> head200Async() {
+    public Single<RestResponse<Void, Boolean>> head200WithRestResponseAsync() {
         return service.head200(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Return 200 status code if successful.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Boolean> object
+     */
+    public Single<Boolean> head200Async() {
+        return head200WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Boolean>, Boolean>() { public Boolean call(RestResponse<Void, Boolean> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -127,7 +139,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Boolean> head204Async(final ServiceCallback<Boolean> serviceCallback) {
+    public ServiceFuture<Boolean> head204Async(ServiceCallback<Boolean> serviceCallback) {
         return ServiceFuture.fromBody(head204Async(), serviceCallback);
     }
 
@@ -135,11 +147,22 @@ public class HttpSuccessImpl implements HttpSuccess {
      * Return 204 status code if successful.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Boolean object
+     * @return a {@link Single} emitting the RestResponse<Void, Boolean> object
      */
-    public Single<Boolean> head204Async() {
+    public Single<RestResponse<Void, Boolean>> head204WithRestResponseAsync() {
         return service.head204(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Return 204 status code if successful.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Boolean> object
+     */
+    public Single<Boolean> head204Async() {
+        return head204WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Boolean>, Boolean>() { public Boolean call(RestResponse<Void, Boolean> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -161,7 +184,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Boolean> head404Async(final ServiceCallback<Boolean> serviceCallback) {
+    public ServiceFuture<Boolean> head404Async(ServiceCallback<Boolean> serviceCallback) {
         return ServiceFuture.fromBody(head404Async(), serviceCallback);
     }
 
@@ -169,11 +192,22 @@ public class HttpSuccessImpl implements HttpSuccess {
      * Return 404 status code if successful.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Boolean object
+     * @return a {@link Single} emitting the RestResponse<Void, Boolean> object
      */
-    public Single<Boolean> head404Async() {
+    public Single<RestResponse<Void, Boolean>> head404WithRestResponseAsync() {
         return service.head404(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Return 404 status code if successful.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Boolean> object
+     */
+    public Single<Boolean> head404Async() {
+        return head404WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Boolean>, Boolean>() { public Boolean call(RestResponse<Void, Boolean> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azure/src/main/java/fixtures/headexceptions/HeadExceptions.java
+++ b/test/azure/src/main/java/fixtures/headexceptions/HeadExceptions.java
@@ -11,6 +11,7 @@
 package fixtures.headexceptions;
 
 import com.microsoft.azure.CloudException;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import java.io.IOException;
@@ -48,6 +49,14 @@ public interface HeadExceptions {
      */
     Single<Void> head200Async();
 
+    /**
+     * Return 200 status code if successful.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> head200WithRestResponseAsync();
+
 
     /**
      * Return 204 status code if successful.
@@ -75,6 +84,14 @@ public interface HeadExceptions {
      */
     Single<Void> head204Async();
 
+    /**
+     * Return 204 status code if successful.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> head204WithRestResponseAsync();
+
 
     /**
      * Return 404 status code if successful.
@@ -101,6 +118,14 @@ public interface HeadExceptions {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> head404Async();
+
+    /**
+     * Return 404 status code if successful.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> head404WithRestResponseAsync();
 
 
 }

--- a/test/azure/src/main/java/fixtures/headexceptions/implementation/AutoRestHeadExceptionTestServiceImpl.java
+++ b/test/azure/src/main/java/fixtures/headexceptions/implementation/AutoRestHeadExceptionTestServiceImpl.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.AzureProxy;
 import com.microsoft.azure.AzureServiceClient;
 import com.microsoft.rest.credentials.ServiceClientCredentials;
 import com.microsoft.rest.RestClient;
+import com.microsoft.rest.RestResponse;
 import fixtures.headexceptions.AutoRestHeadExceptionTestService;
 import fixtures.headexceptions.HeadExceptions;
 import rx.Single;

--- a/test/azure/src/main/java/fixtures/headexceptions/implementation/HeadExceptionsImpl.java
+++ b/test/azure/src/main/java/fixtures/headexceptions/implementation/HeadExceptionsImpl.java
@@ -10,6 +10,7 @@
 
 package fixtures.headexceptions.implementation;
 
+import com.microsoft.rest.RestResponse;
 import fixtures.headexceptions.HeadExceptions;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.CloudException;
@@ -58,19 +59,19 @@ public class HeadExceptionsImpl implements HeadExceptions {
         @HEAD("http/success/200")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> head200(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> head200(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.headexceptions.HeadExceptions head204" })
         @HEAD("http/success/204")
         @ExpectedResponses({204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> head204(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> head204(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.headexceptions.HeadExceptions head404" })
         @HEAD("http/success/404")
         @ExpectedResponses({204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> head404(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> head404(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -80,6 +81,7 @@ public class HeadExceptionsImpl implements HeadExceptions {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void head200() {
         head200Async().toBlocking().value();
@@ -92,7 +94,7 @@ public class HeadExceptionsImpl implements HeadExceptions {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> head200Async(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> head200Async(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(head200Async(), serviceCallback);
     }
 
@@ -100,11 +102,22 @@ public class HeadExceptionsImpl implements HeadExceptions {
      * Return 200 status code if successful.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> head200Async() {
+    public Single<RestResponse<Void, Void>> head200WithRestResponseAsync() {
         return service.head200(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Return 200 status code if successful.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> head200Async() {
+        return head200WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -113,6 +126,7 @@ public class HeadExceptionsImpl implements HeadExceptions {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void head204() {
         head204Async().toBlocking().value();
@@ -125,7 +139,7 @@ public class HeadExceptionsImpl implements HeadExceptions {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> head204Async(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> head204Async(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(head204Async(), serviceCallback);
     }
 
@@ -133,11 +147,22 @@ public class HeadExceptionsImpl implements HeadExceptions {
      * Return 204 status code if successful.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> head204Async() {
+    public Single<RestResponse<Void, Void>> head204WithRestResponseAsync() {
         return service.head204(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Return 204 status code if successful.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> head204Async() {
+        return head204WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -146,6 +171,7 @@ public class HeadExceptionsImpl implements HeadExceptions {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void head404() {
         head404Async().toBlocking().value();
@@ -158,7 +184,7 @@ public class HeadExceptionsImpl implements HeadExceptions {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> head404Async(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> head404Async(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(head404Async(), serviceCallback);
     }
 
@@ -166,11 +192,22 @@ public class HeadExceptionsImpl implements HeadExceptions {
      * Return 404 status code if successful.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> head404Async() {
+    public Single<RestResponse<Void, Void>> head404WithRestResponseAsync() {
         return service.head404(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Return 404 status code if successful.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> head404Async() {
+        return head404WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azure/src/main/java/fixtures/lro/LRORetrys.java
+++ b/test/azure/src/main/java/fixtures/lro/LRORetrys.java
@@ -12,6 +12,7 @@ package fixtures.lro;
 
 import com.microsoft.azure.CloudException;
 import com.microsoft.azure.OperationStatus;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.lro.models.LRORetrysDelete202Retry200Headers;
@@ -59,6 +60,14 @@ public interface LRORetrys {
     /**
      * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> beginPut201CreatingSucceeded200WithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -85,6 +94,15 @@ public interface LRORetrys {
      * @return the observable to the Product object
      */
     Observable<OperationStatus<Product>> beginPut201CreatingSucceeded200Async(Product product);
+
+    /**
+     * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> beginPut201CreatingSucceeded200WithRestResponseAsync(Product product);
 
 
     /**
@@ -116,6 +134,14 @@ public interface LRORetrys {
     /**
      * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> put201CreatingSucceeded200WithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -142,6 +168,15 @@ public interface LRORetrys {
      * @return the observable to the Product object
      */
     Single<Product> put201CreatingSucceeded200Async(Product product);
+
+    /**
+     * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> put201CreatingSucceeded200WithRestResponseAsync(Product product);
 
 
     /**
@@ -173,6 +208,14 @@ public interface LRORetrys {
     /**
      * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LRORetrysPutAsyncRelativeRetrySucceededHeaders, Product> beginPutAsyncRelativeRetrySucceededWithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -199,6 +242,15 @@ public interface LRORetrys {
      * @return the observable to the Product object
      */
     Observable<OperationStatus<Product>> beginPutAsyncRelativeRetrySucceededAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LRORetrysPutAsyncRelativeRetrySucceededHeaders, Product> beginPutAsyncRelativeRetrySucceededWithRestResponseAsync(Product product);
 
 
     /**
@@ -230,6 +282,14 @@ public interface LRORetrys {
     /**
      * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LRORetrysPutAsyncRelativeRetrySucceededHeaders, Product> putAsyncRelativeRetrySucceededWithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -256,6 +316,15 @@ public interface LRORetrys {
      * @return the observable to the Product object
      */
     Single<Product> putAsyncRelativeRetrySucceededAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LRORetrysPutAsyncRelativeRetrySucceededHeaders, Product> putAsyncRelativeRetrySucceededWithRestResponseAsync(Product product);
 
 
     /**
@@ -285,6 +354,14 @@ public interface LRORetrys {
      */
     Observable<OperationStatus<Product>> beginDeleteProvisioning202Accepted200SucceededAsync();
 
+    /**
+     * Long running delete request, service returns a 500, then a  202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LRORetrysDeleteProvisioning202Accepted200SucceededHeaders, Product> beginDeleteProvisioning202Accepted200SucceededWithRestResponseAsync();
+
 
     /**
      * Long running delete request, service returns a 500, then a  202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -313,6 +390,14 @@ public interface LRORetrys {
      */
     Single<Product> deleteProvisioning202Accepted200SucceededAsync();
 
+    /**
+     * Long running delete request, service returns a 500, then a  202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LRORetrysDeleteProvisioning202Accepted200SucceededHeaders, Product> deleteProvisioning202Accepted200SucceededWithRestResponseAsync();
+
 
     /**
      * Long running delete request, service returns a 500, then a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -339,6 +424,14 @@ public interface LRORetrys {
      * @return the {@link Observable<OperationStatus<Void>>} object if successful.
      */
     Observable<OperationStatus<Void>> beginDelete202Retry200Async();
+
+    /**
+     * Long running delete request, service returns a 500, then a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LRORetrysDelete202Retry200Headers, Void>} object if successful.
+     */
+    RestResponse<LRORetrysDelete202Retry200Headers, Void> beginDelete202Retry200WithRestResponseAsync();
 
 
     /**
@@ -367,6 +460,14 @@ public interface LRORetrys {
      */
     Single<Void> delete202Retry200Async();
 
+    /**
+     * Long running delete request, service returns a 500, then a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LRORetrysDelete202Retry200Headers, Void>} object if successful.
+     */
+    RestResponse<LRORetrysDelete202Retry200Headers, Void> delete202Retry200WithRestResponseAsync();
+
 
     /**
      * Long running delete request, service returns a 500, then a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -394,6 +495,14 @@ public interface LRORetrys {
      */
     Observable<OperationStatus<Void>> beginDeleteAsyncRelativeRetrySucceededAsync();
 
+    /**
+     * Long running delete request, service returns a 500, then a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LRORetrysDeleteAsyncRelativeRetrySucceededHeaders, Void>} object if successful.
+     */
+    RestResponse<LRORetrysDeleteAsyncRelativeRetrySucceededHeaders, Void> beginDeleteAsyncRelativeRetrySucceededWithRestResponseAsync();
+
 
     /**
      * Long running delete request, service returns a 500, then a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -420,6 +529,14 @@ public interface LRORetrys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> deleteAsyncRelativeRetrySucceededAsync();
+
+    /**
+     * Long running delete request, service returns a 500, then a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LRORetrysDeleteAsyncRelativeRetrySucceededHeaders, Void>} object if successful.
+     */
+    RestResponse<LRORetrysDeleteAsyncRelativeRetrySucceededHeaders, Void> deleteAsyncRelativeRetrySucceededWithRestResponseAsync();
 
 
     /**
@@ -450,6 +567,14 @@ public interface LRORetrys {
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LRORetrysPost202Retry200Headers, Void>} object if successful.
+     */
+    RestResponse<LRORetrysPost202Retry200Headers, Void> beginPost202Retry200WithRestResponseAsync();
+    }
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -475,6 +600,15 @@ public interface LRORetrys {
      * @return the {@link Observable<OperationStatus<Void>>} object if successful.
      */
     Observable<OperationStatus<Void>> beginPost202Retry200Async(Product product);
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LRORetrysPost202Retry200Headers, Void>} object if successful.
+     */
+    RestResponse<LRORetrysPost202Retry200Headers, Void> beginPost202Retry200WithRestResponseAsync(Product product);
 
 
     /**
@@ -505,6 +639,14 @@ public interface LRORetrys {
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LRORetrysPost202Retry200Headers, Void>} object if successful.
+     */
+    RestResponse<LRORetrysPost202Retry200Headers, Void> post202Retry200WithRestResponseAsync();
+    }
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -530,6 +672,15 @@ public interface LRORetrys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> post202Retry200Async(Product product);
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LRORetrysPost202Retry200Headers, Void>} object if successful.
+     */
+    RestResponse<LRORetrysPost202Retry200Headers, Void> post202Retry200WithRestResponseAsync(Product product);
 
 
     /**
@@ -560,6 +711,14 @@ public interface LRORetrys {
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LRORetrysPostAsyncRelativeRetrySucceededHeaders, Void>} object if successful.
+     */
+    RestResponse<LRORetrysPostAsyncRelativeRetrySucceededHeaders, Void> beginPostAsyncRelativeRetrySucceededWithRestResponseAsync();
+    }
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -585,6 +744,15 @@ public interface LRORetrys {
      * @return the {@link Observable<OperationStatus<Void>>} object if successful.
      */
     Observable<OperationStatus<Void>> beginPostAsyncRelativeRetrySucceededAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LRORetrysPostAsyncRelativeRetrySucceededHeaders, Void>} object if successful.
+     */
+    RestResponse<LRORetrysPostAsyncRelativeRetrySucceededHeaders, Void> beginPostAsyncRelativeRetrySucceededWithRestResponseAsync(Product product);
 
 
     /**
@@ -615,6 +783,14 @@ public interface LRORetrys {
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LRORetrysPostAsyncRelativeRetrySucceededHeaders, Void>} object if successful.
+     */
+    RestResponse<LRORetrysPostAsyncRelativeRetrySucceededHeaders, Void> postAsyncRelativeRetrySucceededWithRestResponseAsync();
+    }
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -640,6 +816,15 @@ public interface LRORetrys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postAsyncRelativeRetrySucceededAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LRORetrysPostAsyncRelativeRetrySucceededHeaders, Void>} object if successful.
+     */
+    RestResponse<LRORetrysPostAsyncRelativeRetrySucceededHeaders, Void> postAsyncRelativeRetrySucceededWithRestResponseAsync(Product product);
 
 
 }

--- a/test/azure/src/main/java/fixtures/lro/LROSADs.java
+++ b/test/azure/src/main/java/fixtures/lro/LROSADs.java
@@ -12,6 +12,7 @@ package fixtures.lro;
 
 import com.microsoft.azure.CloudException;
 import com.microsoft.azure.OperationStatus;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.lro.models.LROSADsDelete202NonRetry400Headers;
@@ -73,6 +74,14 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 400 to the initial request.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> beginPutNonRetry400WithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 400 to the initial request.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -99,6 +108,15 @@ public interface LROSADs {
      * @return the observable to the Product object
      */
     Observable<OperationStatus<Product>> beginPutNonRetry400Async(Product product);
+
+    /**
+     * Long running put request, service returns a 400 to the initial request.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> beginPutNonRetry400WithRestResponseAsync(Product product);
 
 
     /**
@@ -130,6 +148,14 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 400 to the initial request.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> putNonRetry400WithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 400 to the initial request.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -156,6 +182,15 @@ public interface LROSADs {
      * @return the observable to the Product object
      */
     Single<Product> putNonRetry400Async(Product product);
+
+    /**
+     * Long running put request, service returns a 400 to the initial request.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> putNonRetry400WithRestResponseAsync(Product product);
 
 
     /**
@@ -187,6 +222,14 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> beginPutNonRetry201Creating400WithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -213,6 +256,15 @@ public interface LROSADs {
      * @return the observable to the Product object
      */
     Observable<OperationStatus<Product>> beginPutNonRetry201Creating400Async(Product product);
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> beginPutNonRetry201Creating400WithRestResponseAsync(Product product);
 
 
     /**
@@ -244,6 +296,14 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> putNonRetry201Creating400WithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -270,6 +330,15 @@ public interface LROSADs {
      * @return the observable to the Product object
      */
     Single<Product> putNonRetry201Creating400Async(Product product);
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> putNonRetry201Creating400WithRestResponseAsync(Product product);
 
 
     /**
@@ -301,6 +370,14 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> beginPutNonRetry201Creating400InvalidJsonWithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -327,6 +404,15 @@ public interface LROSADs {
      * @return the observable to the Product object
      */
     Observable<OperationStatus<Product>> beginPutNonRetry201Creating400InvalidJsonAsync(Product product);
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> beginPutNonRetry201Creating400InvalidJsonWithRestResponseAsync(Product product);
 
 
     /**
@@ -358,6 +444,14 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> putNonRetry201Creating400InvalidJsonWithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -384,6 +478,15 @@ public interface LROSADs {
      * @return the observable to the Product object
      */
     Single<Product> putNonRetry201Creating400InvalidJsonAsync(Product product);
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> putNonRetry201Creating400InvalidJsonWithRestResponseAsync(Product product);
 
 
     /**
@@ -415,6 +518,14 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROSADsPutAsyncRelativeRetry400Headers, Product> beginPutAsyncRelativeRetry400WithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -441,6 +552,15 @@ public interface LROSADs {
      * @return the observable to the Product object
      */
     Observable<OperationStatus<Product>> beginPutAsyncRelativeRetry400Async(Product product);
+
+    /**
+     * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROSADsPutAsyncRelativeRetry400Headers, Product> beginPutAsyncRelativeRetry400WithRestResponseAsync(Product product);
 
 
     /**
@@ -472,6 +592,14 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROSADsPutAsyncRelativeRetry400Headers, Product> putAsyncRelativeRetry400WithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -498,6 +626,15 @@ public interface LROSADs {
      * @return the observable to the Product object
      */
     Single<Product> putAsyncRelativeRetry400Async(Product product);
+
+    /**
+     * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROSADsPutAsyncRelativeRetry400Headers, Product> putAsyncRelativeRetry400WithRestResponseAsync(Product product);
 
 
     /**
@@ -526,6 +663,14 @@ public interface LROSADs {
      */
     Observable<OperationStatus<Void>> beginDeleteNonRetry400Async();
 
+    /**
+     * Long running delete request, service returns a 400 with an error body.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsDeleteNonRetry400Headers, Void>} object if successful.
+     */
+    RestResponse<LROSADsDeleteNonRetry400Headers, Void> beginDeleteNonRetry400WithRestResponseAsync();
+
 
     /**
      * Long running delete request, service returns a 400 with an error body.
@@ -552,6 +697,14 @@ public interface LROSADs {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> deleteNonRetry400Async();
+
+    /**
+     * Long running delete request, service returns a 400 with an error body.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsDeleteNonRetry400Headers, Void>} object if successful.
+     */
+    RestResponse<LROSADsDeleteNonRetry400Headers, Void> deleteNonRetry400WithRestResponseAsync();
 
 
     /**
@@ -580,6 +733,14 @@ public interface LROSADs {
      */
     Observable<OperationStatus<Void>> beginDelete202NonRetry400Async();
 
+    /**
+     * Long running delete request, service returns a 202 with a location header.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsDelete202NonRetry400Headers, Void>} object if successful.
+     */
+    RestResponse<LROSADsDelete202NonRetry400Headers, Void> beginDelete202NonRetry400WithRestResponseAsync();
+
 
     /**
      * Long running delete request, service returns a 202 with a location header.
@@ -606,6 +767,14 @@ public interface LROSADs {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> delete202NonRetry400Async();
+
+    /**
+     * Long running delete request, service returns a 202 with a location header.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsDelete202NonRetry400Headers, Void>} object if successful.
+     */
+    RestResponse<LROSADsDelete202NonRetry400Headers, Void> delete202NonRetry400WithRestResponseAsync();
 
 
     /**
@@ -634,6 +803,14 @@ public interface LROSADs {
      */
     Observable<OperationStatus<Void>> beginDeleteAsyncRelativeRetry400Async();
 
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsDeleteAsyncRelativeRetry400Headers, Void>} object if successful.
+     */
+    RestResponse<LROSADsDeleteAsyncRelativeRetry400Headers, Void> beginDeleteAsyncRelativeRetry400WithRestResponseAsync();
+
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -660,6 +837,14 @@ public interface LROSADs {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> deleteAsyncRelativeRetry400Async();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsDeleteAsyncRelativeRetry400Headers, Void>} object if successful.
+     */
+    RestResponse<LROSADsDeleteAsyncRelativeRetry400Headers, Void> deleteAsyncRelativeRetry400WithRestResponseAsync();
 
 
     /**
@@ -690,6 +875,14 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 400 with no error body.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsPostNonRetry400Headers, Void>} object if successful.
+     */
+    RestResponse<LROSADsPostNonRetry400Headers, Void> beginPostNonRetry400WithRestResponseAsync();
+    }
+    /**
+     * Long running post request, service returns a 400 with no error body.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -715,6 +908,15 @@ public interface LROSADs {
      * @return the {@link Observable<OperationStatus<Void>>} object if successful.
      */
     Observable<OperationStatus<Void>> beginPostNonRetry400Async(Product product);
+
+    /**
+     * Long running post request, service returns a 400 with no error body.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsPostNonRetry400Headers, Void>} object if successful.
+     */
+    RestResponse<LROSADsPostNonRetry400Headers, Void> beginPostNonRetry400WithRestResponseAsync(Product product);
 
 
     /**
@@ -745,6 +947,14 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 400 with no error body.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsPostNonRetry400Headers, Void>} object if successful.
+     */
+    RestResponse<LROSADsPostNonRetry400Headers, Void> postNonRetry400WithRestResponseAsync();
+    }
+    /**
+     * Long running post request, service returns a 400 with no error body.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -770,6 +980,15 @@ public interface LROSADs {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postNonRetry400Async(Product product);
+
+    /**
+     * Long running post request, service returns a 400 with no error body.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsPostNonRetry400Headers, Void>} object if successful.
+     */
+    RestResponse<LROSADsPostNonRetry400Headers, Void> postNonRetry400WithRestResponseAsync(Product product);
 
 
     /**
@@ -800,6 +1019,14 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 with a location header.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsPost202NonRetry400Headers, Void>} object if successful.
+     */
+    RestResponse<LROSADsPost202NonRetry400Headers, Void> beginPost202NonRetry400WithRestResponseAsync();
+    }
+    /**
+     * Long running post request, service returns a 202 with a location header.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -825,6 +1052,15 @@ public interface LROSADs {
      * @return the {@link Observable<OperationStatus<Void>>} object if successful.
      */
     Observable<OperationStatus<Void>> beginPost202NonRetry400Async(Product product);
+
+    /**
+     * Long running post request, service returns a 202 with a location header.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsPost202NonRetry400Headers, Void>} object if successful.
+     */
+    RestResponse<LROSADsPost202NonRetry400Headers, Void> beginPost202NonRetry400WithRestResponseAsync(Product product);
 
 
     /**
@@ -855,6 +1091,14 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 with a location header.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsPost202NonRetry400Headers, Void>} object if successful.
+     */
+    RestResponse<LROSADsPost202NonRetry400Headers, Void> post202NonRetry400WithRestResponseAsync();
+    }
+    /**
+     * Long running post request, service returns a 202 with a location header.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -880,6 +1124,15 @@ public interface LROSADs {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> post202NonRetry400Async(Product product);
+
+    /**
+     * Long running post request, service returns a 202 with a location header.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsPost202NonRetry400Headers, Void>} object if successful.
+     */
+    RestResponse<LROSADsPost202NonRetry400Headers, Void> post202NonRetry400WithRestResponseAsync(Product product);
 
 
     /**
@@ -910,6 +1163,14 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsPostAsyncRelativeRetry400Headers, Void>} object if successful.
+     */
+    RestResponse<LROSADsPostAsyncRelativeRetry400Headers, Void> beginPostAsyncRelativeRetry400WithRestResponseAsync();
+    }
+    /**
+     * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -935,6 +1196,15 @@ public interface LROSADs {
      * @return the {@link Observable<OperationStatus<Void>>} object if successful.
      */
     Observable<OperationStatus<Void>> beginPostAsyncRelativeRetry400Async(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsPostAsyncRelativeRetry400Headers, Void>} object if successful.
+     */
+    RestResponse<LROSADsPostAsyncRelativeRetry400Headers, Void> beginPostAsyncRelativeRetry400WithRestResponseAsync(Product product);
 
 
     /**
@@ -965,6 +1235,14 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsPostAsyncRelativeRetry400Headers, Void>} object if successful.
+     */
+    RestResponse<LROSADsPostAsyncRelativeRetry400Headers, Void> postAsyncRelativeRetry400WithRestResponseAsync();
+    }
+    /**
+     * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -990,6 +1268,15 @@ public interface LROSADs {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postAsyncRelativeRetry400Async(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsPostAsyncRelativeRetry400Headers, Void>} object if successful.
+     */
+    RestResponse<LROSADsPostAsyncRelativeRetry400Headers, Void> postAsyncRelativeRetry400WithRestResponseAsync(Product product);
 
 
     /**
@@ -1021,6 +1308,14 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 201 to the initial request with no payload.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> beginPutError201NoProvisioningStatePayloadWithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 201 to the initial request with no payload.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -1047,6 +1342,15 @@ public interface LROSADs {
      * @return the observable to the Product object
      */
     Observable<OperationStatus<Product>> beginPutError201NoProvisioningStatePayloadAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 201 to the initial request with no payload.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> beginPutError201NoProvisioningStatePayloadWithRestResponseAsync(Product product);
 
 
     /**
@@ -1078,6 +1382,14 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 201 to the initial request with no payload.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> putError201NoProvisioningStatePayloadWithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 201 to the initial request with no payload.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -1104,6 +1416,15 @@ public interface LROSADs {
      * @return the observable to the Product object
      */
     Single<Product> putError201NoProvisioningStatePayloadAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 201 to the initial request with no payload.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> putError201NoProvisioningStatePayloadWithRestResponseAsync(Product product);
 
 
     /**
@@ -1135,6 +1456,14 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROSADsPutAsyncRelativeRetryNoStatusHeaders, Product> beginPutAsyncRelativeRetryNoStatusWithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -1161,6 +1490,15 @@ public interface LROSADs {
      * @return the observable to the Product object
      */
     Observable<OperationStatus<Product>> beginPutAsyncRelativeRetryNoStatusAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROSADsPutAsyncRelativeRetryNoStatusHeaders, Product> beginPutAsyncRelativeRetryNoStatusWithRestResponseAsync(Product product);
 
 
     /**
@@ -1192,6 +1530,14 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROSADsPutAsyncRelativeRetryNoStatusHeaders, Product> putAsyncRelativeRetryNoStatusWithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -1218,6 +1564,15 @@ public interface LROSADs {
      * @return the observable to the Product object
      */
     Single<Product> putAsyncRelativeRetryNoStatusAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROSADsPutAsyncRelativeRetryNoStatusHeaders, Product> putAsyncRelativeRetryNoStatusWithRestResponseAsync(Product product);
 
 
     /**
@@ -1249,6 +1604,14 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders, Product> beginPutAsyncRelativeRetryNoStatusPayloadWithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -1275,6 +1638,15 @@ public interface LROSADs {
      * @return the observable to the Product object
      */
     Observable<OperationStatus<Product>> beginPutAsyncRelativeRetryNoStatusPayloadAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders, Product> beginPutAsyncRelativeRetryNoStatusPayloadWithRestResponseAsync(Product product);
 
 
     /**
@@ -1306,6 +1678,14 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders, Product> putAsyncRelativeRetryNoStatusPayloadWithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -1332,6 +1712,15 @@ public interface LROSADs {
      * @return the observable to the Product object
      */
     Single<Product> putAsyncRelativeRetryNoStatusPayloadAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders, Product> putAsyncRelativeRetryNoStatusPayloadWithRestResponseAsync(Product product);
 
 
     /**
@@ -1360,6 +1749,14 @@ public interface LROSADs {
      */
     Observable<OperationStatus<Void>> beginDelete204SucceededAsync();
 
+    /**
+     * Long running delete request, service returns a 204 to the initial request, indicating success.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> beginDelete204SucceededWithRestResponseAsync();
+
 
     /**
      * Long running delete request, service returns a 204 to the initial request, indicating success.
@@ -1386,6 +1783,14 @@ public interface LROSADs {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> delete204SucceededAsync();
+
+    /**
+     * Long running delete request, service returns a 204 to the initial request, indicating success.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> delete204SucceededWithRestResponseAsync();
 
 
     /**
@@ -1414,6 +1819,14 @@ public interface LROSADs {
      */
     Observable<OperationStatus<Void>> beginDeleteAsyncRelativeRetryNoStatusAsync();
 
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsDeleteAsyncRelativeRetryNoStatusHeaders, Void>} object if successful.
+     */
+    RestResponse<LROSADsDeleteAsyncRelativeRetryNoStatusHeaders, Void> beginDeleteAsyncRelativeRetryNoStatusWithRestResponseAsync();
+
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1440,6 +1853,14 @@ public interface LROSADs {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> deleteAsyncRelativeRetryNoStatusAsync();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsDeleteAsyncRelativeRetryNoStatusHeaders, Void>} object if successful.
+     */
+    RestResponse<LROSADsDeleteAsyncRelativeRetryNoStatusHeaders, Void> deleteAsyncRelativeRetryNoStatusWithRestResponseAsync();
 
 
     /**
@@ -1470,6 +1891,14 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, without a location header.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsPost202NoLocationHeaders, Void>} object if successful.
+     */
+    RestResponse<LROSADsPost202NoLocationHeaders, Void> beginPost202NoLocationWithRestResponseAsync();
+    }
+    /**
+     * Long running post request, service returns a 202 to the initial request, without a location header.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -1495,6 +1924,15 @@ public interface LROSADs {
      * @return the {@link Observable<OperationStatus<Void>>} object if successful.
      */
     Observable<OperationStatus<Void>> beginPost202NoLocationAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, without a location header.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsPost202NoLocationHeaders, Void>} object if successful.
+     */
+    RestResponse<LROSADsPost202NoLocationHeaders, Void> beginPost202NoLocationWithRestResponseAsync(Product product);
 
 
     /**
@@ -1525,6 +1963,14 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, without a location header.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsPost202NoLocationHeaders, Void>} object if successful.
+     */
+    RestResponse<LROSADsPost202NoLocationHeaders, Void> post202NoLocationWithRestResponseAsync();
+    }
+    /**
+     * Long running post request, service returns a 202 to the initial request, without a location header.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -1550,6 +1996,15 @@ public interface LROSADs {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> post202NoLocationAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, without a location header.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsPost202NoLocationHeaders, Void>} object if successful.
+     */
+    RestResponse<LROSADsPost202NoLocationHeaders, Void> post202NoLocationWithRestResponseAsync(Product product);
 
 
     /**
@@ -1580,6 +2035,14 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsPostAsyncRelativeRetryNoPayloadHeaders, Void>} object if successful.
+     */
+    RestResponse<LROSADsPostAsyncRelativeRetryNoPayloadHeaders, Void> beginPostAsyncRelativeRetryNoPayloadWithRestResponseAsync();
+    }
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -1605,6 +2068,15 @@ public interface LROSADs {
      * @return the {@link Observable<OperationStatus<Void>>} object if successful.
      */
     Observable<OperationStatus<Void>> beginPostAsyncRelativeRetryNoPayloadAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsPostAsyncRelativeRetryNoPayloadHeaders, Void>} object if successful.
+     */
+    RestResponse<LROSADsPostAsyncRelativeRetryNoPayloadHeaders, Void> beginPostAsyncRelativeRetryNoPayloadWithRestResponseAsync(Product product);
 
 
     /**
@@ -1635,6 +2107,14 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsPostAsyncRelativeRetryNoPayloadHeaders, Void>} object if successful.
+     */
+    RestResponse<LROSADsPostAsyncRelativeRetryNoPayloadHeaders, Void> postAsyncRelativeRetryNoPayloadWithRestResponseAsync();
+    }
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -1660,6 +2140,15 @@ public interface LROSADs {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postAsyncRelativeRetryNoPayloadAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsPostAsyncRelativeRetryNoPayloadHeaders, Void>} object if successful.
+     */
+    RestResponse<LROSADsPostAsyncRelativeRetryNoPayloadHeaders, Void> postAsyncRelativeRetryNoPayloadWithRestResponseAsync(Product product);
 
 
     /**
@@ -1691,6 +2180,14 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> beginPut200InvalidJsonWithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -1717,6 +2214,15 @@ public interface LROSADs {
      * @return the observable to the Product object
      */
     Observable<OperationStatus<Product>> beginPut200InvalidJsonAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> beginPut200InvalidJsonWithRestResponseAsync(Product product);
 
 
     /**
@@ -1748,6 +2254,14 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> put200InvalidJsonWithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -1774,6 +2288,15 @@ public interface LROSADs {
      * @return the observable to the Product object
      */
     Single<Product> put200InvalidJsonAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> put200InvalidJsonWithRestResponseAsync(Product product);
 
 
     /**
@@ -1805,6 +2328,14 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders, Product> beginPutAsyncRelativeRetryInvalidHeaderWithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -1831,6 +2362,15 @@ public interface LROSADs {
      * @return the observable to the Product object
      */
     Observable<OperationStatus<Product>> beginPutAsyncRelativeRetryInvalidHeaderAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders, Product> beginPutAsyncRelativeRetryInvalidHeaderWithRestResponseAsync(Product product);
 
 
     /**
@@ -1862,6 +2402,14 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders, Product> putAsyncRelativeRetryInvalidHeaderWithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -1888,6 +2436,15 @@ public interface LROSADs {
      * @return the observable to the Product object
      */
     Single<Product> putAsyncRelativeRetryInvalidHeaderAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders, Product> putAsyncRelativeRetryInvalidHeaderWithRestResponseAsync(Product product);
 
 
     /**
@@ -1919,6 +2476,14 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders, Product> beginPutAsyncRelativeRetryInvalidJsonPollingWithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -1945,6 +2510,15 @@ public interface LROSADs {
      * @return the observable to the Product object
      */
     Observable<OperationStatus<Product>> beginPutAsyncRelativeRetryInvalidJsonPollingAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders, Product> beginPutAsyncRelativeRetryInvalidJsonPollingWithRestResponseAsync(Product product);
 
 
     /**
@@ -1976,6 +2550,14 @@ public interface LROSADs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders, Product> putAsyncRelativeRetryInvalidJsonPollingWithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -2002,6 +2584,15 @@ public interface LROSADs {
      * @return the observable to the Product object
      */
     Single<Product> putAsyncRelativeRetryInvalidJsonPollingAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders, Product> putAsyncRelativeRetryInvalidJsonPollingWithRestResponseAsync(Product product);
 
 
     /**
@@ -2030,6 +2621,14 @@ public interface LROSADs {
      */
     Observable<OperationStatus<Void>> beginDelete202RetryInvalidHeaderAsync();
 
+    /**
+     * Long running delete request, service returns a 202 to the initial request receing a reponse with an invalid 'Location' and 'Retry-After' headers.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsDelete202RetryInvalidHeaderHeaders, Void>} object if successful.
+     */
+    RestResponse<LROSADsDelete202RetryInvalidHeaderHeaders, Void> beginDelete202RetryInvalidHeaderWithRestResponseAsync();
+
 
     /**
      * Long running delete request, service returns a 202 to the initial request receing a reponse with an invalid 'Location' and 'Retry-After' headers.
@@ -2056,6 +2655,14 @@ public interface LROSADs {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> delete202RetryInvalidHeaderAsync();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request receing a reponse with an invalid 'Location' and 'Retry-After' headers.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsDelete202RetryInvalidHeaderHeaders, Void>} object if successful.
+     */
+    RestResponse<LROSADsDelete202RetryInvalidHeaderHeaders, Void> delete202RetryInvalidHeaderWithRestResponseAsync();
 
 
     /**
@@ -2084,6 +2691,14 @@ public interface LROSADs {
      */
     Observable<OperationStatus<Void>> beginDeleteAsyncRelativeRetryInvalidHeaderAsync();
 
+    /**
+     * Long running delete request, service returns a 202 to the initial request. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders, Void>} object if successful.
+     */
+    RestResponse<LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders, Void> beginDeleteAsyncRelativeRetryInvalidHeaderWithRestResponseAsync();
+
 
     /**
      * Long running delete request, service returns a 202 to the initial request. The endpoint indicated in the Azure-AsyncOperation header is invalid.
@@ -2110,6 +2725,14 @@ public interface LROSADs {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> deleteAsyncRelativeRetryInvalidHeaderAsync();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders, Void>} object if successful.
+     */
+    RestResponse<LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders, Void> deleteAsyncRelativeRetryInvalidHeaderWithRestResponseAsync();
 
 
     /**
@@ -2138,6 +2761,14 @@ public interface LROSADs {
      */
     Observable<OperationStatus<Void>> beginDeleteAsyncRelativeRetryInvalidJsonPollingAsync();
 
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders, Void>} object if successful.
+     */
+    RestResponse<LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders, Void> beginDeleteAsyncRelativeRetryInvalidJsonPollingWithRestResponseAsync();
+
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2164,6 +2795,14 @@ public interface LROSADs {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> deleteAsyncRelativeRetryInvalidJsonPollingAsync();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders, Void>} object if successful.
+     */
+    RestResponse<LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders, Void> deleteAsyncRelativeRetryInvalidJsonPollingWithRestResponseAsync();
 
 
     /**
@@ -2194,6 +2833,14 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsPost202RetryInvalidHeaderHeaders, Void>} object if successful.
+     */
+    RestResponse<LROSADsPost202RetryInvalidHeaderHeaders, Void> beginPost202RetryInvalidHeaderWithRestResponseAsync();
+    }
+    /**
+     * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -2219,6 +2866,15 @@ public interface LROSADs {
      * @return the {@link Observable<OperationStatus<Void>>} object if successful.
      */
     Observable<OperationStatus<Void>> beginPost202RetryInvalidHeaderAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsPost202RetryInvalidHeaderHeaders, Void>} object if successful.
+     */
+    RestResponse<LROSADsPost202RetryInvalidHeaderHeaders, Void> beginPost202RetryInvalidHeaderWithRestResponseAsync(Product product);
 
 
     /**
@@ -2249,6 +2905,14 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsPost202RetryInvalidHeaderHeaders, Void>} object if successful.
+     */
+    RestResponse<LROSADsPost202RetryInvalidHeaderHeaders, Void> post202RetryInvalidHeaderWithRestResponseAsync();
+    }
+    /**
+     * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -2274,6 +2938,15 @@ public interface LROSADs {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> post202RetryInvalidHeaderAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsPost202RetryInvalidHeaderHeaders, Void>} object if successful.
+     */
+    RestResponse<LROSADsPost202RetryInvalidHeaderHeaders, Void> post202RetryInvalidHeaderWithRestResponseAsync(Product product);
 
 
     /**
@@ -2304,6 +2977,14 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders, Void>} object if successful.
+     */
+    RestResponse<LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders, Void> beginPostAsyncRelativeRetryInvalidHeaderWithRestResponseAsync();
+    }
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -2329,6 +3010,15 @@ public interface LROSADs {
      * @return the {@link Observable<OperationStatus<Void>>} object if successful.
      */
     Observable<OperationStatus<Void>> beginPostAsyncRelativeRetryInvalidHeaderAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders, Void>} object if successful.
+     */
+    RestResponse<LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders, Void> beginPostAsyncRelativeRetryInvalidHeaderWithRestResponseAsync(Product product);
 
 
     /**
@@ -2359,6 +3049,14 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders, Void>} object if successful.
+     */
+    RestResponse<LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders, Void> postAsyncRelativeRetryInvalidHeaderWithRestResponseAsync();
+    }
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -2384,6 +3082,15 @@ public interface LROSADs {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postAsyncRelativeRetryInvalidHeaderAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders, Void>} object if successful.
+     */
+    RestResponse<LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders, Void> postAsyncRelativeRetryInvalidHeaderWithRestResponseAsync(Product product);
 
 
     /**
@@ -2414,6 +3121,14 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders, Void>} object if successful.
+     */
+    RestResponse<LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders, Void> beginPostAsyncRelativeRetryInvalidJsonPollingWithRestResponseAsync();
+    }
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -2439,6 +3154,15 @@ public interface LROSADs {
      * @return the {@link Observable<OperationStatus<Void>>} object if successful.
      */
     Observable<OperationStatus<Void>> beginPostAsyncRelativeRetryInvalidJsonPollingAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders, Void>} object if successful.
+     */
+    RestResponse<LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders, Void> beginPostAsyncRelativeRetryInvalidJsonPollingWithRestResponseAsync(Product product);
 
 
     /**
@@ -2469,6 +3193,14 @@ public interface LROSADs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders, Void>} object if successful.
+     */
+    RestResponse<LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders, Void> postAsyncRelativeRetryInvalidJsonPollingWithRestResponseAsync();
+    }
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -2494,6 +3226,15 @@ public interface LROSADs {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postAsyncRelativeRetryInvalidJsonPollingAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders, Void>} object if successful.
+     */
+    RestResponse<LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders, Void> postAsyncRelativeRetryInvalidJsonPollingWithRestResponseAsync(Product product);
 
 
 }

--- a/test/azure/src/main/java/fixtures/lro/LROs.java
+++ b/test/azure/src/main/java/fixtures/lro/LROs.java
@@ -12,6 +12,7 @@ package fixtures.lro;
 
 import com.microsoft.azure.CloudException;
 import com.microsoft.azure.OperationStatus;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.lro.models.LROsDelete202NoRetry204Headers;
@@ -78,6 +79,14 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> beginPut200SucceededWithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -104,6 +113,15 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Observable<OperationStatus<Product>> beginPut200SucceededAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> beginPut200SucceededWithRestResponseAsync(Product product);
 
 
     /**
@@ -135,6 +153,14 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> put200SucceededWithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -161,6 +187,15 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Single<Product> put200SucceededAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> put200SucceededWithRestResponseAsync(Product product);
 
 
     /**
@@ -192,6 +227,14 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> beginPut200SucceededNoStateWithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -218,6 +261,15 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Observable<OperationStatus<Product>> beginPut200SucceededNoStateAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> beginPut200SucceededNoStateWithRestResponseAsync(Product product);
 
 
     /**
@@ -249,6 +301,14 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> put200SucceededNoStateWithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -275,6 +335,15 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Single<Product> put200SucceededNoStateAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> put200SucceededNoStateWithRestResponseAsync(Product product);
 
 
     /**
@@ -306,6 +375,14 @@ public interface LROs {
     /**
      * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> beginPut202Retry200WithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -332,6 +409,15 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Observable<OperationStatus<Product>> beginPut202Retry200Async(Product product);
+
+    /**
+     * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> beginPut202Retry200WithRestResponseAsync(Product product);
 
 
     /**
@@ -363,6 +449,14 @@ public interface LROs {
     /**
      * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> put202Retry200WithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -389,6 +483,15 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Single<Product> put202Retry200Async(Product product);
+
+    /**
+     * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> put202Retry200WithRestResponseAsync(Product product);
 
 
     /**
@@ -420,6 +523,14 @@ public interface LROs {
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> beginPut201CreatingSucceeded200WithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -446,6 +557,15 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Observable<OperationStatus<Product>> beginPut201CreatingSucceeded200Async(Product product);
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> beginPut201CreatingSucceeded200WithRestResponseAsync(Product product);
 
 
     /**
@@ -477,6 +597,14 @@ public interface LROs {
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> put201CreatingSucceeded200WithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -503,6 +631,15 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Single<Product> put201CreatingSucceeded200Async(Product product);
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> put201CreatingSucceeded200WithRestResponseAsync(Product product);
 
 
     /**
@@ -534,6 +671,14 @@ public interface LROs {
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> beginPut200UpdatingSucceeded204WithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -560,6 +705,15 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Observable<OperationStatus<Product>> beginPut200UpdatingSucceeded204Async(Product product);
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> beginPut200UpdatingSucceeded204WithRestResponseAsync(Product product);
 
 
     /**
@@ -591,6 +745,14 @@ public interface LROs {
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> put200UpdatingSucceeded204WithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -617,6 +779,15 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Single<Product> put200UpdatingSucceeded204Async(Product product);
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> put200UpdatingSucceeded204WithRestResponseAsync(Product product);
 
 
     /**
@@ -648,6 +819,14 @@ public interface LROs {
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> beginPut201CreatingFailed200WithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -674,6 +853,15 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Observable<OperationStatus<Product>> beginPut201CreatingFailed200Async(Product product);
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> beginPut201CreatingFailed200WithRestResponseAsync(Product product);
 
 
     /**
@@ -705,6 +893,14 @@ public interface LROs {
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> put201CreatingFailed200WithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -731,6 +927,15 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Single<Product> put201CreatingFailed200Async(Product product);
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> put201CreatingFailed200WithRestResponseAsync(Product product);
 
 
     /**
@@ -762,6 +967,14 @@ public interface LROs {
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> beginPut200Acceptedcanceled200WithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -788,6 +1001,15 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Observable<OperationStatus<Product>> beginPut200Acceptedcanceled200Async(Product product);
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> beginPut200Acceptedcanceled200WithRestResponseAsync(Product product);
 
 
     /**
@@ -819,6 +1041,14 @@ public interface LROs {
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> put200Acceptedcanceled200WithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -845,6 +1075,15 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Single<Product> put200Acceptedcanceled200Async(Product product);
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> put200Acceptedcanceled200WithRestResponseAsync(Product product);
 
 
     /**
@@ -876,6 +1115,14 @@ public interface LROs {
     /**
      * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPutNoHeaderInRetryHeaders, Product> beginPutNoHeaderInRetryWithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -902,6 +1149,15 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Observable<OperationStatus<Product>> beginPutNoHeaderInRetryAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPutNoHeaderInRetryHeaders, Product> beginPutNoHeaderInRetryWithRestResponseAsync(Product product);
 
 
     /**
@@ -933,6 +1189,14 @@ public interface LROs {
     /**
      * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPutNoHeaderInRetryHeaders, Product> putNoHeaderInRetryWithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -959,6 +1223,15 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Single<Product> putNoHeaderInRetryAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPutNoHeaderInRetryHeaders, Product> putNoHeaderInRetryWithRestResponseAsync(Product product);
 
 
     /**
@@ -990,6 +1263,14 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPutAsyncRetrySucceededHeaders, Product> beginPutAsyncRetrySucceededWithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -1016,6 +1297,15 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Observable<OperationStatus<Product>> beginPutAsyncRetrySucceededAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPutAsyncRetrySucceededHeaders, Product> beginPutAsyncRetrySucceededWithRestResponseAsync(Product product);
 
 
     /**
@@ -1047,6 +1337,14 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPutAsyncRetrySucceededHeaders, Product> putAsyncRetrySucceededWithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -1073,6 +1371,15 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Single<Product> putAsyncRetrySucceededAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPutAsyncRetrySucceededHeaders, Product> putAsyncRetrySucceededWithRestResponseAsync(Product product);
 
 
     /**
@@ -1104,6 +1411,14 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPutAsyncNoRetrySucceededHeaders, Product> beginPutAsyncNoRetrySucceededWithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -1130,6 +1445,15 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Observable<OperationStatus<Product>> beginPutAsyncNoRetrySucceededAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPutAsyncNoRetrySucceededHeaders, Product> beginPutAsyncNoRetrySucceededWithRestResponseAsync(Product product);
 
 
     /**
@@ -1161,6 +1485,14 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPutAsyncNoRetrySucceededHeaders, Product> putAsyncNoRetrySucceededWithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -1187,6 +1519,15 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Single<Product> putAsyncNoRetrySucceededAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPutAsyncNoRetrySucceededHeaders, Product> putAsyncNoRetrySucceededWithRestResponseAsync(Product product);
 
 
     /**
@@ -1218,6 +1559,14 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPutAsyncRetryFailedHeaders, Product> beginPutAsyncRetryFailedWithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -1244,6 +1593,15 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Observable<OperationStatus<Product>> beginPutAsyncRetryFailedAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPutAsyncRetryFailedHeaders, Product> beginPutAsyncRetryFailedWithRestResponseAsync(Product product);
 
 
     /**
@@ -1275,6 +1633,14 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPutAsyncRetryFailedHeaders, Product> putAsyncRetryFailedWithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -1301,6 +1667,15 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Single<Product> putAsyncRetryFailedAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPutAsyncRetryFailedHeaders, Product> putAsyncRetryFailedWithRestResponseAsync(Product product);
 
 
     /**
@@ -1332,6 +1707,14 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPutAsyncNoRetrycanceledHeaders, Product> beginPutAsyncNoRetrycanceledWithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -1358,6 +1741,15 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Observable<OperationStatus<Product>> beginPutAsyncNoRetrycanceledAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPutAsyncNoRetrycanceledHeaders, Product> beginPutAsyncNoRetrycanceledWithRestResponseAsync(Product product);
 
 
     /**
@@ -1389,6 +1781,14 @@ public interface LROs {
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPutAsyncNoRetrycanceledHeaders, Product> putAsyncNoRetrycanceledWithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -1415,6 +1815,15 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Single<Product> putAsyncNoRetrycanceledAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPutAsyncNoRetrycanceledHeaders, Product> putAsyncNoRetrycanceledWithRestResponseAsync(Product product);
 
 
     /**
@@ -1446,6 +1855,14 @@ public interface LROs {
     /**
      * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPutAsyncNoHeaderInRetryHeaders, Product> beginPutAsyncNoHeaderInRetryWithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -1472,6 +1889,15 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Observable<OperationStatus<Product>> beginPutAsyncNoHeaderInRetryAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPutAsyncNoHeaderInRetryHeaders, Product> beginPutAsyncNoHeaderInRetryWithRestResponseAsync(Product product);
 
 
     /**
@@ -1503,6 +1929,14 @@ public interface LROs {
     /**
      * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPutAsyncNoHeaderInRetryHeaders, Product> putAsyncNoHeaderInRetryWithRestResponseAsync();
+    }
+    /**
+     * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -1529,6 +1963,15 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Single<Product> putAsyncNoHeaderInRetryAsync(Product product);
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPutAsyncNoHeaderInRetryHeaders, Product> putAsyncNoHeaderInRetryWithRestResponseAsync(Product product);
 
 
     /**
@@ -1560,6 +2003,14 @@ public interface LROs {
     /**
      * Long running put request with non resource.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Sku object
+     */
+    RestResponse<Void, Sku> beginPutNonResourceWithRestResponseAsync();
+    }
+    /**
+     * Long running put request with non resource.
+     *
      * @param sku sku to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -1586,6 +2037,15 @@ public interface LROs {
      * @return the observable to the Sku object
      */
     Observable<OperationStatus<Sku>> beginPutNonResourceAsync(Sku sku);
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @param sku sku to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Sku object
+     */
+    RestResponse<Void, Sku> beginPutNonResourceWithRestResponseAsync(Sku sku);
 
 
     /**
@@ -1617,6 +2077,14 @@ public interface LROs {
     /**
      * Long running put request with non resource.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Sku object
+     */
+    RestResponse<Void, Sku> putNonResourceWithRestResponseAsync();
+    }
+    /**
+     * Long running put request with non resource.
+     *
      * @param sku sku to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -1643,6 +2111,15 @@ public interface LROs {
      * @return the observable to the Sku object
      */
     Single<Sku> putNonResourceAsync(Sku sku);
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @param sku sku to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Sku object
+     */
+    RestResponse<Void, Sku> putNonResourceWithRestResponseAsync(Sku sku);
 
 
     /**
@@ -1674,6 +2151,14 @@ public interface LROs {
     /**
      * Long running put request with non resource.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Sku object
+     */
+    RestResponse<Void, Sku> beginPutAsyncNonResourceWithRestResponseAsync();
+    }
+    /**
+     * Long running put request with non resource.
+     *
      * @param sku Sku to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -1700,6 +2185,15 @@ public interface LROs {
      * @return the observable to the Sku object
      */
     Observable<OperationStatus<Sku>> beginPutAsyncNonResourceAsync(Sku sku);
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @param sku Sku to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Sku object
+     */
+    RestResponse<Void, Sku> beginPutAsyncNonResourceWithRestResponseAsync(Sku sku);
 
 
     /**
@@ -1731,6 +2225,14 @@ public interface LROs {
     /**
      * Long running put request with non resource.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Sku object
+     */
+    RestResponse<Void, Sku> putAsyncNonResourceWithRestResponseAsync();
+    }
+    /**
+     * Long running put request with non resource.
+     *
      * @param sku Sku to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -1757,6 +2259,15 @@ public interface LROs {
      * @return the observable to the Sku object
      */
     Single<Sku> putAsyncNonResourceAsync(Sku sku);
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @param sku Sku to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Sku object
+     */
+    RestResponse<Void, Sku> putAsyncNonResourceWithRestResponseAsync(Sku sku);
 
 
     /**
@@ -1788,6 +2299,14 @@ public interface LROs {
     /**
      * Long running put request with sub resource.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the SubProduct object
+     */
+    RestResponse<Void, SubProduct> beginPutSubResourceWithRestResponseAsync();
+    }
+    /**
+     * Long running put request with sub resource.
+     *
      * @param product Sub Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -1814,6 +2333,15 @@ public interface LROs {
      * @return the observable to the SubProduct object
      */
     Observable<OperationStatus<SubProduct>> beginPutSubResourceAsync(SubProduct product);
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @param product Sub Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the SubProduct object
+     */
+    RestResponse<Void, SubProduct> beginPutSubResourceWithRestResponseAsync(SubProduct product);
 
 
     /**
@@ -1845,6 +2373,14 @@ public interface LROs {
     /**
      * Long running put request with sub resource.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the SubProduct object
+     */
+    RestResponse<Void, SubProduct> putSubResourceWithRestResponseAsync();
+    }
+    /**
+     * Long running put request with sub resource.
+     *
      * @param product Sub Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -1871,6 +2407,15 @@ public interface LROs {
      * @return the observable to the SubProduct object
      */
     Single<SubProduct> putSubResourceAsync(SubProduct product);
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @param product Sub Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the SubProduct object
+     */
+    RestResponse<Void, SubProduct> putSubResourceWithRestResponseAsync(SubProduct product);
 
 
     /**
@@ -1902,6 +2447,14 @@ public interface LROs {
     /**
      * Long running put request with sub resource.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the SubProduct object
+     */
+    RestResponse<Void, SubProduct> beginPutAsyncSubResourceWithRestResponseAsync();
+    }
+    /**
+     * Long running put request with sub resource.
+     *
      * @param product Sub Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -1928,6 +2481,15 @@ public interface LROs {
      * @return the observable to the SubProduct object
      */
     Observable<OperationStatus<SubProduct>> beginPutAsyncSubResourceAsync(SubProduct product);
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @param product Sub Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the SubProduct object
+     */
+    RestResponse<Void, SubProduct> beginPutAsyncSubResourceWithRestResponseAsync(SubProduct product);
 
 
     /**
@@ -1959,6 +2521,14 @@ public interface LROs {
     /**
      * Long running put request with sub resource.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the SubProduct object
+     */
+    RestResponse<Void, SubProduct> putAsyncSubResourceWithRestResponseAsync();
+    }
+    /**
+     * Long running put request with sub resource.
+     *
      * @param product Sub Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -1985,6 +2555,15 @@ public interface LROs {
      * @return the observable to the SubProduct object
      */
     Single<SubProduct> putAsyncSubResourceAsync(SubProduct product);
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @param product Sub Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the SubProduct object
+     */
+    RestResponse<Void, SubProduct> putAsyncSubResourceWithRestResponseAsync(SubProduct product);
 
 
     /**
@@ -2014,6 +2593,14 @@ public interface LROs {
      */
     Observable<OperationStatus<Product>> beginDeleteProvisioning202Accepted200SucceededAsync();
 
+    /**
+     * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsDeleteProvisioning202Accepted200SucceededHeaders, Product> beginDeleteProvisioning202Accepted200SucceededWithRestResponseAsync();
+
 
     /**
      * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -2041,6 +2628,14 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Single<Product> deleteProvisioning202Accepted200SucceededAsync();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsDeleteProvisioning202Accepted200SucceededHeaders, Product> deleteProvisioning202Accepted200SucceededWithRestResponseAsync();
 
 
     /**
@@ -2070,6 +2665,14 @@ public interface LROs {
      */
     Observable<OperationStatus<Product>> beginDeleteProvisioning202DeletingFailed200Async();
 
+    /**
+     * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsDeleteProvisioning202DeletingFailed200Headers, Product> beginDeleteProvisioning202DeletingFailed200WithRestResponseAsync();
+
 
     /**
      * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
@@ -2097,6 +2700,14 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Single<Product> deleteProvisioning202DeletingFailed200Async();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsDeleteProvisioning202DeletingFailed200Headers, Product> deleteProvisioning202DeletingFailed200WithRestResponseAsync();
 
 
     /**
@@ -2126,6 +2737,14 @@ public interface LROs {
      */
     Observable<OperationStatus<Product>> beginDeleteProvisioning202Deletingcanceled200Async();
 
+    /**
+     * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsDeleteProvisioning202Deletingcanceled200Headers, Product> beginDeleteProvisioning202Deletingcanceled200WithRestResponseAsync();
+
 
     /**
      * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
@@ -2154,6 +2773,14 @@ public interface LROs {
      */
     Single<Product> deleteProvisioning202Deletingcanceled200Async();
 
+    /**
+     * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsDeleteProvisioning202Deletingcanceled200Headers, Product> deleteProvisioning202Deletingcanceled200WithRestResponseAsync();
+
 
     /**
      * Long running delete succeeds and returns right away.
@@ -2181,6 +2808,14 @@ public interface LROs {
      */
     Observable<OperationStatus<Void>> beginDelete204SucceededAsync();
 
+    /**
+     * Long running delete succeeds and returns right away.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> beginDelete204SucceededWithRestResponseAsync();
+
 
     /**
      * Long running delete succeeds and returns right away.
@@ -2207,6 +2842,14 @@ public interface LROs {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> delete204SucceededAsync();
+
+    /**
+     * Long running delete succeeds and returns right away.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<Void, Void>} object if successful.
+     */
+    RestResponse<Void, Void> delete204SucceededWithRestResponseAsync();
 
 
     /**
@@ -2236,6 +2879,14 @@ public interface LROs {
      */
     Observable<OperationStatus<Product>> beginDelete202Retry200Async();
 
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsDelete202Retry200Headers, Product> beginDelete202Retry200WithRestResponseAsync();
+
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -2263,6 +2914,14 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Single<Product> delete202Retry200Async();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsDelete202Retry200Headers, Product> delete202Retry200WithRestResponseAsync();
 
 
     /**
@@ -2292,6 +2951,14 @@ public interface LROs {
      */
     Observable<OperationStatus<Product>> beginDelete202NoRetry204Async();
 
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsDelete202NoRetry204Headers, Product> beginDelete202NoRetry204WithRestResponseAsync();
+
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -2320,6 +2987,14 @@ public interface LROs {
      */
     Single<Product> delete202NoRetry204Async();
 
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsDelete202NoRetry204Headers, Product> delete202NoRetry204WithRestResponseAsync();
+
 
     /**
      * Long running delete request, service returns a location header in the initial request. Subsequent calls to operation status do not contain location header.
@@ -2346,6 +3021,14 @@ public interface LROs {
      * @return the {@link Observable<OperationStatus<Void>>} object if successful.
      */
     Observable<OperationStatus<Void>> beginDeleteNoHeaderInRetryAsync();
+
+    /**
+     * Long running delete request, service returns a location header in the initial request. Subsequent calls to operation status do not contain location header.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROsDeleteNoHeaderInRetryHeaders, Void>} object if successful.
+     */
+    RestResponse<LROsDeleteNoHeaderInRetryHeaders, Void> beginDeleteNoHeaderInRetryWithRestResponseAsync();
 
 
     /**
@@ -2374,6 +3057,14 @@ public interface LROs {
      */
     Single<Void> deleteNoHeaderInRetryAsync();
 
+    /**
+     * Long running delete request, service returns a location header in the initial request. Subsequent calls to operation status do not contain location header.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROsDeleteNoHeaderInRetryHeaders, Void>} object if successful.
+     */
+    RestResponse<LROsDeleteNoHeaderInRetryHeaders, Void> deleteNoHeaderInRetryWithRestResponseAsync();
+
 
     /**
      * Long running delete request, service returns an Azure-AsyncOperation header in the initial request. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
@@ -2400,6 +3091,14 @@ public interface LROs {
      * @return the {@link Observable<OperationStatus<Void>>} object if successful.
      */
     Observable<OperationStatus<Void>> beginDeleteAsyncNoHeaderInRetryAsync();
+
+    /**
+     * Long running delete request, service returns an Azure-AsyncOperation header in the initial request. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROsDeleteAsyncNoHeaderInRetryHeaders, Void>} object if successful.
+     */
+    RestResponse<LROsDeleteAsyncNoHeaderInRetryHeaders, Void> beginDeleteAsyncNoHeaderInRetryWithRestResponseAsync();
 
 
     /**
@@ -2428,6 +3127,14 @@ public interface LROs {
      */
     Single<Void> deleteAsyncNoHeaderInRetryAsync();
 
+    /**
+     * Long running delete request, service returns an Azure-AsyncOperation header in the initial request. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROsDeleteAsyncNoHeaderInRetryHeaders, Void>} object if successful.
+     */
+    RestResponse<LROsDeleteAsyncNoHeaderInRetryHeaders, Void> deleteAsyncNoHeaderInRetryWithRestResponseAsync();
+
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2454,6 +3161,14 @@ public interface LROs {
      * @return the {@link Observable<OperationStatus<Void>>} object if successful.
      */
     Observable<OperationStatus<Void>> beginDeleteAsyncRetrySucceededAsync();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROsDeleteAsyncRetrySucceededHeaders, Void>} object if successful.
+     */
+    RestResponse<LROsDeleteAsyncRetrySucceededHeaders, Void> beginDeleteAsyncRetrySucceededWithRestResponseAsync();
 
 
     /**
@@ -2482,6 +3197,14 @@ public interface LROs {
      */
     Single<Void> deleteAsyncRetrySucceededAsync();
 
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROsDeleteAsyncRetrySucceededHeaders, Void>} object if successful.
+     */
+    RestResponse<LROsDeleteAsyncRetrySucceededHeaders, Void> deleteAsyncRetrySucceededWithRestResponseAsync();
+
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2508,6 +3231,14 @@ public interface LROs {
      * @return the {@link Observable<OperationStatus<Void>>} object if successful.
      */
     Observable<OperationStatus<Void>> beginDeleteAsyncNoRetrySucceededAsync();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROsDeleteAsyncNoRetrySucceededHeaders, Void>} object if successful.
+     */
+    RestResponse<LROsDeleteAsyncNoRetrySucceededHeaders, Void> beginDeleteAsyncNoRetrySucceededWithRestResponseAsync();
 
 
     /**
@@ -2536,6 +3267,14 @@ public interface LROs {
      */
     Single<Void> deleteAsyncNoRetrySucceededAsync();
 
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROsDeleteAsyncNoRetrySucceededHeaders, Void>} object if successful.
+     */
+    RestResponse<LROsDeleteAsyncNoRetrySucceededHeaders, Void> deleteAsyncNoRetrySucceededWithRestResponseAsync();
+
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2562,6 +3301,14 @@ public interface LROs {
      * @return the {@link Observable<OperationStatus<Void>>} object if successful.
      */
     Observable<OperationStatus<Void>> beginDeleteAsyncRetryFailedAsync();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROsDeleteAsyncRetryFailedHeaders, Void>} object if successful.
+     */
+    RestResponse<LROsDeleteAsyncRetryFailedHeaders, Void> beginDeleteAsyncRetryFailedWithRestResponseAsync();
 
 
     /**
@@ -2590,6 +3337,14 @@ public interface LROs {
      */
     Single<Void> deleteAsyncRetryFailedAsync();
 
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROsDeleteAsyncRetryFailedHeaders, Void>} object if successful.
+     */
+    RestResponse<LROsDeleteAsyncRetryFailedHeaders, Void> deleteAsyncRetryFailedWithRestResponseAsync();
+
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2617,6 +3372,14 @@ public interface LROs {
      */
     Observable<OperationStatus<Void>> beginDeleteAsyncRetrycanceledAsync();
 
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROsDeleteAsyncRetrycanceledHeaders, Void>} object if successful.
+     */
+    RestResponse<LROsDeleteAsyncRetrycanceledHeaders, Void> beginDeleteAsyncRetrycanceledWithRestResponseAsync();
+
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2643,6 +3406,14 @@ public interface LROs {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> deleteAsyncRetrycanceledAsync();
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROsDeleteAsyncRetrycanceledHeaders, Void>} object if successful.
+     */
+    RestResponse<LROsDeleteAsyncRetrycanceledHeaders, Void> deleteAsyncRetrycanceledWithRestResponseAsync();
 
 
     /**
@@ -2672,6 +3443,14 @@ public interface LROs {
      */
     Observable<OperationStatus<Sku>> beginPost200WithPayloadAsync();
 
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' header. Poll returns a 200 with a response body after success.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Sku object
+     */
+    RestResponse<Void, Sku> beginPost200WithPayloadWithRestResponseAsync();
+
 
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' header. Poll returns a 200 with a response body after success.
@@ -2699,6 +3478,14 @@ public interface LROs {
      * @return the observable to the Sku object
      */
     Single<Sku> post200WithPayloadAsync();
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' header. Poll returns a 200 with a response body after success.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Sku object
+     */
+    RestResponse<Void, Sku> post200WithPayloadWithRestResponseAsync();
 
 
     /**
@@ -2729,6 +3516,14 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROsPost202Retry200Headers, Void>} object if successful.
+     */
+    RestResponse<LROsPost202Retry200Headers, Void> beginPost202Retry200WithRestResponseAsync();
+    }
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -2754,6 +3549,15 @@ public interface LROs {
      * @return the {@link Observable<OperationStatus<Void>>} object if successful.
      */
     Observable<OperationStatus<Void>> beginPost202Retry200Async(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROsPost202Retry200Headers, Void>} object if successful.
+     */
+    RestResponse<LROsPost202Retry200Headers, Void> beginPost202Retry200WithRestResponseAsync(Product product);
 
 
     /**
@@ -2784,6 +3588,14 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROsPost202Retry200Headers, Void>} object if successful.
+     */
+    RestResponse<LROsPost202Retry200Headers, Void> post202Retry200WithRestResponseAsync();
+    }
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -2809,6 +3621,15 @@ public interface LROs {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> post202Retry200Async(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROsPost202Retry200Headers, Void>} object if successful.
+     */
+    RestResponse<LROsPost202Retry200Headers, Void> post202Retry200WithRestResponseAsync(Product product);
 
 
     /**
@@ -2840,6 +3661,14 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPost202NoRetry204Headers, Product> beginPost202NoRetry204WithRestResponseAsync();
+    }
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -2866,6 +3695,15 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Observable<OperationStatus<Product>> beginPost202NoRetry204Async(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPost202NoRetry204Headers, Product> beginPost202NoRetry204WithRestResponseAsync(Product product);
 
 
     /**
@@ -2897,6 +3735,14 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPost202NoRetry204Headers, Product> post202NoRetry204WithRestResponseAsync();
+    }
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -2923,6 +3769,15 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Single<Product> post202NoRetry204Async(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPost202NoRetry204Headers, Product> post202NoRetry204WithRestResponseAsync(Product product);
 
 
     /**
@@ -2954,6 +3809,14 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPostAsyncRetrySucceededHeaders, Product> beginPostAsyncRetrySucceededWithRestResponseAsync();
+    }
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -2980,6 +3843,15 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Observable<OperationStatus<Product>> beginPostAsyncRetrySucceededAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPostAsyncRetrySucceededHeaders, Product> beginPostAsyncRetrySucceededWithRestResponseAsync(Product product);
 
 
     /**
@@ -3011,6 +3883,14 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPostAsyncRetrySucceededHeaders, Product> postAsyncRetrySucceededWithRestResponseAsync();
+    }
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -3037,6 +3917,15 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Single<Product> postAsyncRetrySucceededAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPostAsyncRetrySucceededHeaders, Product> postAsyncRetrySucceededWithRestResponseAsync(Product product);
 
 
     /**
@@ -3068,6 +3957,14 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPostAsyncNoRetrySucceededHeaders, Product> beginPostAsyncNoRetrySucceededWithRestResponseAsync();
+    }
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -3094,6 +3991,15 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Observable<OperationStatus<Product>> beginPostAsyncNoRetrySucceededAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPostAsyncNoRetrySucceededHeaders, Product> beginPostAsyncNoRetrySucceededWithRestResponseAsync(Product product);
 
 
     /**
@@ -3125,6 +4031,14 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPostAsyncNoRetrySucceededHeaders, Product> postAsyncNoRetrySucceededWithRestResponseAsync();
+    }
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -3151,6 +4065,15 @@ public interface LROs {
      * @return the observable to the Product object
      */
     Single<Product> postAsyncNoRetrySucceededAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsPostAsyncNoRetrySucceededHeaders, Product> postAsyncNoRetrySucceededWithRestResponseAsync(Product product);
 
 
     /**
@@ -3181,6 +4104,14 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROsPostAsyncRetryFailedHeaders, Void>} object if successful.
+     */
+    RestResponse<LROsPostAsyncRetryFailedHeaders, Void> beginPostAsyncRetryFailedWithRestResponseAsync();
+    }
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -3206,6 +4137,15 @@ public interface LROs {
      * @return the {@link Observable<OperationStatus<Void>>} object if successful.
      */
     Observable<OperationStatus<Void>> beginPostAsyncRetryFailedAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROsPostAsyncRetryFailedHeaders, Void>} object if successful.
+     */
+    RestResponse<LROsPostAsyncRetryFailedHeaders, Void> beginPostAsyncRetryFailedWithRestResponseAsync(Product product);
 
 
     /**
@@ -3236,6 +4176,14 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROsPostAsyncRetryFailedHeaders, Void>} object if successful.
+     */
+    RestResponse<LROsPostAsyncRetryFailedHeaders, Void> postAsyncRetryFailedWithRestResponseAsync();
+    }
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -3261,6 +4209,15 @@ public interface LROs {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postAsyncRetryFailedAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROsPostAsyncRetryFailedHeaders, Void>} object if successful.
+     */
+    RestResponse<LROsPostAsyncRetryFailedHeaders, Void> postAsyncRetryFailedWithRestResponseAsync(Product product);
 
 
     /**
@@ -3291,6 +4248,14 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROsPostAsyncRetrycanceledHeaders, Void>} object if successful.
+     */
+    RestResponse<LROsPostAsyncRetrycanceledHeaders, Void> beginPostAsyncRetrycanceledWithRestResponseAsync();
+    }
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -3316,6 +4281,15 @@ public interface LROs {
      * @return the {@link Observable<OperationStatus<Void>>} object if successful.
      */
     Observable<OperationStatus<Void>> beginPostAsyncRetrycanceledAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROsPostAsyncRetrycanceledHeaders, Void>} object if successful.
+     */
+    RestResponse<LROsPostAsyncRetrycanceledHeaders, Void> beginPostAsyncRetrycanceledWithRestResponseAsync(Product product);
 
 
     /**
@@ -3346,6 +4320,14 @@ public interface LROs {
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROsPostAsyncRetrycanceledHeaders, Void>} object if successful.
+     */
+    RestResponse<LROsPostAsyncRetrycanceledHeaders, Void> postAsyncRetrycanceledWithRestResponseAsync();
+    }
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -3371,6 +4353,15 @@ public interface LROs {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postAsyncRetrycanceledAsync(Product product);
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROsPostAsyncRetrycanceledHeaders, Void>} object if successful.
+     */
+    RestResponse<LROsPostAsyncRetrycanceledHeaders, Void> postAsyncRetrycanceledWithRestResponseAsync(Product product);
 
 
 }

--- a/test/azure/src/main/java/fixtures/lro/LROsCustomHeaders.java
+++ b/test/azure/src/main/java/fixtures/lro/LROsCustomHeaders.java
@@ -12,6 +12,7 @@ package fixtures.lro;
 
 import com.microsoft.azure.CloudException;
 import com.microsoft.azure.OperationStatus;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.lro.models.LROsCustomHeaderPost202Retry200Headers;
@@ -56,6 +57,14 @@ public interface LROsCustomHeaders {
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsCustomHeaderPutAsyncRetrySucceededHeaders, Product> beginPutAsyncRetrySucceededWithRestResponseAsync();
+    }
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -82,6 +91,15 @@ public interface LROsCustomHeaders {
      * @return the observable to the Product object
      */
     Observable<OperationStatus<Product>> beginPutAsyncRetrySucceededAsync(Product product);
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsCustomHeaderPutAsyncRetrySucceededHeaders, Product> beginPutAsyncRetrySucceededWithRestResponseAsync(Product product);
 
 
     /**
@@ -113,6 +131,14 @@ public interface LROsCustomHeaders {
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsCustomHeaderPutAsyncRetrySucceededHeaders, Product> putAsyncRetrySucceededWithRestResponseAsync();
+    }
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -139,6 +165,15 @@ public interface LROsCustomHeaders {
      * @return the observable to the Product object
      */
     Single<Product> putAsyncRetrySucceededAsync(Product product);
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<LROsCustomHeaderPutAsyncRetrySucceededHeaders, Product> putAsyncRetrySucceededWithRestResponseAsync(Product product);
 
 
     /**
@@ -170,6 +205,14 @@ public interface LROsCustomHeaders {
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> beginPut201CreatingSucceeded200WithRestResponseAsync();
+    }
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -196,6 +239,15 @@ public interface LROsCustomHeaders {
      * @return the observable to the Product object
      */
     Observable<OperationStatus<Product>> beginPut201CreatingSucceeded200Async(Product product);
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> beginPut201CreatingSucceeded200WithRestResponseAsync(Product product);
 
 
     /**
@@ -227,6 +279,14 @@ public interface LROsCustomHeaders {
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> put201CreatingSucceeded200WithRestResponseAsync();
+    }
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -253,6 +313,15 @@ public interface LROsCustomHeaders {
      * @return the observable to the Product object
      */
     Single<Product> put201CreatingSucceeded200Async(Product product);
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    RestResponse<Void, Product> put201CreatingSucceeded200WithRestResponseAsync(Product product);
 
 
     /**
@@ -283,6 +352,14 @@ public interface LROsCustomHeaders {
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROsCustomHeaderPost202Retry200Headers, Void>} object if successful.
+     */
+    RestResponse<LROsCustomHeaderPost202Retry200Headers, Void> beginPost202Retry200WithRestResponseAsync();
+    }
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -308,6 +385,15 @@ public interface LROsCustomHeaders {
      * @return the {@link Observable<OperationStatus<Void>>} object if successful.
      */
     Observable<OperationStatus<Void>> beginPost202Retry200Async(Product product);
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROsCustomHeaderPost202Retry200Headers, Void>} object if successful.
+     */
+    RestResponse<LROsCustomHeaderPost202Retry200Headers, Void> beginPost202Retry200WithRestResponseAsync(Product product);
 
 
     /**
@@ -338,6 +424,14 @@ public interface LROsCustomHeaders {
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROsCustomHeaderPost202Retry200Headers, Void>} object if successful.
+     */
+    RestResponse<LROsCustomHeaderPost202Retry200Headers, Void> post202Retry200WithRestResponseAsync();
+    }
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -363,6 +457,15 @@ public interface LROsCustomHeaders {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> post202Retry200Async(Product product);
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROsCustomHeaderPost202Retry200Headers, Void>} object if successful.
+     */
+    RestResponse<LROsCustomHeaderPost202Retry200Headers, Void> post202Retry200WithRestResponseAsync(Product product);
 
 
     /**
@@ -393,6 +496,14 @@ public interface LROsCustomHeaders {
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROsCustomHeaderPostAsyncRetrySucceededHeaders, Void>} object if successful.
+     */
+    RestResponse<LROsCustomHeaderPostAsyncRetrySucceededHeaders, Void> beginPostAsyncRetrySucceededWithRestResponseAsync();
+    }
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -418,6 +529,15 @@ public interface LROsCustomHeaders {
      * @return the {@link Observable<OperationStatus<Void>>} object if successful.
      */
     Observable<OperationStatus<Void>> beginPostAsyncRetrySucceededAsync(Product product);
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROsCustomHeaderPostAsyncRetrySucceededHeaders, Void>} object if successful.
+     */
+    RestResponse<LROsCustomHeaderPostAsyncRetrySucceededHeaders, Void> beginPostAsyncRetrySucceededWithRestResponseAsync(Product product);
 
 
     /**
@@ -448,6 +568,14 @@ public interface LROsCustomHeaders {
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROsCustomHeaderPostAsyncRetrySucceededHeaders, Void>} object if successful.
+     */
+    RestResponse<LROsCustomHeaderPostAsyncRetrySucceededHeaders, Void> postAsyncRetrySucceededWithRestResponseAsync();
+    }
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -473,6 +601,15 @@ public interface LROsCustomHeaders {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postAsyncRetrySucceededAsync(Product product);
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link RestResponse<LROsCustomHeaderPostAsyncRetrySucceededHeaders, Void>} object if successful.
+     */
+    RestResponse<LROsCustomHeaderPostAsyncRetrySucceededHeaders, Void> postAsyncRetrySucceededWithRestResponseAsync(Product product);
 
 
 }

--- a/test/azure/src/main/java/fixtures/lro/implementation/AutoRestLongRunningOperationTestServiceImpl.java
+++ b/test/azure/src/main/java/fixtures/lro/implementation/AutoRestLongRunningOperationTestServiceImpl.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.AzureProxy;
 import com.microsoft.azure.AzureServiceClient;
 import com.microsoft.rest.credentials.ServiceClientCredentials;
 import com.microsoft.rest.RestClient;
+import com.microsoft.rest.RestResponse;
 import fixtures.lro.AutoRestLongRunningOperationTestService;
 import fixtures.lro.LRORetrys;
 import fixtures.lro.LROs;

--- a/test/azure/src/main/java/fixtures/lro/implementation/LRORetrysImpl.java
+++ b/test/azure/src/main/java/fixtures/lro/implementation/LRORetrysImpl.java
@@ -10,6 +10,7 @@
 
 package fixtures.lro.implementation;
 
+import com.microsoft.rest.RestResponse;
 import fixtures.lro.LRORetrys;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.CloudException;
@@ -77,7 +78,7 @@ public class LRORetrysImpl implements LRORetrys {
         @PUT("lro/retryerror/put/201/creating/succeeded/200")
         @ExpectedResponses({200, 201, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> put201CreatingSucceeded200(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Product>> put201CreatingSucceeded200(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LRORetrys beginPutAsyncRelativeRetrySucceeded" })
         @PUT("lro/retryerror/putasync/retry/succeeded")
@@ -89,7 +90,7 @@ public class LRORetrysImpl implements LRORetrys {
         @PUT("lro/retryerror/putasync/retry/succeeded")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> putAsyncRelativeRetrySucceeded(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LRORetrysPutAsyncRelativeRetrySucceededHeaders, Product>> putAsyncRelativeRetrySucceeded(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LRORetrys beginDeleteProvisioning202Accepted200Succeeded" })
         @DELETE("lro/retryerror/delete/provisioning/202/accepted/200/succeeded")
@@ -101,7 +102,7 @@ public class LRORetrysImpl implements LRORetrys {
         @DELETE("lro/retryerror/delete/provisioning/202/accepted/200/succeeded")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> deleteProvisioning202Accepted200Succeeded(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LRORetrysDeleteProvisioning202Accepted200SucceededHeaders, Product>> deleteProvisioning202Accepted200Succeeded(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LRORetrys beginDelete202Retry200" })
         @DELETE("lro/retryerror/delete/202/retry/200")
@@ -113,7 +114,7 @@ public class LRORetrysImpl implements LRORetrys {
         @DELETE("lro/retryerror/delete/202/retry/200")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> delete202Retry200(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LRORetrysDelete202Retry200Headers, Void>> delete202Retry200(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LRORetrys beginDeleteAsyncRelativeRetrySucceeded" })
         @DELETE("lro/retryerror/deleteasync/retry/succeeded")
@@ -125,7 +126,7 @@ public class LRORetrysImpl implements LRORetrys {
         @DELETE("lro/retryerror/deleteasync/retry/succeeded")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> deleteAsyncRelativeRetrySucceeded(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LRORetrysDeleteAsyncRelativeRetrySucceededHeaders, Void>> deleteAsyncRelativeRetrySucceeded(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LRORetrys beginPost202Retry200" })
         @POST("lro/retryerror/post/202/retry/200")
@@ -137,7 +138,7 @@ public class LRORetrysImpl implements LRORetrys {
         @POST("lro/retryerror/post/202/retry/200")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> post202Retry200(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LRORetrysPost202Retry200Headers, Void>> post202Retry200(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LRORetrys beginPostAsyncRelativeRetrySucceeded" })
         @POST("lro/retryerror/postasync/retry/succeeded")
@@ -149,7 +150,7 @@ public class LRORetrysImpl implements LRORetrys {
         @POST("lro/retryerror/postasync/retry/succeeded")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> postAsyncRelativeRetrySucceeded(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LRORetrysPostAsyncRelativeRetrySucceededHeaders, Void>> postAsyncRelativeRetrySucceeded(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -240,7 +241,7 @@ public class LRORetrysImpl implements LRORetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> put201CreatingSucceeded200Async(final ServiceCallback<Product> serviceCallback) {
+    public ServiceFuture<Product> put201CreatingSucceeded200Async(ServiceCallback<Product> serviceCallback) {
         return ServiceFuture.fromBody(put201CreatingSucceeded200Async(), serviceCallback);
     }
 
@@ -248,12 +249,24 @@ public class LRORetrysImpl implements LRORetrys {
      * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
      */
-    public Single<Product> put201CreatingSucceeded200Async() {
+    public Single<RestResponse<Void, Product>> put201CreatingSucceeded200WithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.put201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
+     */
+    public Single<Product> put201CreatingSucceeded200Async() {
+        return put201CreatingSucceeded200WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Product>, Product>() { public Product call(RestResponse<Void, Product> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -276,7 +289,7 @@ public class LRORetrysImpl implements LRORetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> put201CreatingSucceeded200Async(Product product, final ServiceCallback<Product> serviceCallback) {
+    public ServiceFuture<Product> put201CreatingSucceeded200Async(Product product, ServiceCallback<Product> serviceCallback) {
         return ServiceFuture.fromBody(put201CreatingSucceeded200Async(product), serviceCallback);
     }
 
@@ -285,12 +298,24 @@ public class LRORetrysImpl implements LRORetrys {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
      */
-    public Single<Product> put201CreatingSucceeded200Async(Product product) {
+    public Single<RestResponse<Void, Product>> put201CreatingSucceeded200WithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.put201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
+     */
+    public Single<Product> put201CreatingSucceeded200Async(Product product) {
+        return put201CreatingSucceeded200WithRestResponseAsync(product)
+            .map(new Func1<RestResponse<Void, Product>, Product>() { public Product call(RestResponse<Void, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -380,20 +405,32 @@ public class LRORetrysImpl implements LRORetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> putAsyncRelativeRetrySucceededAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRelativeRetrySucceededAsync(), serviceCallback);
+    public ServiceFuture<Product> putAsyncRelativeRetrySucceededAsync(ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRelativeRetrySucceededAsync(), serviceCallback);
     }
 
     /**
      * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LRORetrysPutAsyncRelativeRetrySucceededHeaders, Product> object
      */
-    public Single<Product> putAsyncRelativeRetrySucceededAsync() {
+    public Single<RestResponse<LRORetrysPutAsyncRelativeRetrySucceededHeaders, Product>> putAsyncRelativeRetrySucceededWithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.putAsyncRelativeRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LRORetrysPutAsyncRelativeRetrySucceededHeaders, Product> object
+     */
+    public Single<Product> putAsyncRelativeRetrySucceededAsync() {
+        return putAsyncRelativeRetrySucceededWithRestResponseAsync()
+            .map(new Func1<RestResponse<LRORetrysPutAsyncRelativeRetrySucceededHeaders, Product>, Product>() { public Product call(RestResponse<LRORetrysPutAsyncRelativeRetrySucceededHeaders, Product> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -416,8 +453,8 @@ public class LRORetrysImpl implements LRORetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> putAsyncRelativeRetrySucceededAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRelativeRetrySucceededAsync(product), serviceCallback);
+    public ServiceFuture<Product> putAsyncRelativeRetrySucceededAsync(Product product, ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRelativeRetrySucceededAsync(product), serviceCallback);
     }
 
     /**
@@ -425,12 +462,24 @@ public class LRORetrysImpl implements LRORetrys {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LRORetrysPutAsyncRelativeRetrySucceededHeaders, Product> object
      */
-    public Single<Product> putAsyncRelativeRetrySucceededAsync(Product product) {
+    public Single<RestResponse<LRORetrysPutAsyncRelativeRetrySucceededHeaders, Product>> putAsyncRelativeRetrySucceededWithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.putAsyncRelativeRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LRORetrysPutAsyncRelativeRetrySucceededHeaders, Product> object
+     */
+    public Single<Product> putAsyncRelativeRetrySucceededAsync(Product product) {
+        return putAsyncRelativeRetrySucceededWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LRORetrysPutAsyncRelativeRetrySucceededHeaders, Product>, Product>() { public Product call(RestResponse<LRORetrysPutAsyncRelativeRetrySucceededHeaders, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -485,19 +534,30 @@ public class LRORetrysImpl implements LRORetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> deleteProvisioning202Accepted200SucceededAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(deleteProvisioning202Accepted200SucceededAsync(), serviceCallback);
+    public ServiceFuture<Product> deleteProvisioning202Accepted200SucceededAsync(ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(deleteProvisioning202Accepted200SucceededAsync(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 500, then a  202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LRORetrysDeleteProvisioning202Accepted200SucceededHeaders, Product> object
      */
-    public Single<Product> deleteProvisioning202Accepted200SucceededAsync() {
+    public Single<RestResponse<LRORetrysDeleteProvisioning202Accepted200SucceededHeaders, Product>> deleteProvisioning202Accepted200SucceededWithRestResponseAsync() {
         return service.deleteProvisioning202Accepted200Succeeded(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 500, then a  202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LRORetrysDeleteProvisioning202Accepted200SucceededHeaders, Product> object
+     */
+    public Single<Product> deleteProvisioning202Accepted200SucceededAsync() {
+        return deleteProvisioning202Accepted200SucceededWithRestResponseAsync()
+            .map(new Func1<RestResponse<LRORetrysDeleteProvisioning202Accepted200SucceededHeaders, Product>, Product>() { public Product call(RestResponse<LRORetrysDeleteProvisioning202Accepted200SucceededHeaders, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -538,6 +598,7 @@ public class LRORetrysImpl implements LRORetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void delete202Retry200() {
         delete202Retry200Async().toBlocking().value();
@@ -550,19 +611,30 @@ public class LRORetrysImpl implements LRORetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> delete202Retry200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(delete202Retry200Async(), serviceCallback);
+    public ServiceFuture<Void> delete202Retry200Async(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(delete202Retry200Async(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 500, then a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LRORetrysDelete202Retry200Headers, Void> object
      */
-    public Single<Void> delete202Retry200Async() {
+    public Single<RestResponse<LRORetrysDelete202Retry200Headers, Void>> delete202Retry200WithRestResponseAsync() {
         return service.delete202Retry200(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 500, then a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LRORetrysDelete202Retry200Headers, Void> object
+     */
+    public Single<Void> delete202Retry200Async() {
+        return delete202Retry200WithRestResponseAsync()
+            .map(new Func1<RestResponse<LRORetrysDelete202Retry200Headers, Void>, Void>() { public Void call(RestResponse<LRORetrysDelete202Retry200Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -603,6 +675,7 @@ public class LRORetrysImpl implements LRORetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void deleteAsyncRelativeRetrySucceeded() {
         deleteAsyncRelativeRetrySucceededAsync().toBlocking().value();
@@ -615,19 +688,30 @@ public class LRORetrysImpl implements LRORetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> deleteAsyncRelativeRetrySucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(deleteAsyncRelativeRetrySucceededAsync(), serviceCallback);
+    public ServiceFuture<Void> deleteAsyncRelativeRetrySucceededAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(deleteAsyncRelativeRetrySucceededAsync(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 500, then a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LRORetrysDeleteAsyncRelativeRetrySucceededHeaders, Void> object
      */
-    public Single<Void> deleteAsyncRelativeRetrySucceededAsync() {
+    public Single<RestResponse<LRORetrysDeleteAsyncRelativeRetrySucceededHeaders, Void>> deleteAsyncRelativeRetrySucceededWithRestResponseAsync() {
         return service.deleteAsyncRelativeRetrySucceeded(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 500, then a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LRORetrysDeleteAsyncRelativeRetrySucceededHeaders, Void> object
+     */
+    public Single<Void> deleteAsyncRelativeRetrySucceededAsync() {
+        return deleteAsyncRelativeRetrySucceededWithRestResponseAsync()
+            .map(new Func1<RestResponse<LRORetrysDeleteAsyncRelativeRetrySucceededHeaders, Void>, Void>() { public Void call(RestResponse<LRORetrysDeleteAsyncRelativeRetrySucceededHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -702,6 +786,7 @@ public class LRORetrysImpl implements LRORetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post202Retry200() {
         post202Retry200Async().toBlocking().value();
@@ -714,20 +799,32 @@ public class LRORetrysImpl implements LRORetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post202Retry200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(post202Retry200Async(), serviceCallback);
+    public ServiceFuture<Void> post202Retry200Async(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(post202Retry200Async(), serviceCallback);
     }
 
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LRORetrysPost202Retry200Headers, Void> object
      */
-    public Single<Void> post202Retry200Async() {
+    public Single<RestResponse<LRORetrysPost202Retry200Headers, Void>> post202Retry200WithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.post202Retry200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LRORetrysPost202Retry200Headers, Void> object
+     */
+    public Single<Void> post202Retry200Async() {
+        return post202Retry200WithRestResponseAsync()
+            .map(new Func1<RestResponse<LRORetrysPost202Retry200Headers, Void>, Void>() { public Void call(RestResponse<LRORetrysPost202Retry200Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
@@ -736,6 +833,7 @@ public class LRORetrysImpl implements LRORetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post202Retry200(Product product) {
         post202Retry200Async(product).toBlocking().value();
@@ -749,8 +847,8 @@ public class LRORetrysImpl implements LRORetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post202Retry200Async(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(post202Retry200Async(product), serviceCallback);
+    public ServiceFuture<Void> post202Retry200Async(Product product, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(post202Retry200Async(product), serviceCallback);
     }
 
     /**
@@ -758,12 +856,24 @@ public class LRORetrysImpl implements LRORetrys {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LRORetrysPost202Retry200Headers, Void> object
      */
-    public Single<Void> post202Retry200Async(Product product) {
+    public Single<RestResponse<LRORetrysPost202Retry200Headers, Void>> post202Retry200WithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.post202Retry200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LRORetrysPost202Retry200Headers, Void> object
+     */
+    public Single<Void> post202Retry200Async(Product product) {
+        return post202Retry200WithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LRORetrysPost202Retry200Headers, Void>, Void>() { public Void call(RestResponse<LRORetrysPost202Retry200Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -838,6 +948,7 @@ public class LRORetrysImpl implements LRORetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postAsyncRelativeRetrySucceeded() {
         postAsyncRelativeRetrySucceededAsync().toBlocking().value();
@@ -850,20 +961,32 @@ public class LRORetrysImpl implements LRORetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postAsyncRelativeRetrySucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRelativeRetrySucceededAsync(), serviceCallback);
+    public ServiceFuture<Void> postAsyncRelativeRetrySucceededAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRelativeRetrySucceededAsync(), serviceCallback);
     }
 
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LRORetrysPostAsyncRelativeRetrySucceededHeaders, Void> object
      */
-    public Single<Void> postAsyncRelativeRetrySucceededAsync() {
+    public Single<RestResponse<LRORetrysPostAsyncRelativeRetrySucceededHeaders, Void>> postAsyncRelativeRetrySucceededWithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.postAsyncRelativeRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LRORetrysPostAsyncRelativeRetrySucceededHeaders, Void> object
+     */
+    public Single<Void> postAsyncRelativeRetrySucceededAsync() {
+        return postAsyncRelativeRetrySucceededWithRestResponseAsync()
+            .map(new Func1<RestResponse<LRORetrysPostAsyncRelativeRetrySucceededHeaders, Void>, Void>() { public Void call(RestResponse<LRORetrysPostAsyncRelativeRetrySucceededHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -872,6 +995,7 @@ public class LRORetrysImpl implements LRORetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postAsyncRelativeRetrySucceeded(Product product) {
         postAsyncRelativeRetrySucceededAsync(product).toBlocking().value();
@@ -885,8 +1009,8 @@ public class LRORetrysImpl implements LRORetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postAsyncRelativeRetrySucceededAsync(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRelativeRetrySucceededAsync(product), serviceCallback);
+    public ServiceFuture<Void> postAsyncRelativeRetrySucceededAsync(Product product, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRelativeRetrySucceededAsync(product), serviceCallback);
     }
 
     /**
@@ -894,12 +1018,24 @@ public class LRORetrysImpl implements LRORetrys {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LRORetrysPostAsyncRelativeRetrySucceededHeaders, Void> object
      */
-    public Single<Void> postAsyncRelativeRetrySucceededAsync(Product product) {
+    public Single<RestResponse<LRORetrysPostAsyncRelativeRetrySucceededHeaders, Void>> postAsyncRelativeRetrySucceededWithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.postAsyncRelativeRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LRORetrysPostAsyncRelativeRetrySucceededHeaders, Void> object
+     */
+    public Single<Void> postAsyncRelativeRetrySucceededAsync(Product product) {
+        return postAsyncRelativeRetrySucceededWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LRORetrysPostAsyncRelativeRetrySucceededHeaders, Void>, Void>() { public Void call(RestResponse<LRORetrysPostAsyncRelativeRetrySucceededHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azure/src/main/java/fixtures/lro/implementation/LROSADsImpl.java
+++ b/test/azure/src/main/java/fixtures/lro/implementation/LROSADsImpl.java
@@ -10,6 +10,7 @@
 
 package fixtures.lro.implementation;
 
+import com.microsoft.rest.RestResponse;
 import fixtures.lro.LROSADs;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.CloudException;
@@ -91,7 +92,7 @@ public class LROSADsImpl implements LROSADs {
         @PUT("lro/nonretryerror/put/400")
         @ExpectedResponses({200, 201, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> putNonRetry400(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Product>> putNonRetry400(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginPutNonRetry201Creating400" })
         @PUT("lro/nonretryerror/put/201/creating/400")
@@ -103,7 +104,7 @@ public class LROSADsImpl implements LROSADs {
         @PUT("lro/nonretryerror/put/201/creating/400")
         @ExpectedResponses({200, 201, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> putNonRetry201Creating400(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Product>> putNonRetry201Creating400(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginPutNonRetry201Creating400InvalidJson" })
         @PUT("lro/nonretryerror/put/201/creating/400/invalidjson")
@@ -115,7 +116,7 @@ public class LROSADsImpl implements LROSADs {
         @PUT("lro/nonretryerror/put/201/creating/400/invalidjson")
         @ExpectedResponses({200, 201, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> putNonRetry201Creating400InvalidJson(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Product>> putNonRetry201Creating400InvalidJson(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginPutAsyncRelativeRetry400" })
         @PUT("lro/nonretryerror/putasync/retry/400")
@@ -127,7 +128,7 @@ public class LROSADsImpl implements LROSADs {
         @PUT("lro/nonretryerror/putasync/retry/400")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> putAsyncRelativeRetry400(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsPutAsyncRelativeRetry400Headers, Product>> putAsyncRelativeRetry400(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginDeleteNonRetry400" })
         @DELETE("lro/nonretryerror/delete/400")
@@ -139,7 +140,7 @@ public class LROSADsImpl implements LROSADs {
         @DELETE("lro/nonretryerror/delete/400")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> deleteNonRetry400(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsDeleteNonRetry400Headers, Void>> deleteNonRetry400(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginDelete202NonRetry400" })
         @DELETE("lro/nonretryerror/delete/202/retry/400")
@@ -151,7 +152,7 @@ public class LROSADsImpl implements LROSADs {
         @DELETE("lro/nonretryerror/delete/202/retry/400")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> delete202NonRetry400(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsDelete202NonRetry400Headers, Void>> delete202NonRetry400(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginDeleteAsyncRelativeRetry400" })
         @DELETE("lro/nonretryerror/deleteasync/retry/400")
@@ -163,7 +164,7 @@ public class LROSADsImpl implements LROSADs {
         @DELETE("lro/nonretryerror/deleteasync/retry/400")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> deleteAsyncRelativeRetry400(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsDeleteAsyncRelativeRetry400Headers, Void>> deleteAsyncRelativeRetry400(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginPostNonRetry400" })
         @POST("lro/nonretryerror/post/400")
@@ -175,7 +176,7 @@ public class LROSADsImpl implements LROSADs {
         @POST("lro/nonretryerror/post/400")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> postNonRetry400(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsPostNonRetry400Headers, Void>> postNonRetry400(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginPost202NonRetry400" })
         @POST("lro/nonretryerror/post/202/retry/400")
@@ -187,7 +188,7 @@ public class LROSADsImpl implements LROSADs {
         @POST("lro/nonretryerror/post/202/retry/400")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> post202NonRetry400(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsPost202NonRetry400Headers, Void>> post202NonRetry400(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginPostAsyncRelativeRetry400" })
         @POST("lro/nonretryerror/postasync/retry/400")
@@ -199,7 +200,7 @@ public class LROSADsImpl implements LROSADs {
         @POST("lro/nonretryerror/postasync/retry/400")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> postAsyncRelativeRetry400(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsPostAsyncRelativeRetry400Headers, Void>> postAsyncRelativeRetry400(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginPutError201NoProvisioningStatePayload" })
         @PUT("lro/error/put/201/noprovisioningstatepayload")
@@ -211,7 +212,7 @@ public class LROSADsImpl implements LROSADs {
         @PUT("lro/error/put/201/noprovisioningstatepayload")
         @ExpectedResponses({200, 201, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> putError201NoProvisioningStatePayload(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Product>> putError201NoProvisioningStatePayload(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginPutAsyncRelativeRetryNoStatus" })
         @PUT("lro/error/putasync/retry/nostatus")
@@ -223,7 +224,7 @@ public class LROSADsImpl implements LROSADs {
         @PUT("lro/error/putasync/retry/nostatus")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> putAsyncRelativeRetryNoStatus(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsPutAsyncRelativeRetryNoStatusHeaders, Product>> putAsyncRelativeRetryNoStatus(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginPutAsyncRelativeRetryNoStatusPayload" })
         @PUT("lro/error/putasync/retry/nostatuspayload")
@@ -235,7 +236,7 @@ public class LROSADsImpl implements LROSADs {
         @PUT("lro/error/putasync/retry/nostatuspayload")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> putAsyncRelativeRetryNoStatusPayload(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders, Product>> putAsyncRelativeRetryNoStatusPayload(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginDelete204Succeeded" })
         @DELETE("lro/error/delete/204/nolocation")
@@ -247,7 +248,7 @@ public class LROSADsImpl implements LROSADs {
         @DELETE("lro/error/delete/204/nolocation")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> delete204Succeeded(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> delete204Succeeded(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginDeleteAsyncRelativeRetryNoStatus" })
         @DELETE("lro/error/deleteasync/retry/nostatus")
@@ -259,7 +260,7 @@ public class LROSADsImpl implements LROSADs {
         @DELETE("lro/error/deleteasync/retry/nostatus")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> deleteAsyncRelativeRetryNoStatus(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsDeleteAsyncRelativeRetryNoStatusHeaders, Void>> deleteAsyncRelativeRetryNoStatus(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginPost202NoLocation" })
         @POST("lro/error/post/202/nolocation")
@@ -271,7 +272,7 @@ public class LROSADsImpl implements LROSADs {
         @POST("lro/error/post/202/nolocation")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> post202NoLocation(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsPost202NoLocationHeaders, Void>> post202NoLocation(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginPostAsyncRelativeRetryNoPayload" })
         @POST("lro/error/postasync/retry/nopayload")
@@ -283,7 +284,7 @@ public class LROSADsImpl implements LROSADs {
         @POST("lro/error/postasync/retry/nopayload")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> postAsyncRelativeRetryNoPayload(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsPostAsyncRelativeRetryNoPayloadHeaders, Void>> postAsyncRelativeRetryNoPayload(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginPut200InvalidJson" })
         @PUT("lro/error/put/200/invalidjson")
@@ -295,7 +296,7 @@ public class LROSADsImpl implements LROSADs {
         @PUT("lro/error/put/200/invalidjson")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> put200InvalidJson(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Product>> put200InvalidJson(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginPutAsyncRelativeRetryInvalidHeader" })
         @PUT("lro/error/putasync/retry/invalidheader")
@@ -307,7 +308,7 @@ public class LROSADsImpl implements LROSADs {
         @PUT("lro/error/putasync/retry/invalidheader")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> putAsyncRelativeRetryInvalidHeader(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders, Product>> putAsyncRelativeRetryInvalidHeader(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginPutAsyncRelativeRetryInvalidJsonPolling" })
         @PUT("lro/error/putasync/retry/invalidjsonpolling")
@@ -319,7 +320,7 @@ public class LROSADsImpl implements LROSADs {
         @PUT("lro/error/putasync/retry/invalidjsonpolling")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> putAsyncRelativeRetryInvalidJsonPolling(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders, Product>> putAsyncRelativeRetryInvalidJsonPolling(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginDelete202RetryInvalidHeader" })
         @DELETE("lro/error/delete/202/retry/invalidheader")
@@ -331,7 +332,7 @@ public class LROSADsImpl implements LROSADs {
         @DELETE("lro/error/delete/202/retry/invalidheader")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> delete202RetryInvalidHeader(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsDelete202RetryInvalidHeaderHeaders, Void>> delete202RetryInvalidHeader(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginDeleteAsyncRelativeRetryInvalidHeader" })
         @DELETE("lro/error/deleteasync/retry/invalidheader")
@@ -343,7 +344,7 @@ public class LROSADsImpl implements LROSADs {
         @DELETE("lro/error/deleteasync/retry/invalidheader")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> deleteAsyncRelativeRetryInvalidHeader(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders, Void>> deleteAsyncRelativeRetryInvalidHeader(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginDeleteAsyncRelativeRetryInvalidJsonPolling" })
         @DELETE("lro/error/deleteasync/retry/invalidjsonpolling")
@@ -355,7 +356,7 @@ public class LROSADsImpl implements LROSADs {
         @DELETE("lro/error/deleteasync/retry/invalidjsonpolling")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> deleteAsyncRelativeRetryInvalidJsonPolling(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders, Void>> deleteAsyncRelativeRetryInvalidJsonPolling(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginPost202RetryInvalidHeader" })
         @POST("lro/error/post/202/retry/invalidheader")
@@ -367,7 +368,7 @@ public class LROSADsImpl implements LROSADs {
         @POST("lro/error/post/202/retry/invalidheader")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> post202RetryInvalidHeader(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsPost202RetryInvalidHeaderHeaders, Void>> post202RetryInvalidHeader(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginPostAsyncRelativeRetryInvalidHeader" })
         @POST("lro/error/postasync/retry/invalidheader")
@@ -379,7 +380,7 @@ public class LROSADsImpl implements LROSADs {
         @POST("lro/error/postasync/retry/invalidheader")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> postAsyncRelativeRetryInvalidHeader(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders, Void>> postAsyncRelativeRetryInvalidHeader(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginPostAsyncRelativeRetryInvalidJsonPolling" })
         @POST("lro/error/postasync/retry/invalidjsonpolling")
@@ -391,7 +392,7 @@ public class LROSADsImpl implements LROSADs {
         @POST("lro/error/postasync/retry/invalidjsonpolling")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> postAsyncRelativeRetryInvalidJsonPolling(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders, Void>> postAsyncRelativeRetryInvalidJsonPolling(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -482,7 +483,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> putNonRetry400Async(final ServiceCallback<Product> serviceCallback) {
+    public ServiceFuture<Product> putNonRetry400Async(ServiceCallback<Product> serviceCallback) {
         return ServiceFuture.fromBody(putNonRetry400Async(), serviceCallback);
     }
 
@@ -490,12 +491,24 @@ public class LROSADsImpl implements LROSADs {
      * Long running put request, service returns a 400 to the initial request.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
      */
-    public Single<Product> putNonRetry400Async() {
+    public Single<RestResponse<Void, Product>> putNonRetry400WithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.putNonRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 400 to the initial request.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
+     */
+    public Single<Product> putNonRetry400Async() {
+        return putNonRetry400WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Product>, Product>() { public Product call(RestResponse<Void, Product> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 400 to the initial request.
@@ -518,7 +531,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> putNonRetry400Async(Product product, final ServiceCallback<Product> serviceCallback) {
+    public ServiceFuture<Product> putNonRetry400Async(Product product, ServiceCallback<Product> serviceCallback) {
         return ServiceFuture.fromBody(putNonRetry400Async(product), serviceCallback);
     }
 
@@ -527,12 +540,24 @@ public class LROSADsImpl implements LROSADs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
      */
-    public Single<Product> putNonRetry400Async(Product product) {
+    public Single<RestResponse<Void, Product>> putNonRetry400WithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.putNonRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 400 to the initial request.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
+     */
+    public Single<Product> putNonRetry400Async(Product product) {
+        return putNonRetry400WithRestResponseAsync(product)
+            .map(new Func1<RestResponse<Void, Product>, Product>() { public Product call(RestResponse<Void, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -622,7 +647,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> putNonRetry201Creating400Async(final ServiceCallback<Product> serviceCallback) {
+    public ServiceFuture<Product> putNonRetry201Creating400Async(ServiceCallback<Product> serviceCallback) {
         return ServiceFuture.fromBody(putNonRetry201Creating400Async(), serviceCallback);
     }
 
@@ -630,12 +655,24 @@ public class LROSADsImpl implements LROSADs {
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
      */
-    public Single<Product> putNonRetry201Creating400Async() {
+    public Single<RestResponse<Void, Product>> putNonRetry201Creating400WithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.putNonRetry201Creating400(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
+     */
+    public Single<Product> putNonRetry201Creating400Async() {
+        return putNonRetry201Creating400WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Product>, Product>() { public Product call(RestResponse<Void, Product> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
@@ -658,7 +695,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> putNonRetry201Creating400Async(Product product, final ServiceCallback<Product> serviceCallback) {
+    public ServiceFuture<Product> putNonRetry201Creating400Async(Product product, ServiceCallback<Product> serviceCallback) {
         return ServiceFuture.fromBody(putNonRetry201Creating400Async(product), serviceCallback);
     }
 
@@ -667,12 +704,24 @@ public class LROSADsImpl implements LROSADs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
      */
-    public Single<Product> putNonRetry201Creating400Async(Product product) {
+    public Single<RestResponse<Void, Product>> putNonRetry201Creating400WithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.putNonRetry201Creating400(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
+     */
+    public Single<Product> putNonRetry201Creating400Async(Product product) {
+        return putNonRetry201Creating400WithRestResponseAsync(product)
+            .map(new Func1<RestResponse<Void, Product>, Product>() { public Product call(RestResponse<Void, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -762,7 +811,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> putNonRetry201Creating400InvalidJsonAsync(final ServiceCallback<Product> serviceCallback) {
+    public ServiceFuture<Product> putNonRetry201Creating400InvalidJsonAsync(ServiceCallback<Product> serviceCallback) {
         return ServiceFuture.fromBody(putNonRetry201Creating400InvalidJsonAsync(), serviceCallback);
     }
 
@@ -770,12 +819,24 @@ public class LROSADsImpl implements LROSADs {
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
      */
-    public Single<Product> putNonRetry201Creating400InvalidJsonAsync() {
+    public Single<RestResponse<Void, Product>> putNonRetry201Creating400InvalidJsonWithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.putNonRetry201Creating400InvalidJson(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
+     */
+    public Single<Product> putNonRetry201Creating400InvalidJsonAsync() {
+        return putNonRetry201Creating400InvalidJsonWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Product>, Product>() { public Product call(RestResponse<Void, Product> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
@@ -798,7 +859,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> putNonRetry201Creating400InvalidJsonAsync(Product product, final ServiceCallback<Product> serviceCallback) {
+    public ServiceFuture<Product> putNonRetry201Creating400InvalidJsonAsync(Product product, ServiceCallback<Product> serviceCallback) {
         return ServiceFuture.fromBody(putNonRetry201Creating400InvalidJsonAsync(product), serviceCallback);
     }
 
@@ -807,12 +868,24 @@ public class LROSADsImpl implements LROSADs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
      */
-    public Single<Product> putNonRetry201Creating400InvalidJsonAsync(Product product) {
+    public Single<RestResponse<Void, Product>> putNonRetry201Creating400InvalidJsonWithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.putNonRetry201Creating400InvalidJson(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
+     */
+    public Single<Product> putNonRetry201Creating400InvalidJsonAsync(Product product) {
+        return putNonRetry201Creating400InvalidJsonWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<Void, Product>, Product>() { public Product call(RestResponse<Void, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -902,20 +975,32 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> putAsyncRelativeRetry400Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRelativeRetry400Async(), serviceCallback);
+    public ServiceFuture<Product> putAsyncRelativeRetry400Async(ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRelativeRetry400Async(), serviceCallback);
     }
 
     /**
      * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetry400Headers, Product> object
      */
-    public Single<Product> putAsyncRelativeRetry400Async() {
+    public Single<RestResponse<LROSADsPutAsyncRelativeRetry400Headers, Product>> putAsyncRelativeRetry400WithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.putAsyncRelativeRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetry400Headers, Product> object
+     */
+    public Single<Product> putAsyncRelativeRetry400Async() {
+        return putAsyncRelativeRetry400WithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsPutAsyncRelativeRetry400Headers, Product>, Product>() { public Product call(RestResponse<LROSADsPutAsyncRelativeRetry400Headers, Product> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -938,8 +1023,8 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> putAsyncRelativeRetry400Async(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRelativeRetry400Async(product), serviceCallback);
+    public ServiceFuture<Product> putAsyncRelativeRetry400Async(Product product, ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRelativeRetry400Async(product), serviceCallback);
     }
 
     /**
@@ -947,12 +1032,24 @@ public class LROSADsImpl implements LROSADs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetry400Headers, Product> object
      */
-    public Single<Product> putAsyncRelativeRetry400Async(Product product) {
+    public Single<RestResponse<LROSADsPutAsyncRelativeRetry400Headers, Product>> putAsyncRelativeRetry400WithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.putAsyncRelativeRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetry400Headers, Product> object
+     */
+    public Single<Product> putAsyncRelativeRetry400Async(Product product) {
+        return putAsyncRelativeRetry400WithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROSADsPutAsyncRelativeRetry400Headers, Product>, Product>() { public Product call(RestResponse<LROSADsPutAsyncRelativeRetry400Headers, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -993,6 +1090,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void deleteNonRetry400() {
         deleteNonRetry400Async().toBlocking().value();
@@ -1005,19 +1103,30 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> deleteNonRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(deleteNonRetry400Async(), serviceCallback);
+    public ServiceFuture<Void> deleteNonRetry400Async(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(deleteNonRetry400Async(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 400 with an error body.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsDeleteNonRetry400Headers, Void> object
      */
-    public Single<Void> deleteNonRetry400Async() {
+    public Single<RestResponse<LROSADsDeleteNonRetry400Headers, Void>> deleteNonRetry400WithRestResponseAsync() {
         return service.deleteNonRetry400(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 400 with an error body.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsDeleteNonRetry400Headers, Void> object
+     */
+    public Single<Void> deleteNonRetry400Async() {
+        return deleteNonRetry400WithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsDeleteNonRetry400Headers, Void>, Void>() { public Void call(RestResponse<LROSADsDeleteNonRetry400Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1058,6 +1167,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void delete202NonRetry400() {
         delete202NonRetry400Async().toBlocking().value();
@@ -1070,19 +1180,30 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> delete202NonRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(delete202NonRetry400Async(), serviceCallback);
+    public ServiceFuture<Void> delete202NonRetry400Async(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(delete202NonRetry400Async(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 202 with a location header.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsDelete202NonRetry400Headers, Void> object
      */
-    public Single<Void> delete202NonRetry400Async() {
+    public Single<RestResponse<LROSADsDelete202NonRetry400Headers, Void>> delete202NonRetry400WithRestResponseAsync() {
         return service.delete202NonRetry400(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 202 with a location header.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsDelete202NonRetry400Headers, Void> object
+     */
+    public Single<Void> delete202NonRetry400Async() {
+        return delete202NonRetry400WithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsDelete202NonRetry400Headers, Void>, Void>() { public Void call(RestResponse<LROSADsDelete202NonRetry400Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1123,6 +1244,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void deleteAsyncRelativeRetry400() {
         deleteAsyncRelativeRetry400Async().toBlocking().value();
@@ -1135,19 +1257,30 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> deleteAsyncRelativeRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(deleteAsyncRelativeRetry400Async(), serviceCallback);
+    public ServiceFuture<Void> deleteAsyncRelativeRetry400Async(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(deleteAsyncRelativeRetry400Async(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsDeleteAsyncRelativeRetry400Headers, Void> object
      */
-    public Single<Void> deleteAsyncRelativeRetry400Async() {
+    public Single<RestResponse<LROSADsDeleteAsyncRelativeRetry400Headers, Void>> deleteAsyncRelativeRetry400WithRestResponseAsync() {
         return service.deleteAsyncRelativeRetry400(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsDeleteAsyncRelativeRetry400Headers, Void> object
+     */
+    public Single<Void> deleteAsyncRelativeRetry400Async() {
+        return deleteAsyncRelativeRetry400WithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsDeleteAsyncRelativeRetry400Headers, Void>, Void>() { public Void call(RestResponse<LROSADsDeleteAsyncRelativeRetry400Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1222,6 +1355,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postNonRetry400() {
         postNonRetry400Async().toBlocking().value();
@@ -1234,20 +1368,32 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postNonRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postNonRetry400Async(), serviceCallback);
+    public ServiceFuture<Void> postNonRetry400Async(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postNonRetry400Async(), serviceCallback);
     }
 
     /**
      * Long running post request, service returns a 400 with no error body.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostNonRetry400Headers, Void> object
      */
-    public Single<Void> postNonRetry400Async() {
+    public Single<RestResponse<LROSADsPostNonRetry400Headers, Void>> postNonRetry400WithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.postNonRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 400 with no error body.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostNonRetry400Headers, Void> object
+     */
+    public Single<Void> postNonRetry400Async() {
+        return postNonRetry400WithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsPostNonRetry400Headers, Void>, Void>() { public Void call(RestResponse<LROSADsPostNonRetry400Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running post request, service returns a 400 with no error body.
@@ -1256,6 +1402,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postNonRetry400(Product product) {
         postNonRetry400Async(product).toBlocking().value();
@@ -1269,8 +1416,8 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postNonRetry400Async(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postNonRetry400Async(product), serviceCallback);
+    public ServiceFuture<Void> postNonRetry400Async(Product product, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postNonRetry400Async(product), serviceCallback);
     }
 
     /**
@@ -1278,12 +1425,24 @@ public class LROSADsImpl implements LROSADs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostNonRetry400Headers, Void> object
      */
-    public Single<Void> postNonRetry400Async(Product product) {
+    public Single<RestResponse<LROSADsPostNonRetry400Headers, Void>> postNonRetry400WithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.postNonRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 400 with no error body.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostNonRetry400Headers, Void> object
+     */
+    public Single<Void> postNonRetry400Async(Product product) {
+        return postNonRetry400WithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROSADsPostNonRetry400Headers, Void>, Void>() { public Void call(RestResponse<LROSADsPostNonRetry400Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1358,6 +1517,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post202NonRetry400() {
         post202NonRetry400Async().toBlocking().value();
@@ -1370,20 +1530,32 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post202NonRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(post202NonRetry400Async(), serviceCallback);
+    public ServiceFuture<Void> post202NonRetry400Async(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(post202NonRetry400Async(), serviceCallback);
     }
 
     /**
      * Long running post request, service returns a 202 with a location header.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsPost202NonRetry400Headers, Void> object
      */
-    public Single<Void> post202NonRetry400Async() {
+    public Single<RestResponse<LROSADsPost202NonRetry400Headers, Void>> post202NonRetry400WithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.post202NonRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 with a location header.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPost202NonRetry400Headers, Void> object
+     */
+    public Single<Void> post202NonRetry400Async() {
+        return post202NonRetry400WithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsPost202NonRetry400Headers, Void>, Void>() { public Void call(RestResponse<LROSADsPost202NonRetry400Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running post request, service returns a 202 with a location header.
@@ -1392,6 +1564,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post202NonRetry400(Product product) {
         post202NonRetry400Async(product).toBlocking().value();
@@ -1405,8 +1578,8 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post202NonRetry400Async(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(post202NonRetry400Async(product), serviceCallback);
+    public ServiceFuture<Void> post202NonRetry400Async(Product product, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(post202NonRetry400Async(product), serviceCallback);
     }
 
     /**
@@ -1414,12 +1587,24 @@ public class LROSADsImpl implements LROSADs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsPost202NonRetry400Headers, Void> object
      */
-    public Single<Void> post202NonRetry400Async(Product product) {
+    public Single<RestResponse<LROSADsPost202NonRetry400Headers, Void>> post202NonRetry400WithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.post202NonRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 with a location header.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPost202NonRetry400Headers, Void> object
+     */
+    public Single<Void> post202NonRetry400Async(Product product) {
+        return post202NonRetry400WithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROSADsPost202NonRetry400Headers, Void>, Void>() { public Void call(RestResponse<LROSADsPost202NonRetry400Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1494,6 +1679,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postAsyncRelativeRetry400() {
         postAsyncRelativeRetry400Async().toBlocking().value();
@@ -1506,20 +1692,32 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postAsyncRelativeRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRelativeRetry400Async(), serviceCallback);
+    public ServiceFuture<Void> postAsyncRelativeRetry400Async(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRelativeRetry400Async(), serviceCallback);
     }
 
     /**
      * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostAsyncRelativeRetry400Headers, Void> object
      */
-    public Single<Void> postAsyncRelativeRetry400Async() {
+    public Single<RestResponse<LROSADsPostAsyncRelativeRetry400Headers, Void>> postAsyncRelativeRetry400WithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.postAsyncRelativeRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostAsyncRelativeRetry400Headers, Void> object
+     */
+    public Single<Void> postAsyncRelativeRetry400Async() {
+        return postAsyncRelativeRetry400WithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsPostAsyncRelativeRetry400Headers, Void>, Void>() { public Void call(RestResponse<LROSADsPostAsyncRelativeRetry400Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1528,6 +1726,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postAsyncRelativeRetry400(Product product) {
         postAsyncRelativeRetry400Async(product).toBlocking().value();
@@ -1541,8 +1740,8 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postAsyncRelativeRetry400Async(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRelativeRetry400Async(product), serviceCallback);
+    public ServiceFuture<Void> postAsyncRelativeRetry400Async(Product product, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRelativeRetry400Async(product), serviceCallback);
     }
 
     /**
@@ -1550,12 +1749,24 @@ public class LROSADsImpl implements LROSADs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostAsyncRelativeRetry400Headers, Void> object
      */
-    public Single<Void> postAsyncRelativeRetry400Async(Product product) {
+    public Single<RestResponse<LROSADsPostAsyncRelativeRetry400Headers, Void>> postAsyncRelativeRetry400WithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.postAsyncRelativeRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostAsyncRelativeRetry400Headers, Void> object
+     */
+    public Single<Void> postAsyncRelativeRetry400Async(Product product) {
+        return postAsyncRelativeRetry400WithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROSADsPostAsyncRelativeRetry400Headers, Void>, Void>() { public Void call(RestResponse<LROSADsPostAsyncRelativeRetry400Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1645,7 +1856,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> putError201NoProvisioningStatePayloadAsync(final ServiceCallback<Product> serviceCallback) {
+    public ServiceFuture<Product> putError201NoProvisioningStatePayloadAsync(ServiceCallback<Product> serviceCallback) {
         return ServiceFuture.fromBody(putError201NoProvisioningStatePayloadAsync(), serviceCallback);
     }
 
@@ -1653,12 +1864,24 @@ public class LROSADsImpl implements LROSADs {
      * Long running put request, service returns a 201 to the initial request with no payload.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
      */
-    public Single<Product> putError201NoProvisioningStatePayloadAsync() {
+    public Single<RestResponse<Void, Product>> putError201NoProvisioningStatePayloadWithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.putError201NoProvisioningStatePayload(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request with no payload.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
+     */
+    public Single<Product> putError201NoProvisioningStatePayloadAsync() {
+        return putError201NoProvisioningStatePayloadWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Product>, Product>() { public Product call(RestResponse<Void, Product> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 201 to the initial request with no payload.
@@ -1681,7 +1904,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> putError201NoProvisioningStatePayloadAsync(Product product, final ServiceCallback<Product> serviceCallback) {
+    public ServiceFuture<Product> putError201NoProvisioningStatePayloadAsync(Product product, ServiceCallback<Product> serviceCallback) {
         return ServiceFuture.fromBody(putError201NoProvisioningStatePayloadAsync(product), serviceCallback);
     }
 
@@ -1690,12 +1913,24 @@ public class LROSADsImpl implements LROSADs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
      */
-    public Single<Product> putError201NoProvisioningStatePayloadAsync(Product product) {
+    public Single<RestResponse<Void, Product>> putError201NoProvisioningStatePayloadWithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.putError201NoProvisioningStatePayload(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request with no payload.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
+     */
+    public Single<Product> putError201NoProvisioningStatePayloadAsync(Product product) {
+        return putError201NoProvisioningStatePayloadWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<Void, Product>, Product>() { public Product call(RestResponse<Void, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1785,20 +2020,32 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> putAsyncRelativeRetryNoStatusAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRelativeRetryNoStatusAsync(), serviceCallback);
+    public ServiceFuture<Product> putAsyncRelativeRetryNoStatusAsync(ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRelativeRetryNoStatusAsync(), serviceCallback);
     }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetryNoStatusHeaders, Product> object
      */
-    public Single<Product> putAsyncRelativeRetryNoStatusAsync() {
+    public Single<RestResponse<LROSADsPutAsyncRelativeRetryNoStatusHeaders, Product>> putAsyncRelativeRetryNoStatusWithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.putAsyncRelativeRetryNoStatus(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetryNoStatusHeaders, Product> object
+     */
+    public Single<Product> putAsyncRelativeRetryNoStatusAsync() {
+        return putAsyncRelativeRetryNoStatusWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsPutAsyncRelativeRetryNoStatusHeaders, Product>, Product>() { public Product call(RestResponse<LROSADsPutAsyncRelativeRetryNoStatusHeaders, Product> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1821,8 +2068,8 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> putAsyncRelativeRetryNoStatusAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRelativeRetryNoStatusAsync(product), serviceCallback);
+    public ServiceFuture<Product> putAsyncRelativeRetryNoStatusAsync(Product product, ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRelativeRetryNoStatusAsync(product), serviceCallback);
     }
 
     /**
@@ -1830,12 +2077,24 @@ public class LROSADsImpl implements LROSADs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetryNoStatusHeaders, Product> object
      */
-    public Single<Product> putAsyncRelativeRetryNoStatusAsync(Product product) {
+    public Single<RestResponse<LROSADsPutAsyncRelativeRetryNoStatusHeaders, Product>> putAsyncRelativeRetryNoStatusWithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.putAsyncRelativeRetryNoStatus(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetryNoStatusHeaders, Product> object
+     */
+    public Single<Product> putAsyncRelativeRetryNoStatusAsync(Product product) {
+        return putAsyncRelativeRetryNoStatusWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROSADsPutAsyncRelativeRetryNoStatusHeaders, Product>, Product>() { public Product call(RestResponse<LROSADsPutAsyncRelativeRetryNoStatusHeaders, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1925,20 +2184,32 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> putAsyncRelativeRetryNoStatusPayloadAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRelativeRetryNoStatusPayloadAsync(), serviceCallback);
+    public ServiceFuture<Product> putAsyncRelativeRetryNoStatusPayloadAsync(ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRelativeRetryNoStatusPayloadAsync(), serviceCallback);
     }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders, Product> object
      */
-    public Single<Product> putAsyncRelativeRetryNoStatusPayloadAsync() {
+    public Single<RestResponse<LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders, Product>> putAsyncRelativeRetryNoStatusPayloadWithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.putAsyncRelativeRetryNoStatusPayload(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders, Product> object
+     */
+    public Single<Product> putAsyncRelativeRetryNoStatusPayloadAsync() {
+        return putAsyncRelativeRetryNoStatusPayloadWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders, Product>, Product>() { public Product call(RestResponse<LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders, Product> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1961,8 +2232,8 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> putAsyncRelativeRetryNoStatusPayloadAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRelativeRetryNoStatusPayloadAsync(product), serviceCallback);
+    public ServiceFuture<Product> putAsyncRelativeRetryNoStatusPayloadAsync(Product product, ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRelativeRetryNoStatusPayloadAsync(product), serviceCallback);
     }
 
     /**
@@ -1970,12 +2241,24 @@ public class LROSADsImpl implements LROSADs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders, Product> object
      */
-    public Single<Product> putAsyncRelativeRetryNoStatusPayloadAsync(Product product) {
+    public Single<RestResponse<LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders, Product>> putAsyncRelativeRetryNoStatusPayloadWithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.putAsyncRelativeRetryNoStatusPayload(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders, Product> object
+     */
+    public Single<Product> putAsyncRelativeRetryNoStatusPayloadAsync(Product product) {
+        return putAsyncRelativeRetryNoStatusPayloadWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders, Product>, Product>() { public Product call(RestResponse<LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2016,6 +2299,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void delete204Succeeded() {
         delete204SucceededAsync().toBlocking().value();
@@ -2028,7 +2312,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> delete204SucceededAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> delete204SucceededAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(delete204SucceededAsync(), serviceCallback);
     }
 
@@ -2036,11 +2320,22 @@ public class LROSADsImpl implements LROSADs {
      * Long running delete request, service returns a 204 to the initial request, indicating success.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> delete204SucceededAsync() {
+    public Single<RestResponse<Void, Void>> delete204SucceededWithRestResponseAsync() {
         return service.delete204Succeeded(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 204 to the initial request, indicating success.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> delete204SucceededAsync() {
+        return delete204SucceededWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2081,6 +2376,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void deleteAsyncRelativeRetryNoStatus() {
         deleteAsyncRelativeRetryNoStatusAsync().toBlocking().value();
@@ -2093,19 +2389,30 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> deleteAsyncRelativeRetryNoStatusAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(deleteAsyncRelativeRetryNoStatusAsync(), serviceCallback);
+    public ServiceFuture<Void> deleteAsyncRelativeRetryNoStatusAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(deleteAsyncRelativeRetryNoStatusAsync(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsDeleteAsyncRelativeRetryNoStatusHeaders, Void> object
      */
-    public Single<Void> deleteAsyncRelativeRetryNoStatusAsync() {
+    public Single<RestResponse<LROSADsDeleteAsyncRelativeRetryNoStatusHeaders, Void>> deleteAsyncRelativeRetryNoStatusWithRestResponseAsync() {
         return service.deleteAsyncRelativeRetryNoStatus(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsDeleteAsyncRelativeRetryNoStatusHeaders, Void> object
+     */
+    public Single<Void> deleteAsyncRelativeRetryNoStatusAsync() {
+        return deleteAsyncRelativeRetryNoStatusWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsDeleteAsyncRelativeRetryNoStatusHeaders, Void>, Void>() { public Void call(RestResponse<LROSADsDeleteAsyncRelativeRetryNoStatusHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2180,6 +2487,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post202NoLocation() {
         post202NoLocationAsync().toBlocking().value();
@@ -2192,20 +2500,32 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post202NoLocationAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(post202NoLocationAsync(), serviceCallback);
+    public ServiceFuture<Void> post202NoLocationAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(post202NoLocationAsync(), serviceCallback);
     }
 
     /**
      * Long running post request, service returns a 202 to the initial request, without a location header.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsPost202NoLocationHeaders, Void> object
      */
-    public Single<Void> post202NoLocationAsync() {
+    public Single<RestResponse<LROSADsPost202NoLocationHeaders, Void>> post202NoLocationWithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.post202NoLocation(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, without a location header.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPost202NoLocationHeaders, Void> object
+     */
+    public Single<Void> post202NoLocationAsync() {
+        return post202NoLocationWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsPost202NoLocationHeaders, Void>, Void>() { public Void call(RestResponse<LROSADsPost202NoLocationHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running post request, service returns a 202 to the initial request, without a location header.
@@ -2214,6 +2534,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post202NoLocation(Product product) {
         post202NoLocationAsync(product).toBlocking().value();
@@ -2227,8 +2548,8 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post202NoLocationAsync(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(post202NoLocationAsync(product), serviceCallback);
+    public ServiceFuture<Void> post202NoLocationAsync(Product product, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(post202NoLocationAsync(product), serviceCallback);
     }
 
     /**
@@ -2236,12 +2557,24 @@ public class LROSADsImpl implements LROSADs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsPost202NoLocationHeaders, Void> object
      */
-    public Single<Void> post202NoLocationAsync(Product product) {
+    public Single<RestResponse<LROSADsPost202NoLocationHeaders, Void>> post202NoLocationWithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.post202NoLocation(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, without a location header.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPost202NoLocationHeaders, Void> object
+     */
+    public Single<Void> post202NoLocationAsync(Product product) {
+        return post202NoLocationWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROSADsPost202NoLocationHeaders, Void>, Void>() { public Void call(RestResponse<LROSADsPost202NoLocationHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2316,6 +2649,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postAsyncRelativeRetryNoPayload() {
         postAsyncRelativeRetryNoPayloadAsync().toBlocking().value();
@@ -2328,20 +2662,32 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postAsyncRelativeRetryNoPayloadAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRelativeRetryNoPayloadAsync(), serviceCallback);
+    public ServiceFuture<Void> postAsyncRelativeRetryNoPayloadAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRelativeRetryNoPayloadAsync(), serviceCallback);
     }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostAsyncRelativeRetryNoPayloadHeaders, Void> object
      */
-    public Single<Void> postAsyncRelativeRetryNoPayloadAsync() {
+    public Single<RestResponse<LROSADsPostAsyncRelativeRetryNoPayloadHeaders, Void>> postAsyncRelativeRetryNoPayloadWithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.postAsyncRelativeRetryNoPayload(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostAsyncRelativeRetryNoPayloadHeaders, Void> object
+     */
+    public Single<Void> postAsyncRelativeRetryNoPayloadAsync() {
+        return postAsyncRelativeRetryNoPayloadWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsPostAsyncRelativeRetryNoPayloadHeaders, Void>, Void>() { public Void call(RestResponse<LROSADsPostAsyncRelativeRetryNoPayloadHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2350,6 +2696,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postAsyncRelativeRetryNoPayload(Product product) {
         postAsyncRelativeRetryNoPayloadAsync(product).toBlocking().value();
@@ -2363,8 +2710,8 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postAsyncRelativeRetryNoPayloadAsync(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRelativeRetryNoPayloadAsync(product), serviceCallback);
+    public ServiceFuture<Void> postAsyncRelativeRetryNoPayloadAsync(Product product, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRelativeRetryNoPayloadAsync(product), serviceCallback);
     }
 
     /**
@@ -2372,12 +2719,24 @@ public class LROSADsImpl implements LROSADs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostAsyncRelativeRetryNoPayloadHeaders, Void> object
      */
-    public Single<Void> postAsyncRelativeRetryNoPayloadAsync(Product product) {
+    public Single<RestResponse<LROSADsPostAsyncRelativeRetryNoPayloadHeaders, Void>> postAsyncRelativeRetryNoPayloadWithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.postAsyncRelativeRetryNoPayload(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostAsyncRelativeRetryNoPayloadHeaders, Void> object
+     */
+    public Single<Void> postAsyncRelativeRetryNoPayloadAsync(Product product) {
+        return postAsyncRelativeRetryNoPayloadWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROSADsPostAsyncRelativeRetryNoPayloadHeaders, Void>, Void>() { public Void call(RestResponse<LROSADsPostAsyncRelativeRetryNoPayloadHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2467,7 +2826,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> put200InvalidJsonAsync(final ServiceCallback<Product> serviceCallback) {
+    public ServiceFuture<Product> put200InvalidJsonAsync(ServiceCallback<Product> serviceCallback) {
         return ServiceFuture.fromBody(put200InvalidJsonAsync(), serviceCallback);
     }
 
@@ -2475,12 +2834,24 @@ public class LROSADsImpl implements LROSADs {
      * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
      */
-    public Single<Product> put200InvalidJsonAsync() {
+    public Single<RestResponse<Void, Product>> put200InvalidJsonWithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.put200InvalidJson(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
+     */
+    public Single<Product> put200InvalidJsonAsync() {
+        return put200InvalidJsonWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Product>, Product>() { public Product call(RestResponse<Void, Product> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
@@ -2503,7 +2874,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> put200InvalidJsonAsync(Product product, final ServiceCallback<Product> serviceCallback) {
+    public ServiceFuture<Product> put200InvalidJsonAsync(Product product, ServiceCallback<Product> serviceCallback) {
         return ServiceFuture.fromBody(put200InvalidJsonAsync(product), serviceCallback);
     }
 
@@ -2512,12 +2883,24 @@ public class LROSADsImpl implements LROSADs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
      */
-    public Single<Product> put200InvalidJsonAsync(Product product) {
+    public Single<RestResponse<Void, Product>> put200InvalidJsonWithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.put200InvalidJson(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
+     */
+    public Single<Product> put200InvalidJsonAsync(Product product) {
+        return put200InvalidJsonWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<Void, Product>, Product>() { public Product call(RestResponse<Void, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2607,20 +2990,32 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> putAsyncRelativeRetryInvalidHeaderAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRelativeRetryInvalidHeaderAsync(), serviceCallback);
+    public ServiceFuture<Product> putAsyncRelativeRetryInvalidHeaderAsync(ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRelativeRetryInvalidHeaderAsync(), serviceCallback);
     }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders, Product> object
      */
-    public Single<Product> putAsyncRelativeRetryInvalidHeaderAsync() {
+    public Single<RestResponse<LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders, Product>> putAsyncRelativeRetryInvalidHeaderWithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.putAsyncRelativeRetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders, Product> object
+     */
+    public Single<Product> putAsyncRelativeRetryInvalidHeaderAsync() {
+        return putAsyncRelativeRetryInvalidHeaderWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders, Product>, Product>() { public Product call(RestResponse<LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders, Product> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
@@ -2643,8 +3038,8 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> putAsyncRelativeRetryInvalidHeaderAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRelativeRetryInvalidHeaderAsync(product), serviceCallback);
+    public ServiceFuture<Product> putAsyncRelativeRetryInvalidHeaderAsync(Product product, ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRelativeRetryInvalidHeaderAsync(product), serviceCallback);
     }
 
     /**
@@ -2652,12 +3047,24 @@ public class LROSADsImpl implements LROSADs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders, Product> object
      */
-    public Single<Product> putAsyncRelativeRetryInvalidHeaderAsync(Product product) {
+    public Single<RestResponse<LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders, Product>> putAsyncRelativeRetryInvalidHeaderWithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.putAsyncRelativeRetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders, Product> object
+     */
+    public Single<Product> putAsyncRelativeRetryInvalidHeaderAsync(Product product) {
+        return putAsyncRelativeRetryInvalidHeaderWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders, Product>, Product>() { public Product call(RestResponse<LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2747,20 +3154,32 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> putAsyncRelativeRetryInvalidJsonPollingAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRelativeRetryInvalidJsonPollingAsync(), serviceCallback);
+    public ServiceFuture<Product> putAsyncRelativeRetryInvalidJsonPollingAsync(ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRelativeRetryInvalidJsonPollingAsync(), serviceCallback);
     }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders, Product> object
      */
-    public Single<Product> putAsyncRelativeRetryInvalidJsonPollingAsync() {
+    public Single<RestResponse<LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders, Product>> putAsyncRelativeRetryInvalidJsonPollingWithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.putAsyncRelativeRetryInvalidJsonPolling(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders, Product> object
+     */
+    public Single<Product> putAsyncRelativeRetryInvalidJsonPollingAsync() {
+        return putAsyncRelativeRetryInvalidJsonPollingWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders, Product>, Product>() { public Product call(RestResponse<LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders, Product> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2783,8 +3202,8 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> putAsyncRelativeRetryInvalidJsonPollingAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRelativeRetryInvalidJsonPollingAsync(product), serviceCallback);
+    public ServiceFuture<Product> putAsyncRelativeRetryInvalidJsonPollingAsync(Product product, ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRelativeRetryInvalidJsonPollingAsync(product), serviceCallback);
     }
 
     /**
@@ -2792,12 +3211,24 @@ public class LROSADsImpl implements LROSADs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders, Product> object
      */
-    public Single<Product> putAsyncRelativeRetryInvalidJsonPollingAsync(Product product) {
+    public Single<RestResponse<LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders, Product>> putAsyncRelativeRetryInvalidJsonPollingWithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.putAsyncRelativeRetryInvalidJsonPolling(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders, Product> object
+     */
+    public Single<Product> putAsyncRelativeRetryInvalidJsonPollingAsync(Product product) {
+        return putAsyncRelativeRetryInvalidJsonPollingWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders, Product>, Product>() { public Product call(RestResponse<LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2838,6 +3269,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void delete202RetryInvalidHeader() {
         delete202RetryInvalidHeaderAsync().toBlocking().value();
@@ -2850,19 +3282,30 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> delete202RetryInvalidHeaderAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(delete202RetryInvalidHeaderAsync(), serviceCallback);
+    public ServiceFuture<Void> delete202RetryInvalidHeaderAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(delete202RetryInvalidHeaderAsync(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 202 to the initial request receing a reponse with an invalid 'Location' and 'Retry-After' headers.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsDelete202RetryInvalidHeaderHeaders, Void> object
      */
-    public Single<Void> delete202RetryInvalidHeaderAsync() {
+    public Single<RestResponse<LROSADsDelete202RetryInvalidHeaderHeaders, Void>> delete202RetryInvalidHeaderWithRestResponseAsync() {
         return service.delete202RetryInvalidHeader(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request receing a reponse with an invalid 'Location' and 'Retry-After' headers.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsDelete202RetryInvalidHeaderHeaders, Void> object
+     */
+    public Single<Void> delete202RetryInvalidHeaderAsync() {
+        return delete202RetryInvalidHeaderWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsDelete202RetryInvalidHeaderHeaders, Void>, Void>() { public Void call(RestResponse<LROSADsDelete202RetryInvalidHeaderHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2903,6 +3346,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void deleteAsyncRelativeRetryInvalidHeader() {
         deleteAsyncRelativeRetryInvalidHeaderAsync().toBlocking().value();
@@ -2915,19 +3359,30 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> deleteAsyncRelativeRetryInvalidHeaderAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(deleteAsyncRelativeRetryInvalidHeaderAsync(), serviceCallback);
+    public ServiceFuture<Void> deleteAsyncRelativeRetryInvalidHeaderAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(deleteAsyncRelativeRetryInvalidHeaderAsync(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 202 to the initial request. The endpoint indicated in the Azure-AsyncOperation header is invalid.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders, Void> object
      */
-    public Single<Void> deleteAsyncRelativeRetryInvalidHeaderAsync() {
+    public Single<RestResponse<LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders, Void>> deleteAsyncRelativeRetryInvalidHeaderWithRestResponseAsync() {
         return service.deleteAsyncRelativeRetryInvalidHeader(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders, Void> object
+     */
+    public Single<Void> deleteAsyncRelativeRetryInvalidHeaderAsync() {
+        return deleteAsyncRelativeRetryInvalidHeaderWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders, Void>, Void>() { public Void call(RestResponse<LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2968,6 +3423,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void deleteAsyncRelativeRetryInvalidJsonPolling() {
         deleteAsyncRelativeRetryInvalidJsonPollingAsync().toBlocking().value();
@@ -2980,19 +3436,30 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> deleteAsyncRelativeRetryInvalidJsonPollingAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(deleteAsyncRelativeRetryInvalidJsonPollingAsync(), serviceCallback);
+    public ServiceFuture<Void> deleteAsyncRelativeRetryInvalidJsonPollingAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(deleteAsyncRelativeRetryInvalidJsonPollingAsync(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders, Void> object
      */
-    public Single<Void> deleteAsyncRelativeRetryInvalidJsonPollingAsync() {
+    public Single<RestResponse<LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders, Void>> deleteAsyncRelativeRetryInvalidJsonPollingWithRestResponseAsync() {
         return service.deleteAsyncRelativeRetryInvalidJsonPolling(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders, Void> object
+     */
+    public Single<Void> deleteAsyncRelativeRetryInvalidJsonPollingAsync() {
+        return deleteAsyncRelativeRetryInvalidJsonPollingWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders, Void>, Void>() { public Void call(RestResponse<LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -3067,6 +3534,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post202RetryInvalidHeader() {
         post202RetryInvalidHeaderAsync().toBlocking().value();
@@ -3079,20 +3547,32 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post202RetryInvalidHeaderAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(post202RetryInvalidHeaderAsync(), serviceCallback);
+    public ServiceFuture<Void> post202RetryInvalidHeaderAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(post202RetryInvalidHeaderAsync(), serviceCallback);
     }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsPost202RetryInvalidHeaderHeaders, Void> object
      */
-    public Single<Void> post202RetryInvalidHeaderAsync() {
+    public Single<RestResponse<LROSADsPost202RetryInvalidHeaderHeaders, Void>> post202RetryInvalidHeaderWithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.post202RetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPost202RetryInvalidHeaderHeaders, Void> object
+     */
+    public Single<Void> post202RetryInvalidHeaderAsync() {
+        return post202RetryInvalidHeaderWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsPost202RetryInvalidHeaderHeaders, Void>, Void>() { public Void call(RestResponse<LROSADsPost202RetryInvalidHeaderHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
@@ -3101,6 +3581,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post202RetryInvalidHeader(Product product) {
         post202RetryInvalidHeaderAsync(product).toBlocking().value();
@@ -3114,8 +3595,8 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post202RetryInvalidHeaderAsync(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(post202RetryInvalidHeaderAsync(product), serviceCallback);
+    public ServiceFuture<Void> post202RetryInvalidHeaderAsync(Product product, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(post202RetryInvalidHeaderAsync(product), serviceCallback);
     }
 
     /**
@@ -3123,12 +3604,24 @@ public class LROSADsImpl implements LROSADs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsPost202RetryInvalidHeaderHeaders, Void> object
      */
-    public Single<Void> post202RetryInvalidHeaderAsync(Product product) {
+    public Single<RestResponse<LROSADsPost202RetryInvalidHeaderHeaders, Void>> post202RetryInvalidHeaderWithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.post202RetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPost202RetryInvalidHeaderHeaders, Void> object
+     */
+    public Single<Void> post202RetryInvalidHeaderAsync(Product product) {
+        return post202RetryInvalidHeaderWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROSADsPost202RetryInvalidHeaderHeaders, Void>, Void>() { public Void call(RestResponse<LROSADsPost202RetryInvalidHeaderHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -3203,6 +3696,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postAsyncRelativeRetryInvalidHeader() {
         postAsyncRelativeRetryInvalidHeaderAsync().toBlocking().value();
@@ -3215,20 +3709,32 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postAsyncRelativeRetryInvalidHeaderAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRelativeRetryInvalidHeaderAsync(), serviceCallback);
+    public ServiceFuture<Void> postAsyncRelativeRetryInvalidHeaderAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRelativeRetryInvalidHeaderAsync(), serviceCallback);
     }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders, Void> object
      */
-    public Single<Void> postAsyncRelativeRetryInvalidHeaderAsync() {
+    public Single<RestResponse<LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders, Void>> postAsyncRelativeRetryInvalidHeaderWithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.postAsyncRelativeRetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders, Void> object
+     */
+    public Single<Void> postAsyncRelativeRetryInvalidHeaderAsync() {
+        return postAsyncRelativeRetryInvalidHeaderWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders, Void>, Void>() { public Void call(RestResponse<LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
@@ -3237,6 +3743,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postAsyncRelativeRetryInvalidHeader(Product product) {
         postAsyncRelativeRetryInvalidHeaderAsync(product).toBlocking().value();
@@ -3250,8 +3757,8 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postAsyncRelativeRetryInvalidHeaderAsync(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRelativeRetryInvalidHeaderAsync(product), serviceCallback);
+    public ServiceFuture<Void> postAsyncRelativeRetryInvalidHeaderAsync(Product product, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRelativeRetryInvalidHeaderAsync(product), serviceCallback);
     }
 
     /**
@@ -3259,12 +3766,24 @@ public class LROSADsImpl implements LROSADs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders, Void> object
      */
-    public Single<Void> postAsyncRelativeRetryInvalidHeaderAsync(Product product) {
+    public Single<RestResponse<LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders, Void>> postAsyncRelativeRetryInvalidHeaderWithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.postAsyncRelativeRetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders, Void> object
+     */
+    public Single<Void> postAsyncRelativeRetryInvalidHeaderAsync(Product product) {
+        return postAsyncRelativeRetryInvalidHeaderWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders, Void>, Void>() { public Void call(RestResponse<LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -3339,6 +3858,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postAsyncRelativeRetryInvalidJsonPolling() {
         postAsyncRelativeRetryInvalidJsonPollingAsync().toBlocking().value();
@@ -3351,20 +3871,32 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postAsyncRelativeRetryInvalidJsonPollingAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRelativeRetryInvalidJsonPollingAsync(), serviceCallback);
+    public ServiceFuture<Void> postAsyncRelativeRetryInvalidJsonPollingAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRelativeRetryInvalidJsonPollingAsync(), serviceCallback);
     }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders, Void> object
      */
-    public Single<Void> postAsyncRelativeRetryInvalidJsonPollingAsync() {
+    public Single<RestResponse<LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders, Void>> postAsyncRelativeRetryInvalidJsonPollingWithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.postAsyncRelativeRetryInvalidJsonPolling(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders, Void> object
+     */
+    public Single<Void> postAsyncRelativeRetryInvalidJsonPollingAsync() {
+        return postAsyncRelativeRetryInvalidJsonPollingWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders, Void>, Void>() { public Void call(RestResponse<LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -3373,6 +3905,7 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postAsyncRelativeRetryInvalidJsonPolling(Product product) {
         postAsyncRelativeRetryInvalidJsonPollingAsync(product).toBlocking().value();
@@ -3386,8 +3919,8 @@ public class LROSADsImpl implements LROSADs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postAsyncRelativeRetryInvalidJsonPollingAsync(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRelativeRetryInvalidJsonPollingAsync(product), serviceCallback);
+    public ServiceFuture<Void> postAsyncRelativeRetryInvalidJsonPollingAsync(Product product, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRelativeRetryInvalidJsonPollingAsync(product), serviceCallback);
     }
 
     /**
@@ -3395,12 +3928,24 @@ public class LROSADsImpl implements LROSADs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders, Void> object
      */
-    public Single<Void> postAsyncRelativeRetryInvalidJsonPollingAsync(Product product) {
+    public Single<RestResponse<LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders, Void>> postAsyncRelativeRetryInvalidJsonPollingWithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.postAsyncRelativeRetryInvalidJsonPolling(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders, Void> object
+     */
+    public Single<Void> postAsyncRelativeRetryInvalidJsonPollingAsync(Product product) {
+        return postAsyncRelativeRetryInvalidJsonPollingWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders, Void>, Void>() { public Void call(RestResponse<LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azure/src/main/java/fixtures/lro/implementation/LROsCustomHeadersImpl.java
+++ b/test/azure/src/main/java/fixtures/lro/implementation/LROsCustomHeadersImpl.java
@@ -10,6 +10,7 @@
 
 package fixtures.lro.implementation;
 
+import com.microsoft.rest.RestResponse;
 import fixtures.lro.LROsCustomHeaders;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.CloudException;
@@ -73,7 +74,7 @@ public class LROsCustomHeadersImpl implements LROsCustomHeaders {
         @PUT("lro/customheader/putasync/retry/succeeded")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> putAsyncRetrySucceeded(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsCustomHeaderPutAsyncRetrySucceededHeaders, Product>> putAsyncRetrySucceeded(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROsCustomHeaders beginPut201CreatingSucceeded200" })
         @PUT("lro/customheader/put/201/creating/succeeded/200")
@@ -85,7 +86,7 @@ public class LROsCustomHeadersImpl implements LROsCustomHeaders {
         @PUT("lro/customheader/put/201/creating/succeeded/200")
         @ExpectedResponses({200, 201, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> put201CreatingSucceeded200(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Product>> put201CreatingSucceeded200(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROsCustomHeaders beginPost202Retry200" })
         @POST("lro/customheader/post/202/retry/200")
@@ -97,7 +98,7 @@ public class LROsCustomHeadersImpl implements LROsCustomHeaders {
         @POST("lro/customheader/post/202/retry/200")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> post202Retry200(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsCustomHeaderPost202Retry200Headers, Void>> post202Retry200(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROsCustomHeaders beginPostAsyncRetrySucceeded" })
         @POST("lro/customheader/postasync/retry/succeeded")
@@ -109,7 +110,7 @@ public class LROsCustomHeadersImpl implements LROsCustomHeaders {
         @POST("lro/customheader/postasync/retry/succeeded")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> postAsyncRetrySucceeded(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsCustomHeaderPostAsyncRetrySucceededHeaders, Void>> postAsyncRetrySucceeded(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -200,20 +201,32 @@ public class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> putAsyncRetrySucceededAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRetrySucceededAsync(), serviceCallback);
+    public ServiceFuture<Product> putAsyncRetrySucceededAsync(ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRetrySucceededAsync(), serviceCallback);
     }
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROsCustomHeaderPutAsyncRetrySucceededHeaders, Product> object
      */
-    public Single<Product> putAsyncRetrySucceededAsync() {
+    public Single<RestResponse<LROsCustomHeaderPutAsyncRetrySucceededHeaders, Product>> putAsyncRetrySucceededWithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.putAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsCustomHeaderPutAsyncRetrySucceededHeaders, Product> object
+     */
+    public Single<Product> putAsyncRetrySucceededAsync() {
+        return putAsyncRetrySucceededWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsCustomHeaderPutAsyncRetrySucceededHeaders, Product>, Product>() { public Product call(RestResponse<LROsCustomHeaderPutAsyncRetrySucceededHeaders, Product> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -236,8 +249,8 @@ public class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> putAsyncRetrySucceededAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRetrySucceededAsync(product), serviceCallback);
+    public ServiceFuture<Product> putAsyncRetrySucceededAsync(Product product, ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRetrySucceededAsync(product), serviceCallback);
     }
 
     /**
@@ -245,12 +258,24 @@ public class LROsCustomHeadersImpl implements LROsCustomHeaders {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROsCustomHeaderPutAsyncRetrySucceededHeaders, Product> object
      */
-    public Single<Product> putAsyncRetrySucceededAsync(Product product) {
+    public Single<RestResponse<LROsCustomHeaderPutAsyncRetrySucceededHeaders, Product>> putAsyncRetrySucceededWithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.putAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsCustomHeaderPutAsyncRetrySucceededHeaders, Product> object
+     */
+    public Single<Product> putAsyncRetrySucceededAsync(Product product) {
+        return putAsyncRetrySucceededWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROsCustomHeaderPutAsyncRetrySucceededHeaders, Product>, Product>() { public Product call(RestResponse<LROsCustomHeaderPutAsyncRetrySucceededHeaders, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -340,7 +365,7 @@ public class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> put201CreatingSucceeded200Async(final ServiceCallback<Product> serviceCallback) {
+    public ServiceFuture<Product> put201CreatingSucceeded200Async(ServiceCallback<Product> serviceCallback) {
         return ServiceFuture.fromBody(put201CreatingSucceeded200Async(), serviceCallback);
     }
 
@@ -348,12 +373,24 @@ public class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
      */
-    public Single<Product> put201CreatingSucceeded200Async() {
+    public Single<RestResponse<Void, Product>> put201CreatingSucceeded200WithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.put201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
+     */
+    public Single<Product> put201CreatingSucceeded200Async() {
+        return put201CreatingSucceeded200WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Product>, Product>() { public Product call(RestResponse<Void, Product> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -376,7 +413,7 @@ public class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> put201CreatingSucceeded200Async(Product product, final ServiceCallback<Product> serviceCallback) {
+    public ServiceFuture<Product> put201CreatingSucceeded200Async(Product product, ServiceCallback<Product> serviceCallback) {
         return ServiceFuture.fromBody(put201CreatingSucceeded200Async(product), serviceCallback);
     }
 
@@ -385,12 +422,24 @@ public class LROsCustomHeadersImpl implements LROsCustomHeaders {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
      */
-    public Single<Product> put201CreatingSucceeded200Async(Product product) {
+    public Single<RestResponse<Void, Product>> put201CreatingSucceeded200WithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.put201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
+     */
+    public Single<Product> put201CreatingSucceeded200Async(Product product) {
+        return put201CreatingSucceeded200WithRestResponseAsync(product)
+            .map(new Func1<RestResponse<Void, Product>, Product>() { public Product call(RestResponse<Void, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -465,6 +514,7 @@ public class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post202Retry200() {
         post202Retry200Async().toBlocking().value();
@@ -477,20 +527,32 @@ public class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post202Retry200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(post202Retry200Async(), serviceCallback);
+    public ServiceFuture<Void> post202Retry200Async(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(post202Retry200Async(), serviceCallback);
     }
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROsCustomHeaderPost202Retry200Headers, Void> object
      */
-    public Single<Void> post202Retry200Async() {
+    public Single<RestResponse<LROsCustomHeaderPost202Retry200Headers, Void>> post202Retry200WithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.post202Retry200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsCustomHeaderPost202Retry200Headers, Void> object
+     */
+    public Single<Void> post202Retry200Async() {
+        return post202Retry200WithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsCustomHeaderPost202Retry200Headers, Void>, Void>() { public Void call(RestResponse<LROsCustomHeaderPost202Retry200Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
@@ -499,6 +561,7 @@ public class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post202Retry200(Product product) {
         post202Retry200Async(product).toBlocking().value();
@@ -512,8 +575,8 @@ public class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post202Retry200Async(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(post202Retry200Async(product), serviceCallback);
+    public ServiceFuture<Void> post202Retry200Async(Product product, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(post202Retry200Async(product), serviceCallback);
     }
 
     /**
@@ -521,12 +584,24 @@ public class LROsCustomHeadersImpl implements LROsCustomHeaders {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROsCustomHeaderPost202Retry200Headers, Void> object
      */
-    public Single<Void> post202Retry200Async(Product product) {
+    public Single<RestResponse<LROsCustomHeaderPost202Retry200Headers, Void>> post202Retry200WithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.post202Retry200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsCustomHeaderPost202Retry200Headers, Void> object
+     */
+    public Single<Void> post202Retry200Async(Product product) {
+        return post202Retry200WithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROsCustomHeaderPost202Retry200Headers, Void>, Void>() { public Void call(RestResponse<LROsCustomHeaderPost202Retry200Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -601,6 +676,7 @@ public class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postAsyncRetrySucceeded() {
         postAsyncRetrySucceededAsync().toBlocking().value();
@@ -613,20 +689,32 @@ public class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postAsyncRetrySucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRetrySucceededAsync(), serviceCallback);
+    public ServiceFuture<Void> postAsyncRetrySucceededAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRetrySucceededAsync(), serviceCallback);
     }
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROsCustomHeaderPostAsyncRetrySucceededHeaders, Void> object
      */
-    public Single<Void> postAsyncRetrySucceededAsync() {
+    public Single<RestResponse<LROsCustomHeaderPostAsyncRetrySucceededHeaders, Void>> postAsyncRetrySucceededWithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.postAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsCustomHeaderPostAsyncRetrySucceededHeaders, Void> object
+     */
+    public Single<Void> postAsyncRetrySucceededAsync() {
+        return postAsyncRetrySucceededWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsCustomHeaderPostAsyncRetrySucceededHeaders, Void>, Void>() { public Void call(RestResponse<LROsCustomHeaderPostAsyncRetrySucceededHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -635,6 +723,7 @@ public class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postAsyncRetrySucceeded(Product product) {
         postAsyncRetrySucceededAsync(product).toBlocking().value();
@@ -648,8 +737,8 @@ public class LROsCustomHeadersImpl implements LROsCustomHeaders {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postAsyncRetrySucceededAsync(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRetrySucceededAsync(product), serviceCallback);
+    public ServiceFuture<Void> postAsyncRetrySucceededAsync(Product product, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRetrySucceededAsync(product), serviceCallback);
     }
 
     /**
@@ -657,12 +746,24 @@ public class LROsCustomHeadersImpl implements LROsCustomHeaders {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROsCustomHeaderPostAsyncRetrySucceededHeaders, Void> object
      */
-    public Single<Void> postAsyncRetrySucceededAsync(Product product) {
+    public Single<RestResponse<LROsCustomHeaderPostAsyncRetrySucceededHeaders, Void>> postAsyncRetrySucceededWithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.postAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsCustomHeaderPostAsyncRetrySucceededHeaders, Void> object
+     */
+    public Single<Void> postAsyncRetrySucceededAsync(Product product) {
+        return postAsyncRetrySucceededWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROsCustomHeaderPostAsyncRetrySucceededHeaders, Void>, Void>() { public Void call(RestResponse<LROsCustomHeaderPostAsyncRetrySucceededHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azure/src/main/java/fixtures/lro/implementation/LROsImpl.java
+++ b/test/azure/src/main/java/fixtures/lro/implementation/LROsImpl.java
@@ -10,6 +10,7 @@
 
 package fixtures.lro.implementation;
 
+import com.microsoft.rest.RestResponse;
 import fixtures.lro.LROs;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.CloudException;
@@ -96,7 +97,7 @@ public class LROsImpl implements LROs {
         @PUT("lro/put/200/succeeded")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> put200Succeeded(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Product>> put200Succeeded(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPut200SucceededNoState" })
         @PUT("lro/put/200/succeeded/nostate")
@@ -108,7 +109,7 @@ public class LROsImpl implements LROs {
         @PUT("lro/put/200/succeeded/nostate")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> put200SucceededNoState(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Product>> put200SucceededNoState(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPut202Retry200" })
         @PUT("lro/put/202/retry/200")
@@ -120,7 +121,7 @@ public class LROsImpl implements LROs {
         @PUT("lro/put/202/retry/200")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> put202Retry200(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Product>> put202Retry200(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPut201CreatingSucceeded200" })
         @PUT("lro/put/201/creating/succeeded/200")
@@ -132,7 +133,7 @@ public class LROsImpl implements LROs {
         @PUT("lro/put/201/creating/succeeded/200")
         @ExpectedResponses({200, 201, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> put201CreatingSucceeded200(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Product>> put201CreatingSucceeded200(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPut200UpdatingSucceeded204" })
         @PUT("lro/put/200/updating/succeeded/200")
@@ -144,7 +145,7 @@ public class LROsImpl implements LROs {
         @PUT("lro/put/200/updating/succeeded/200")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> put200UpdatingSucceeded204(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Product>> put200UpdatingSucceeded204(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPut201CreatingFailed200" })
         @PUT("lro/put/201/created/failed/200")
@@ -156,7 +157,7 @@ public class LROsImpl implements LROs {
         @PUT("lro/put/201/created/failed/200")
         @ExpectedResponses({200, 201, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> put201CreatingFailed200(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Product>> put201CreatingFailed200(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPut200Acceptedcanceled200" })
         @PUT("lro/put/200/accepted/canceled/200")
@@ -168,7 +169,7 @@ public class LROsImpl implements LROs {
         @PUT("lro/put/200/accepted/canceled/200")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> put200Acceptedcanceled200(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Product>> put200Acceptedcanceled200(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPutNoHeaderInRetry" })
         @PUT("lro/put/noheader/202/200")
@@ -180,7 +181,7 @@ public class LROsImpl implements LROs {
         @PUT("lro/put/noheader/202/200")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> putNoHeaderInRetry(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsPutNoHeaderInRetryHeaders, Product>> putNoHeaderInRetry(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPutAsyncRetrySucceeded" })
         @PUT("lro/putasync/retry/succeeded")
@@ -192,7 +193,7 @@ public class LROsImpl implements LROs {
         @PUT("lro/putasync/retry/succeeded")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> putAsyncRetrySucceeded(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsPutAsyncRetrySucceededHeaders, Product>> putAsyncRetrySucceeded(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPutAsyncNoRetrySucceeded" })
         @PUT("lro/putasync/noretry/succeeded")
@@ -204,7 +205,7 @@ public class LROsImpl implements LROs {
         @PUT("lro/putasync/noretry/succeeded")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> putAsyncNoRetrySucceeded(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsPutAsyncNoRetrySucceededHeaders, Product>> putAsyncNoRetrySucceeded(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPutAsyncRetryFailed" })
         @PUT("lro/putasync/retry/failed")
@@ -216,7 +217,7 @@ public class LROsImpl implements LROs {
         @PUT("lro/putasync/retry/failed")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> putAsyncRetryFailed(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsPutAsyncRetryFailedHeaders, Product>> putAsyncRetryFailed(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPutAsyncNoRetrycanceled" })
         @PUT("lro/putasync/noretry/canceled")
@@ -228,7 +229,7 @@ public class LROsImpl implements LROs {
         @PUT("lro/putasync/noretry/canceled")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> putAsyncNoRetrycanceled(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsPutAsyncNoRetrycanceledHeaders, Product>> putAsyncNoRetrycanceled(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPutAsyncNoHeaderInRetry" })
         @PUT("lro/putasync/noheader/201/200")
@@ -240,7 +241,7 @@ public class LROsImpl implements LROs {
         @PUT("lro/putasync/noheader/201/200")
         @ExpectedResponses({200, 201, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> putAsyncNoHeaderInRetry(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsPutAsyncNoHeaderInRetryHeaders, Product>> putAsyncNoHeaderInRetry(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPutNonResource" })
         @PUT("lro/putnonresource/202/200")
@@ -252,7 +253,7 @@ public class LROsImpl implements LROs {
         @PUT("lro/putnonresource/202/200")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Sku> putNonResource(@BodyParam("application/json; charset=utf-8") Sku sku, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Sku>> putNonResource(@BodyParam("application/json; charset=utf-8") Sku sku, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPutAsyncNonResource" })
         @PUT("lro/putnonresourceasync/202/200")
@@ -264,7 +265,7 @@ public class LROsImpl implements LROs {
         @PUT("lro/putnonresourceasync/202/200")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Sku> putAsyncNonResource(@BodyParam("application/json; charset=utf-8") Sku sku, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Sku>> putAsyncNonResource(@BodyParam("application/json; charset=utf-8") Sku sku, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPutSubResource" })
         @PUT("lro/putsubresource/202/200")
@@ -276,7 +277,7 @@ public class LROsImpl implements LROs {
         @PUT("lro/putsubresource/202/200")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<SubProduct> putSubResource(@BodyParam("application/json; charset=utf-8") SubProduct product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, SubProduct>> putSubResource(@BodyParam("application/json; charset=utf-8") SubProduct product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPutAsyncSubResource" })
         @PUT("lro/putsubresourceasync/202/200")
@@ -288,7 +289,7 @@ public class LROsImpl implements LROs {
         @PUT("lro/putsubresourceasync/202/200")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<SubProduct> putAsyncSubResource(@BodyParam("application/json; charset=utf-8") SubProduct product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, SubProduct>> putAsyncSubResource(@BodyParam("application/json; charset=utf-8") SubProduct product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginDeleteProvisioning202Accepted200Succeeded" })
         @DELETE("lro/delete/provisioning/202/accepted/200/succeeded")
@@ -300,7 +301,7 @@ public class LROsImpl implements LROs {
         @DELETE("lro/delete/provisioning/202/accepted/200/succeeded")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> deleteProvisioning202Accepted200Succeeded(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsDeleteProvisioning202Accepted200SucceededHeaders, Product>> deleteProvisioning202Accepted200Succeeded(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginDeleteProvisioning202DeletingFailed200" })
         @DELETE("lro/delete/provisioning/202/deleting/200/failed")
@@ -312,7 +313,7 @@ public class LROsImpl implements LROs {
         @DELETE("lro/delete/provisioning/202/deleting/200/failed")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> deleteProvisioning202DeletingFailed200(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsDeleteProvisioning202DeletingFailed200Headers, Product>> deleteProvisioning202DeletingFailed200(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginDeleteProvisioning202Deletingcanceled200" })
         @DELETE("lro/delete/provisioning/202/deleting/200/canceled")
@@ -324,7 +325,7 @@ public class LROsImpl implements LROs {
         @DELETE("lro/delete/provisioning/202/deleting/200/canceled")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> deleteProvisioning202Deletingcanceled200(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsDeleteProvisioning202Deletingcanceled200Headers, Product>> deleteProvisioning202Deletingcanceled200(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginDelete204Succeeded" })
         @DELETE("lro/delete/204/succeeded")
@@ -336,7 +337,7 @@ public class LROsImpl implements LROs {
         @DELETE("lro/delete/204/succeeded")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> delete204Succeeded(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> delete204Succeeded(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginDelete202Retry200" })
         @DELETE("lro/delete/202/retry/200")
@@ -348,7 +349,7 @@ public class LROsImpl implements LROs {
         @DELETE("lro/delete/202/retry/200")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> delete202Retry200(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsDelete202Retry200Headers, Product>> delete202Retry200(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginDelete202NoRetry204" })
         @DELETE("lro/delete/202/noretry/204")
@@ -360,7 +361,7 @@ public class LROsImpl implements LROs {
         @DELETE("lro/delete/202/noretry/204")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> delete202NoRetry204(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsDelete202NoRetry204Headers, Product>> delete202NoRetry204(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginDeleteNoHeaderInRetry" })
         @DELETE("lro/delete/noheader")
@@ -372,7 +373,7 @@ public class LROsImpl implements LROs {
         @DELETE("lro/delete/noheader")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> deleteNoHeaderInRetry(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsDeleteNoHeaderInRetryHeaders, Void>> deleteNoHeaderInRetry(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginDeleteAsyncNoHeaderInRetry" })
         @DELETE("lro/deleteasync/noheader/202/204")
@@ -384,7 +385,7 @@ public class LROsImpl implements LROs {
         @DELETE("lro/deleteasync/noheader/202/204")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> deleteAsyncNoHeaderInRetry(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsDeleteAsyncNoHeaderInRetryHeaders, Void>> deleteAsyncNoHeaderInRetry(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginDeleteAsyncRetrySucceeded" })
         @DELETE("lro/deleteasync/retry/succeeded")
@@ -396,7 +397,7 @@ public class LROsImpl implements LROs {
         @DELETE("lro/deleteasync/retry/succeeded")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> deleteAsyncRetrySucceeded(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsDeleteAsyncRetrySucceededHeaders, Void>> deleteAsyncRetrySucceeded(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginDeleteAsyncNoRetrySucceeded" })
         @DELETE("lro/deleteasync/noretry/succeeded")
@@ -408,7 +409,7 @@ public class LROsImpl implements LROs {
         @DELETE("lro/deleteasync/noretry/succeeded")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> deleteAsyncNoRetrySucceeded(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsDeleteAsyncNoRetrySucceededHeaders, Void>> deleteAsyncNoRetrySucceeded(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginDeleteAsyncRetryFailed" })
         @DELETE("lro/deleteasync/retry/failed")
@@ -420,7 +421,7 @@ public class LROsImpl implements LROs {
         @DELETE("lro/deleteasync/retry/failed")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> deleteAsyncRetryFailed(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsDeleteAsyncRetryFailedHeaders, Void>> deleteAsyncRetryFailed(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginDeleteAsyncRetrycanceled" })
         @DELETE("lro/deleteasync/retry/canceled")
@@ -432,7 +433,7 @@ public class LROsImpl implements LROs {
         @DELETE("lro/deleteasync/retry/canceled")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> deleteAsyncRetrycanceled(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsDeleteAsyncRetrycanceledHeaders, Void>> deleteAsyncRetrycanceled(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPost200WithPayload" })
         @POST("lro/post/payload/200")
@@ -444,7 +445,7 @@ public class LROsImpl implements LROs {
         @POST("lro/post/payload/200")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Sku> post200WithPayload(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Sku>> post200WithPayload(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPost202Retry200" })
         @POST("lro/post/202/retry/200")
@@ -456,7 +457,7 @@ public class LROsImpl implements LROs {
         @POST("lro/post/202/retry/200")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> post202Retry200(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsPost202Retry200Headers, Void>> post202Retry200(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPost202NoRetry204" })
         @POST("lro/post/202/noretry/204")
@@ -468,7 +469,7 @@ public class LROsImpl implements LROs {
         @POST("lro/post/202/noretry/204")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> post202NoRetry204(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsPost202NoRetry204Headers, Product>> post202NoRetry204(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPostAsyncRetrySucceeded" })
         @POST("lro/postasync/retry/succeeded")
@@ -480,7 +481,7 @@ public class LROsImpl implements LROs {
         @POST("lro/postasync/retry/succeeded")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> postAsyncRetrySucceeded(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsPostAsyncRetrySucceededHeaders, Product>> postAsyncRetrySucceeded(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPostAsyncNoRetrySucceeded" })
         @POST("lro/postasync/noretry/succeeded")
@@ -492,7 +493,7 @@ public class LROsImpl implements LROs {
         @POST("lro/postasync/noretry/succeeded")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Product> postAsyncNoRetrySucceeded(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsPostAsyncNoRetrySucceededHeaders, Product>> postAsyncNoRetrySucceeded(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPostAsyncRetryFailed" })
         @POST("lro/postasync/retry/failed")
@@ -504,7 +505,7 @@ public class LROsImpl implements LROs {
         @POST("lro/postasync/retry/failed")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> postAsyncRetryFailed(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsPostAsyncRetryFailedHeaders, Void>> postAsyncRetryFailed(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPostAsyncRetrycanceled" })
         @POST("lro/postasync/retry/canceled")
@@ -516,7 +517,7 @@ public class LROsImpl implements LROs {
         @POST("lro/postasync/retry/canceled")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> postAsyncRetrycanceled(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsPostAsyncRetrycanceledHeaders, Void>> postAsyncRetrycanceled(@BodyParam("application/json; charset=utf-8") Product product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -607,7 +608,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> put200SucceededAsync(final ServiceCallback<Product> serviceCallback) {
+    public ServiceFuture<Product> put200SucceededAsync(ServiceCallback<Product> serviceCallback) {
         return ServiceFuture.fromBody(put200SucceededAsync(), serviceCallback);
     }
 
@@ -615,12 +616,24 @@ public class LROsImpl implements LROs {
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
      */
-    public Single<Product> put200SucceededAsync() {
+    public Single<RestResponse<Void, Product>> put200SucceededWithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.put200Succeeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
+     */
+    public Single<Product> put200SucceededAsync() {
+        return put200SucceededWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Product>, Product>() { public Product call(RestResponse<Void, Product> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
@@ -643,7 +656,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> put200SucceededAsync(Product product, final ServiceCallback<Product> serviceCallback) {
+    public ServiceFuture<Product> put200SucceededAsync(Product product, ServiceCallback<Product> serviceCallback) {
         return ServiceFuture.fromBody(put200SucceededAsync(product), serviceCallback);
     }
 
@@ -652,12 +665,24 @@ public class LROsImpl implements LROs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
      */
-    public Single<Product> put200SucceededAsync(Product product) {
+    public Single<RestResponse<Void, Product>> put200SucceededWithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.put200Succeeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
+     */
+    public Single<Product> put200SucceededAsync(Product product) {
+        return put200SucceededWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<Void, Product>, Product>() { public Product call(RestResponse<Void, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -747,7 +772,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> put200SucceededNoStateAsync(final ServiceCallback<Product> serviceCallback) {
+    public ServiceFuture<Product> put200SucceededNoStateAsync(ServiceCallback<Product> serviceCallback) {
         return ServiceFuture.fromBody(put200SucceededNoStateAsync(), serviceCallback);
     }
 
@@ -755,12 +780,24 @@ public class LROsImpl implements LROs {
      * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
      */
-    public Single<Product> put200SucceededNoStateAsync() {
+    public Single<RestResponse<Void, Product>> put200SucceededNoStateWithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.put200SucceededNoState(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
+     */
+    public Single<Product> put200SucceededNoStateAsync() {
+        return put200SucceededNoStateWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Product>, Product>() { public Product call(RestResponse<Void, Product> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
@@ -783,7 +820,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> put200SucceededNoStateAsync(Product product, final ServiceCallback<Product> serviceCallback) {
+    public ServiceFuture<Product> put200SucceededNoStateAsync(Product product, ServiceCallback<Product> serviceCallback) {
         return ServiceFuture.fromBody(put200SucceededNoStateAsync(product), serviceCallback);
     }
 
@@ -792,12 +829,24 @@ public class LROsImpl implements LROs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
      */
-    public Single<Product> put200SucceededNoStateAsync(Product product) {
+    public Single<RestResponse<Void, Product>> put200SucceededNoStateWithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.put200SucceededNoState(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
+     */
+    public Single<Product> put200SucceededNoStateAsync(Product product) {
+        return put200SucceededNoStateWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<Void, Product>, Product>() { public Product call(RestResponse<Void, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -887,7 +936,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> put202Retry200Async(final ServiceCallback<Product> serviceCallback) {
+    public ServiceFuture<Product> put202Retry200Async(ServiceCallback<Product> serviceCallback) {
         return ServiceFuture.fromBody(put202Retry200Async(), serviceCallback);
     }
 
@@ -895,12 +944,24 @@ public class LROsImpl implements LROs {
      * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
      */
-    public Single<Product> put202Retry200Async() {
+    public Single<RestResponse<Void, Product>> put202Retry200WithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.put202Retry200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
+     */
+    public Single<Product> put202Retry200Async() {
+        return put202Retry200WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Product>, Product>() { public Product call(RestResponse<Void, Product> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
@@ -923,7 +984,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> put202Retry200Async(Product product, final ServiceCallback<Product> serviceCallback) {
+    public ServiceFuture<Product> put202Retry200Async(Product product, ServiceCallback<Product> serviceCallback) {
         return ServiceFuture.fromBody(put202Retry200Async(product), serviceCallback);
     }
 
@@ -932,12 +993,24 @@ public class LROsImpl implements LROs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
      */
-    public Single<Product> put202Retry200Async(Product product) {
+    public Single<RestResponse<Void, Product>> put202Retry200WithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.put202Retry200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
+     */
+    public Single<Product> put202Retry200Async(Product product) {
+        return put202Retry200WithRestResponseAsync(product)
+            .map(new Func1<RestResponse<Void, Product>, Product>() { public Product call(RestResponse<Void, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1027,7 +1100,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> put201CreatingSucceeded200Async(final ServiceCallback<Product> serviceCallback) {
+    public ServiceFuture<Product> put201CreatingSucceeded200Async(ServiceCallback<Product> serviceCallback) {
         return ServiceFuture.fromBody(put201CreatingSucceeded200Async(), serviceCallback);
     }
 
@@ -1035,12 +1108,24 @@ public class LROsImpl implements LROs {
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
      */
-    public Single<Product> put201CreatingSucceeded200Async() {
+    public Single<RestResponse<Void, Product>> put201CreatingSucceeded200WithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.put201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
+     */
+    public Single<Product> put201CreatingSucceeded200Async() {
+        return put201CreatingSucceeded200WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Product>, Product>() { public Product call(RestResponse<Void, Product> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -1063,7 +1148,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> put201CreatingSucceeded200Async(Product product, final ServiceCallback<Product> serviceCallback) {
+    public ServiceFuture<Product> put201CreatingSucceeded200Async(Product product, ServiceCallback<Product> serviceCallback) {
         return ServiceFuture.fromBody(put201CreatingSucceeded200Async(product), serviceCallback);
     }
 
@@ -1072,12 +1157,24 @@ public class LROsImpl implements LROs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
      */
-    public Single<Product> put201CreatingSucceeded200Async(Product product) {
+    public Single<RestResponse<Void, Product>> put201CreatingSucceeded200WithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.put201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
+     */
+    public Single<Product> put201CreatingSucceeded200Async(Product product) {
+        return put201CreatingSucceeded200WithRestResponseAsync(product)
+            .map(new Func1<RestResponse<Void, Product>, Product>() { public Product call(RestResponse<Void, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1167,7 +1264,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> put200UpdatingSucceeded204Async(final ServiceCallback<Product> serviceCallback) {
+    public ServiceFuture<Product> put200UpdatingSucceeded204Async(ServiceCallback<Product> serviceCallback) {
         return ServiceFuture.fromBody(put200UpdatingSucceeded204Async(), serviceCallback);
     }
 
@@ -1175,12 +1272,24 @@ public class LROsImpl implements LROs {
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
      */
-    public Single<Product> put200UpdatingSucceeded204Async() {
+    public Single<RestResponse<Void, Product>> put200UpdatingSucceeded204WithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.put200UpdatingSucceeded204(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
+     */
+    public Single<Product> put200UpdatingSucceeded204Async() {
+        return put200UpdatingSucceeded204WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Product>, Product>() { public Product call(RestResponse<Void, Product> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -1203,7 +1312,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> put200UpdatingSucceeded204Async(Product product, final ServiceCallback<Product> serviceCallback) {
+    public ServiceFuture<Product> put200UpdatingSucceeded204Async(Product product, ServiceCallback<Product> serviceCallback) {
         return ServiceFuture.fromBody(put200UpdatingSucceeded204Async(product), serviceCallback);
     }
 
@@ -1212,12 +1321,24 @@ public class LROsImpl implements LROs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
      */
-    public Single<Product> put200UpdatingSucceeded204Async(Product product) {
+    public Single<RestResponse<Void, Product>> put200UpdatingSucceeded204WithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.put200UpdatingSucceeded204(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
+     */
+    public Single<Product> put200UpdatingSucceeded204Async(Product product) {
+        return put200UpdatingSucceeded204WithRestResponseAsync(product)
+            .map(new Func1<RestResponse<Void, Product>, Product>() { public Product call(RestResponse<Void, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1307,7 +1428,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> put201CreatingFailed200Async(final ServiceCallback<Product> serviceCallback) {
+    public ServiceFuture<Product> put201CreatingFailed200Async(ServiceCallback<Product> serviceCallback) {
         return ServiceFuture.fromBody(put201CreatingFailed200Async(), serviceCallback);
     }
 
@@ -1315,12 +1436,24 @@ public class LROsImpl implements LROs {
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
      */
-    public Single<Product> put201CreatingFailed200Async() {
+    public Single<RestResponse<Void, Product>> put201CreatingFailed200WithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.put201CreatingFailed200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
+     */
+    public Single<Product> put201CreatingFailed200Async() {
+        return put201CreatingFailed200WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Product>, Product>() { public Product call(RestResponse<Void, Product> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
@@ -1343,7 +1476,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> put201CreatingFailed200Async(Product product, final ServiceCallback<Product> serviceCallback) {
+    public ServiceFuture<Product> put201CreatingFailed200Async(Product product, ServiceCallback<Product> serviceCallback) {
         return ServiceFuture.fromBody(put201CreatingFailed200Async(product), serviceCallback);
     }
 
@@ -1352,12 +1485,24 @@ public class LROsImpl implements LROs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
      */
-    public Single<Product> put201CreatingFailed200Async(Product product) {
+    public Single<RestResponse<Void, Product>> put201CreatingFailed200WithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.put201CreatingFailed200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
+     */
+    public Single<Product> put201CreatingFailed200Async(Product product) {
+        return put201CreatingFailed200WithRestResponseAsync(product)
+            .map(new Func1<RestResponse<Void, Product>, Product>() { public Product call(RestResponse<Void, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1447,7 +1592,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> put200Acceptedcanceled200Async(final ServiceCallback<Product> serviceCallback) {
+    public ServiceFuture<Product> put200Acceptedcanceled200Async(ServiceCallback<Product> serviceCallback) {
         return ServiceFuture.fromBody(put200Acceptedcanceled200Async(), serviceCallback);
     }
 
@@ -1455,12 +1600,24 @@ public class LROsImpl implements LROs {
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
      */
-    public Single<Product> put200Acceptedcanceled200Async() {
+    public Single<RestResponse<Void, Product>> put200Acceptedcanceled200WithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.put200Acceptedcanceled200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
+     */
+    public Single<Product> put200Acceptedcanceled200Async() {
+        return put200Acceptedcanceled200WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Product>, Product>() { public Product call(RestResponse<Void, Product> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
@@ -1483,7 +1640,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> put200Acceptedcanceled200Async(Product product, final ServiceCallback<Product> serviceCallback) {
+    public ServiceFuture<Product> put200Acceptedcanceled200Async(Product product, ServiceCallback<Product> serviceCallback) {
         return ServiceFuture.fromBody(put200Acceptedcanceled200Async(product), serviceCallback);
     }
 
@@ -1492,12 +1649,24 @@ public class LROsImpl implements LROs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
      */
-    public Single<Product> put200Acceptedcanceled200Async(Product product) {
+    public Single<RestResponse<Void, Product>> put200Acceptedcanceled200WithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.put200Acceptedcanceled200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
+     */
+    public Single<Product> put200Acceptedcanceled200Async(Product product) {
+        return put200Acceptedcanceled200WithRestResponseAsync(product)
+            .map(new Func1<RestResponse<Void, Product>, Product>() { public Product call(RestResponse<Void, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1587,20 +1756,32 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> putNoHeaderInRetryAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putNoHeaderInRetryAsync(), serviceCallback);
+    public ServiceFuture<Product> putNoHeaderInRetryAsync(ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(putNoHeaderInRetryAsync(), serviceCallback);
     }
 
     /**
      * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROsPutNoHeaderInRetryHeaders, Product> object
      */
-    public Single<Product> putNoHeaderInRetryAsync() {
+    public Single<RestResponse<LROsPutNoHeaderInRetryHeaders, Product>> putNoHeaderInRetryWithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.putNoHeaderInRetry(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPutNoHeaderInRetryHeaders, Product> object
+     */
+    public Single<Product> putNoHeaderInRetryAsync() {
+        return putNoHeaderInRetryWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsPutNoHeaderInRetryHeaders, Product>, Product>() { public Product call(RestResponse<LROsPutNoHeaderInRetryHeaders, Product> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
@@ -1623,8 +1804,8 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> putNoHeaderInRetryAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putNoHeaderInRetryAsync(product), serviceCallback);
+    public ServiceFuture<Product> putNoHeaderInRetryAsync(Product product, ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(putNoHeaderInRetryAsync(product), serviceCallback);
     }
 
     /**
@@ -1632,12 +1813,24 @@ public class LROsImpl implements LROs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROsPutNoHeaderInRetryHeaders, Product> object
      */
-    public Single<Product> putNoHeaderInRetryAsync(Product product) {
+    public Single<RestResponse<LROsPutNoHeaderInRetryHeaders, Product>> putNoHeaderInRetryWithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.putNoHeaderInRetry(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPutNoHeaderInRetryHeaders, Product> object
+     */
+    public Single<Product> putNoHeaderInRetryAsync(Product product) {
+        return putNoHeaderInRetryWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROsPutNoHeaderInRetryHeaders, Product>, Product>() { public Product call(RestResponse<LROsPutNoHeaderInRetryHeaders, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1727,20 +1920,32 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> putAsyncRetrySucceededAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRetrySucceededAsync(), serviceCallback);
+    public ServiceFuture<Product> putAsyncRetrySucceededAsync(ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRetrySucceededAsync(), serviceCallback);
     }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncRetrySucceededHeaders, Product> object
      */
-    public Single<Product> putAsyncRetrySucceededAsync() {
+    public Single<RestResponse<LROsPutAsyncRetrySucceededHeaders, Product>> putAsyncRetrySucceededWithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.putAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncRetrySucceededHeaders, Product> object
+     */
+    public Single<Product> putAsyncRetrySucceededAsync() {
+        return putAsyncRetrySucceededWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsPutAsyncRetrySucceededHeaders, Product>, Product>() { public Product call(RestResponse<LROsPutAsyncRetrySucceededHeaders, Product> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1763,8 +1968,8 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> putAsyncRetrySucceededAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRetrySucceededAsync(product), serviceCallback);
+    public ServiceFuture<Product> putAsyncRetrySucceededAsync(Product product, ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRetrySucceededAsync(product), serviceCallback);
     }
 
     /**
@@ -1772,12 +1977,24 @@ public class LROsImpl implements LROs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncRetrySucceededHeaders, Product> object
      */
-    public Single<Product> putAsyncRetrySucceededAsync(Product product) {
+    public Single<RestResponse<LROsPutAsyncRetrySucceededHeaders, Product>> putAsyncRetrySucceededWithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.putAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncRetrySucceededHeaders, Product> object
+     */
+    public Single<Product> putAsyncRetrySucceededAsync(Product product) {
+        return putAsyncRetrySucceededWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROsPutAsyncRetrySucceededHeaders, Product>, Product>() { public Product call(RestResponse<LROsPutAsyncRetrySucceededHeaders, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1867,20 +2084,32 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> putAsyncNoRetrySucceededAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncNoRetrySucceededAsync(), serviceCallback);
+    public ServiceFuture<Product> putAsyncNoRetrySucceededAsync(ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncNoRetrySucceededAsync(), serviceCallback);
     }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncNoRetrySucceededHeaders, Product> object
      */
-    public Single<Product> putAsyncNoRetrySucceededAsync() {
+    public Single<RestResponse<LROsPutAsyncNoRetrySucceededHeaders, Product>> putAsyncNoRetrySucceededWithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.putAsyncNoRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncNoRetrySucceededHeaders, Product> object
+     */
+    public Single<Product> putAsyncNoRetrySucceededAsync() {
+        return putAsyncNoRetrySucceededWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsPutAsyncNoRetrySucceededHeaders, Product>, Product>() { public Product call(RestResponse<LROsPutAsyncNoRetrySucceededHeaders, Product> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1903,8 +2132,8 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> putAsyncNoRetrySucceededAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncNoRetrySucceededAsync(product), serviceCallback);
+    public ServiceFuture<Product> putAsyncNoRetrySucceededAsync(Product product, ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncNoRetrySucceededAsync(product), serviceCallback);
     }
 
     /**
@@ -1912,12 +2141,24 @@ public class LROsImpl implements LROs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncNoRetrySucceededHeaders, Product> object
      */
-    public Single<Product> putAsyncNoRetrySucceededAsync(Product product) {
+    public Single<RestResponse<LROsPutAsyncNoRetrySucceededHeaders, Product>> putAsyncNoRetrySucceededWithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.putAsyncNoRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncNoRetrySucceededHeaders, Product> object
+     */
+    public Single<Product> putAsyncNoRetrySucceededAsync(Product product) {
+        return putAsyncNoRetrySucceededWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROsPutAsyncNoRetrySucceededHeaders, Product>, Product>() { public Product call(RestResponse<LROsPutAsyncNoRetrySucceededHeaders, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2007,20 +2248,32 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> putAsyncRetryFailedAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRetryFailedAsync(), serviceCallback);
+    public ServiceFuture<Product> putAsyncRetryFailedAsync(ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRetryFailedAsync(), serviceCallback);
     }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncRetryFailedHeaders, Product> object
      */
-    public Single<Product> putAsyncRetryFailedAsync() {
+    public Single<RestResponse<LROsPutAsyncRetryFailedHeaders, Product>> putAsyncRetryFailedWithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.putAsyncRetryFailed(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncRetryFailedHeaders, Product> object
+     */
+    public Single<Product> putAsyncRetryFailedAsync() {
+        return putAsyncRetryFailedWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsPutAsyncRetryFailedHeaders, Product>, Product>() { public Product call(RestResponse<LROsPutAsyncRetryFailedHeaders, Product> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2043,8 +2296,8 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> putAsyncRetryFailedAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRetryFailedAsync(product), serviceCallback);
+    public ServiceFuture<Product> putAsyncRetryFailedAsync(Product product, ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRetryFailedAsync(product), serviceCallback);
     }
 
     /**
@@ -2052,12 +2305,24 @@ public class LROsImpl implements LROs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncRetryFailedHeaders, Product> object
      */
-    public Single<Product> putAsyncRetryFailedAsync(Product product) {
+    public Single<RestResponse<LROsPutAsyncRetryFailedHeaders, Product>> putAsyncRetryFailedWithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.putAsyncRetryFailed(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncRetryFailedHeaders, Product> object
+     */
+    public Single<Product> putAsyncRetryFailedAsync(Product product) {
+        return putAsyncRetryFailedWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROsPutAsyncRetryFailedHeaders, Product>, Product>() { public Product call(RestResponse<LROsPutAsyncRetryFailedHeaders, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2147,20 +2412,32 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> putAsyncNoRetrycanceledAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncNoRetrycanceledAsync(), serviceCallback);
+    public ServiceFuture<Product> putAsyncNoRetrycanceledAsync(ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncNoRetrycanceledAsync(), serviceCallback);
     }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncNoRetrycanceledHeaders, Product> object
      */
-    public Single<Product> putAsyncNoRetrycanceledAsync() {
+    public Single<RestResponse<LROsPutAsyncNoRetrycanceledHeaders, Product>> putAsyncNoRetrycanceledWithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.putAsyncNoRetrycanceled(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncNoRetrycanceledHeaders, Product> object
+     */
+    public Single<Product> putAsyncNoRetrycanceledAsync() {
+        return putAsyncNoRetrycanceledWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsPutAsyncNoRetrycanceledHeaders, Product>, Product>() { public Product call(RestResponse<LROsPutAsyncNoRetrycanceledHeaders, Product> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2183,8 +2460,8 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> putAsyncNoRetrycanceledAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncNoRetrycanceledAsync(product), serviceCallback);
+    public ServiceFuture<Product> putAsyncNoRetrycanceledAsync(Product product, ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncNoRetrycanceledAsync(product), serviceCallback);
     }
 
     /**
@@ -2192,12 +2469,24 @@ public class LROsImpl implements LROs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncNoRetrycanceledHeaders, Product> object
      */
-    public Single<Product> putAsyncNoRetrycanceledAsync(Product product) {
+    public Single<RestResponse<LROsPutAsyncNoRetrycanceledHeaders, Product>> putAsyncNoRetrycanceledWithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.putAsyncNoRetrycanceled(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncNoRetrycanceledHeaders, Product> object
+     */
+    public Single<Product> putAsyncNoRetrycanceledAsync(Product product) {
+        return putAsyncNoRetrycanceledWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROsPutAsyncNoRetrycanceledHeaders, Product>, Product>() { public Product call(RestResponse<LROsPutAsyncNoRetrycanceledHeaders, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2287,20 +2576,32 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> putAsyncNoHeaderInRetryAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncNoHeaderInRetryAsync(), serviceCallback);
+    public ServiceFuture<Product> putAsyncNoHeaderInRetryAsync(ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncNoHeaderInRetryAsync(), serviceCallback);
     }
 
     /**
      * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncNoHeaderInRetryHeaders, Product> object
      */
-    public Single<Product> putAsyncNoHeaderInRetryAsync() {
+    public Single<RestResponse<LROsPutAsyncNoHeaderInRetryHeaders, Product>> putAsyncNoHeaderInRetryWithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.putAsyncNoHeaderInRetry(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncNoHeaderInRetryHeaders, Product> object
+     */
+    public Single<Product> putAsyncNoHeaderInRetryAsync() {
+        return putAsyncNoHeaderInRetryWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsPutAsyncNoHeaderInRetryHeaders, Product>, Product>() { public Product call(RestResponse<LROsPutAsyncNoHeaderInRetryHeaders, Product> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
@@ -2323,8 +2624,8 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> putAsyncNoHeaderInRetryAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncNoHeaderInRetryAsync(product), serviceCallback);
+    public ServiceFuture<Product> putAsyncNoHeaderInRetryAsync(Product product, ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncNoHeaderInRetryAsync(product), serviceCallback);
     }
 
     /**
@@ -2332,12 +2633,24 @@ public class LROsImpl implements LROs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncNoHeaderInRetryHeaders, Product> object
      */
-    public Single<Product> putAsyncNoHeaderInRetryAsync(Product product) {
+    public Single<RestResponse<LROsPutAsyncNoHeaderInRetryHeaders, Product>> putAsyncNoHeaderInRetryWithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.putAsyncNoHeaderInRetry(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncNoHeaderInRetryHeaders, Product> object
+     */
+    public Single<Product> putAsyncNoHeaderInRetryAsync(Product product) {
+        return putAsyncNoHeaderInRetryWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROsPutAsyncNoHeaderInRetryHeaders, Product>, Product>() { public Product call(RestResponse<LROsPutAsyncNoHeaderInRetryHeaders, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2427,7 +2740,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Sku> putNonResourceAsync(final ServiceCallback<Sku> serviceCallback) {
+    public ServiceFuture<Sku> putNonResourceAsync(ServiceCallback<Sku> serviceCallback) {
         return ServiceFuture.fromBody(putNonResourceAsync(), serviceCallback);
     }
 
@@ -2435,12 +2748,24 @@ public class LROsImpl implements LROs {
      * Long running put request with non resource.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Sku object
+     * @return a {@link Single} emitting the RestResponse<Void, Sku> object
      */
-    public Single<Sku> putNonResourceAsync() {
+    public Single<RestResponse<Void, Sku>> putNonResourceWithRestResponseAsync() {
         final Sku sku = null;
+        Validator.validate(sku);
         return service.putNonResource(sku, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Sku> object
+     */
+    public Single<Sku> putNonResourceAsync() {
+        return putNonResourceWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Sku>, Sku>() { public Sku call(RestResponse<Void, Sku> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request with non resource.
@@ -2463,7 +2788,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Sku> putNonResourceAsync(Sku sku, final ServiceCallback<Sku> serviceCallback) {
+    public ServiceFuture<Sku> putNonResourceAsync(Sku sku, ServiceCallback<Sku> serviceCallback) {
         return ServiceFuture.fromBody(putNonResourceAsync(sku), serviceCallback);
     }
 
@@ -2472,12 +2797,24 @@ public class LROsImpl implements LROs {
      *
      * @param sku sku to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Sku object
+     * @return a {@link Single} emitting the RestResponse<Void, Sku> object
      */
-    public Single<Sku> putNonResourceAsync(Sku sku) {
+    public Single<RestResponse<Void, Sku>> putNonResourceWithRestResponseAsync(Sku sku) {
         Validator.validate(sku);
         return service.putNonResource(sku, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @param sku sku to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Sku> object
+     */
+    public Single<Sku> putNonResourceAsync(Sku sku) {
+        return putNonResourceWithRestResponseAsync(sku)
+            .map(new Func1<RestResponse<Void, Sku>, Sku>() { public Sku call(RestResponse<Void, Sku> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2567,7 +2904,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Sku> putAsyncNonResourceAsync(final ServiceCallback<Sku> serviceCallback) {
+    public ServiceFuture<Sku> putAsyncNonResourceAsync(ServiceCallback<Sku> serviceCallback) {
         return ServiceFuture.fromBody(putAsyncNonResourceAsync(), serviceCallback);
     }
 
@@ -2575,12 +2912,24 @@ public class LROsImpl implements LROs {
      * Long running put request with non resource.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Sku object
+     * @return a {@link Single} emitting the RestResponse<Void, Sku> object
      */
-    public Single<Sku> putAsyncNonResourceAsync() {
+    public Single<RestResponse<Void, Sku>> putAsyncNonResourceWithRestResponseAsync() {
         final Sku sku = null;
+        Validator.validate(sku);
         return service.putAsyncNonResource(sku, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Sku> object
+     */
+    public Single<Sku> putAsyncNonResourceAsync() {
+        return putAsyncNonResourceWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Sku>, Sku>() { public Sku call(RestResponse<Void, Sku> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request with non resource.
@@ -2603,7 +2952,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Sku> putAsyncNonResourceAsync(Sku sku, final ServiceCallback<Sku> serviceCallback) {
+    public ServiceFuture<Sku> putAsyncNonResourceAsync(Sku sku, ServiceCallback<Sku> serviceCallback) {
         return ServiceFuture.fromBody(putAsyncNonResourceAsync(sku), serviceCallback);
     }
 
@@ -2612,12 +2961,24 @@ public class LROsImpl implements LROs {
      *
      * @param sku Sku to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Sku object
+     * @return a {@link Single} emitting the RestResponse<Void, Sku> object
      */
-    public Single<Sku> putAsyncNonResourceAsync(Sku sku) {
+    public Single<RestResponse<Void, Sku>> putAsyncNonResourceWithRestResponseAsync(Sku sku) {
         Validator.validate(sku);
         return service.putAsyncNonResource(sku, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @param sku Sku to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Sku> object
+     */
+    public Single<Sku> putAsyncNonResourceAsync(Sku sku) {
+        return putAsyncNonResourceWithRestResponseAsync(sku)
+            .map(new Func1<RestResponse<Void, Sku>, Sku>() { public Sku call(RestResponse<Void, Sku> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2707,7 +3068,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<SubProduct> putSubResourceAsync(final ServiceCallback<SubProduct> serviceCallback) {
+    public ServiceFuture<SubProduct> putSubResourceAsync(ServiceCallback<SubProduct> serviceCallback) {
         return ServiceFuture.fromBody(putSubResourceAsync(), serviceCallback);
     }
 
@@ -2715,12 +3076,24 @@ public class LROsImpl implements LROs {
      * Long running put request with sub resource.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the SubProduct object
+     * @return a {@link Single} emitting the RestResponse<Void, SubProduct> object
      */
-    public Single<SubProduct> putSubResourceAsync() {
+    public Single<RestResponse<Void, SubProduct>> putSubResourceWithRestResponseAsync() {
         final SubProduct product = null;
+        Validator.validate(product);
         return service.putSubResource(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, SubProduct> object
+     */
+    public Single<SubProduct> putSubResourceAsync() {
+        return putSubResourceWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, SubProduct>, SubProduct>() { public SubProduct call(RestResponse<Void, SubProduct> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request with sub resource.
@@ -2743,7 +3116,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<SubProduct> putSubResourceAsync(SubProduct product, final ServiceCallback<SubProduct> serviceCallback) {
+    public ServiceFuture<SubProduct> putSubResourceAsync(SubProduct product, ServiceCallback<SubProduct> serviceCallback) {
         return ServiceFuture.fromBody(putSubResourceAsync(product), serviceCallback);
     }
 
@@ -2752,12 +3125,24 @@ public class LROsImpl implements LROs {
      *
      * @param product Sub Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the SubProduct object
+     * @return a {@link Single} emitting the RestResponse<Void, SubProduct> object
      */
-    public Single<SubProduct> putSubResourceAsync(SubProduct product) {
+    public Single<RestResponse<Void, SubProduct>> putSubResourceWithRestResponseAsync(SubProduct product) {
         Validator.validate(product);
         return service.putSubResource(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @param product Sub Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, SubProduct> object
+     */
+    public Single<SubProduct> putSubResourceAsync(SubProduct product) {
+        return putSubResourceWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<Void, SubProduct>, SubProduct>() { public SubProduct call(RestResponse<Void, SubProduct> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2847,7 +3232,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<SubProduct> putAsyncSubResourceAsync(final ServiceCallback<SubProduct> serviceCallback) {
+    public ServiceFuture<SubProduct> putAsyncSubResourceAsync(ServiceCallback<SubProduct> serviceCallback) {
         return ServiceFuture.fromBody(putAsyncSubResourceAsync(), serviceCallback);
     }
 
@@ -2855,12 +3240,24 @@ public class LROsImpl implements LROs {
      * Long running put request with sub resource.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the SubProduct object
+     * @return a {@link Single} emitting the RestResponse<Void, SubProduct> object
      */
-    public Single<SubProduct> putAsyncSubResourceAsync() {
+    public Single<RestResponse<Void, SubProduct>> putAsyncSubResourceWithRestResponseAsync() {
         final SubProduct product = null;
+        Validator.validate(product);
         return service.putAsyncSubResource(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, SubProduct> object
+     */
+    public Single<SubProduct> putAsyncSubResourceAsync() {
+        return putAsyncSubResourceWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, SubProduct>, SubProduct>() { public SubProduct call(RestResponse<Void, SubProduct> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request with sub resource.
@@ -2883,7 +3280,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<SubProduct> putAsyncSubResourceAsync(SubProduct product, final ServiceCallback<SubProduct> serviceCallback) {
+    public ServiceFuture<SubProduct> putAsyncSubResourceAsync(SubProduct product, ServiceCallback<SubProduct> serviceCallback) {
         return ServiceFuture.fromBody(putAsyncSubResourceAsync(product), serviceCallback);
     }
 
@@ -2892,12 +3289,24 @@ public class LROsImpl implements LROs {
      *
      * @param product Sub Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the SubProduct object
+     * @return a {@link Single} emitting the RestResponse<Void, SubProduct> object
      */
-    public Single<SubProduct> putAsyncSubResourceAsync(SubProduct product) {
+    public Single<RestResponse<Void, SubProduct>> putAsyncSubResourceWithRestResponseAsync(SubProduct product) {
         Validator.validate(product);
         return service.putAsyncSubResource(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @param product Sub Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, SubProduct> object
+     */
+    public Single<SubProduct> putAsyncSubResourceAsync(SubProduct product) {
+        return putAsyncSubResourceWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<Void, SubProduct>, SubProduct>() { public SubProduct call(RestResponse<Void, SubProduct> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2952,19 +3361,30 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> deleteProvisioning202Accepted200SucceededAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(deleteProvisioning202Accepted200SucceededAsync(), serviceCallback);
+    public ServiceFuture<Product> deleteProvisioning202Accepted200SucceededAsync(ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(deleteProvisioning202Accepted200SucceededAsync(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteProvisioning202Accepted200SucceededHeaders, Product> object
      */
-    public Single<Product> deleteProvisioning202Accepted200SucceededAsync() {
+    public Single<RestResponse<LROsDeleteProvisioning202Accepted200SucceededHeaders, Product>> deleteProvisioning202Accepted200SucceededWithRestResponseAsync() {
         return service.deleteProvisioning202Accepted200Succeeded(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteProvisioning202Accepted200SucceededHeaders, Product> object
+     */
+    public Single<Product> deleteProvisioning202Accepted200SucceededAsync() {
+        return deleteProvisioning202Accepted200SucceededWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsDeleteProvisioning202Accepted200SucceededHeaders, Product>, Product>() { public Product call(RestResponse<LROsDeleteProvisioning202Accepted200SucceededHeaders, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -3019,19 +3439,30 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> deleteProvisioning202DeletingFailed200Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(deleteProvisioning202DeletingFailed200Async(), serviceCallback);
+    public ServiceFuture<Product> deleteProvisioning202DeletingFailed200Async(ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(deleteProvisioning202DeletingFailed200Async(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteProvisioning202DeletingFailed200Headers, Product> object
      */
-    public Single<Product> deleteProvisioning202DeletingFailed200Async() {
+    public Single<RestResponse<LROsDeleteProvisioning202DeletingFailed200Headers, Product>> deleteProvisioning202DeletingFailed200WithRestResponseAsync() {
         return service.deleteProvisioning202DeletingFailed200(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteProvisioning202DeletingFailed200Headers, Product> object
+     */
+    public Single<Product> deleteProvisioning202DeletingFailed200Async() {
+        return deleteProvisioning202DeletingFailed200WithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsDeleteProvisioning202DeletingFailed200Headers, Product>, Product>() { public Product call(RestResponse<LROsDeleteProvisioning202DeletingFailed200Headers, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -3086,19 +3517,30 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> deleteProvisioning202Deletingcanceled200Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(deleteProvisioning202Deletingcanceled200Async(), serviceCallback);
+    public ServiceFuture<Product> deleteProvisioning202Deletingcanceled200Async(ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(deleteProvisioning202Deletingcanceled200Async(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteProvisioning202Deletingcanceled200Headers, Product> object
      */
-    public Single<Product> deleteProvisioning202Deletingcanceled200Async() {
+    public Single<RestResponse<LROsDeleteProvisioning202Deletingcanceled200Headers, Product>> deleteProvisioning202Deletingcanceled200WithRestResponseAsync() {
         return service.deleteProvisioning202Deletingcanceled200(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteProvisioning202Deletingcanceled200Headers, Product> object
+     */
+    public Single<Product> deleteProvisioning202Deletingcanceled200Async() {
+        return deleteProvisioning202Deletingcanceled200WithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsDeleteProvisioning202Deletingcanceled200Headers, Product>, Product>() { public Product call(RestResponse<LROsDeleteProvisioning202Deletingcanceled200Headers, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -3139,6 +3581,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void delete204Succeeded() {
         delete204SucceededAsync().toBlocking().value();
@@ -3151,7 +3594,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> delete204SucceededAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> delete204SucceededAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(delete204SucceededAsync(), serviceCallback);
     }
 
@@ -3159,11 +3602,22 @@ public class LROsImpl implements LROs {
      * Long running delete succeeds and returns right away.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> delete204SucceededAsync() {
+    public Single<RestResponse<Void, Void>> delete204SucceededWithRestResponseAsync() {
         return service.delete204Succeeded(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete succeeds and returns right away.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> delete204SucceededAsync() {
+        return delete204SucceededWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -3218,19 +3672,30 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> delete202Retry200Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(delete202Retry200Async(), serviceCallback);
+    public ServiceFuture<Product> delete202Retry200Async(ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(delete202Retry200Async(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROsDelete202Retry200Headers, Product> object
      */
-    public Single<Product> delete202Retry200Async() {
+    public Single<RestResponse<LROsDelete202Retry200Headers, Product>> delete202Retry200WithRestResponseAsync() {
         return service.delete202Retry200(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsDelete202Retry200Headers, Product> object
+     */
+    public Single<Product> delete202Retry200Async() {
+        return delete202Retry200WithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsDelete202Retry200Headers, Product>, Product>() { public Product call(RestResponse<LROsDelete202Retry200Headers, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -3285,19 +3750,30 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> delete202NoRetry204Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(delete202NoRetry204Async(), serviceCallback);
+    public ServiceFuture<Product> delete202NoRetry204Async(ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(delete202NoRetry204Async(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROsDelete202NoRetry204Headers, Product> object
      */
-    public Single<Product> delete202NoRetry204Async() {
+    public Single<RestResponse<LROsDelete202NoRetry204Headers, Product>> delete202NoRetry204WithRestResponseAsync() {
         return service.delete202NoRetry204(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsDelete202NoRetry204Headers, Product> object
+     */
+    public Single<Product> delete202NoRetry204Async() {
+        return delete202NoRetry204WithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsDelete202NoRetry204Headers, Product>, Product>() { public Product call(RestResponse<LROsDelete202NoRetry204Headers, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -3338,6 +3814,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void deleteNoHeaderInRetry() {
         deleteNoHeaderInRetryAsync().toBlocking().value();
@@ -3350,19 +3827,30 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> deleteNoHeaderInRetryAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(deleteNoHeaderInRetryAsync(), serviceCallback);
+    public ServiceFuture<Void> deleteNoHeaderInRetryAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(deleteNoHeaderInRetryAsync(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a location header in the initial request. Subsequent calls to operation status do not contain location header.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteNoHeaderInRetryHeaders, Void> object
      */
-    public Single<Void> deleteNoHeaderInRetryAsync() {
+    public Single<RestResponse<LROsDeleteNoHeaderInRetryHeaders, Void>> deleteNoHeaderInRetryWithRestResponseAsync() {
         return service.deleteNoHeaderInRetry(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a location header in the initial request. Subsequent calls to operation status do not contain location header.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteNoHeaderInRetryHeaders, Void> object
+     */
+    public Single<Void> deleteNoHeaderInRetryAsync() {
+        return deleteNoHeaderInRetryWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsDeleteNoHeaderInRetryHeaders, Void>, Void>() { public Void call(RestResponse<LROsDeleteNoHeaderInRetryHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -3403,6 +3891,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void deleteAsyncNoHeaderInRetry() {
         deleteAsyncNoHeaderInRetryAsync().toBlocking().value();
@@ -3415,19 +3904,30 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> deleteAsyncNoHeaderInRetryAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(deleteAsyncNoHeaderInRetryAsync(), serviceCallback);
+    public ServiceFuture<Void> deleteAsyncNoHeaderInRetryAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(deleteAsyncNoHeaderInRetryAsync(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns an Azure-AsyncOperation header in the initial request. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteAsyncNoHeaderInRetryHeaders, Void> object
      */
-    public Single<Void> deleteAsyncNoHeaderInRetryAsync() {
+    public Single<RestResponse<LROsDeleteAsyncNoHeaderInRetryHeaders, Void>> deleteAsyncNoHeaderInRetryWithRestResponseAsync() {
         return service.deleteAsyncNoHeaderInRetry(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns an Azure-AsyncOperation header in the initial request. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteAsyncNoHeaderInRetryHeaders, Void> object
+     */
+    public Single<Void> deleteAsyncNoHeaderInRetryAsync() {
+        return deleteAsyncNoHeaderInRetryWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsDeleteAsyncNoHeaderInRetryHeaders, Void>, Void>() { public Void call(RestResponse<LROsDeleteAsyncNoHeaderInRetryHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -3468,6 +3968,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void deleteAsyncRetrySucceeded() {
         deleteAsyncRetrySucceededAsync().toBlocking().value();
@@ -3480,19 +3981,30 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> deleteAsyncRetrySucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(deleteAsyncRetrySucceededAsync(), serviceCallback);
+    public ServiceFuture<Void> deleteAsyncRetrySucceededAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(deleteAsyncRetrySucceededAsync(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteAsyncRetrySucceededHeaders, Void> object
      */
-    public Single<Void> deleteAsyncRetrySucceededAsync() {
+    public Single<RestResponse<LROsDeleteAsyncRetrySucceededHeaders, Void>> deleteAsyncRetrySucceededWithRestResponseAsync() {
         return service.deleteAsyncRetrySucceeded(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteAsyncRetrySucceededHeaders, Void> object
+     */
+    public Single<Void> deleteAsyncRetrySucceededAsync() {
+        return deleteAsyncRetrySucceededWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsDeleteAsyncRetrySucceededHeaders, Void>, Void>() { public Void call(RestResponse<LROsDeleteAsyncRetrySucceededHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -3533,6 +4045,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void deleteAsyncNoRetrySucceeded() {
         deleteAsyncNoRetrySucceededAsync().toBlocking().value();
@@ -3545,19 +4058,30 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> deleteAsyncNoRetrySucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(deleteAsyncNoRetrySucceededAsync(), serviceCallback);
+    public ServiceFuture<Void> deleteAsyncNoRetrySucceededAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(deleteAsyncNoRetrySucceededAsync(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteAsyncNoRetrySucceededHeaders, Void> object
      */
-    public Single<Void> deleteAsyncNoRetrySucceededAsync() {
+    public Single<RestResponse<LROsDeleteAsyncNoRetrySucceededHeaders, Void>> deleteAsyncNoRetrySucceededWithRestResponseAsync() {
         return service.deleteAsyncNoRetrySucceeded(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteAsyncNoRetrySucceededHeaders, Void> object
+     */
+    public Single<Void> deleteAsyncNoRetrySucceededAsync() {
+        return deleteAsyncNoRetrySucceededWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsDeleteAsyncNoRetrySucceededHeaders, Void>, Void>() { public Void call(RestResponse<LROsDeleteAsyncNoRetrySucceededHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -3598,6 +4122,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void deleteAsyncRetryFailed() {
         deleteAsyncRetryFailedAsync().toBlocking().value();
@@ -3610,19 +4135,30 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> deleteAsyncRetryFailedAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(deleteAsyncRetryFailedAsync(), serviceCallback);
+    public ServiceFuture<Void> deleteAsyncRetryFailedAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(deleteAsyncRetryFailedAsync(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteAsyncRetryFailedHeaders, Void> object
      */
-    public Single<Void> deleteAsyncRetryFailedAsync() {
+    public Single<RestResponse<LROsDeleteAsyncRetryFailedHeaders, Void>> deleteAsyncRetryFailedWithRestResponseAsync() {
         return service.deleteAsyncRetryFailed(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteAsyncRetryFailedHeaders, Void> object
+     */
+    public Single<Void> deleteAsyncRetryFailedAsync() {
+        return deleteAsyncRetryFailedWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsDeleteAsyncRetryFailedHeaders, Void>, Void>() { public Void call(RestResponse<LROsDeleteAsyncRetryFailedHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -3663,6 +4199,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void deleteAsyncRetrycanceled() {
         deleteAsyncRetrycanceledAsync().toBlocking().value();
@@ -3675,19 +4212,30 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> deleteAsyncRetrycanceledAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(deleteAsyncRetrycanceledAsync(), serviceCallback);
+    public ServiceFuture<Void> deleteAsyncRetrycanceledAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(deleteAsyncRetrycanceledAsync(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteAsyncRetrycanceledHeaders, Void> object
      */
-    public Single<Void> deleteAsyncRetrycanceledAsync() {
+    public Single<RestResponse<LROsDeleteAsyncRetrycanceledHeaders, Void>> deleteAsyncRetrycanceledWithRestResponseAsync() {
         return service.deleteAsyncRetrycanceled(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteAsyncRetrycanceledHeaders, Void> object
+     */
+    public Single<Void> deleteAsyncRetrycanceledAsync() {
+        return deleteAsyncRetrycanceledWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsDeleteAsyncRetrycanceledHeaders, Void>, Void>() { public Void call(RestResponse<LROsDeleteAsyncRetrycanceledHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -3742,7 +4290,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Sku> post200WithPayloadAsync(final ServiceCallback<Sku> serviceCallback) {
+    public ServiceFuture<Sku> post200WithPayloadAsync(ServiceCallback<Sku> serviceCallback) {
         return ServiceFuture.fromBody(post200WithPayloadAsync(), serviceCallback);
     }
 
@@ -3750,11 +4298,22 @@ public class LROsImpl implements LROs {
      * Long running post request, service returns a 202 to the initial request, with 'Location' header. Poll returns a 200 with a response body after success.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Sku object
+     * @return a {@link Single} emitting the RestResponse<Void, Sku> object
      */
-    public Single<Sku> post200WithPayloadAsync() {
+    public Single<RestResponse<Void, Sku>> post200WithPayloadWithRestResponseAsync() {
         return service.post200WithPayload(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' header. Poll returns a 200 with a response body after success.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Sku> object
+     */
+    public Single<Sku> post200WithPayloadAsync() {
+        return post200WithPayloadWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Sku>, Sku>() { public Sku call(RestResponse<Void, Sku> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -3829,6 +4388,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post202Retry200() {
         post202Retry200Async().toBlocking().value();
@@ -3841,20 +4401,32 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post202Retry200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(post202Retry200Async(), serviceCallback);
+    public ServiceFuture<Void> post202Retry200Async(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(post202Retry200Async(), serviceCallback);
     }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROsPost202Retry200Headers, Void> object
      */
-    public Single<Void> post202Retry200Async() {
+    public Single<RestResponse<LROsPost202Retry200Headers, Void>> post202Retry200WithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.post202Retry200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPost202Retry200Headers, Void> object
+     */
+    public Single<Void> post202Retry200Async() {
+        return post202Retry200WithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsPost202Retry200Headers, Void>, Void>() { public Void call(RestResponse<LROsPost202Retry200Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
@@ -3863,6 +4435,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post202Retry200(Product product) {
         post202Retry200Async(product).toBlocking().value();
@@ -3876,8 +4449,8 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post202Retry200Async(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(post202Retry200Async(product), serviceCallback);
+    public ServiceFuture<Void> post202Retry200Async(Product product, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(post202Retry200Async(product), serviceCallback);
     }
 
     /**
@@ -3885,12 +4458,24 @@ public class LROsImpl implements LROs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROsPost202Retry200Headers, Void> object
      */
-    public Single<Void> post202Retry200Async(Product product) {
+    public Single<RestResponse<LROsPost202Retry200Headers, Void>> post202Retry200WithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.post202Retry200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPost202Retry200Headers, Void> object
+     */
+    public Single<Void> post202Retry200Async(Product product) {
+        return post202Retry200WithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROsPost202Retry200Headers, Void>, Void>() { public Void call(RestResponse<LROsPost202Retry200Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -3980,20 +4565,32 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> post202NoRetry204Async(final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(post202NoRetry204Async(), serviceCallback);
+    public ServiceFuture<Product> post202NoRetry204Async(ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(post202NoRetry204Async(), serviceCallback);
     }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROsPost202NoRetry204Headers, Product> object
      */
-    public Single<Product> post202NoRetry204Async() {
+    public Single<RestResponse<LROsPost202NoRetry204Headers, Product>> post202NoRetry204WithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.post202NoRetry204(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPost202NoRetry204Headers, Product> object
+     */
+    public Single<Product> post202NoRetry204Async() {
+        return post202NoRetry204WithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsPost202NoRetry204Headers, Product>, Product>() { public Product call(RestResponse<LROsPost202NoRetry204Headers, Product> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
@@ -4016,8 +4613,8 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> post202NoRetry204Async(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(post202NoRetry204Async(product), serviceCallback);
+    public ServiceFuture<Product> post202NoRetry204Async(Product product, ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(post202NoRetry204Async(product), serviceCallback);
     }
 
     /**
@@ -4025,12 +4622,24 @@ public class LROsImpl implements LROs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROsPost202NoRetry204Headers, Product> object
      */
-    public Single<Product> post202NoRetry204Async(Product product) {
+    public Single<RestResponse<LROsPost202NoRetry204Headers, Product>> post202NoRetry204WithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.post202NoRetry204(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPost202NoRetry204Headers, Product> object
+     */
+    public Single<Product> post202NoRetry204Async(Product product) {
+        return post202NoRetry204WithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROsPost202NoRetry204Headers, Product>, Product>() { public Product call(RestResponse<LROsPost202NoRetry204Headers, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -4120,20 +4729,32 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> postAsyncRetrySucceededAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRetrySucceededAsync(), serviceCallback);
+    public ServiceFuture<Product> postAsyncRetrySucceededAsync(ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRetrySucceededAsync(), serviceCallback);
     }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROsPostAsyncRetrySucceededHeaders, Product> object
      */
-    public Single<Product> postAsyncRetrySucceededAsync() {
+    public Single<RestResponse<LROsPostAsyncRetrySucceededHeaders, Product>> postAsyncRetrySucceededWithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.postAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPostAsyncRetrySucceededHeaders, Product> object
+     */
+    public Single<Product> postAsyncRetrySucceededAsync() {
+        return postAsyncRetrySucceededWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsPostAsyncRetrySucceededHeaders, Product>, Product>() { public Product call(RestResponse<LROsPostAsyncRetrySucceededHeaders, Product> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -4156,8 +4777,8 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> postAsyncRetrySucceededAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRetrySucceededAsync(product), serviceCallback);
+    public ServiceFuture<Product> postAsyncRetrySucceededAsync(Product product, ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRetrySucceededAsync(product), serviceCallback);
     }
 
     /**
@@ -4165,12 +4786,24 @@ public class LROsImpl implements LROs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROsPostAsyncRetrySucceededHeaders, Product> object
      */
-    public Single<Product> postAsyncRetrySucceededAsync(Product product) {
+    public Single<RestResponse<LROsPostAsyncRetrySucceededHeaders, Product>> postAsyncRetrySucceededWithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.postAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPostAsyncRetrySucceededHeaders, Product> object
+     */
+    public Single<Product> postAsyncRetrySucceededAsync(Product product) {
+        return postAsyncRetrySucceededWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROsPostAsyncRetrySucceededHeaders, Product>, Product>() { public Product call(RestResponse<LROsPostAsyncRetrySucceededHeaders, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -4260,20 +4893,32 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> postAsyncNoRetrySucceededAsync(final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncNoRetrySucceededAsync(), serviceCallback);
+    public ServiceFuture<Product> postAsyncNoRetrySucceededAsync(ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncNoRetrySucceededAsync(), serviceCallback);
     }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROsPostAsyncNoRetrySucceededHeaders, Product> object
      */
-    public Single<Product> postAsyncNoRetrySucceededAsync() {
+    public Single<RestResponse<LROsPostAsyncNoRetrySucceededHeaders, Product>> postAsyncNoRetrySucceededWithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.postAsyncNoRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPostAsyncNoRetrySucceededHeaders, Product> object
+     */
+    public Single<Product> postAsyncNoRetrySucceededAsync() {
+        return postAsyncNoRetrySucceededWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsPostAsyncNoRetrySucceededHeaders, Product>, Product>() { public Product call(RestResponse<LROsPostAsyncNoRetrySucceededHeaders, Product> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -4296,8 +4941,8 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> postAsyncNoRetrySucceededAsync(Product product, final ServiceCallback<Product> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncNoRetrySucceededAsync(product), serviceCallback);
+    public ServiceFuture<Product> postAsyncNoRetrySucceededAsync(Product product, ServiceCallback<Product> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncNoRetrySucceededAsync(product), serviceCallback);
     }
 
     /**
@@ -4305,12 +4950,24 @@ public class LROsImpl implements LROs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<LROsPostAsyncNoRetrySucceededHeaders, Product> object
      */
-    public Single<Product> postAsyncNoRetrySucceededAsync(Product product) {
+    public Single<RestResponse<LROsPostAsyncNoRetrySucceededHeaders, Product>> postAsyncNoRetrySucceededWithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.postAsyncNoRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPostAsyncNoRetrySucceededHeaders, Product> object
+     */
+    public Single<Product> postAsyncNoRetrySucceededAsync(Product product) {
+        return postAsyncNoRetrySucceededWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROsPostAsyncNoRetrySucceededHeaders, Product>, Product>() { public Product call(RestResponse<LROsPostAsyncNoRetrySucceededHeaders, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -4385,6 +5042,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postAsyncRetryFailed() {
         postAsyncRetryFailedAsync().toBlocking().value();
@@ -4397,20 +5055,32 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postAsyncRetryFailedAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRetryFailedAsync(), serviceCallback);
+    public ServiceFuture<Void> postAsyncRetryFailedAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRetryFailedAsync(), serviceCallback);
     }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROsPostAsyncRetryFailedHeaders, Void> object
      */
-    public Single<Void> postAsyncRetryFailedAsync() {
+    public Single<RestResponse<LROsPostAsyncRetryFailedHeaders, Void>> postAsyncRetryFailedWithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.postAsyncRetryFailed(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPostAsyncRetryFailedHeaders, Void> object
+     */
+    public Single<Void> postAsyncRetryFailedAsync() {
+        return postAsyncRetryFailedWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsPostAsyncRetryFailedHeaders, Void>, Void>() { public Void call(RestResponse<LROsPostAsyncRetryFailedHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -4419,6 +5089,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postAsyncRetryFailed(Product product) {
         postAsyncRetryFailedAsync(product).toBlocking().value();
@@ -4432,8 +5103,8 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postAsyncRetryFailedAsync(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRetryFailedAsync(product), serviceCallback);
+    public ServiceFuture<Void> postAsyncRetryFailedAsync(Product product, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRetryFailedAsync(product), serviceCallback);
     }
 
     /**
@@ -4441,12 +5112,24 @@ public class LROsImpl implements LROs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROsPostAsyncRetryFailedHeaders, Void> object
      */
-    public Single<Void> postAsyncRetryFailedAsync(Product product) {
+    public Single<RestResponse<LROsPostAsyncRetryFailedHeaders, Void>> postAsyncRetryFailedWithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.postAsyncRetryFailed(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPostAsyncRetryFailedHeaders, Void> object
+     */
+    public Single<Void> postAsyncRetryFailedAsync(Product product) {
+        return postAsyncRetryFailedWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROsPostAsyncRetryFailedHeaders, Void>, Void>() { public Void call(RestResponse<LROsPostAsyncRetryFailedHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -4521,6 +5204,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postAsyncRetrycanceled() {
         postAsyncRetrycanceledAsync().toBlocking().value();
@@ -4533,20 +5217,32 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postAsyncRetrycanceledAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRetrycanceledAsync(), serviceCallback);
+    public ServiceFuture<Void> postAsyncRetrycanceledAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRetrycanceledAsync(), serviceCallback);
     }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROsPostAsyncRetrycanceledHeaders, Void> object
      */
-    public Single<Void> postAsyncRetrycanceledAsync() {
+    public Single<RestResponse<LROsPostAsyncRetrycanceledHeaders, Void>> postAsyncRetrycanceledWithRestResponseAsync() {
         final Product product = null;
+        Validator.validate(product);
         return service.postAsyncRetrycanceled(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPostAsyncRetrycanceledHeaders, Void> object
+     */
+    public Single<Void> postAsyncRetrycanceledAsync() {
+        return postAsyncRetrycanceledWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsPostAsyncRetrycanceledHeaders, Void>, Void>() { public Void call(RestResponse<LROsPostAsyncRetrycanceledHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -4555,6 +5251,7 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postAsyncRetrycanceled(Product product) {
         postAsyncRetrycanceledAsync(product).toBlocking().value();
@@ -4568,8 +5265,8 @@ public class LROsImpl implements LROs {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postAsyncRetrycanceledAsync(Product product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRetrycanceledAsync(product), serviceCallback);
+    public ServiceFuture<Void> postAsyncRetrycanceledAsync(Product product, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRetrycanceledAsync(product), serviceCallback);
     }
 
     /**
@@ -4577,12 +5274,24 @@ public class LROsImpl implements LROs {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROsPostAsyncRetrycanceledHeaders, Void> object
      */
-    public Single<Void> postAsyncRetrycanceledAsync(Product product) {
+    public Single<RestResponse<LROsPostAsyncRetrycanceledHeaders, Void>> postAsyncRetrycanceledWithRestResponseAsync(Product product) {
         Validator.validate(product);
         return service.postAsyncRetrycanceled(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPostAsyncRetrycanceledHeaders, Void> object
+     */
+    public Single<Void> postAsyncRetrycanceledAsync(Product product) {
+        return postAsyncRetrycanceledWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROsPostAsyncRetrycanceledHeaders, Void>, Void>() { public Void call(RestResponse<LROsPostAsyncRetrycanceledHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azure/src/main/java/fixtures/paging/Pagings.java
+++ b/test/azure/src/main/java/fixtures/paging/Pagings.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.CloudException;
 import com.microsoft.azure.ListOperationCallback;
 import com.microsoft.azure.Page;
 import com.microsoft.azure.PagedList;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.paging.models.CustomParameterGroup;
 import fixtures.paging.models.PagingGetMultiplePagesOptions;
@@ -49,6 +50,14 @@ public interface Pagings {
      */
     Observable<Page<Product>> getSinglePagesAsync();
 
+    /**
+     * A paging operation that finishes on the first call without a nextlink.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the PagedList&lt;Product&gt; object
+     */
+    RestResponse<Void, Page<Product>> getSinglePagesWithRestResponseAsync();
+
 
     /**
      * A paging operation that includes a nextLink that has 10 pages.
@@ -67,6 +76,14 @@ public interface Pagings {
      * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getMultiplePagesAsync();
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the PagedList&lt;Product&gt; object
+     */
+    RestResponse<Void, Page<Product>> getMultiplePagesWithRestResponseAsync();
+    }
     /**
      * A paging operation that includes a nextLink that has 10 pages.
      *
@@ -89,6 +106,16 @@ public interface Pagings {
      */
     Observable<Page<Product>> getMultiplePagesAsync(final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions);
 
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param clientRequestId the String value
+     * @param pagingGetMultiplePagesOptions Additional parameters for the operation
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the PagedList&lt;Product&gt; object
+     */
+    RestResponse<Void, Page<Product>> getMultiplePagesWithRestResponseAsync(final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions);
+
 
     /**
      * A paging operation that includes a nextLink in odata format that has 10 pages.
@@ -110,6 +137,14 @@ public interface Pagings {
     /**
      * A paging operation that includes a nextLink in odata format that has 10 pages.
      *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the PagedList&lt;Product&gt; object
+     */
+    RestResponse<Void, Page<Product>> getOdataMultiplePagesWithRestResponseAsync();
+    }
+    /**
+     * A paging operation that includes a nextLink in odata format that has 10 pages.
+     *
      * @param clientRequestId the String value
      * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
@@ -128,6 +163,16 @@ public interface Pagings {
      * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getOdataMultiplePagesAsync(final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions);
+
+    /**
+     * A paging operation that includes a nextLink in odata format that has 10 pages.
+     *
+     * @param clientRequestId the String value
+     * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the PagedList&lt;Product&gt; object
+     */
+    RestResponse<Void, Page<Product>> getOdataMultiplePagesWithRestResponseAsync(final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions);
 
 
     /**
@@ -153,6 +198,15 @@ public interface Pagings {
      * A paging operation that includes a nextLink that has 10 pages.
      *
      * @param pagingGetMultiplePagesWithOffsetOptions Additional parameters for the operation
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the PagedList&lt;Product&gt; object
+     */
+    RestResponse<Void, Page<Product>> getMultiplePagesWithOffsetWithRestResponseAsync(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions);
+    }
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param pagingGetMultiplePagesWithOffsetOptions Additional parameters for the operation
      * @param clientRequestId the String value
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
@@ -170,6 +224,16 @@ public interface Pagings {
      * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getMultiplePagesWithOffsetAsync(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions, final String clientRequestId);
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param pagingGetMultiplePagesWithOffsetOptions Additional parameters for the operation
+     * @param clientRequestId the String value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the PagedList&lt;Product&gt; object
+     */
+    RestResponse<Void, Page<Product>> getMultiplePagesWithOffsetWithRestResponseAsync(final PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions, final String clientRequestId);
 
 
     /**
@@ -190,6 +254,14 @@ public interface Pagings {
      */
     Observable<Page<Product>> getMultiplePagesRetryFirstAsync();
 
+    /**
+     * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the PagedList&lt;Product&gt; object
+     */
+    RestResponse<Void, Page<Product>> getMultiplePagesRetryFirstWithRestResponseAsync();
+
 
     /**
      * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
@@ -208,6 +280,14 @@ public interface Pagings {
      * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getMultiplePagesRetrySecondAsync();
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the PagedList&lt;Product&gt; object
+     */
+    RestResponse<Void, Page<Product>> getMultiplePagesRetrySecondWithRestResponseAsync();
 
 
     /**
@@ -228,6 +308,14 @@ public interface Pagings {
      */
     Observable<Page<Product>> getSinglePagesFailureAsync();
 
+    /**
+     * A paging operation that receives a 400 on the first call.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the PagedList&lt;Product&gt; object
+     */
+    RestResponse<Void, Page<Product>> getSinglePagesFailureWithRestResponseAsync();
+
 
     /**
      * A paging operation that receives a 400 on the second call.
@@ -247,6 +335,14 @@ public interface Pagings {
      */
     Observable<Page<Product>> getMultiplePagesFailureAsync();
 
+    /**
+     * A paging operation that receives a 400 on the second call.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the PagedList&lt;Product&gt; object
+     */
+    RestResponse<Void, Page<Product>> getMultiplePagesFailureWithRestResponseAsync();
+
 
     /**
      * A paging operation that receives an invalid nextLink.
@@ -265,6 +361,14 @@ public interface Pagings {
      * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getMultiplePagesFailureUriAsync();
+
+    /**
+     * A paging operation that receives an invalid nextLink.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the PagedList&lt;Product&gt; object
+     */
+    RestResponse<Void, Page<Product>> getMultiplePagesFailureUriWithRestResponseAsync();
 
 
     /**
@@ -289,6 +393,16 @@ public interface Pagings {
      */
     Observable<Page<Product>> getMultiplePagesFragmentNextLinkAsync(final String tenant, final String apiVersion);
 
+    /**
+     * A paging operation that doesn't return a full URL, just a fragment.
+     *
+     * @param tenant Sets the tenant to use.
+     * @param apiVersion Sets the api version to use.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the PagedList&lt;Product&gt; object
+     */
+    RestResponse<Void, Page<Product>> getMultiplePagesFragmentNextLinkWithRestResponseAsync(final String tenant, final String apiVersion);
+
 
     /**
      * A paging operation that doesn't return a full URL, just a fragment with parameters grouped.
@@ -309,6 +423,15 @@ public interface Pagings {
      * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getMultiplePagesFragmentWithGroupingNextLinkAsync(final CustomParameterGroup customParameterGroup);
+
+    /**
+     * A paging operation that doesn't return a full URL, just a fragment with parameters grouped.
+     *
+     * @param customParameterGroup Additional parameters for the operation
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the PagedList&lt;Product&gt; object
+     */
+    RestResponse<Void, Page<Product>> getMultiplePagesFragmentWithGroupingNextLinkWithRestResponseAsync(final CustomParameterGroup customParameterGroup);
 
 
     /**
@@ -335,6 +458,17 @@ public interface Pagings {
      */
     Observable<Page<Product>> nextFragmentAsync(final String tenant, final String nextLink, final String apiVersion);
 
+    /**
+     * A paging operation that doesn't return a full URL, just a fragment.
+     *
+     * @param tenant Sets the tenant to use.
+     * @param nextLink Next link for list operation.
+     * @param apiVersion Sets the api version to use.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the PagedList&lt;Product&gt; object
+     */
+    RestResponse<Void, Page<Product>> nextFragmentWithRestResponseAsync(final String tenant, final String nextLink, final String apiVersion);
+
 
     /**
      * A paging operation that doesn't return a full URL, just a fragment.
@@ -358,6 +492,16 @@ public interface Pagings {
      */
     Observable<Page<Product>> nextFragmentWithGroupingAsync(final String nextLink, final CustomParameterGroup customParameterGroup);
 
+    /**
+     * A paging operation that doesn't return a full URL, just a fragment.
+     *
+     * @param nextLink Next link for list operation.
+     * @param customParameterGroup Additional parameters for the operation
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the PagedList&lt;Product&gt; object
+     */
+    RestResponse<Void, Page<Product>> nextFragmentWithGroupingWithRestResponseAsync(final String nextLink, final CustomParameterGroup customParameterGroup);
+
 
     /**
      * A paging operation that finishes on the first call without a nextlink.
@@ -378,6 +522,15 @@ public interface Pagings {
      * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getSinglePagesNextAsync(final String nextPageLink);
+
+    /**
+     * A paging operation that finishes on the first call without a nextlink.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the PagedList&lt;Product&gt; object
+     */
+    RestResponse<Void, Page<Product>> getSinglePagesNextWithRestResponseAsync(final String nextPageLink);
 
 
     /**
@@ -403,6 +556,15 @@ public interface Pagings {
      * A paging operation that includes a nextLink that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the PagedList&lt;Product&gt; object
+     */
+    RestResponse<Void, Page<Product>> getMultiplePagesNextWithRestResponseAsync(final String nextPageLink);
+    }
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @param clientRequestId the String value
      * @param pagingGetMultiplePagesOptions Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
@@ -422,6 +584,17 @@ public interface Pagings {
      * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getMultiplePagesNextAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions);
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param clientRequestId the String value
+     * @param pagingGetMultiplePagesOptions Additional parameters for the operation
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the PagedList&lt;Product&gt; object
+     */
+    RestResponse<Void, Page<Product>> getMultiplePagesNextWithRestResponseAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions);
 
 
     /**
@@ -447,6 +620,15 @@ public interface Pagings {
      * A paging operation that includes a nextLink in odata format that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the PagedList&lt;Product&gt; object
+     */
+    RestResponse<Void, Page<Product>> getOdataMultiplePagesNextWithRestResponseAsync(final String nextPageLink);
+    }
+    /**
+     * A paging operation that includes a nextLink in odata format that has 10 pages.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @param clientRequestId the String value
      * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
@@ -466,6 +648,17 @@ public interface Pagings {
      * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getOdataMultiplePagesNextAsync(final String nextPageLink, final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions);
+
+    /**
+     * A paging operation that includes a nextLink in odata format that has 10 pages.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param clientRequestId the String value
+     * @param pagingGetOdataMultiplePagesOptions Additional parameters for the operation
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the PagedList&lt;Product&gt; object
+     */
+    RestResponse<Void, Page<Product>> getOdataMultiplePagesNextWithRestResponseAsync(final String nextPageLink, final String clientRequestId, final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions);
 
 
     /**
@@ -491,6 +684,15 @@ public interface Pagings {
      * A paging operation that includes a nextLink that has 10 pages.
      *
      * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the PagedList&lt;Product&gt; object
+     */
+    RestResponse<Void, Page<Product>> getMultiplePagesWithOffsetNextWithRestResponseAsync(final String nextPageLink);
+    }
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
      * @param clientRequestId the String value
      * @param pagingGetMultiplePagesWithOffsetNextOptions Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
@@ -510,6 +712,17 @@ public interface Pagings {
      * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getMultiplePagesWithOffsetNextAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesWithOffsetNextOptions pagingGetMultiplePagesWithOffsetNextOptions);
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param clientRequestId the String value
+     * @param pagingGetMultiplePagesWithOffsetNextOptions Additional parameters for the operation
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the PagedList&lt;Product&gt; object
+     */
+    RestResponse<Void, Page<Product>> getMultiplePagesWithOffsetNextWithRestResponseAsync(final String nextPageLink, final String clientRequestId, final PagingGetMultiplePagesWithOffsetNextOptions pagingGetMultiplePagesWithOffsetNextOptions);
 
 
     /**
@@ -532,6 +745,15 @@ public interface Pagings {
      */
     Observable<Page<Product>> getMultiplePagesRetryFirstNextAsync(final String nextPageLink);
 
+    /**
+     * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the PagedList&lt;Product&gt; object
+     */
+    RestResponse<Void, Page<Product>> getMultiplePagesRetryFirstNextWithRestResponseAsync(final String nextPageLink);
+
 
     /**
      * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
@@ -552,6 +774,15 @@ public interface Pagings {
      * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getMultiplePagesRetrySecondNextAsync(final String nextPageLink);
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the PagedList&lt;Product&gt; object
+     */
+    RestResponse<Void, Page<Product>> getMultiplePagesRetrySecondNextWithRestResponseAsync(final String nextPageLink);
 
 
     /**
@@ -574,6 +805,15 @@ public interface Pagings {
      */
     Observable<Page<Product>> getSinglePagesFailureNextAsync(final String nextPageLink);
 
+    /**
+     * A paging operation that receives a 400 on the first call.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the PagedList&lt;Product&gt; object
+     */
+    RestResponse<Void, Page<Product>> getSinglePagesFailureNextWithRestResponseAsync(final String nextPageLink);
+
 
     /**
      * A paging operation that receives a 400 on the second call.
@@ -595,6 +835,15 @@ public interface Pagings {
      */
     Observable<Page<Product>> getMultiplePagesFailureNextAsync(final String nextPageLink);
 
+    /**
+     * A paging operation that receives a 400 on the second call.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the PagedList&lt;Product&gt; object
+     */
+    RestResponse<Void, Page<Product>> getMultiplePagesFailureNextWithRestResponseAsync(final String nextPageLink);
+
 
     /**
      * A paging operation that receives an invalid nextLink.
@@ -615,6 +864,15 @@ public interface Pagings {
      * @return the observable to the PagedList&lt;Product&gt; object
      */
     Observable<Page<Product>> getMultiplePagesFailureUriNextAsync(final String nextPageLink);
+
+    /**
+     * A paging operation that receives an invalid nextLink.
+     *
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the PagedList&lt;Product&gt; object
+     */
+    RestResponse<Void, Page<Product>> getMultiplePagesFailureUriNextWithRestResponseAsync(final String nextPageLink);
 
 
 }

--- a/test/azure/src/main/java/fixtures/paging/implementation/AutoRestPagingTestServiceImpl.java
+++ b/test/azure/src/main/java/fixtures/paging/implementation/AutoRestPagingTestServiceImpl.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.AzureProxy;
 import com.microsoft.azure.AzureServiceClient;
 import com.microsoft.rest.credentials.ServiceClientCredentials;
 import com.microsoft.rest.RestClient;
+import com.microsoft.rest.RestResponse;
 import fixtures.paging.AutoRestPagingTestService;
 import fixtures.paging.Pagings;
 import rx.Single;

--- a/test/azure/src/main/java/fixtures/paging/implementation/PagingsImpl.java
+++ b/test/azure/src/main/java/fixtures/paging/implementation/PagingsImpl.java
@@ -10,6 +10,7 @@
 
 package fixtures.paging.implementation;
 
+import com.microsoft.rest.RestResponse;
 import fixtures.paging.Pagings;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.CloudException;
@@ -72,133 +73,133 @@ public class PagingsImpl implements Pagings {
         @GET("paging/single")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl<Product>> getSinglePages(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl<Product>>> getSinglePages(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getMultiplePages" })
         @GET("paging/multiple")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl<Product>> getMultiplePages(@HeaderParam("client-request-id") String clientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("maxresults") Integer maxresults, @HeaderParam("timeout") Integer timeout, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl<Product>>> getMultiplePages(@HeaderParam("client-request-id") String clientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("maxresults") Integer maxresults, @HeaderParam("timeout") Integer timeout, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getOdataMultiplePages" })
         @GET("paging/multiple/odata")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl1<Product>> getOdataMultiplePages(@HeaderParam("client-request-id") String clientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("maxresults") Integer maxresults, @HeaderParam("timeout") Integer timeout, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl1<Product>>> getOdataMultiplePages(@HeaderParam("client-request-id") String clientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("maxresults") Integer maxresults, @HeaderParam("timeout") Integer timeout, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getMultiplePagesWithOffset" })
         @GET("paging/multiple/withpath/{offset}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl<Product>> getMultiplePagesWithOffset(@PathParam("offset") int offset, @HeaderParam("client-request-id") String clientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("maxresults") Integer maxresults, @HeaderParam("timeout") Integer timeout, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl<Product>>> getMultiplePagesWithOffset(@PathParam("offset") int offset, @HeaderParam("client-request-id") String clientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("maxresults") Integer maxresults, @HeaderParam("timeout") Integer timeout, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getMultiplePagesRetryFirst" })
         @GET("paging/multiple/retryfirst")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl<Product>> getMultiplePagesRetryFirst(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl<Product>>> getMultiplePagesRetryFirst(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getMultiplePagesRetrySecond" })
         @GET("paging/multiple/retrysecond")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl<Product>> getMultiplePagesRetrySecond(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl<Product>>> getMultiplePagesRetrySecond(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getSinglePagesFailure" })
         @GET("paging/single/failure")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl<Product>> getSinglePagesFailure(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl<Product>>> getSinglePagesFailure(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getMultiplePagesFailure" })
         @GET("paging/multiple/failure")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl<Product>> getMultiplePagesFailure(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl<Product>>> getMultiplePagesFailure(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getMultiplePagesFailureUri" })
         @GET("paging/multiple/failureuri")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl<Product>> getMultiplePagesFailureUri(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl<Product>>> getMultiplePagesFailureUri(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getMultiplePagesFragmentNextLink" })
         @GET("paging/multiple/fragment/{tenant}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl1<Product>> getMultiplePagesFragmentNextLink(@PathParam("tenant") String tenant, @QueryParam("api_version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl1<Product>>> getMultiplePagesFragmentNextLink(@PathParam("tenant") String tenant, @QueryParam("api_version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getMultiplePagesFragmentWithGroupingNextLink" })
         @GET("paging/multiple/fragmentwithgrouping/{tenant}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl1<Product>> getMultiplePagesFragmentWithGroupingNextLink(@PathParam("tenant") String tenant, @HeaderParam("accept-language") String acceptLanguage, @QueryParam("api_version") String apiVersion, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl1<Product>>> getMultiplePagesFragmentWithGroupingNextLink(@PathParam("tenant") String tenant, @HeaderParam("accept-language") String acceptLanguage, @QueryParam("api_version") String apiVersion, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings nextFragment" })
         @GET("{nextUrl}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl1<Product>> nextFragment(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @QueryParam("api_version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl1<Product>>> nextFragment(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @QueryParam("api_version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings nextFragmentWithGrouping" })
         @GET("{nextUrl}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl1<Product>> nextFragmentWithGrouping(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("accept-language") String acceptLanguage, @QueryParam("api_version") String apiVersion, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl1<Product>>> nextFragmentWithGrouping(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("accept-language") String acceptLanguage, @QueryParam("api_version") String apiVersion, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getSinglePagesNext" })
         @GET("{nextUrl}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl<Product>> getSinglePagesNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl<Product>>> getSinglePagesNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getMultiplePagesNext" })
         @GET("{nextUrl}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl<Product>> getMultiplePagesNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("client-request-id") String clientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("maxresults") Integer maxresults, @HeaderParam("timeout") Integer timeout, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl<Product>>> getMultiplePagesNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("client-request-id") String clientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("maxresults") Integer maxresults, @HeaderParam("timeout") Integer timeout, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getOdataMultiplePagesNext" })
         @GET("{nextUrl}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl1<Product>> getOdataMultiplePagesNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("client-request-id") String clientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("maxresults") Integer maxresults, @HeaderParam("timeout") Integer timeout, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl1<Product>>> getOdataMultiplePagesNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("client-request-id") String clientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("maxresults") Integer maxresults, @HeaderParam("timeout") Integer timeout, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getMultiplePagesWithOffsetNext" })
         @GET("{nextUrl}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl<Product>> getMultiplePagesWithOffsetNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("client-request-id") String clientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("maxresults") Integer maxresults, @HeaderParam("timeout") Integer timeout, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl<Product>>> getMultiplePagesWithOffsetNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("client-request-id") String clientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("maxresults") Integer maxresults, @HeaderParam("timeout") Integer timeout, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getMultiplePagesRetryFirstNext" })
         @GET("{nextUrl}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl<Product>> getMultiplePagesRetryFirstNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl<Product>>> getMultiplePagesRetryFirstNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getMultiplePagesRetrySecondNext" })
         @GET("{nextUrl}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl<Product>> getMultiplePagesRetrySecondNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl<Product>>> getMultiplePagesRetrySecondNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getSinglePagesFailureNext" })
         @GET("{nextUrl}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl<Product>> getSinglePagesFailureNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl<Product>>> getSinglePagesFailureNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getMultiplePagesFailureNext" })
         @GET("{nextUrl}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl<Product>> getMultiplePagesFailureNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl<Product>>> getMultiplePagesFailureNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getMultiplePagesFailureUriNext" })
         @GET("{nextUrl}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl<Product>> getMultiplePagesFailureUriNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl<Product>>> getMultiplePagesFailureUriNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -248,10 +249,10 @@ public class PagingsImpl implements Pagings {
      * @return the PagedList<Product> object if successful.
      */
     public Single<Page<Product>> getSinglePagesSinglePageAsync() {
-        return service.getSinglePages(this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<PageImpl<Product>, Page<Product>>() {
+        return service.getSinglePages(this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<Product>>, Page<Product>>() {
                 @Override
-                public Page<Product> call(PageImpl<Product> productPage) {
-                    return productPage;
+                public Page<Product> call(RestResponse<Void, PageImpl<Product>> response) {
+                    return response.body();
                 }
             });
     }
@@ -307,10 +308,10 @@ public class PagingsImpl implements Pagings {
         final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions = null;
         Integer maxresults = null;
         Integer timeout = null;
-        return service.getMultiplePages(clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<PageImpl<Product>, Page<Product>>() {
+        return service.getMultiplePages(clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<Product>>, Page<Product>>() {
                 @Override
-                public Page<Product> call(PageImpl<Product> productPage) {
-                    return productPage;
+                public Page<Product> call(RestResponse<Void, PageImpl<Product>> response) {
+                    return response.body();
                 }
             });
     }
@@ -376,10 +377,10 @@ public class PagingsImpl implements Pagings {
         if (pagingGetMultiplePagesOptions != null) {
             timeout = pagingGetMultiplePagesOptions.timeout();
         }
-        return service.getMultiplePages(clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<PageImpl<Product>, Page<Product>>() {
+        return service.getMultiplePages(clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<Product>>, Page<Product>>() {
                 @Override
-                public Page<Product> call(PageImpl<Product> productPage) {
-                    return productPage;
+                public Page<Product> call(RestResponse<Void, PageImpl<Product>> response) {
+                    return response.body();
                 }
             });
     }
@@ -435,10 +436,10 @@ public class PagingsImpl implements Pagings {
         final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions = null;
         Integer maxresults = null;
         Integer timeout = null;
-        return service.getOdataMultiplePages(clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<PageImpl1<Product>, Page<Product>>() {
+        return service.getOdataMultiplePages(clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl1<Product>>, Page<Product>>() {
                 @Override
-                public Page<Product> call(PageImpl1<Product> productPage) {
-                    return productPage;
+                public Page<Product> call(RestResponse<Void, PageImpl1<Product>> response) {
+                    return response.body();
                 }
             });
     }
@@ -504,10 +505,10 @@ public class PagingsImpl implements Pagings {
         if (pagingGetOdataMultiplePagesOptions != null) {
             timeout = pagingGetOdataMultiplePagesOptions.timeout();
         }
-        return service.getOdataMultiplePages(clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<PageImpl1<Product>, Page<Product>>() {
+        return service.getOdataMultiplePages(clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl1<Product>>, Page<Product>>() {
                 @Override
-                public Page<Product> call(PageImpl1<Product> productPage) {
-                    return productPage;
+                public Page<Product> call(RestResponse<Void, PageImpl1<Product>> response) {
+                    return response.body();
                 }
             });
     }
@@ -576,10 +577,10 @@ public class PagingsImpl implements Pagings {
         Integer maxresults = pagingGetMultiplePagesWithOffsetOptions.maxresults();
         int offset = pagingGetMultiplePagesWithOffsetOptions.offset();
         Integer timeout = pagingGetMultiplePagesWithOffsetOptions.timeout();
-        return service.getMultiplePagesWithOffset(offset, clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<PageImpl<Product>, Page<Product>>() {
+        return service.getMultiplePagesWithOffset(offset, clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<Product>>, Page<Product>>() {
                 @Override
-                public Page<Product> call(PageImpl<Product> productPage) {
-                    return productPage;
+                public Page<Product> call(RestResponse<Void, PageImpl<Product>> response) {
+                    return response.body();
                 }
             });
     }
@@ -649,10 +650,10 @@ public class PagingsImpl implements Pagings {
         Integer maxresults = pagingGetMultiplePagesWithOffsetOptions.maxresults();
         int offset = pagingGetMultiplePagesWithOffsetOptions.offset();
         Integer timeout = pagingGetMultiplePagesWithOffsetOptions.timeout();
-        return service.getMultiplePagesWithOffset(offset, clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<PageImpl<Product>, Page<Product>>() {
+        return service.getMultiplePagesWithOffset(offset, clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<Product>>, Page<Product>>() {
                 @Override
-                public Page<Product> call(PageImpl<Product> productPage) {
-                    return productPage;
+                public Page<Product> call(RestResponse<Void, PageImpl<Product>> response) {
+                    return response.body();
                 }
             });
     }
@@ -704,10 +705,10 @@ public class PagingsImpl implements Pagings {
      * @return the PagedList<Product> object if successful.
      */
     public Single<Page<Product>> getMultiplePagesRetryFirstSinglePageAsync() {
-        return service.getMultiplePagesRetryFirst(this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<PageImpl<Product>, Page<Product>>() {
+        return service.getMultiplePagesRetryFirst(this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<Product>>, Page<Product>>() {
                 @Override
-                public Page<Product> call(PageImpl<Product> productPage) {
-                    return productPage;
+                public Page<Product> call(RestResponse<Void, PageImpl<Product>> response) {
+                    return response.body();
                 }
             });
     }
@@ -759,10 +760,10 @@ public class PagingsImpl implements Pagings {
      * @return the PagedList<Product> object if successful.
      */
     public Single<Page<Product>> getMultiplePagesRetrySecondSinglePageAsync() {
-        return service.getMultiplePagesRetrySecond(this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<PageImpl<Product>, Page<Product>>() {
+        return service.getMultiplePagesRetrySecond(this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<Product>>, Page<Product>>() {
                 @Override
-                public Page<Product> call(PageImpl<Product> productPage) {
-                    return productPage;
+                public Page<Product> call(RestResponse<Void, PageImpl<Product>> response) {
+                    return response.body();
                 }
             });
     }
@@ -814,10 +815,10 @@ public class PagingsImpl implements Pagings {
      * @return the PagedList<Product> object if successful.
      */
     public Single<Page<Product>> getSinglePagesFailureSinglePageAsync() {
-        return service.getSinglePagesFailure(this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<PageImpl<Product>, Page<Product>>() {
+        return service.getSinglePagesFailure(this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<Product>>, Page<Product>>() {
                 @Override
-                public Page<Product> call(PageImpl<Product> productPage) {
-                    return productPage;
+                public Page<Product> call(RestResponse<Void, PageImpl<Product>> response) {
+                    return response.body();
                 }
             });
     }
@@ -869,10 +870,10 @@ public class PagingsImpl implements Pagings {
      * @return the PagedList<Product> object if successful.
      */
     public Single<Page<Product>> getMultiplePagesFailureSinglePageAsync() {
-        return service.getMultiplePagesFailure(this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<PageImpl<Product>, Page<Product>>() {
+        return service.getMultiplePagesFailure(this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<Product>>, Page<Product>>() {
                 @Override
-                public Page<Product> call(PageImpl<Product> productPage) {
-                    return productPage;
+                public Page<Product> call(RestResponse<Void, PageImpl<Product>> response) {
+                    return response.body();
                 }
             });
     }
@@ -924,10 +925,10 @@ public class PagingsImpl implements Pagings {
      * @return the PagedList<Product> object if successful.
      */
     public Single<Page<Product>> getMultiplePagesFailureUriSinglePageAsync() {
-        return service.getMultiplePagesFailureUri(this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<PageImpl<Product>, Page<Product>>() {
+        return service.getMultiplePagesFailureUri(this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<Product>>, Page<Product>>() {
                 @Override
-                public Page<Product> call(PageImpl<Product> productPage) {
-                    return productPage;
+                public Page<Product> call(RestResponse<Void, PageImpl<Product>> response) {
+                    return response.body();
                 }
             });
     }
@@ -991,10 +992,10 @@ public class PagingsImpl implements Pagings {
         if (apiVersion == null) {
             throw new IllegalArgumentException("Parameter apiVersion is required and cannot be null.");
         }
-        return service.getMultiplePagesFragmentNextLink(tenant, apiVersion, this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<PageImpl1<Product>, Page<Product>>() {
+        return service.getMultiplePagesFragmentNextLink(tenant, apiVersion, this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl1<Product>>, Page<Product>>() {
                 @Override
-                public Page<Product> call(PageImpl1<Product> productPage) {
-                    return productPage;
+                public Page<Product> call(RestResponse<Void, PageImpl1<Product>> response) {
+                    return response.body();
                 }
             });
     }
@@ -1055,10 +1056,10 @@ public class PagingsImpl implements Pagings {
         Validator.validate(customParameterGroup);
         String apiVersion = customParameterGroup.apiVersion();
         String tenant = customParameterGroup.tenant();
-        return service.getMultiplePagesFragmentWithGroupingNextLink(tenant, this.client.acceptLanguage(), apiVersion, this.client.userAgent()).map(new Func1<PageImpl1<Product>, Page<Product>>() {
+        return service.getMultiplePagesFragmentWithGroupingNextLink(tenant, this.client.acceptLanguage(), apiVersion, this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl1<Product>>, Page<Product>>() {
                 @Override
-                public Page<Product> call(PageImpl1<Product> productPage) {
-                    return productPage;
+                public Page<Product> call(RestResponse<Void, PageImpl1<Product>> response) {
+                    return response.body();
                 }
             });
     }
@@ -1129,10 +1130,10 @@ public class PagingsImpl implements Pagings {
             throw new IllegalArgumentException("Parameter apiVersion is required and cannot be null.");
         }
         String nextUrl = String.format("paging/multiple/fragment/%s/%s", tenant, nextLink);
-        return service.nextFragment(nextUrl, apiVersion, this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<PageImpl1<Product>, Page<Product>>() {
+        return service.nextFragment(nextUrl, apiVersion, this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl1<Product>>, Page<Product>>() {
                 @Override
-                public Page<Product> call(PageImpl1<Product> productPage) {
-                    return productPage;
+                public Page<Product> call(RestResponse<Void, PageImpl1<Product>> response) {
+                    return response.body();
                 }
             });
     }
@@ -1200,10 +1201,10 @@ public class PagingsImpl implements Pagings {
         String apiVersion = customParameterGroup.apiVersion();
         String tenant = customParameterGroup.tenant();
         String nextUrl = String.format("paging/multiple/fragmentwithgrouping/%s/%s", tenant, nextLink);
-        return service.nextFragmentWithGrouping(nextUrl, this.client.acceptLanguage(), apiVersion, this.client.userAgent()).map(new Func1<PageImpl1<Product>, Page<Product>>() {
+        return service.nextFragmentWithGrouping(nextUrl, this.client.acceptLanguage(), apiVersion, this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl1<Product>>, Page<Product>>() {
                 @Override
-                public Page<Product> call(PageImpl1<Product> productPage) {
-                    return productPage;
+                public Page<Product> call(RestResponse<Void, PageImpl1<Product>> response) {
+                    return response.body();
                 }
             });
     }
@@ -1262,10 +1263,10 @@ public class PagingsImpl implements Pagings {
             throw new IllegalArgumentException("Parameter nextPageLink is required and cannot be null.");
         }
         String nextUrl = String.format("%s", nextPageLink);
-        return service.getSinglePagesNext(nextUrl, this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<PageImpl<Product>, Page<Product>>() {
+        return service.getSinglePagesNext(nextUrl, this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<Product>>, Page<Product>>() {
                 @Override
-                public Page<Product> call(PageImpl<Product> productPage) {
-                    return productPage;
+                public Page<Product> call(RestResponse<Void, PageImpl<Product>> response) {
+                    return response.body();
                 }
             });
     }
@@ -1328,10 +1329,10 @@ public class PagingsImpl implements Pagings {
         Integer maxresults = null;
         Integer timeout = null;
         String nextUrl = String.format("%s", nextPageLink);
-        return service.getMultiplePagesNext(nextUrl, clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<PageImpl<Product>, Page<Product>>() {
+        return service.getMultiplePagesNext(nextUrl, clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<Product>>, Page<Product>>() {
                 @Override
-                public Page<Product> call(PageImpl<Product> productPage) {
-                    return productPage;
+                public Page<Product> call(RestResponse<Void, PageImpl<Product>> response) {
+                    return response.body();
                 }
             });
     }
@@ -1404,10 +1405,10 @@ public class PagingsImpl implements Pagings {
             timeout = pagingGetMultiplePagesOptions.timeout();
         }
         String nextUrl = String.format("%s", nextPageLink);
-        return service.getMultiplePagesNext(nextUrl, clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<PageImpl<Product>, Page<Product>>() {
+        return service.getMultiplePagesNext(nextUrl, clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<Product>>, Page<Product>>() {
                 @Override
-                public Page<Product> call(PageImpl<Product> productPage) {
-                    return productPage;
+                public Page<Product> call(RestResponse<Void, PageImpl<Product>> response) {
+                    return response.body();
                 }
             });
     }
@@ -1470,10 +1471,10 @@ public class PagingsImpl implements Pagings {
         Integer maxresults = null;
         Integer timeout = null;
         String nextUrl = String.format("%s", nextPageLink);
-        return service.getOdataMultiplePagesNext(nextUrl, clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<PageImpl1<Product>, Page<Product>>() {
+        return service.getOdataMultiplePagesNext(nextUrl, clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl1<Product>>, Page<Product>>() {
                 @Override
-                public Page<Product> call(PageImpl1<Product> productPage) {
-                    return productPage;
+                public Page<Product> call(RestResponse<Void, PageImpl1<Product>> response) {
+                    return response.body();
                 }
             });
     }
@@ -1546,10 +1547,10 @@ public class PagingsImpl implements Pagings {
             timeout = pagingGetOdataMultiplePagesOptions.timeout();
         }
         String nextUrl = String.format("%s", nextPageLink);
-        return service.getOdataMultiplePagesNext(nextUrl, clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<PageImpl1<Product>, Page<Product>>() {
+        return service.getOdataMultiplePagesNext(nextUrl, clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl1<Product>>, Page<Product>>() {
                 @Override
-                public Page<Product> call(PageImpl1<Product> productPage) {
-                    return productPage;
+                public Page<Product> call(RestResponse<Void, PageImpl1<Product>> response) {
+                    return response.body();
                 }
             });
     }
@@ -1612,10 +1613,10 @@ public class PagingsImpl implements Pagings {
         Integer maxresults = null;
         Integer timeout = null;
         String nextUrl = String.format("%s", nextPageLink);
-        return service.getMultiplePagesWithOffsetNext(nextUrl, clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<PageImpl<Product>, Page<Product>>() {
+        return service.getMultiplePagesWithOffsetNext(nextUrl, clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<Product>>, Page<Product>>() {
                 @Override
-                public Page<Product> call(PageImpl<Product> productPage) {
-                    return productPage;
+                public Page<Product> call(RestResponse<Void, PageImpl<Product>> response) {
+                    return response.body();
                 }
             });
     }
@@ -1688,10 +1689,10 @@ public class PagingsImpl implements Pagings {
             timeout = pagingGetMultiplePagesWithOffsetNextOptions.timeout();
         }
         String nextUrl = String.format("%s", nextPageLink);
-        return service.getMultiplePagesWithOffsetNext(nextUrl, clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<PageImpl<Product>, Page<Product>>() {
+        return service.getMultiplePagesWithOffsetNext(nextUrl, clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<Product>>, Page<Product>>() {
                 @Override
-                public Page<Product> call(PageImpl<Product> productPage) {
-                    return productPage;
+                public Page<Product> call(RestResponse<Void, PageImpl<Product>> response) {
+                    return response.body();
                 }
             });
     }
@@ -1750,10 +1751,10 @@ public class PagingsImpl implements Pagings {
             throw new IllegalArgumentException("Parameter nextPageLink is required and cannot be null.");
         }
         String nextUrl = String.format("%s", nextPageLink);
-        return service.getMultiplePagesRetryFirstNext(nextUrl, this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<PageImpl<Product>, Page<Product>>() {
+        return service.getMultiplePagesRetryFirstNext(nextUrl, this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<Product>>, Page<Product>>() {
                 @Override
-                public Page<Product> call(PageImpl<Product> productPage) {
-                    return productPage;
+                public Page<Product> call(RestResponse<Void, PageImpl<Product>> response) {
+                    return response.body();
                 }
             });
     }
@@ -1812,10 +1813,10 @@ public class PagingsImpl implements Pagings {
             throw new IllegalArgumentException("Parameter nextPageLink is required and cannot be null.");
         }
         String nextUrl = String.format("%s", nextPageLink);
-        return service.getMultiplePagesRetrySecondNext(nextUrl, this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<PageImpl<Product>, Page<Product>>() {
+        return service.getMultiplePagesRetrySecondNext(nextUrl, this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<Product>>, Page<Product>>() {
                 @Override
-                public Page<Product> call(PageImpl<Product> productPage) {
-                    return productPage;
+                public Page<Product> call(RestResponse<Void, PageImpl<Product>> response) {
+                    return response.body();
                 }
             });
     }
@@ -1874,10 +1875,10 @@ public class PagingsImpl implements Pagings {
             throw new IllegalArgumentException("Parameter nextPageLink is required and cannot be null.");
         }
         String nextUrl = String.format("%s", nextPageLink);
-        return service.getSinglePagesFailureNext(nextUrl, this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<PageImpl<Product>, Page<Product>>() {
+        return service.getSinglePagesFailureNext(nextUrl, this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<Product>>, Page<Product>>() {
                 @Override
-                public Page<Product> call(PageImpl<Product> productPage) {
-                    return productPage;
+                public Page<Product> call(RestResponse<Void, PageImpl<Product>> response) {
+                    return response.body();
                 }
             });
     }
@@ -1936,10 +1937,10 @@ public class PagingsImpl implements Pagings {
             throw new IllegalArgumentException("Parameter nextPageLink is required and cannot be null.");
         }
         String nextUrl = String.format("%s", nextPageLink);
-        return service.getMultiplePagesFailureNext(nextUrl, this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<PageImpl<Product>, Page<Product>>() {
+        return service.getMultiplePagesFailureNext(nextUrl, this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<Product>>, Page<Product>>() {
                 @Override
-                public Page<Product> call(PageImpl<Product> productPage) {
-                    return productPage;
+                public Page<Product> call(RestResponse<Void, PageImpl<Product>> response) {
+                    return response.body();
                 }
             });
     }
@@ -1998,10 +1999,10 @@ public class PagingsImpl implements Pagings {
             throw new IllegalArgumentException("Parameter nextPageLink is required and cannot be null.");
         }
         String nextUrl = String.format("%s", nextPageLink);
-        return service.getMultiplePagesFailureUriNext(nextUrl, this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<PageImpl<Product>, Page<Product>>() {
+        return service.getMultiplePagesFailureUriNext(nextUrl, this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<Product>>, Page<Product>>() {
                 @Override
-                public Page<Product> call(PageImpl<Product> productPage) {
-                    return productPage;
+                public Page<Product> call(RestResponse<Void, PageImpl<Product>> response) {
+                    return response.body();
                 }
             });
     }

--- a/test/azure/src/main/java/fixtures/subscriptionidapiversion/Groups.java
+++ b/test/azure/src/main/java/fixtures/subscriptionidapiversion/Groups.java
@@ -10,6 +10,7 @@
 
 package fixtures.subscriptionidapiversion;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.subscriptionidapiversion.models.ErrorException;
@@ -52,6 +53,15 @@ public interface Groups {
      * @return the observable to the SampleResourceGroup object
      */
     Single<SampleResourceGroup> getSampleResourceGroupAsync(String resourceGroupName);
+
+    /**
+     * Provides a resouce group with name 'testgroup101' and location 'West US'.
+     *
+     * @param resourceGroupName Resource Group name 'testgroup101'.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the SampleResourceGroup object
+     */
+    RestResponse<Void, SampleResourceGroup> getSampleResourceGroupWithRestResponseAsync(String resourceGroupName);
 
 
 }

--- a/test/azure/src/main/java/fixtures/subscriptionidapiversion/implementation/GroupsImpl.java
+++ b/test/azure/src/main/java/fixtures/subscriptionidapiversion/implementation/GroupsImpl.java
@@ -10,6 +10,7 @@
 
 package fixtures.subscriptionidapiversion.implementation;
 
+import com.microsoft.rest.RestResponse;
 import fixtures.subscriptionidapiversion.Groups;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.ExpectedResponses;
@@ -61,7 +62,7 @@ public class GroupsImpl implements Groups {
         @GET("subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<SampleResourceGroup> getSampleResourceGroup(@PathParam("subscriptionId") String subscriptionId, @PathParam("resourceGroupName") String resourceGroupName, @QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, SampleResourceGroup>> getSampleResourceGroup(@PathParam("subscriptionId") String subscriptionId, @PathParam("resourceGroupName") String resourceGroupName, @QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -86,7 +87,7 @@ public class GroupsImpl implements Groups {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<SampleResourceGroup> getSampleResourceGroupAsync(String resourceGroupName, final ServiceCallback<SampleResourceGroup> serviceCallback) {
+    public ServiceFuture<SampleResourceGroup> getSampleResourceGroupAsync(String resourceGroupName, ServiceCallback<SampleResourceGroup> serviceCallback) {
         return ServiceFuture.fromBody(getSampleResourceGroupAsync(resourceGroupName), serviceCallback);
     }
 
@@ -95,9 +96,9 @@ public class GroupsImpl implements Groups {
      *
      * @param resourceGroupName Resource Group name 'testgroup101'.
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the SampleResourceGroup object
+     * @return a {@link Single} emitting the RestResponse<Void, SampleResourceGroup> object
      */
-    public Single<SampleResourceGroup> getSampleResourceGroupAsync(String resourceGroupName) {
+    public Single<RestResponse<Void, SampleResourceGroup>> getSampleResourceGroupWithRestResponseAsync(String resourceGroupName) {
         if (this.client.subscriptionId() == null) {
             throw new IllegalArgumentException("Parameter this.client.subscriptionId() is required and cannot be null.");
         }
@@ -109,6 +110,18 @@ public class GroupsImpl implements Groups {
         }
         return service.getSampleResourceGroup(this.client.subscriptionId(), resourceGroupName, this.client.apiVersion(), this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Provides a resouce group with name 'testgroup101' and location 'West US'.
+     *
+     * @param resourceGroupName Resource Group name 'testgroup101'.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, SampleResourceGroup> object
+     */
+    public Single<SampleResourceGroup> getSampleResourceGroupAsync(String resourceGroupName) {
+        return getSampleResourceGroupWithRestResponseAsync(resourceGroupName)
+            .map(new Func1<RestResponse<Void, SampleResourceGroup>, SampleResourceGroup>() { public SampleResourceGroup call(RestResponse<Void, SampleResourceGroup> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azure/src/main/java/fixtures/subscriptionidapiversion/implementation/MicrosoftAzureTestUrlImpl.java
+++ b/test/azure/src/main/java/fixtures/subscriptionidapiversion/implementation/MicrosoftAzureTestUrlImpl.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.AzureProxy;
 import com.microsoft.azure.AzureServiceClient;
 import com.microsoft.rest.credentials.ServiceClientCredentials;
 import com.microsoft.rest.RestClient;
+import com.microsoft.rest.RestResponse;
 import fixtures.subscriptionidapiversion.Groups;
 import fixtures.subscriptionidapiversion.MicrosoftAzureTestUrl;
 import rx.Single;

--- a/test/azurefluent/src/main/java/fixtures/azureparametergrouping/implementation/AutoRestParameterGroupingTestServiceImpl.java
+++ b/test/azurefluent/src/main/java/fixtures/azureparametergrouping/implementation/AutoRestParameterGroupingTestServiceImpl.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.AzureProxy;
 import com.microsoft.azure.AzureServiceClient;
 import com.microsoft.rest.credentials.ServiceClientCredentials;
 import com.microsoft.rest.RestClient;
+import com.microsoft.rest.RestResponse;
 import rx.Single;
 
 /**

--- a/test/azurefluent/src/main/java/fixtures/azureparametergrouping/implementation/ParameterGroupingsInner.java
+++ b/test/azurefluent/src/main/java/fixtures/azureparametergrouping/implementation/ParameterGroupingsInner.java
@@ -10,6 +10,7 @@
 
 package fixtures.azureparametergrouping.implementation;
 
+import com.microsoft.rest.RestResponse;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.BodyParam;
 import com.microsoft.rest.annotations.ExpectedResponses;
@@ -61,25 +62,25 @@ public class ParameterGroupingsInner {
         @POST("parameterGrouping/postRequired/{path}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postRequired(@PathParam("path") String path, @HeaderParam("accept-language") String acceptLanguage, @BodyParam("application/json; charset=utf-8") int body, @HeaderParam("customHeader") String customHeader, @QueryParam("query") Integer query, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> postRequired(@PathParam("path") String path, @HeaderParam("accept-language") String acceptLanguage, @BodyParam("application/json; charset=utf-8") int body, @HeaderParam("customHeader") String customHeader, @QueryParam("query") Integer query, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azureparametergrouping.ParameterGroupings postOptional" })
         @POST("parameterGrouping/postOptional")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postOptional(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("customHeader") String customHeader, @QueryParam("query") Integer query, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> postOptional(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("customHeader") String customHeader, @QueryParam("query") Integer query, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azureparametergrouping.ParameterGroupings postMultiParamGroups" })
         @POST("parameterGrouping/postMultipleParameterGroups")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postMultiParamGroups(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("header-one") String headerOne, @QueryParam("query-one") Integer queryOne, @HeaderParam("header-two") String headerTwo, @QueryParam("query-two") Integer queryTwo, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> postMultiParamGroups(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("header-one") String headerOne, @QueryParam("query-one") Integer queryOne, @HeaderParam("header-two") String headerTwo, @QueryParam("query-two") Integer queryTwo, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azureparametergrouping.ParameterGroupings postSharedParameterGroupObject" })
         @POST("parameterGrouping/sharedParameterGroupObject")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postSharedParameterGroupObject(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("header-one") String headerOne, @QueryParam("query-one") Integer queryOne, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> postSharedParameterGroupObject(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("header-one") String headerOne, @QueryParam("query-one") Integer queryOne, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -90,6 +91,7 @@ public class ParameterGroupingsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postRequired(ParameterGroupingPostRequiredParametersInner parameterGroupingPostRequiredParameters) {
         postRequiredAsync(parameterGroupingPostRequiredParameters).toBlocking().value();
@@ -103,7 +105,7 @@ public class ParameterGroupingsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postRequiredAsync(ParameterGroupingPostRequiredParametersInner parameterGroupingPostRequiredParameters, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postRequiredAsync(ParameterGroupingPostRequiredParametersInner parameterGroupingPostRequiredParameters, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postRequiredAsync(parameterGroupingPostRequiredParameters), serviceCallback);
     }
 
@@ -112,19 +114,31 @@ public class ParameterGroupingsInner {
      *
      * @param parameterGroupingPostRequiredParameters Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postRequiredAsync(ParameterGroupingPostRequiredParametersInner parameterGroupingPostRequiredParameters) {
+    public Single<RestResponse<Void, Void>> postRequiredWithRestResponseAsync(ParameterGroupingPostRequiredParametersInner parameterGroupingPostRequiredParameters) {
         if (parameterGroupingPostRequiredParameters == null) {
             throw new IllegalArgumentException("Parameter parameterGroupingPostRequiredParameters is required and cannot be null.");
         }
         Validator.validate(parameterGroupingPostRequiredParameters);
-        int body = parameterGroupingPostRequiredParameters.body();
-        String customHeader = parameterGroupingPostRequiredParameters.customHeader();
-        Integer query = parameterGroupingPostRequiredParameters.query();
-        String path = parameterGroupingPostRequiredParameters.path();
+    int body = parameterGroupingPostRequiredParameters.body();
+    String customHeader = parameterGroupingPostRequiredParameters.customHeader();
+    Integer query = parameterGroupingPostRequiredParameters.query();
+    String path = parameterGroupingPostRequiredParameters.path();
         return service.postRequired(path, this.client.acceptLanguage(), body, customHeader, query, this.client.userAgent());
     }
+
+    /**
+     * Post a bunch of required parameters grouped.
+     *
+     * @param parameterGroupingPostRequiredParameters Additional parameters for the operation
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postRequiredAsync(ParameterGroupingPostRequiredParametersInner parameterGroupingPostRequiredParameters) {
+        return postRequiredWithRestResponseAsync(parameterGroupingPostRequiredParameters)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -133,6 +147,7 @@ public class ParameterGroupingsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postOptional() {
         postOptionalAsync().toBlocking().value();
@@ -145,7 +160,7 @@ public class ParameterGroupingsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postOptionalAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postOptionalAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postOptionalAsync(), serviceCallback);
     }
 
@@ -153,14 +168,26 @@ public class ParameterGroupingsInner {
      * Post a bunch of optional parameters grouped.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postOptionalAsync() {
+    public Single<RestResponse<Void, Void>> postOptionalWithRestResponseAsync() {
         final ParameterGroupingPostOptionalParametersInner parameterGroupingPostOptionalParameters = null;
-        String customHeader = null;
-        Integer query = null;
+        Validator.validate(parameterGroupingPostOptionalParameters);
+    String customHeader = null;
+    Integer query = null;
         return service.postOptional(this.client.acceptLanguage(), customHeader, query, this.client.userAgent());
     }
+
+    /**
+     * Post a bunch of optional parameters grouped.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postOptionalAsync() {
+        return postOptionalWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Post a bunch of optional parameters grouped.
@@ -169,6 +196,7 @@ public class ParameterGroupingsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postOptional(ParameterGroupingPostOptionalParametersInner parameterGroupingPostOptionalParameters) {
         postOptionalAsync(parameterGroupingPostOptionalParameters).toBlocking().value();
@@ -182,7 +210,7 @@ public class ParameterGroupingsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postOptionalAsync(ParameterGroupingPostOptionalParametersInner parameterGroupingPostOptionalParameters, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postOptionalAsync(ParameterGroupingPostOptionalParametersInner parameterGroupingPostOptionalParameters, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postOptionalAsync(parameterGroupingPostOptionalParameters), serviceCallback);
     }
 
@@ -191,20 +219,32 @@ public class ParameterGroupingsInner {
      *
      * @param parameterGroupingPostOptionalParameters Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postOptionalAsync(ParameterGroupingPostOptionalParametersInner parameterGroupingPostOptionalParameters) {
+    public Single<RestResponse<Void, Void>> postOptionalWithRestResponseAsync(ParameterGroupingPostOptionalParametersInner parameterGroupingPostOptionalParameters) {
         Validator.validate(parameterGroupingPostOptionalParameters);
-        String customHeader = null;
-        if (parameterGroupingPostOptionalParameters != null) {
-            customHeader = parameterGroupingPostOptionalParameters.customHeader();
-        }
-        Integer query = null;
-        if (parameterGroupingPostOptionalParameters != null) {
-            query = parameterGroupingPostOptionalParameters.query();
-        }
+    String customHeader = null;
+    if (parameterGroupingPostOptionalParameters != null) {
+        customHeader = parameterGroupingPostOptionalParameters.customHeader();
+    }
+    Integer query = null;
+    if (parameterGroupingPostOptionalParameters != null) {
+        query = parameterGroupingPostOptionalParameters.query();
+    }
         return service.postOptional(this.client.acceptLanguage(), customHeader, query, this.client.userAgent());
     }
+
+    /**
+     * Post a bunch of optional parameters grouped.
+     *
+     * @param parameterGroupingPostOptionalParameters Additional parameters for the operation
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postOptionalAsync(ParameterGroupingPostOptionalParametersInner parameterGroupingPostOptionalParameters) {
+        return postOptionalWithRestResponseAsync(parameterGroupingPostOptionalParameters)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -213,6 +253,7 @@ public class ParameterGroupingsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postMultiParamGroups() {
         postMultiParamGroupsAsync().toBlocking().value();
@@ -225,7 +266,7 @@ public class ParameterGroupingsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postMultiParamGroupsAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postMultiParamGroupsAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postMultiParamGroupsAsync(), serviceCallback);
     }
 
@@ -233,17 +274,30 @@ public class ParameterGroupingsInner {
      * Post parameters from multiple different parameter groups.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postMultiParamGroupsAsync() {
+    public Single<RestResponse<Void, Void>> postMultiParamGroupsWithRestResponseAsync() {
         final FirstParameterGroupInner firstParameterGroup = null;
         final ParameterGroupingPostMultiParamGroupsSecondParamGroupInner parameterGroupingPostMultiParamGroupsSecondParamGroup = null;
-        String headerOne = null;
-        Integer queryOne = null;
-        String headerTwo = null;
-        Integer queryTwo = null;
+        Validator.validate(firstParameterGroup);
+        Validator.validate(parameterGroupingPostMultiParamGroupsSecondParamGroup);
+    String headerOne = null;
+    Integer queryOne = null;
+    String headerTwo = null;
+    Integer queryTwo = null;
         return service.postMultiParamGroups(this.client.acceptLanguage(), headerOne, queryOne, headerTwo, queryTwo, this.client.userAgent());
     }
+
+    /**
+     * Post parameters from multiple different parameter groups.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postMultiParamGroupsAsync() {
+        return postMultiParamGroupsWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Post parameters from multiple different parameter groups.
@@ -253,6 +307,7 @@ public class ParameterGroupingsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postMultiParamGroups(FirstParameterGroupInner firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroupInner parameterGroupingPostMultiParamGroupsSecondParamGroup) {
         postMultiParamGroupsAsync(firstParameterGroup, parameterGroupingPostMultiParamGroupsSecondParamGroup).toBlocking().value();
@@ -267,7 +322,7 @@ public class ParameterGroupingsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postMultiParamGroupsAsync(FirstParameterGroupInner firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroupInner parameterGroupingPostMultiParamGroupsSecondParamGroup, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postMultiParamGroupsAsync(FirstParameterGroupInner firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroupInner parameterGroupingPostMultiParamGroupsSecondParamGroup, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postMultiParamGroupsAsync(firstParameterGroup, parameterGroupingPostMultiParamGroupsSecondParamGroup), serviceCallback);
     }
 
@@ -277,29 +332,42 @@ public class ParameterGroupingsInner {
      * @param firstParameterGroup Additional parameters for the operation
      * @param parameterGroupingPostMultiParamGroupsSecondParamGroup Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postMultiParamGroupsAsync(FirstParameterGroupInner firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroupInner parameterGroupingPostMultiParamGroupsSecondParamGroup) {
+    public Single<RestResponse<Void, Void>> postMultiParamGroupsWithRestResponseAsync(FirstParameterGroupInner firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroupInner parameterGroupingPostMultiParamGroupsSecondParamGroup) {
         Validator.validate(firstParameterGroup);
         Validator.validate(parameterGroupingPostMultiParamGroupsSecondParamGroup);
-        String headerOne = null;
-        if (firstParameterGroup != null) {
-            headerOne = firstParameterGroup.headerOne();
-        }
-        Integer queryOne = null;
-        if (firstParameterGroup != null) {
-            queryOne = firstParameterGroup.queryOne();
-        }
-        String headerTwo = null;
-        if (parameterGroupingPostMultiParamGroupsSecondParamGroup != null) {
-            headerTwo = parameterGroupingPostMultiParamGroupsSecondParamGroup.headerTwo();
-        }
-        Integer queryTwo = null;
-        if (parameterGroupingPostMultiParamGroupsSecondParamGroup != null) {
-            queryTwo = parameterGroupingPostMultiParamGroupsSecondParamGroup.queryTwo();
-        }
+    String headerOne = null;
+    if (firstParameterGroup != null) {
+        headerOne = firstParameterGroup.headerOne();
+    }
+    Integer queryOne = null;
+    if (firstParameterGroup != null) {
+        queryOne = firstParameterGroup.queryOne();
+    }
+    String headerTwo = null;
+    if (parameterGroupingPostMultiParamGroupsSecondParamGroup != null) {
+        headerTwo = parameterGroupingPostMultiParamGroupsSecondParamGroup.headerTwo();
+    }
+    Integer queryTwo = null;
+    if (parameterGroupingPostMultiParamGroupsSecondParamGroup != null) {
+        queryTwo = parameterGroupingPostMultiParamGroupsSecondParamGroup.queryTwo();
+    }
         return service.postMultiParamGroups(this.client.acceptLanguage(), headerOne, queryOne, headerTwo, queryTwo, this.client.userAgent());
     }
+
+    /**
+     * Post parameters from multiple different parameter groups.
+     *
+     * @param firstParameterGroup Additional parameters for the operation
+     * @param parameterGroupingPostMultiParamGroupsSecondParamGroup Additional parameters for the operation
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postMultiParamGroupsAsync(FirstParameterGroupInner firstParameterGroup, ParameterGroupingPostMultiParamGroupsSecondParamGroupInner parameterGroupingPostMultiParamGroupsSecondParamGroup) {
+        return postMultiParamGroupsWithRestResponseAsync(firstParameterGroup, parameterGroupingPostMultiParamGroupsSecondParamGroup)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -308,6 +376,7 @@ public class ParameterGroupingsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postSharedParameterGroupObject() {
         postSharedParameterGroupObjectAsync().toBlocking().value();
@@ -320,7 +389,7 @@ public class ParameterGroupingsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postSharedParameterGroupObjectAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postSharedParameterGroupObjectAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postSharedParameterGroupObjectAsync(), serviceCallback);
     }
 
@@ -328,14 +397,26 @@ public class ParameterGroupingsInner {
      * Post parameters with a shared parameter group object.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postSharedParameterGroupObjectAsync() {
+    public Single<RestResponse<Void, Void>> postSharedParameterGroupObjectWithRestResponseAsync() {
         final FirstParameterGroupInner firstParameterGroup = null;
-        String headerOne = null;
-        Integer queryOne = null;
+        Validator.validate(firstParameterGroup);
+    String headerOne = null;
+    Integer queryOne = null;
         return service.postSharedParameterGroupObject(this.client.acceptLanguage(), headerOne, queryOne, this.client.userAgent());
     }
+
+    /**
+     * Post parameters with a shared parameter group object.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postSharedParameterGroupObjectAsync() {
+        return postSharedParameterGroupObjectWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Post parameters with a shared parameter group object.
@@ -344,6 +425,7 @@ public class ParameterGroupingsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postSharedParameterGroupObject(FirstParameterGroupInner firstParameterGroup) {
         postSharedParameterGroupObjectAsync(firstParameterGroup).toBlocking().value();
@@ -357,7 +439,7 @@ public class ParameterGroupingsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postSharedParameterGroupObjectAsync(FirstParameterGroupInner firstParameterGroup, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postSharedParameterGroupObjectAsync(FirstParameterGroupInner firstParameterGroup, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postSharedParameterGroupObjectAsync(firstParameterGroup), serviceCallback);
     }
 
@@ -366,20 +448,32 @@ public class ParameterGroupingsInner {
      *
      * @param firstParameterGroup Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postSharedParameterGroupObjectAsync(FirstParameterGroupInner firstParameterGroup) {
+    public Single<RestResponse<Void, Void>> postSharedParameterGroupObjectWithRestResponseAsync(FirstParameterGroupInner firstParameterGroup) {
         Validator.validate(firstParameterGroup);
-        String headerOne = null;
-        if (firstParameterGroup != null) {
-            headerOne = firstParameterGroup.headerOne();
-        }
-        Integer queryOne = null;
-        if (firstParameterGroup != null) {
-            queryOne = firstParameterGroup.queryOne();
-        }
+    String headerOne = null;
+    if (firstParameterGroup != null) {
+        headerOne = firstParameterGroup.headerOne();
+    }
+    Integer queryOne = null;
+    if (firstParameterGroup != null) {
+        queryOne = firstParameterGroup.queryOne();
+    }
         return service.postSharedParameterGroupObject(this.client.acceptLanguage(), headerOne, queryOne, this.client.userAgent());
     }
+
+    /**
+     * Post parameters with a shared parameter group object.
+     *
+     * @param firstParameterGroup Additional parameters for the operation
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postSharedParameterGroupObjectAsync(FirstParameterGroupInner firstParameterGroup) {
+        return postSharedParameterGroupObjectWithRestResponseAsync(firstParameterGroup)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azurefluent/src/main/java/fixtures/azurereport/implementation/AutoRestReportServiceForAzureImpl.java
+++ b/test/azurefluent/src/main/java/fixtures/azurereport/implementation/AutoRestReportServiceForAzureImpl.java
@@ -22,6 +22,7 @@ import com.microsoft.rest.annotations.UnexpectedResponseExceptionType;
 import com.microsoft.rest.credentials.ServiceClientCredentials;
 import com.microsoft.rest.http.HttpClient;
 import com.microsoft.rest.RestClient;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.azurereport.ErrorException;
@@ -169,7 +170,7 @@ public class AutoRestReportServiceForAzureImpl extends AzureServiceClient {
         @GET("report/azure")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, Integer>> getReport(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Map<String, Integer>>> getReport(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -192,7 +193,7 @@ public class AutoRestReportServiceForAzureImpl extends AzureServiceClient {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, Integer>> getReportAsync(final ServiceCallback<Map<String, Integer>> serviceCallback) {
+    public ServiceFuture<Map<String, Integer>> getReportAsync(ServiceCallback<Map<String, Integer>> serviceCallback) {
         return ServiceFuture.fromBody(getReportAsync(), serviceCallback);
     }
 
@@ -200,11 +201,22 @@ public class AutoRestReportServiceForAzureImpl extends AzureServiceClient {
      * Get test coverage report.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, Integer&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Integer>> object
      */
-    public Single<Map<String, Integer>> getReportAsync() {
+    public Single<RestResponse<Void, Map<String, Integer>>> getReportWithRestResponseAsync() {
         return service.getReport(this.acceptLanguage(), this.userAgent());
     }
+
+    /**
+     * Get test coverage report.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Integer>> object
+     */
+    public Single<Map<String, Integer>> getReportAsync() {
+        return getReportWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, Integer>>, Map<String, Integer>>() { public Map<String, Integer> call(RestResponse<Void, Map<String, Integer>> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azurefluent/src/main/java/fixtures/azureresource/implementation/AutoRestResourceFlatteningTestServiceImpl.java
+++ b/test/azurefluent/src/main/java/fixtures/azureresource/implementation/AutoRestResourceFlatteningTestServiceImpl.java
@@ -25,6 +25,7 @@ import com.microsoft.rest.annotations.UnexpectedResponseExceptionType;
 import com.microsoft.rest.credentials.ServiceClientCredentials;
 import com.microsoft.rest.http.HttpClient;
 import com.microsoft.rest.RestClient;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import com.microsoft.rest.Validator;
@@ -174,37 +175,37 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
         @PUT("azure/resource-flatten/array")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putArray(@BodyParam("application/json; charset=utf-8") List<Resource> resourceArray, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> putArray(@BodyParam("application/json; charset=utf-8") List<Resource> resourceArray, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azureresource.AutoRestResourceFlatteningTestService getArray" })
         @GET("azure/resource-flatten/array")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<FlattenedProductInner>> getArray(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, List<FlattenedProductInner>>> getArray(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azureresource.AutoRestResourceFlatteningTestService putDictionary" })
         @PUT("azure/resource-flatten/dictionary")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putDictionary(@BodyParam("application/json; charset=utf-8") Map<String, FlattenedProductInner> resourceDictionary, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> putDictionary(@BodyParam("application/json; charset=utf-8") Map<String, FlattenedProductInner> resourceDictionary, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azureresource.AutoRestResourceFlatteningTestService getDictionary" })
         @GET("azure/resource-flatten/dictionary")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, FlattenedProductInner>> getDictionary(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Map<String, FlattenedProductInner>>> getDictionary(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azureresource.AutoRestResourceFlatteningTestService putResourceCollection" })
         @PUT("azure/resource-flatten/resourcecollection")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putResourceCollection(@BodyParam("application/json; charset=utf-8") ResourceCollectionInner resourceComplexObject, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> putResourceCollection(@BodyParam("application/json; charset=utf-8") ResourceCollectionInner resourceComplexObject, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azureresource.AutoRestResourceFlatteningTestService getResourceCollection" })
         @GET("azure/resource-flatten/resourcecollection")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<ResourceCollectionInner> getResourceCollection(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, ResourceCollectionInner>> getResourceCollection(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -214,6 +215,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putArray() {
         putArrayAsync().toBlocking().value();
@@ -226,7 +228,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putArrayAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putArrayAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putArrayAsync(), serviceCallback);
     }
 
@@ -234,12 +236,24 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * Put External Resource as an Array.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putArrayAsync() {
+    public Single<RestResponse<Void, Void>> putArrayWithRestResponseAsync() {
         final List<Resource> resourceArray = null;
+        Validator.validate(resourceArray);
         return service.putArray(resourceArray, this.acceptLanguage(), this.userAgent());
     }
+
+    /**
+     * Put External Resource as an Array.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putArrayAsync() {
+        return putArrayWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Put External Resource as an Array.
@@ -248,6 +262,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putArray(List<Resource> resourceArray) {
         putArrayAsync(resourceArray).toBlocking().value();
@@ -261,7 +276,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putArrayAsync(List<Resource> resourceArray, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putArrayAsync(List<Resource> resourceArray, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putArrayAsync(resourceArray), serviceCallback);
     }
 
@@ -270,12 +285,24 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      *
      * @param resourceArray External Resource as an Array to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putArrayAsync(List<Resource> resourceArray) {
+    public Single<RestResponse<Void, Void>> putArrayWithRestResponseAsync(List<Resource> resourceArray) {
         Validator.validate(resourceArray);
         return service.putArray(resourceArray, this.acceptLanguage(), this.userAgent());
     }
+
+    /**
+     * Put External Resource as an Array.
+     *
+     * @param resourceArray External Resource as an Array to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putArrayAsync(List<Resource> resourceArray) {
+        return putArrayWithRestResponseAsync(resourceArray)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -297,7 +324,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<FlattenedProductInner>> getArrayAsync(final ServiceCallback<List<FlattenedProductInner>> serviceCallback) {
+    public ServiceFuture<List<FlattenedProductInner>> getArrayAsync(ServiceCallback<List<FlattenedProductInner>> serviceCallback) {
         return ServiceFuture.fromBody(getArrayAsync(), serviceCallback);
     }
 
@@ -305,11 +332,22 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * Get External Resource as an Array.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;FlattenedProductInner&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<FlattenedProductInner>> object
      */
-    public Single<List<FlattenedProductInner>> getArrayAsync() {
+    public Single<RestResponse<Void, List<FlattenedProductInner>>> getArrayWithRestResponseAsync() {
         return service.getArray(this.acceptLanguage(), this.userAgent());
     }
+
+    /**
+     * Get External Resource as an Array.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<FlattenedProductInner>> object
+     */
+    public Single<List<FlattenedProductInner>> getArrayAsync() {
+        return getArrayWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<FlattenedProductInner>>, List<FlattenedProductInner>>() { public List<FlattenedProductInner> call(RestResponse<Void, List<FlattenedProductInner>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -318,6 +356,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putDictionary() {
         putDictionaryAsync().toBlocking().value();
@@ -330,7 +369,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putDictionaryAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putDictionaryAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putDictionaryAsync(), serviceCallback);
     }
 
@@ -338,12 +377,24 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * Put External Resource as a Dictionary.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putDictionaryAsync() {
+    public Single<RestResponse<Void, Void>> putDictionaryWithRestResponseAsync() {
         final Map<String, FlattenedProductInner> resourceDictionary = null;
+        Validator.validate(resourceDictionary);
         return service.putDictionary(resourceDictionary, this.acceptLanguage(), this.userAgent());
     }
+
+    /**
+     * Put External Resource as a Dictionary.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putDictionaryAsync() {
+        return putDictionaryWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Put External Resource as a Dictionary.
@@ -352,6 +403,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putDictionary(Map<String, FlattenedProductInner> resourceDictionary) {
         putDictionaryAsync(resourceDictionary).toBlocking().value();
@@ -365,7 +417,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putDictionaryAsync(Map<String, FlattenedProductInner> resourceDictionary, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putDictionaryAsync(Map<String, FlattenedProductInner> resourceDictionary, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putDictionaryAsync(resourceDictionary), serviceCallback);
     }
 
@@ -374,12 +426,24 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      *
      * @param resourceDictionary External Resource as a Dictionary to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putDictionaryAsync(Map<String, FlattenedProductInner> resourceDictionary) {
+    public Single<RestResponse<Void, Void>> putDictionaryWithRestResponseAsync(Map<String, FlattenedProductInner> resourceDictionary) {
         Validator.validate(resourceDictionary);
         return service.putDictionary(resourceDictionary, this.acceptLanguage(), this.userAgent());
     }
+
+    /**
+     * Put External Resource as a Dictionary.
+     *
+     * @param resourceDictionary External Resource as a Dictionary to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putDictionaryAsync(Map<String, FlattenedProductInner> resourceDictionary) {
+        return putDictionaryWithRestResponseAsync(resourceDictionary)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -401,7 +465,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, FlattenedProductInner>> getDictionaryAsync(final ServiceCallback<Map<String, FlattenedProductInner>> serviceCallback) {
+    public ServiceFuture<Map<String, FlattenedProductInner>> getDictionaryAsync(ServiceCallback<Map<String, FlattenedProductInner>> serviceCallback) {
         return ServiceFuture.fromBody(getDictionaryAsync(), serviceCallback);
     }
 
@@ -409,11 +473,22 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * Get External Resource as a Dictionary.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, FlattenedProductInner&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, FlattenedProductInner>> object
      */
-    public Single<Map<String, FlattenedProductInner>> getDictionaryAsync() {
+    public Single<RestResponse<Void, Map<String, FlattenedProductInner>>> getDictionaryWithRestResponseAsync() {
         return service.getDictionary(this.acceptLanguage(), this.userAgent());
     }
+
+    /**
+     * Get External Resource as a Dictionary.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, FlattenedProductInner>> object
+     */
+    public Single<Map<String, FlattenedProductInner>> getDictionaryAsync() {
+        return getDictionaryWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, FlattenedProductInner>>, Map<String, FlattenedProductInner>>() { public Map<String, FlattenedProductInner> call(RestResponse<Void, Map<String, FlattenedProductInner>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -422,6 +497,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putResourceCollection() {
         putResourceCollectionAsync().toBlocking().value();
@@ -434,7 +510,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putResourceCollectionAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putResourceCollectionAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putResourceCollectionAsync(), serviceCallback);
     }
 
@@ -442,12 +518,24 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * Put External Resource as a ResourceCollection.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putResourceCollectionAsync() {
+    public Single<RestResponse<Void, Void>> putResourceCollectionWithRestResponseAsync() {
         final ResourceCollectionInner resourceComplexObject = null;
+        Validator.validate(resourceComplexObject);
         return service.putResourceCollection(resourceComplexObject, this.acceptLanguage(), this.userAgent());
     }
+
+    /**
+     * Put External Resource as a ResourceCollection.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putResourceCollectionAsync() {
+        return putResourceCollectionWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Put External Resource as a ResourceCollection.
@@ -456,6 +544,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putResourceCollection(ResourceCollectionInner resourceComplexObject) {
         putResourceCollectionAsync(resourceComplexObject).toBlocking().value();
@@ -469,7 +558,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putResourceCollectionAsync(ResourceCollectionInner resourceComplexObject, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putResourceCollectionAsync(ResourceCollectionInner resourceComplexObject, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putResourceCollectionAsync(resourceComplexObject), serviceCallback);
     }
 
@@ -478,12 +567,24 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      *
      * @param resourceComplexObject External Resource as a ResourceCollection to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putResourceCollectionAsync(ResourceCollectionInner resourceComplexObject) {
+    public Single<RestResponse<Void, Void>> putResourceCollectionWithRestResponseAsync(ResourceCollectionInner resourceComplexObject) {
         Validator.validate(resourceComplexObject);
         return service.putResourceCollection(resourceComplexObject, this.acceptLanguage(), this.userAgent());
     }
+
+    /**
+     * Put External Resource as a ResourceCollection.
+     *
+     * @param resourceComplexObject External Resource as a ResourceCollection to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putResourceCollectionAsync(ResourceCollectionInner resourceComplexObject) {
+        return putResourceCollectionWithRestResponseAsync(resourceComplexObject)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -505,7 +606,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ResourceCollectionInner> getResourceCollectionAsync(final ServiceCallback<ResourceCollectionInner> serviceCallback) {
+    public ServiceFuture<ResourceCollectionInner> getResourceCollectionAsync(ServiceCallback<ResourceCollectionInner> serviceCallback) {
         return ServiceFuture.fromBody(getResourceCollectionAsync(), serviceCallback);
     }
 
@@ -513,11 +614,22 @@ public class AutoRestResourceFlatteningTestServiceImpl extends AzureServiceClien
      * Get External Resource as a ResourceCollection.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ResourceCollectionInner object
+     * @return a {@link Single} emitting the RestResponse<Void, ResourceCollectionInner> object
      */
-    public Single<ResourceCollectionInner> getResourceCollectionAsync() {
+    public Single<RestResponse<Void, ResourceCollectionInner>> getResourceCollectionWithRestResponseAsync() {
         return service.getResourceCollection(this.acceptLanguage(), this.userAgent());
     }
+
+    /**
+     * Get External Resource as a ResourceCollection.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ResourceCollectionInner> object
+     */
+    public Single<ResourceCollectionInner> getResourceCollectionAsync() {
+        return getResourceCollectionWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, ResourceCollectionInner>, ResourceCollectionInner>() { public ResourceCollectionInner call(RestResponse<Void, ResourceCollectionInner> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azurefluent/src/main/java/fixtures/azurespecials/implementation/ApiVersionDefaultsInner.java
+++ b/test/azurefluent/src/main/java/fixtures/azurespecials/implementation/ApiVersionDefaultsInner.java
@@ -10,6 +10,7 @@
 
 package fixtures.azurespecials.implementation;
 
+import com.microsoft.rest.RestResponse;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.ExpectedResponses;
 import com.microsoft.rest.annotations.GET;
@@ -58,25 +59,25 @@ public class ApiVersionDefaultsInner {
         @GET("azurespecials/apiVersion/method/string/none/query/global/2015-07-01-preview")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getMethodGlobalValid(@QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> getMethodGlobalValid(@QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.ApiVersionDefaults getMethodGlobalNotProvidedValid" })
         @GET("azurespecials/apiVersion/method/string/none/query/globalNotProvided/2015-07-01-preview")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getMethodGlobalNotProvidedValid(@QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> getMethodGlobalNotProvidedValid(@QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.ApiVersionDefaults getPathGlobalValid" })
         @GET("azurespecials/apiVersion/path/string/none/query/global/2015-07-01-preview")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getPathGlobalValid(@QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> getPathGlobalValid(@QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.ApiVersionDefaults getSwaggerGlobalValid" })
         @GET("azurespecials/apiVersion/swagger/string/none/query/global/2015-07-01-preview")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getSwaggerGlobalValid(@QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> getSwaggerGlobalValid(@QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -86,6 +87,7 @@ public class ApiVersionDefaultsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getMethodGlobalValid() {
         getMethodGlobalValidAsync().toBlocking().value();
@@ -98,7 +100,7 @@ public class ApiVersionDefaultsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getMethodGlobalValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getMethodGlobalValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getMethodGlobalValidAsync(), serviceCallback);
     }
 
@@ -106,14 +108,25 @@ public class ApiVersionDefaultsInner {
      * GET method with api-version modeled in global settings.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getMethodGlobalValidAsync() {
+    public Single<RestResponse<Void, Void>> getMethodGlobalValidWithRestResponseAsync() {
         if (this.client.apiVersion() == null) {
             throw new IllegalArgumentException("Parameter this.client.apiVersion() is required and cannot be null.");
         }
         return service.getMethodGlobalValid(this.client.apiVersion(), this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * GET method with api-version modeled in global settings.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getMethodGlobalValidAsync() {
+        return getMethodGlobalValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -122,6 +135,7 @@ public class ApiVersionDefaultsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getMethodGlobalNotProvidedValid() {
         getMethodGlobalNotProvidedValidAsync().toBlocking().value();
@@ -134,7 +148,7 @@ public class ApiVersionDefaultsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getMethodGlobalNotProvidedValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getMethodGlobalNotProvidedValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getMethodGlobalNotProvidedValidAsync(), serviceCallback);
     }
 
@@ -142,14 +156,25 @@ public class ApiVersionDefaultsInner {
      * GET method with api-version modeled in global settings.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getMethodGlobalNotProvidedValidAsync() {
+    public Single<RestResponse<Void, Void>> getMethodGlobalNotProvidedValidWithRestResponseAsync() {
         if (this.client.apiVersion() == null) {
             throw new IllegalArgumentException("Parameter this.client.apiVersion() is required and cannot be null.");
         }
         return service.getMethodGlobalNotProvidedValid(this.client.apiVersion(), this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * GET method with api-version modeled in global settings.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getMethodGlobalNotProvidedValidAsync() {
+        return getMethodGlobalNotProvidedValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -158,6 +183,7 @@ public class ApiVersionDefaultsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getPathGlobalValid() {
         getPathGlobalValidAsync().toBlocking().value();
@@ -170,7 +196,7 @@ public class ApiVersionDefaultsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getPathGlobalValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getPathGlobalValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getPathGlobalValidAsync(), serviceCallback);
     }
 
@@ -178,14 +204,25 @@ public class ApiVersionDefaultsInner {
      * GET method with api-version modeled in global settings.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getPathGlobalValidAsync() {
+    public Single<RestResponse<Void, Void>> getPathGlobalValidWithRestResponseAsync() {
         if (this.client.apiVersion() == null) {
             throw new IllegalArgumentException("Parameter this.client.apiVersion() is required and cannot be null.");
         }
         return service.getPathGlobalValid(this.client.apiVersion(), this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * GET method with api-version modeled in global settings.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getPathGlobalValidAsync() {
+        return getPathGlobalValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -194,6 +231,7 @@ public class ApiVersionDefaultsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getSwaggerGlobalValid() {
         getSwaggerGlobalValidAsync().toBlocking().value();
@@ -206,7 +244,7 @@ public class ApiVersionDefaultsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getSwaggerGlobalValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getSwaggerGlobalValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getSwaggerGlobalValidAsync(), serviceCallback);
     }
 
@@ -214,14 +252,25 @@ public class ApiVersionDefaultsInner {
      * GET method with api-version modeled in global settings.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getSwaggerGlobalValidAsync() {
+    public Single<RestResponse<Void, Void>> getSwaggerGlobalValidWithRestResponseAsync() {
         if (this.client.apiVersion() == null) {
             throw new IllegalArgumentException("Parameter this.client.apiVersion() is required and cannot be null.");
         }
         return service.getSwaggerGlobalValid(this.client.apiVersion(), this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * GET method with api-version modeled in global settings.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getSwaggerGlobalValidAsync() {
+        return getSwaggerGlobalValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azurefluent/src/main/java/fixtures/azurespecials/implementation/ApiVersionLocalsInner.java
+++ b/test/azurefluent/src/main/java/fixtures/azurespecials/implementation/ApiVersionLocalsInner.java
@@ -10,6 +10,7 @@
 
 package fixtures.azurespecials.implementation;
 
+import com.microsoft.rest.RestResponse;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.ExpectedResponses;
 import com.microsoft.rest.annotations.GET;
@@ -58,25 +59,25 @@ public class ApiVersionLocalsInner {
         @GET("azurespecials/apiVersion/method/string/none/query/local/2.0")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getMethodLocalValid(@QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> getMethodLocalValid(@QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.ApiVersionLocals getMethodLocalNull" })
         @GET("azurespecials/apiVersion/method/string/none/query/local/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getMethodLocalNull(@QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> getMethodLocalNull(@QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.ApiVersionLocals getPathLocalValid" })
         @GET("azurespecials/apiVersion/path/string/none/query/local/2.0")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getPathLocalValid(@QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> getPathLocalValid(@QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.ApiVersionLocals getSwaggerLocalValid" })
         @GET("azurespecials/apiVersion/swagger/string/none/query/local/2.0")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getSwaggerLocalValid(@QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> getSwaggerLocalValid(@QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -86,6 +87,7 @@ public class ApiVersionLocalsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getMethodLocalValid() {
         getMethodLocalValidAsync().toBlocking().value();
@@ -98,7 +100,7 @@ public class ApiVersionLocalsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getMethodLocalValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getMethodLocalValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getMethodLocalValidAsync(), serviceCallback);
     }
 
@@ -106,12 +108,23 @@ public class ApiVersionLocalsInner {
      * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getMethodLocalValidAsync() {
+    public Single<RestResponse<Void, Void>> getMethodLocalValidWithRestResponseAsync() {
         final String apiVersion = "2.0";
         return service.getMethodLocalValid(apiVersion, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getMethodLocalValidAsync() {
+        return getMethodLocalValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -120,6 +133,7 @@ public class ApiVersionLocalsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getMethodLocalNull() {
         getMethodLocalNullAsync().toBlocking().value();
@@ -132,7 +146,7 @@ public class ApiVersionLocalsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getMethodLocalNullAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getMethodLocalNullAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getMethodLocalNullAsync(), serviceCallback);
     }
 
@@ -140,12 +154,23 @@ public class ApiVersionLocalsInner {
      * Get method with api-version modeled in the method.  pass in api-version = null to succeed.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getMethodLocalNullAsync() {
+    public Single<RestResponse<Void, Void>> getMethodLocalNullWithRestResponseAsync() {
         final String apiVersion = null;
         return service.getMethodLocalNull(apiVersion, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Get method with api-version modeled in the method.  pass in api-version = null to succeed.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getMethodLocalNullAsync() {
+        return getMethodLocalNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Get method with api-version modeled in the method.  pass in api-version = null to succeed.
@@ -154,6 +179,7 @@ public class ApiVersionLocalsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getMethodLocalNull(String apiVersion) {
         getMethodLocalNullAsync(apiVersion).toBlocking().value();
@@ -167,7 +193,7 @@ public class ApiVersionLocalsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getMethodLocalNullAsync(String apiVersion, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getMethodLocalNullAsync(String apiVersion, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getMethodLocalNullAsync(apiVersion), serviceCallback);
     }
 
@@ -176,11 +202,23 @@ public class ApiVersionLocalsInner {
      *
      * @param apiVersion This should appear as a method parameter, use value null, this should result in no serialized parameter
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getMethodLocalNullAsync(String apiVersion) {
+    public Single<RestResponse<Void, Void>> getMethodLocalNullWithRestResponseAsync(String apiVersion) {
         return service.getMethodLocalNull(apiVersion, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Get method with api-version modeled in the method.  pass in api-version = null to succeed.
+     *
+     * @param apiVersion This should appear as a method parameter, use value null, this should result in no serialized parameter
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getMethodLocalNullAsync(String apiVersion) {
+        return getMethodLocalNullWithRestResponseAsync(apiVersion)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -189,6 +227,7 @@ public class ApiVersionLocalsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getPathLocalValid() {
         getPathLocalValidAsync().toBlocking().value();
@@ -201,7 +240,7 @@ public class ApiVersionLocalsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getPathLocalValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getPathLocalValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getPathLocalValidAsync(), serviceCallback);
     }
 
@@ -209,12 +248,23 @@ public class ApiVersionLocalsInner {
      * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getPathLocalValidAsync() {
+    public Single<RestResponse<Void, Void>> getPathLocalValidWithRestResponseAsync() {
         final String apiVersion = "2.0";
         return service.getPathLocalValid(apiVersion, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getPathLocalValidAsync() {
+        return getPathLocalValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -223,6 +273,7 @@ public class ApiVersionLocalsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getSwaggerLocalValid() {
         getSwaggerLocalValidAsync().toBlocking().value();
@@ -235,7 +286,7 @@ public class ApiVersionLocalsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getSwaggerLocalValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getSwaggerLocalValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getSwaggerLocalValidAsync(), serviceCallback);
     }
 
@@ -243,12 +294,23 @@ public class ApiVersionLocalsInner {
      * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getSwaggerLocalValidAsync() {
+    public Single<RestResponse<Void, Void>> getSwaggerLocalValidWithRestResponseAsync() {
         final String apiVersion = "2.0";
         return service.getSwaggerLocalValid(apiVersion, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getSwaggerLocalValidAsync() {
+        return getSwaggerLocalValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azurefluent/src/main/java/fixtures/azurespecials/implementation/AutoRestAzureSpecialParametersTestClientImpl.java
+++ b/test/azurefluent/src/main/java/fixtures/azurespecials/implementation/AutoRestAzureSpecialParametersTestClientImpl.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.AzureProxy;
 import com.microsoft.azure.AzureServiceClient;
 import com.microsoft.rest.credentials.ServiceClientCredentials;
 import com.microsoft.rest.RestClient;
+import com.microsoft.rest.RestResponse;
 import rx.Single;
 
 /**

--- a/test/azurefluent/src/main/java/fixtures/azurespecials/implementation/HeadersInner.java
+++ b/test/azurefluent/src/main/java/fixtures/azurespecials/implementation/HeadersInner.java
@@ -10,6 +10,7 @@
 
 package fixtures.azurespecials.implementation;
 
+import com.microsoft.rest.RestResponse;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.ExpectedResponses;
 import com.microsoft.rest.annotations.HEAD;
@@ -59,19 +60,19 @@ public class HeadersInner {
         @POST("azurespecials/customNamedRequestId")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> customNamedRequestId(@HeaderParam("foo-client-request-id") String fooClientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<HeaderCustomNamedRequestIdHeadersInner, Void>> customNamedRequestId(@HeaderParam("foo-client-request-id") String fooClientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.Headers customNamedRequestIdParamGrouping" })
         @POST("azurespecials/customNamedRequestIdParamGrouping")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> customNamedRequestIdParamGrouping(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("foo-client-request-id") String fooClientRequestId, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<HeaderCustomNamedRequestIdParamGroupingHeadersInner, Void>> customNamedRequestIdParamGrouping(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("foo-client-request-id") String fooClientRequestId, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.Headers customNamedRequestIdHead" })
         @HEAD("azurespecials/customNamedRequestIdHead")
         @ExpectedResponses({200, 404})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Boolean> customNamedRequestIdHead(@HeaderParam("foo-client-request-id") String fooClientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<HeaderCustomNamedRequestIdHeadHeadersInner, Boolean>> customNamedRequestIdHead(@HeaderParam("foo-client-request-id") String fooClientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -82,6 +83,7 @@ public class HeadersInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void customNamedRequestId(String fooClientRequestId) {
         customNamedRequestIdAsync(fooClientRequestId).toBlocking().value();
@@ -95,8 +97,8 @@ public class HeadersInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> customNamedRequestIdAsync(String fooClientRequestId, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(customNamedRequestIdAsync(fooClientRequestId), serviceCallback);
+    public ServiceFuture<Void> customNamedRequestIdAsync(String fooClientRequestId, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(customNamedRequestIdAsync(fooClientRequestId), serviceCallback);
     }
 
     /**
@@ -104,14 +106,26 @@ public class HeadersInner {
      *
      * @param fooClientRequestId The fooRequestId
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HeaderCustomNamedRequestIdHeadersInner, Void> object
      */
-    public Single<Void> customNamedRequestIdAsync(String fooClientRequestId) {
+    public Single<RestResponse<HeaderCustomNamedRequestIdHeadersInner, Void>> customNamedRequestIdWithRestResponseAsync(String fooClientRequestId) {
         if (fooClientRequestId == null) {
             throw new IllegalArgumentException("Parameter fooClientRequestId is required and cannot be null.");
         }
         return service.customNamedRequestId(fooClientRequestId, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request.
+     *
+     * @param fooClientRequestId The fooRequestId
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HeaderCustomNamedRequestIdHeadersInner, Void> object
+     */
+    public Single<Void> customNamedRequestIdAsync(String fooClientRequestId) {
+        return customNamedRequestIdWithRestResponseAsync(fooClientRequestId)
+            .map(new Func1<RestResponse<HeaderCustomNamedRequestIdHeadersInner, Void>, Void>() { public Void call(RestResponse<HeaderCustomNamedRequestIdHeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -121,6 +135,7 @@ public class HeadersInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void customNamedRequestIdParamGrouping(HeaderCustomNamedRequestIdParamGroupingParametersInner headerCustomNamedRequestIdParamGroupingParameters) {
         customNamedRequestIdParamGroupingAsync(headerCustomNamedRequestIdParamGroupingParameters).toBlocking().value();
@@ -134,8 +149,8 @@ public class HeadersInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> customNamedRequestIdParamGroupingAsync(HeaderCustomNamedRequestIdParamGroupingParametersInner headerCustomNamedRequestIdParamGroupingParameters, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(customNamedRequestIdParamGroupingAsync(headerCustomNamedRequestIdParamGroupingParameters), serviceCallback);
+    public ServiceFuture<Void> customNamedRequestIdParamGroupingAsync(HeaderCustomNamedRequestIdParamGroupingParametersInner headerCustomNamedRequestIdParamGroupingParameters, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(customNamedRequestIdParamGroupingAsync(headerCustomNamedRequestIdParamGroupingParameters), serviceCallback);
     }
 
     /**
@@ -143,16 +158,28 @@ public class HeadersInner {
      *
      * @param headerCustomNamedRequestIdParamGroupingParameters Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HeaderCustomNamedRequestIdParamGroupingHeadersInner, Void> object
      */
-    public Single<Void> customNamedRequestIdParamGroupingAsync(HeaderCustomNamedRequestIdParamGroupingParametersInner headerCustomNamedRequestIdParamGroupingParameters) {
+    public Single<RestResponse<HeaderCustomNamedRequestIdParamGroupingHeadersInner, Void>> customNamedRequestIdParamGroupingWithRestResponseAsync(HeaderCustomNamedRequestIdParamGroupingParametersInner headerCustomNamedRequestIdParamGroupingParameters) {
         if (headerCustomNamedRequestIdParamGroupingParameters == null) {
             throw new IllegalArgumentException("Parameter headerCustomNamedRequestIdParamGroupingParameters is required and cannot be null.");
         }
         Validator.validate(headerCustomNamedRequestIdParamGroupingParameters);
-        String fooClientRequestId = headerCustomNamedRequestIdParamGroupingParameters.fooClientRequestId();
+    String fooClientRequestId = headerCustomNamedRequestIdParamGroupingParameters.fooClientRequestId();
         return service.customNamedRequestIdParamGrouping(this.client.acceptLanguage(), fooClientRequestId, this.client.userAgent());
     }
+
+    /**
+     * Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request, via a parameter group.
+     *
+     * @param headerCustomNamedRequestIdParamGroupingParameters Additional parameters for the operation
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HeaderCustomNamedRequestIdParamGroupingHeadersInner, Void> object
+     */
+    public Single<Void> customNamedRequestIdParamGroupingAsync(HeaderCustomNamedRequestIdParamGroupingParametersInner headerCustomNamedRequestIdParamGroupingParameters) {
+        return customNamedRequestIdParamGroupingWithRestResponseAsync(headerCustomNamedRequestIdParamGroupingParameters)
+            .map(new Func1<RestResponse<HeaderCustomNamedRequestIdParamGroupingHeadersInner, Void>, Void>() { public Void call(RestResponse<HeaderCustomNamedRequestIdParamGroupingHeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -176,8 +203,8 @@ public class HeadersInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Boolean> customNamedRequestIdHeadAsync(String fooClientRequestId, final ServiceCallback<Boolean> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(customNamedRequestIdHeadAsync(fooClientRequestId), serviceCallback);
+    public ServiceFuture<Boolean> customNamedRequestIdHeadAsync(String fooClientRequestId, ServiceCallback<Boolean> serviceCallback) {
+        return ServiceFuture.fromBody(customNamedRequestIdHeadAsync(fooClientRequestId), serviceCallback);
     }
 
     /**
@@ -185,14 +212,26 @@ public class HeadersInner {
      *
      * @param fooClientRequestId The fooRequestId
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Boolean object
+     * @return a {@link Single} emitting the RestResponse<HeaderCustomNamedRequestIdHeadHeadersInner, Boolean> object
      */
-    public Single<Boolean> customNamedRequestIdHeadAsync(String fooClientRequestId) {
+    public Single<RestResponse<HeaderCustomNamedRequestIdHeadHeadersInner, Boolean>> customNamedRequestIdHeadWithRestResponseAsync(String fooClientRequestId) {
         if (fooClientRequestId == null) {
             throw new IllegalArgumentException("Parameter fooClientRequestId is required and cannot be null.");
         }
         return service.customNamedRequestIdHead(fooClientRequestId, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request.
+     *
+     * @param fooClientRequestId The fooRequestId
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HeaderCustomNamedRequestIdHeadHeadersInner, Boolean> object
+     */
+    public Single<Boolean> customNamedRequestIdHeadAsync(String fooClientRequestId) {
+        return customNamedRequestIdHeadWithRestResponseAsync(fooClientRequestId)
+            .map(new Func1<RestResponse<HeaderCustomNamedRequestIdHeadHeadersInner, Boolean>, Boolean>() { public Boolean call(RestResponse<HeaderCustomNamedRequestIdHeadHeadersInner, Boolean> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azurefluent/src/main/java/fixtures/azurespecials/implementation/OdatasInner.java
+++ b/test/azurefluent/src/main/java/fixtures/azurespecials/implementation/OdatasInner.java
@@ -10,6 +10,7 @@
 
 package fixtures.azurespecials.implementation;
 
+import com.microsoft.rest.RestResponse;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.ExpectedResponses;
 import com.microsoft.rest.annotations.GET;
@@ -58,7 +59,7 @@ public class OdatasInner {
         @GET("azurespecials/odata/filter")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getWithFilter(@QueryParam("$filter") String filter, @QueryParam("$top") Integer top, @QueryParam("$orderby") String orderby, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> getWithFilter(@QueryParam("$filter") String filter, @QueryParam("$top") Integer top, @QueryParam("$orderby") String orderby, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -68,6 +69,7 @@ public class OdatasInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getWithFilter() {
         getWithFilterAsync().toBlocking().value();
@@ -80,7 +82,7 @@ public class OdatasInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getWithFilterAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getWithFilterAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getWithFilterAsync(), serviceCallback);
     }
 
@@ -88,14 +90,25 @@ public class OdatasInner {
      * Specify filter parameter with value '$filter=id gt 5 and name eq 'foo'&amp;$orderby=id&amp;$top=10'.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getWithFilterAsync() {
+    public Single<RestResponse<Void, Void>> getWithFilterWithRestResponseAsync() {
         final String filter = null;
         final Integer top = null;
         final String orderby = null;
         return service.getWithFilter(filter, top, orderby, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Specify filter parameter with value '$filter=id gt 5 and name eq 'foo'&amp;$orderby=id&amp;$top=10'.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getWithFilterAsync() {
+        return getWithFilterWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Specify filter parameter with value '$filter=id gt 5 and name eq 'foo'&amp;$orderby=id&amp;$top=10'.
@@ -106,6 +119,7 @@ public class OdatasInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getWithFilter(String filter, Integer top, String orderby) {
         getWithFilterAsync(filter, top, orderby).toBlocking().value();
@@ -121,7 +135,7 @@ public class OdatasInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getWithFilterAsync(String filter, Integer top, String orderby, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getWithFilterAsync(String filter, Integer top, String orderby, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getWithFilterAsync(filter, top, orderby), serviceCallback);
     }
 
@@ -132,11 +146,25 @@ public class OdatasInner {
      * @param top The top parameter with value 10.
      * @param orderby The orderby parameter with value id.
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getWithFilterAsync(String filter, Integer top, String orderby) {
+    public Single<RestResponse<Void, Void>> getWithFilterWithRestResponseAsync(String filter, Integer top, String orderby) {
         return service.getWithFilter(filter, top, orderby, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Specify filter parameter with value '$filter=id gt 5 and name eq 'foo'&amp;$orderby=id&amp;$top=10'.
+     *
+     * @param filter The filter parameter with value '$filter=id gt 5 and name eq 'foo''.
+     * @param top The top parameter with value 10.
+     * @param orderby The orderby parameter with value id.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getWithFilterAsync(String filter, Integer top, String orderby) {
+        return getWithFilterWithRestResponseAsync(filter, top, orderby)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azurefluent/src/main/java/fixtures/azurespecials/implementation/SkipUrlEncodingsInner.java
+++ b/test/azurefluent/src/main/java/fixtures/azurespecials/implementation/SkipUrlEncodingsInner.java
@@ -10,6 +10,7 @@
 
 package fixtures.azurespecials.implementation;
 
+import com.microsoft.rest.RestResponse;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.ExpectedResponses;
 import com.microsoft.rest.annotations.GET;
@@ -59,43 +60,43 @@ public class SkipUrlEncodingsInner {
         @GET("azurespecials/skipUrlEncoding/method/path/valid/{unencodedPathParam}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getMethodPathValid(@PathParam(value = "unencodedPathParam", encoded = true) String unencodedPathParam, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> getMethodPathValid(@PathParam(value = "unencodedPathParam", encoded = true) String unencodedPathParam, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.SkipUrlEncodings getPathPathValid" })
         @GET("azurespecials/skipUrlEncoding/path/path/valid/{unencodedPathParam}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getPathPathValid(@PathParam(value = "unencodedPathParam", encoded = true) String unencodedPathParam, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> getPathPathValid(@PathParam(value = "unencodedPathParam", encoded = true) String unencodedPathParam, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.SkipUrlEncodings getSwaggerPathValid" })
         @GET("azurespecials/skipUrlEncoding/swagger/path/valid/{unencodedPathParam}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getSwaggerPathValid(@PathParam(value = "unencodedPathParam", encoded = true) String unencodedPathParam, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> getSwaggerPathValid(@PathParam(value = "unencodedPathParam", encoded = true) String unencodedPathParam, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.SkipUrlEncodings getMethodQueryValid" })
         @GET("azurespecials/skipUrlEncoding/method/query/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getMethodQueryValid(@QueryParam(value = "q1", encoded = true) String q1, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> getMethodQueryValid(@QueryParam(value = "q1", encoded = true) String q1, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.SkipUrlEncodings getMethodQueryNull" })
         @GET("azurespecials/skipUrlEncoding/method/query/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getMethodQueryNull(@QueryParam(value = "q1", encoded = true) String q1, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> getMethodQueryNull(@QueryParam(value = "q1", encoded = true) String q1, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.SkipUrlEncodings getPathQueryValid" })
         @GET("azurespecials/skipUrlEncoding/path/query/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getPathQueryValid(@QueryParam(value = "q1", encoded = true) String q1, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> getPathQueryValid(@QueryParam(value = "q1", encoded = true) String q1, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.SkipUrlEncodings getSwaggerQueryValid" })
         @GET("azurespecials/skipUrlEncoding/swagger/query/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getSwaggerQueryValid(@QueryParam(value = "q1", encoded = true) String q1, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> getSwaggerQueryValid(@QueryParam(value = "q1", encoded = true) String q1, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -106,6 +107,7 @@ public class SkipUrlEncodingsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getMethodPathValid(String unencodedPathParam) {
         getMethodPathValidAsync(unencodedPathParam).toBlocking().value();
@@ -119,7 +121,7 @@ public class SkipUrlEncodingsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getMethodPathValidAsync(String unencodedPathParam, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getMethodPathValidAsync(String unencodedPathParam, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getMethodPathValidAsync(unencodedPathParam), serviceCallback);
     }
 
@@ -128,14 +130,26 @@ public class SkipUrlEncodingsInner {
      *
      * @param unencodedPathParam Unencoded path parameter with value 'path1/path2/path3'
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getMethodPathValidAsync(String unencodedPathParam) {
+    public Single<RestResponse<Void, Void>> getMethodPathValidWithRestResponseAsync(String unencodedPathParam) {
         if (unencodedPathParam == null) {
             throw new IllegalArgumentException("Parameter unencodedPathParam is required and cannot be null.");
         }
         return service.getMethodPathValid(unencodedPathParam, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Get method with unencoded path parameter with value 'path1/path2/path3'.
+     *
+     * @param unencodedPathParam Unencoded path parameter with value 'path1/path2/path3'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getMethodPathValidAsync(String unencodedPathParam) {
+        return getMethodPathValidWithRestResponseAsync(unencodedPathParam)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -145,6 +159,7 @@ public class SkipUrlEncodingsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getPathPathValid(String unencodedPathParam) {
         getPathPathValidAsync(unencodedPathParam).toBlocking().value();
@@ -158,7 +173,7 @@ public class SkipUrlEncodingsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getPathPathValidAsync(String unencodedPathParam, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getPathPathValidAsync(String unencodedPathParam, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getPathPathValidAsync(unencodedPathParam), serviceCallback);
     }
 
@@ -167,14 +182,26 @@ public class SkipUrlEncodingsInner {
      *
      * @param unencodedPathParam Unencoded path parameter with value 'path1/path2/path3'
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getPathPathValidAsync(String unencodedPathParam) {
+    public Single<RestResponse<Void, Void>> getPathPathValidWithRestResponseAsync(String unencodedPathParam) {
         if (unencodedPathParam == null) {
             throw new IllegalArgumentException("Parameter unencodedPathParam is required and cannot be null.");
         }
         return service.getPathPathValid(unencodedPathParam, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Get method with unencoded path parameter with value 'path1/path2/path3'.
+     *
+     * @param unencodedPathParam Unencoded path parameter with value 'path1/path2/path3'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getPathPathValidAsync(String unencodedPathParam) {
+        return getPathPathValidWithRestResponseAsync(unencodedPathParam)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -183,6 +210,7 @@ public class SkipUrlEncodingsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getSwaggerPathValid() {
         getSwaggerPathValidAsync().toBlocking().value();
@@ -195,7 +223,7 @@ public class SkipUrlEncodingsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getSwaggerPathValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getSwaggerPathValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getSwaggerPathValidAsync(), serviceCallback);
     }
 
@@ -203,12 +231,23 @@ public class SkipUrlEncodingsInner {
      * Get method with unencoded path parameter with value 'path1/path2/path3'.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getSwaggerPathValidAsync() {
+    public Single<RestResponse<Void, Void>> getSwaggerPathValidWithRestResponseAsync() {
         final String unencodedPathParam = "path1/path2/path3";
         return service.getSwaggerPathValid(unencodedPathParam, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Get method with unencoded path parameter with value 'path1/path2/path3'.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getSwaggerPathValidAsync() {
+        return getSwaggerPathValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -218,6 +257,7 @@ public class SkipUrlEncodingsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getMethodQueryValid(String q1) {
         getMethodQueryValidAsync(q1).toBlocking().value();
@@ -231,7 +271,7 @@ public class SkipUrlEncodingsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getMethodQueryValidAsync(String q1, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getMethodQueryValidAsync(String q1, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getMethodQueryValidAsync(q1), serviceCallback);
     }
 
@@ -240,14 +280,26 @@ public class SkipUrlEncodingsInner {
      *
      * @param q1 Unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getMethodQueryValidAsync(String q1) {
+    public Single<RestResponse<Void, Void>> getMethodQueryValidWithRestResponseAsync(String q1) {
         if (q1 == null) {
             throw new IllegalArgumentException("Parameter q1 is required and cannot be null.");
         }
         return service.getMethodQueryValid(q1, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Get method with unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'.
+     *
+     * @param q1 Unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getMethodQueryValidAsync(String q1) {
+        return getMethodQueryValidWithRestResponseAsync(q1)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -256,6 +308,7 @@ public class SkipUrlEncodingsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getMethodQueryNull() {
         getMethodQueryNullAsync().toBlocking().value();
@@ -268,7 +321,7 @@ public class SkipUrlEncodingsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getMethodQueryNullAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getMethodQueryNullAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getMethodQueryNullAsync(), serviceCallback);
     }
 
@@ -276,12 +329,23 @@ public class SkipUrlEncodingsInner {
      * Get method with unencoded query parameter with value null.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getMethodQueryNullAsync() {
+    public Single<RestResponse<Void, Void>> getMethodQueryNullWithRestResponseAsync() {
         final String q1 = null;
         return service.getMethodQueryNull(q1, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Get method with unencoded query parameter with value null.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getMethodQueryNullAsync() {
+        return getMethodQueryNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Get method with unencoded query parameter with value null.
@@ -290,6 +354,7 @@ public class SkipUrlEncodingsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getMethodQueryNull(String q1) {
         getMethodQueryNullAsync(q1).toBlocking().value();
@@ -303,7 +368,7 @@ public class SkipUrlEncodingsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getMethodQueryNullAsync(String q1, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getMethodQueryNullAsync(String q1, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getMethodQueryNullAsync(q1), serviceCallback);
     }
 
@@ -312,11 +377,23 @@ public class SkipUrlEncodingsInner {
      *
      * @param q1 Unencoded query parameter with value null
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getMethodQueryNullAsync(String q1) {
+    public Single<RestResponse<Void, Void>> getMethodQueryNullWithRestResponseAsync(String q1) {
         return service.getMethodQueryNull(q1, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Get method with unencoded query parameter with value null.
+     *
+     * @param q1 Unencoded query parameter with value null
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getMethodQueryNullAsync(String q1) {
+        return getMethodQueryNullWithRestResponseAsync(q1)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -326,6 +403,7 @@ public class SkipUrlEncodingsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getPathQueryValid(String q1) {
         getPathQueryValidAsync(q1).toBlocking().value();
@@ -339,7 +417,7 @@ public class SkipUrlEncodingsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getPathQueryValidAsync(String q1, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getPathQueryValidAsync(String q1, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getPathQueryValidAsync(q1), serviceCallback);
     }
 
@@ -348,14 +426,26 @@ public class SkipUrlEncodingsInner {
      *
      * @param q1 Unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getPathQueryValidAsync(String q1) {
+    public Single<RestResponse<Void, Void>> getPathQueryValidWithRestResponseAsync(String q1) {
         if (q1 == null) {
             throw new IllegalArgumentException("Parameter q1 is required and cannot be null.");
         }
         return service.getPathQueryValid(q1, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Get method with unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'.
+     *
+     * @param q1 Unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getPathQueryValidAsync(String q1) {
+        return getPathQueryValidWithRestResponseAsync(q1)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -364,6 +454,7 @@ public class SkipUrlEncodingsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getSwaggerQueryValid() {
         getSwaggerQueryValidAsync().toBlocking().value();
@@ -376,7 +467,7 @@ public class SkipUrlEncodingsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getSwaggerQueryValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getSwaggerQueryValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getSwaggerQueryValidAsync(), serviceCallback);
     }
 
@@ -384,12 +475,23 @@ public class SkipUrlEncodingsInner {
      * Get method with unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getSwaggerQueryValidAsync() {
+    public Single<RestResponse<Void, Void>> getSwaggerQueryValidWithRestResponseAsync() {
         final String q1 = "value1&q2=value2&q3=value3";
         return service.getSwaggerQueryValid(q1, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Get method with unencoded query parameter with value 'value1&amp;q2=value2&amp;q3=value3'.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getSwaggerQueryValidAsync() {
+        return getSwaggerQueryValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azurefluent/src/main/java/fixtures/azurespecials/implementation/SubscriptionInCredentialsInner.java
+++ b/test/azurefluent/src/main/java/fixtures/azurespecials/implementation/SubscriptionInCredentialsInner.java
@@ -10,6 +10,7 @@
 
 package fixtures.azurespecials.implementation;
 
+import com.microsoft.rest.RestResponse;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.ExpectedResponses;
 import com.microsoft.rest.annotations.HeaderParam;
@@ -59,31 +60,31 @@ public class SubscriptionInCredentialsInner {
         @POST("azurespecials/subscriptionId/method/string/none/path/global/1234-5678-9012-3456/{subscriptionId}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postMethodGlobalValid(@PathParam("subscriptionId") String subscriptionId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> postMethodGlobalValid(@PathParam("subscriptionId") String subscriptionId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.SubscriptionInCredentials postMethodGlobalNull" })
         @POST("azurespecials/subscriptionId/method/string/none/path/global/null/{subscriptionId}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postMethodGlobalNull(@PathParam("subscriptionId") String subscriptionId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> postMethodGlobalNull(@PathParam("subscriptionId") String subscriptionId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.SubscriptionInCredentials postMethodGlobalNotProvidedValid" })
         @POST("azurespecials/subscriptionId/method/string/none/path/globalNotProvided/1234-5678-9012-3456/{subscriptionId}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postMethodGlobalNotProvidedValid(@PathParam("subscriptionId") String subscriptionId, @QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> postMethodGlobalNotProvidedValid(@PathParam("subscriptionId") String subscriptionId, @QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.SubscriptionInCredentials postPathGlobalValid" })
         @POST("azurespecials/subscriptionId/path/string/none/path/global/1234-5678-9012-3456/{subscriptionId}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postPathGlobalValid(@PathParam("subscriptionId") String subscriptionId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> postPathGlobalValid(@PathParam("subscriptionId") String subscriptionId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.SubscriptionInCredentials postSwaggerGlobalValid" })
         @POST("azurespecials/subscriptionId/swagger/string/none/path/global/1234-5678-9012-3456/{subscriptionId}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postSwaggerGlobalValid(@PathParam("subscriptionId") String subscriptionId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> postSwaggerGlobalValid(@PathParam("subscriptionId") String subscriptionId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -93,6 +94,7 @@ public class SubscriptionInCredentialsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postMethodGlobalValid() {
         postMethodGlobalValidAsync().toBlocking().value();
@@ -105,7 +107,7 @@ public class SubscriptionInCredentialsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postMethodGlobalValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postMethodGlobalValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postMethodGlobalValidAsync(), serviceCallback);
     }
 
@@ -113,14 +115,25 @@ public class SubscriptionInCredentialsInner {
      * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postMethodGlobalValidAsync() {
+    public Single<RestResponse<Void, Void>> postMethodGlobalValidWithRestResponseAsync() {
         if (this.client.subscriptionId() == null) {
             throw new IllegalArgumentException("Parameter this.client.subscriptionId() is required and cannot be null.");
         }
         return service.postMethodGlobalValid(this.client.subscriptionId(), this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postMethodGlobalValidAsync() {
+        return postMethodGlobalValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -129,6 +142,7 @@ public class SubscriptionInCredentialsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postMethodGlobalNull() {
         postMethodGlobalNullAsync().toBlocking().value();
@@ -141,7 +155,7 @@ public class SubscriptionInCredentialsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postMethodGlobalNullAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postMethodGlobalNullAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postMethodGlobalNullAsync(), serviceCallback);
     }
 
@@ -149,14 +163,25 @@ public class SubscriptionInCredentialsInner {
      * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to null, and client-side validation should prevent you from making this call.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postMethodGlobalNullAsync() {
+    public Single<RestResponse<Void, Void>> postMethodGlobalNullWithRestResponseAsync() {
         if (this.client.subscriptionId() == null) {
             throw new IllegalArgumentException("Parameter this.client.subscriptionId() is required and cannot be null.");
         }
         return service.postMethodGlobalNull(this.client.subscriptionId(), this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to null, and client-side validation should prevent you from making this call.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postMethodGlobalNullAsync() {
+        return postMethodGlobalNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -165,6 +190,7 @@ public class SubscriptionInCredentialsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postMethodGlobalNotProvidedValid() {
         postMethodGlobalNotProvidedValidAsync().toBlocking().value();
@@ -177,7 +203,7 @@ public class SubscriptionInCredentialsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postMethodGlobalNotProvidedValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postMethodGlobalNotProvidedValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postMethodGlobalNotProvidedValidAsync(), serviceCallback);
     }
 
@@ -185,9 +211,9 @@ public class SubscriptionInCredentialsInner {
      * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postMethodGlobalNotProvidedValidAsync() {
+    public Single<RestResponse<Void, Void>> postMethodGlobalNotProvidedValidWithRestResponseAsync() {
         if (this.client.subscriptionId() == null) {
             throw new IllegalArgumentException("Parameter this.client.subscriptionId() is required and cannot be null.");
         }
@@ -197,6 +223,17 @@ public class SubscriptionInCredentialsInner {
         return service.postMethodGlobalNotProvidedValid(this.client.subscriptionId(), this.client.apiVersion(), this.client.acceptLanguage(), this.client.userAgent());
     }
 
+    /**
+     * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postMethodGlobalNotProvidedValidAsync() {
+        return postMethodGlobalNotProvidedValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
+
 
     /**
      * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
@@ -204,6 +241,7 @@ public class SubscriptionInCredentialsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postPathGlobalValid() {
         postPathGlobalValidAsync().toBlocking().value();
@@ -216,7 +254,7 @@ public class SubscriptionInCredentialsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postPathGlobalValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postPathGlobalValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postPathGlobalValidAsync(), serviceCallback);
     }
 
@@ -224,14 +262,25 @@ public class SubscriptionInCredentialsInner {
      * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postPathGlobalValidAsync() {
+    public Single<RestResponse<Void, Void>> postPathGlobalValidWithRestResponseAsync() {
         if (this.client.subscriptionId() == null) {
             throw new IllegalArgumentException("Parameter this.client.subscriptionId() is required and cannot be null.");
         }
         return service.postPathGlobalValid(this.client.subscriptionId(), this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postPathGlobalValidAsync() {
+        return postPathGlobalValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -240,6 +289,7 @@ public class SubscriptionInCredentialsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postSwaggerGlobalValid() {
         postSwaggerGlobalValidAsync().toBlocking().value();
@@ -252,7 +302,7 @@ public class SubscriptionInCredentialsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postSwaggerGlobalValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postSwaggerGlobalValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postSwaggerGlobalValidAsync(), serviceCallback);
     }
 
@@ -260,14 +310,25 @@ public class SubscriptionInCredentialsInner {
      * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postSwaggerGlobalValidAsync() {
+    public Single<RestResponse<Void, Void>> postSwaggerGlobalValidWithRestResponseAsync() {
         if (this.client.subscriptionId() == null) {
             throw new IllegalArgumentException("Parameter this.client.subscriptionId() is required and cannot be null.");
         }
         return service.postSwaggerGlobalValid(this.client.subscriptionId(), this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postSwaggerGlobalValidAsync() {
+        return postSwaggerGlobalValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azurefluent/src/main/java/fixtures/azurespecials/implementation/SubscriptionInMethodsInner.java
+++ b/test/azurefluent/src/main/java/fixtures/azurespecials/implementation/SubscriptionInMethodsInner.java
@@ -10,6 +10,7 @@
 
 package fixtures.azurespecials.implementation;
 
+import com.microsoft.rest.RestResponse;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.ExpectedResponses;
 import com.microsoft.rest.annotations.HeaderParam;
@@ -58,25 +59,25 @@ public class SubscriptionInMethodsInner {
         @POST("azurespecials/subscriptionId/method/string/none/path/local/1234-5678-9012-3456/{subscriptionId}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postMethodLocalValid(@PathParam("subscriptionId") String subscriptionId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> postMethodLocalValid(@PathParam("subscriptionId") String subscriptionId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.SubscriptionInMethods postMethodLocalNull" })
         @POST("azurespecials/subscriptionId/method/string/none/path/local/null/{subscriptionId}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postMethodLocalNull(@PathParam("subscriptionId") String subscriptionId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> postMethodLocalNull(@PathParam("subscriptionId") String subscriptionId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.SubscriptionInMethods postPathLocalValid" })
         @POST("azurespecials/subscriptionId/path/string/none/path/local/1234-5678-9012-3456/{subscriptionId}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postPathLocalValid(@PathParam("subscriptionId") String subscriptionId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> postPathLocalValid(@PathParam("subscriptionId") String subscriptionId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.SubscriptionInMethods postSwaggerLocalValid" })
         @POST("azurespecials/subscriptionId/swagger/string/none/path/local/1234-5678-9012-3456/{subscriptionId}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postSwaggerLocalValid(@PathParam("subscriptionId") String subscriptionId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> postSwaggerLocalValid(@PathParam("subscriptionId") String subscriptionId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -87,6 +88,7 @@ public class SubscriptionInMethodsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postMethodLocalValid(String subscriptionId) {
         postMethodLocalValidAsync(subscriptionId).toBlocking().value();
@@ -100,7 +102,7 @@ public class SubscriptionInMethodsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postMethodLocalValidAsync(String subscriptionId, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postMethodLocalValidAsync(String subscriptionId, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postMethodLocalValidAsync(subscriptionId), serviceCallback);
     }
 
@@ -109,14 +111,26 @@ public class SubscriptionInMethodsInner {
      *
      * @param subscriptionId This should appear as a method parameter, use value '1234-5678-9012-3456'
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postMethodLocalValidAsync(String subscriptionId) {
+    public Single<RestResponse<Void, Void>> postMethodLocalValidWithRestResponseAsync(String subscriptionId) {
         if (subscriptionId == null) {
             throw new IllegalArgumentException("Parameter subscriptionId is required and cannot be null.");
         }
         return service.postMethodLocalValid(subscriptionId, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed.
+     *
+     * @param subscriptionId This should appear as a method parameter, use value '1234-5678-9012-3456'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postMethodLocalValidAsync(String subscriptionId) {
+        return postMethodLocalValidWithRestResponseAsync(subscriptionId)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -126,6 +140,7 @@ public class SubscriptionInMethodsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postMethodLocalNull(String subscriptionId) {
         postMethodLocalNullAsync(subscriptionId).toBlocking().value();
@@ -139,7 +154,7 @@ public class SubscriptionInMethodsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postMethodLocalNullAsync(String subscriptionId, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postMethodLocalNullAsync(String subscriptionId, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postMethodLocalNullAsync(subscriptionId), serviceCallback);
     }
 
@@ -148,14 +163,26 @@ public class SubscriptionInMethodsInner {
      *
      * @param subscriptionId This should appear as a method parameter, use value null, client-side validation should prvenet the call
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postMethodLocalNullAsync(String subscriptionId) {
+    public Single<RestResponse<Void, Void>> postMethodLocalNullWithRestResponseAsync(String subscriptionId) {
         if (subscriptionId == null) {
             throw new IllegalArgumentException("Parameter subscriptionId is required and cannot be null.");
         }
         return service.postMethodLocalNull(subscriptionId, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * POST method with subscriptionId modeled in the method.  pass in subscription id = null, client-side validation should prevent you from making this call.
+     *
+     * @param subscriptionId This should appear as a method parameter, use value null, client-side validation should prvenet the call
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postMethodLocalNullAsync(String subscriptionId) {
+        return postMethodLocalNullWithRestResponseAsync(subscriptionId)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -165,6 +192,7 @@ public class SubscriptionInMethodsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postPathLocalValid(String subscriptionId) {
         postPathLocalValidAsync(subscriptionId).toBlocking().value();
@@ -178,7 +206,7 @@ public class SubscriptionInMethodsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postPathLocalValidAsync(String subscriptionId, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postPathLocalValidAsync(String subscriptionId, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postPathLocalValidAsync(subscriptionId), serviceCallback);
     }
 
@@ -187,14 +215,26 @@ public class SubscriptionInMethodsInner {
      *
      * @param subscriptionId Should appear as a method parameter -use value '1234-5678-9012-3456'
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postPathLocalValidAsync(String subscriptionId) {
+    public Single<RestResponse<Void, Void>> postPathLocalValidWithRestResponseAsync(String subscriptionId) {
         if (subscriptionId == null) {
             throw new IllegalArgumentException("Parameter subscriptionId is required and cannot be null.");
         }
         return service.postPathLocalValid(subscriptionId, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed.
+     *
+     * @param subscriptionId Should appear as a method parameter -use value '1234-5678-9012-3456'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postPathLocalValidAsync(String subscriptionId) {
+        return postPathLocalValidWithRestResponseAsync(subscriptionId)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -204,6 +244,7 @@ public class SubscriptionInMethodsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postSwaggerLocalValid(String subscriptionId) {
         postSwaggerLocalValidAsync(subscriptionId).toBlocking().value();
@@ -217,7 +258,7 @@ public class SubscriptionInMethodsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postSwaggerLocalValidAsync(String subscriptionId, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postSwaggerLocalValidAsync(String subscriptionId, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postSwaggerLocalValidAsync(subscriptionId), serviceCallback);
     }
 
@@ -226,14 +267,26 @@ public class SubscriptionInMethodsInner {
      *
      * @param subscriptionId The subscriptionId, which appears in the path, the value is always '1234-5678-9012-3456'
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postSwaggerLocalValidAsync(String subscriptionId) {
+    public Single<RestResponse<Void, Void>> postSwaggerLocalValidWithRestResponseAsync(String subscriptionId) {
         if (subscriptionId == null) {
             throw new IllegalArgumentException("Parameter subscriptionId is required and cannot be null.");
         }
         return service.postSwaggerLocalValid(subscriptionId, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed.
+     *
+     * @param subscriptionId The subscriptionId, which appears in the path, the value is always '1234-5678-9012-3456'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postSwaggerLocalValidAsync(String subscriptionId) {
+        return postSwaggerLocalValidWithRestResponseAsync(subscriptionId)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azurefluent/src/main/java/fixtures/azurespecials/implementation/XMsClientRequestIdsInner.java
+++ b/test/azurefluent/src/main/java/fixtures/azurespecials/implementation/XMsClientRequestIdsInner.java
@@ -10,6 +10,7 @@
 
 package fixtures.azurespecials.implementation;
 
+import com.microsoft.rest.RestResponse;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.CloudException;
 import com.microsoft.rest.annotations.ExpectedResponses;
@@ -58,13 +59,13 @@ public class XMsClientRequestIdsInner {
         @GET("azurespecials/overwrite/x-ms-client-request-id/method/")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> get(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> get(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.azurespecials.XMsClientRequestIds paramGet" })
         @GET("azurespecials/overwrite/x-ms-client-request-id/via-param/method/")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> paramGet(@HeaderParam("x-ms-client-request-id") String xMsClientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> paramGet(@HeaderParam("x-ms-client-request-id") String xMsClientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -74,6 +75,7 @@ public class XMsClientRequestIdsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void get() {
         getAsync().toBlocking().value();
@@ -86,7 +88,7 @@ public class XMsClientRequestIdsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getAsync(), serviceCallback);
     }
 
@@ -94,11 +96,22 @@ public class XMsClientRequestIdsInner {
      * Get method that overwrites x-ms-client-request header with value 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getAsync() {
+    public Single<RestResponse<Void, Void>> getWithRestResponseAsync() {
         return service.get(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Get method that overwrites x-ms-client-request header with value 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getAsync() {
+        return getWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -108,6 +121,7 @@ public class XMsClientRequestIdsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void paramGet(String xMsClientRequestId) {
         paramGetAsync(xMsClientRequestId).toBlocking().value();
@@ -121,7 +135,7 @@ public class XMsClientRequestIdsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> paramGetAsync(String xMsClientRequestId, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> paramGetAsync(String xMsClientRequestId, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(paramGetAsync(xMsClientRequestId), serviceCallback);
     }
 
@@ -130,14 +144,26 @@ public class XMsClientRequestIdsInner {
      *
      * @param xMsClientRequestId This should appear as a method parameter, use value '9C4D50EE-2D56-4CD3-8152-34347DC9F2B0'
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> paramGetAsync(String xMsClientRequestId) {
+    public Single<RestResponse<Void, Void>> paramGetWithRestResponseAsync(String xMsClientRequestId) {
         if (xMsClientRequestId == null) {
             throw new IllegalArgumentException("Parameter xMsClientRequestId is required and cannot be null.");
         }
         return service.paramGet(xMsClientRequestId, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Get method that overwrites x-ms-client-request header with value 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+     *
+     * @param xMsClientRequestId This should appear as a method parameter, use value '9C4D50EE-2D56-4CD3-8152-34347DC9F2B0'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> paramGetAsync(String xMsClientRequestId) {
+        return paramGetWithRestResponseAsync(xMsClientRequestId)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azurefluent/src/main/java/fixtures/custombaseuri/implementation/AutoRestParameterizedHostTestClientImpl.java
+++ b/test/azurefluent/src/main/java/fixtures/custombaseuri/implementation/AutoRestParameterizedHostTestClientImpl.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.AzureProxy;
 import com.microsoft.azure.AzureServiceClient;
 import com.microsoft.rest.credentials.ServiceClientCredentials;
 import com.microsoft.rest.RestClient;
+import com.microsoft.rest.RestResponse;
 import rx.Single;
 
 /**

--- a/test/azurefluent/src/main/java/fixtures/custombaseuri/implementation/PathsInner.java
+++ b/test/azurefluent/src/main/java/fixtures/custombaseuri/implementation/PathsInner.java
@@ -10,6 +10,7 @@
 
 package fixtures.custombaseuri.implementation;
 
+import com.microsoft.rest.RestResponse;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.ExpectedResponses;
 import com.microsoft.rest.annotations.GET;
@@ -59,7 +60,7 @@ public class PathsInner {
         @GET("customuri")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getEmpty(@HostParam("accountName") String accountName, @HostParam("host") String host, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> getEmpty(@HostParam("accountName") String accountName, @HostParam("host") String host, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -70,6 +71,7 @@ public class PathsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getEmpty(String accountName) {
         getEmptyAsync(accountName).toBlocking().value();
@@ -83,7 +85,7 @@ public class PathsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getEmptyAsync(String accountName, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getEmptyAsync(String accountName, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getEmptyAsync(accountName), serviceCallback);
     }
 
@@ -92,9 +94,9 @@ public class PathsInner {
      *
      * @param accountName Account Name
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getEmptyAsync(String accountName) {
+    public Single<RestResponse<Void, Void>> getEmptyWithRestResponseAsync(String accountName) {
         if (accountName == null) {
             throw new IllegalArgumentException("Parameter accountName is required and cannot be null.");
         }
@@ -103,6 +105,18 @@ public class PathsInner {
         }
         return service.getEmpty(accountName, this.client.host(), this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Get a 200 to test a valid base uri.
+     *
+     * @param accountName Account Name
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getEmptyAsync(String accountName) {
+        return getEmptyWithRestResponseAsync(accountName)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azurefluent/src/main/java/fixtures/head/implementation/AutoRestHeadTestServiceImpl.java
+++ b/test/azurefluent/src/main/java/fixtures/head/implementation/AutoRestHeadTestServiceImpl.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.AzureProxy;
 import com.microsoft.azure.AzureServiceClient;
 import com.microsoft.rest.credentials.ServiceClientCredentials;
 import com.microsoft.rest.RestClient;
+import com.microsoft.rest.RestResponse;
 import rx.Single;
 
 /**

--- a/test/azurefluent/src/main/java/fixtures/head/implementation/HttpSuccessInner.java
+++ b/test/azurefluent/src/main/java/fixtures/head/implementation/HttpSuccessInner.java
@@ -10,6 +10,7 @@
 
 package fixtures.head.implementation;
 
+import com.microsoft.rest.RestResponse;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.CloudException;
 import com.microsoft.rest.annotations.ExpectedResponses;
@@ -57,19 +58,19 @@ public class HttpSuccessInner {
         @HEAD("http/success/200")
         @ExpectedResponses({200, 404})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Boolean> head200(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Boolean>> head200(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.head.HttpSuccess head204" })
         @HEAD("http/success/204")
         @ExpectedResponses({204, 404})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Boolean> head204(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Boolean>> head204(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.head.HttpSuccess head404" })
         @HEAD("http/success/404")
         @ExpectedResponses({204, 404})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Boolean> head404(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Boolean>> head404(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -92,7 +93,7 @@ public class HttpSuccessInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Boolean> head200Async(final ServiceCallback<Boolean> serviceCallback) {
+    public ServiceFuture<Boolean> head200Async(ServiceCallback<Boolean> serviceCallback) {
         return ServiceFuture.fromBody(head200Async(), serviceCallback);
     }
 
@@ -100,11 +101,22 @@ public class HttpSuccessInner {
      * Return 200 status code if successful.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Boolean object
+     * @return a {@link Single} emitting the RestResponse<Void, Boolean> object
      */
-    public Single<Boolean> head200Async() {
+    public Single<RestResponse<Void, Boolean>> head200WithRestResponseAsync() {
         return service.head200(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Return 200 status code if successful.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Boolean> object
+     */
+    public Single<Boolean> head200Async() {
+        return head200WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Boolean>, Boolean>() { public Boolean call(RestResponse<Void, Boolean> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -126,7 +138,7 @@ public class HttpSuccessInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Boolean> head204Async(final ServiceCallback<Boolean> serviceCallback) {
+    public ServiceFuture<Boolean> head204Async(ServiceCallback<Boolean> serviceCallback) {
         return ServiceFuture.fromBody(head204Async(), serviceCallback);
     }
 
@@ -134,11 +146,22 @@ public class HttpSuccessInner {
      * Return 204 status code if successful.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Boolean object
+     * @return a {@link Single} emitting the RestResponse<Void, Boolean> object
      */
-    public Single<Boolean> head204Async() {
+    public Single<RestResponse<Void, Boolean>> head204WithRestResponseAsync() {
         return service.head204(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Return 204 status code if successful.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Boolean> object
+     */
+    public Single<Boolean> head204Async() {
+        return head204WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Boolean>, Boolean>() { public Boolean call(RestResponse<Void, Boolean> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -160,7 +183,7 @@ public class HttpSuccessInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Boolean> head404Async(final ServiceCallback<Boolean> serviceCallback) {
+    public ServiceFuture<Boolean> head404Async(ServiceCallback<Boolean> serviceCallback) {
         return ServiceFuture.fromBody(head404Async(), serviceCallback);
     }
 
@@ -168,11 +191,22 @@ public class HttpSuccessInner {
      * Return 404 status code if successful.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Boolean object
+     * @return a {@link Single} emitting the RestResponse<Void, Boolean> object
      */
-    public Single<Boolean> head404Async() {
+    public Single<RestResponse<Void, Boolean>> head404WithRestResponseAsync() {
         return service.head404(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Return 404 status code if successful.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Boolean> object
+     */
+    public Single<Boolean> head404Async() {
+        return head404WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Boolean>, Boolean>() { public Boolean call(RestResponse<Void, Boolean> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azurefluent/src/main/java/fixtures/headexceptions/implementation/AutoRestHeadExceptionTestServiceImpl.java
+++ b/test/azurefluent/src/main/java/fixtures/headexceptions/implementation/AutoRestHeadExceptionTestServiceImpl.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.AzureProxy;
 import com.microsoft.azure.AzureServiceClient;
 import com.microsoft.rest.credentials.ServiceClientCredentials;
 import com.microsoft.rest.RestClient;
+import com.microsoft.rest.RestResponse;
 import rx.Single;
 
 /**

--- a/test/azurefluent/src/main/java/fixtures/headexceptions/implementation/HeadExceptionsInner.java
+++ b/test/azurefluent/src/main/java/fixtures/headexceptions/implementation/HeadExceptionsInner.java
@@ -10,6 +10,7 @@
 
 package fixtures.headexceptions.implementation;
 
+import com.microsoft.rest.RestResponse;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.CloudException;
 import com.microsoft.rest.annotations.ExpectedResponses;
@@ -57,19 +58,19 @@ public class HeadExceptionsInner {
         @HEAD("http/success/200")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> head200(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> head200(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.headexceptions.HeadExceptions head204" })
         @HEAD("http/success/204")
         @ExpectedResponses({204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> head204(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> head204(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.headexceptions.HeadExceptions head404" })
         @HEAD("http/success/404")
         @ExpectedResponses({204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> head404(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> head404(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -79,6 +80,7 @@ public class HeadExceptionsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void head200() {
         head200Async().toBlocking().value();
@@ -91,7 +93,7 @@ public class HeadExceptionsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> head200Async(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> head200Async(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(head200Async(), serviceCallback);
     }
 
@@ -99,11 +101,22 @@ public class HeadExceptionsInner {
      * Return 200 status code if successful.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> head200Async() {
+    public Single<RestResponse<Void, Void>> head200WithRestResponseAsync() {
         return service.head200(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Return 200 status code if successful.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> head200Async() {
+        return head200WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -112,6 +125,7 @@ public class HeadExceptionsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void head204() {
         head204Async().toBlocking().value();
@@ -124,7 +138,7 @@ public class HeadExceptionsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> head204Async(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> head204Async(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(head204Async(), serviceCallback);
     }
 
@@ -132,11 +146,22 @@ public class HeadExceptionsInner {
      * Return 204 status code if successful.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> head204Async() {
+    public Single<RestResponse<Void, Void>> head204WithRestResponseAsync() {
         return service.head204(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Return 204 status code if successful.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> head204Async() {
+        return head204WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -145,6 +170,7 @@ public class HeadExceptionsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void head404() {
         head404Async().toBlocking().value();
@@ -157,7 +183,7 @@ public class HeadExceptionsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> head404Async(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> head404Async(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(head404Async(), serviceCallback);
     }
 
@@ -165,11 +191,22 @@ public class HeadExceptionsInner {
      * Return 404 status code if successful.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> head404Async() {
+    public Single<RestResponse<Void, Void>> head404WithRestResponseAsync() {
         return service.head404(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Return 404 status code if successful.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> head404Async() {
+        return head404WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azurefluent/src/main/java/fixtures/lro/implementation/AutoRestLongRunningOperationTestServiceImpl.java
+++ b/test/azurefluent/src/main/java/fixtures/lro/implementation/AutoRestLongRunningOperationTestServiceImpl.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.AzureProxy;
 import com.microsoft.azure.AzureServiceClient;
 import com.microsoft.rest.credentials.ServiceClientCredentials;
 import com.microsoft.rest.RestClient;
+import com.microsoft.rest.RestResponse;
 import rx.Single;
 
 /**

--- a/test/azurefluent/src/main/java/fixtures/lro/implementation/LRORetrysInner.java
+++ b/test/azurefluent/src/main/java/fixtures/lro/implementation/LRORetrysInner.java
@@ -10,6 +10,7 @@
 
 package fixtures.lro.implementation;
 
+import com.microsoft.rest.RestResponse;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.CloudException;
 import com.microsoft.azure.OperationStatus;
@@ -69,7 +70,7 @@ public class LRORetrysInner {
         @PUT("lro/retryerror/put/201/creating/succeeded/200")
         @ExpectedResponses({200, 201, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> put201CreatingSucceeded200(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, ProductInner>> put201CreatingSucceeded200(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LRORetrys beginPutAsyncRelativeRetrySucceeded" })
         @PUT("lro/retryerror/putasync/retry/succeeded")
@@ -81,7 +82,7 @@ public class LRORetrysInner {
         @PUT("lro/retryerror/putasync/retry/succeeded")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> putAsyncRelativeRetrySucceeded(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LRORetrysPutAsyncRelativeRetrySucceededHeadersInner, ProductInner>> putAsyncRelativeRetrySucceeded(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LRORetrys beginDeleteProvisioning202Accepted200Succeeded" })
         @DELETE("lro/retryerror/delete/provisioning/202/accepted/200/succeeded")
@@ -93,7 +94,7 @@ public class LRORetrysInner {
         @DELETE("lro/retryerror/delete/provisioning/202/accepted/200/succeeded")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> deleteProvisioning202Accepted200Succeeded(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LRORetrysDeleteProvisioning202Accepted200SucceededHeadersInner, ProductInner>> deleteProvisioning202Accepted200Succeeded(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LRORetrys beginDelete202Retry200" })
         @DELETE("lro/retryerror/delete/202/retry/200")
@@ -105,7 +106,7 @@ public class LRORetrysInner {
         @DELETE("lro/retryerror/delete/202/retry/200")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> delete202Retry200(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LRORetrysDelete202Retry200HeadersInner, Void>> delete202Retry200(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LRORetrys beginDeleteAsyncRelativeRetrySucceeded" })
         @DELETE("lro/retryerror/deleteasync/retry/succeeded")
@@ -117,7 +118,7 @@ public class LRORetrysInner {
         @DELETE("lro/retryerror/deleteasync/retry/succeeded")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> deleteAsyncRelativeRetrySucceeded(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LRORetrysDeleteAsyncRelativeRetrySucceededHeadersInner, Void>> deleteAsyncRelativeRetrySucceeded(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LRORetrys beginPost202Retry200" })
         @POST("lro/retryerror/post/202/retry/200")
@@ -129,7 +130,7 @@ public class LRORetrysInner {
         @POST("lro/retryerror/post/202/retry/200")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> post202Retry200(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LRORetrysPost202Retry200HeadersInner, Void>> post202Retry200(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LRORetrys beginPostAsyncRelativeRetrySucceeded" })
         @POST("lro/retryerror/postasync/retry/succeeded")
@@ -141,7 +142,7 @@ public class LRORetrysInner {
         @POST("lro/retryerror/postasync/retry/succeeded")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> postAsyncRelativeRetrySucceeded(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LRORetrysPostAsyncRelativeRetrySucceededHeadersInner, Void>> postAsyncRelativeRetrySucceeded(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -232,7 +233,7 @@ public class LRORetrysInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> put201CreatingSucceeded200Async(final ServiceCallback<ProductInner> serviceCallback) {
+    public ServiceFuture<ProductInner> put201CreatingSucceeded200Async(ServiceCallback<ProductInner> serviceCallback) {
         return ServiceFuture.fromBody(put201CreatingSucceeded200Async(), serviceCallback);
     }
 
@@ -240,12 +241,24 @@ public class LRORetrysInner {
      * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
      */
-    public Single<ProductInner> put201CreatingSucceeded200Async() {
+    public Single<RestResponse<Void, ProductInner>> put201CreatingSucceeded200WithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.put201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
+     */
+    public Single<ProductInner> put201CreatingSucceeded200Async() {
+        return put201CreatingSucceeded200WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<Void, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -268,7 +281,7 @@ public class LRORetrysInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> put201CreatingSucceeded200Async(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
+    public ServiceFuture<ProductInner> put201CreatingSucceeded200Async(ProductInner product, ServiceCallback<ProductInner> serviceCallback) {
         return ServiceFuture.fromBody(put201CreatingSucceeded200Async(product), serviceCallback);
     }
 
@@ -277,12 +290,24 @@ public class LRORetrysInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
      */
-    public Single<ProductInner> put201CreatingSucceeded200Async(ProductInner product) {
+    public Single<RestResponse<Void, ProductInner>> put201CreatingSucceeded200WithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.put201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
+     */
+    public Single<ProductInner> put201CreatingSucceeded200Async(ProductInner product) {
+        return put201CreatingSucceeded200WithRestResponseAsync(product)
+            .map(new Func1<RestResponse<Void, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<Void, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -372,20 +397,32 @@ public class LRORetrysInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> putAsyncRelativeRetrySucceededAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRelativeRetrySucceededAsync(), serviceCallback);
+    public ServiceFuture<ProductInner> putAsyncRelativeRetrySucceededAsync(ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRelativeRetrySucceededAsync(), serviceCallback);
     }
 
     /**
      * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LRORetrysPutAsyncRelativeRetrySucceededHeadersInner, ProductInner> object
      */
-    public Single<ProductInner> putAsyncRelativeRetrySucceededAsync() {
+    public Single<RestResponse<LRORetrysPutAsyncRelativeRetrySucceededHeadersInner, ProductInner>> putAsyncRelativeRetrySucceededWithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.putAsyncRelativeRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LRORetrysPutAsyncRelativeRetrySucceededHeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> putAsyncRelativeRetrySucceededAsync() {
+        return putAsyncRelativeRetrySucceededWithRestResponseAsync()
+            .map(new Func1<RestResponse<LRORetrysPutAsyncRelativeRetrySucceededHeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LRORetrysPutAsyncRelativeRetrySucceededHeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -408,8 +445,8 @@ public class LRORetrysInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> putAsyncRelativeRetrySucceededAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRelativeRetrySucceededAsync(product), serviceCallback);
+    public ServiceFuture<ProductInner> putAsyncRelativeRetrySucceededAsync(ProductInner product, ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRelativeRetrySucceededAsync(product), serviceCallback);
     }
 
     /**
@@ -417,12 +454,24 @@ public class LRORetrysInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LRORetrysPutAsyncRelativeRetrySucceededHeadersInner, ProductInner> object
      */
-    public Single<ProductInner> putAsyncRelativeRetrySucceededAsync(ProductInner product) {
+    public Single<RestResponse<LRORetrysPutAsyncRelativeRetrySucceededHeadersInner, ProductInner>> putAsyncRelativeRetrySucceededWithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.putAsyncRelativeRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LRORetrysPutAsyncRelativeRetrySucceededHeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> putAsyncRelativeRetrySucceededAsync(ProductInner product) {
+        return putAsyncRelativeRetrySucceededWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LRORetrysPutAsyncRelativeRetrySucceededHeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LRORetrysPutAsyncRelativeRetrySucceededHeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -477,19 +526,30 @@ public class LRORetrysInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> deleteProvisioning202Accepted200SucceededAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(deleteProvisioning202Accepted200SucceededAsync(), serviceCallback);
+    public ServiceFuture<ProductInner> deleteProvisioning202Accepted200SucceededAsync(ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(deleteProvisioning202Accepted200SucceededAsync(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 500, then a  202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LRORetrysDeleteProvisioning202Accepted200SucceededHeadersInner, ProductInner> object
      */
-    public Single<ProductInner> deleteProvisioning202Accepted200SucceededAsync() {
+    public Single<RestResponse<LRORetrysDeleteProvisioning202Accepted200SucceededHeadersInner, ProductInner>> deleteProvisioning202Accepted200SucceededWithRestResponseAsync() {
         return service.deleteProvisioning202Accepted200Succeeded(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 500, then a  202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LRORetrysDeleteProvisioning202Accepted200SucceededHeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> deleteProvisioning202Accepted200SucceededAsync() {
+        return deleteProvisioning202Accepted200SucceededWithRestResponseAsync()
+            .map(new Func1<RestResponse<LRORetrysDeleteProvisioning202Accepted200SucceededHeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LRORetrysDeleteProvisioning202Accepted200SucceededHeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -530,6 +590,7 @@ public class LRORetrysInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void delete202Retry200() {
         delete202Retry200Async().toBlocking().value();
@@ -542,19 +603,30 @@ public class LRORetrysInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> delete202Retry200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(delete202Retry200Async(), serviceCallback);
+    public ServiceFuture<Void> delete202Retry200Async(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(delete202Retry200Async(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 500, then a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LRORetrysDelete202Retry200HeadersInner, Void> object
      */
-    public Single<Void> delete202Retry200Async() {
+    public Single<RestResponse<LRORetrysDelete202Retry200HeadersInner, Void>> delete202Retry200WithRestResponseAsync() {
         return service.delete202Retry200(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 500, then a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LRORetrysDelete202Retry200HeadersInner, Void> object
+     */
+    public Single<Void> delete202Retry200Async() {
+        return delete202Retry200WithRestResponseAsync()
+            .map(new Func1<RestResponse<LRORetrysDelete202Retry200HeadersInner, Void>, Void>() { public Void call(RestResponse<LRORetrysDelete202Retry200HeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -595,6 +667,7 @@ public class LRORetrysInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void deleteAsyncRelativeRetrySucceeded() {
         deleteAsyncRelativeRetrySucceededAsync().toBlocking().value();
@@ -607,19 +680,30 @@ public class LRORetrysInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> deleteAsyncRelativeRetrySucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(deleteAsyncRelativeRetrySucceededAsync(), serviceCallback);
+    public ServiceFuture<Void> deleteAsyncRelativeRetrySucceededAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(deleteAsyncRelativeRetrySucceededAsync(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 500, then a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LRORetrysDeleteAsyncRelativeRetrySucceededHeadersInner, Void> object
      */
-    public Single<Void> deleteAsyncRelativeRetrySucceededAsync() {
+    public Single<RestResponse<LRORetrysDeleteAsyncRelativeRetrySucceededHeadersInner, Void>> deleteAsyncRelativeRetrySucceededWithRestResponseAsync() {
         return service.deleteAsyncRelativeRetrySucceeded(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 500, then a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LRORetrysDeleteAsyncRelativeRetrySucceededHeadersInner, Void> object
+     */
+    public Single<Void> deleteAsyncRelativeRetrySucceededAsync() {
+        return deleteAsyncRelativeRetrySucceededWithRestResponseAsync()
+            .map(new Func1<RestResponse<LRORetrysDeleteAsyncRelativeRetrySucceededHeadersInner, Void>, Void>() { public Void call(RestResponse<LRORetrysDeleteAsyncRelativeRetrySucceededHeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -694,6 +778,7 @@ public class LRORetrysInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post202Retry200() {
         post202Retry200Async().toBlocking().value();
@@ -706,20 +791,32 @@ public class LRORetrysInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post202Retry200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(post202Retry200Async(), serviceCallback);
+    public ServiceFuture<Void> post202Retry200Async(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(post202Retry200Async(), serviceCallback);
     }
 
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LRORetrysPost202Retry200HeadersInner, Void> object
      */
-    public Single<Void> post202Retry200Async() {
+    public Single<RestResponse<LRORetrysPost202Retry200HeadersInner, Void>> post202Retry200WithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.post202Retry200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LRORetrysPost202Retry200HeadersInner, Void> object
+     */
+    public Single<Void> post202Retry200Async() {
+        return post202Retry200WithRestResponseAsync()
+            .map(new Func1<RestResponse<LRORetrysPost202Retry200HeadersInner, Void>, Void>() { public Void call(RestResponse<LRORetrysPost202Retry200HeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
@@ -728,6 +825,7 @@ public class LRORetrysInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post202Retry200(ProductInner product) {
         post202Retry200Async(product).toBlocking().value();
@@ -741,8 +839,8 @@ public class LRORetrysInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post202Retry200Async(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(post202Retry200Async(product), serviceCallback);
+    public ServiceFuture<Void> post202Retry200Async(ProductInner product, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(post202Retry200Async(product), serviceCallback);
     }
 
     /**
@@ -750,12 +848,24 @@ public class LRORetrysInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LRORetrysPost202Retry200HeadersInner, Void> object
      */
-    public Single<Void> post202Retry200Async(ProductInner product) {
+    public Single<RestResponse<LRORetrysPost202Retry200HeadersInner, Void>> post202Retry200WithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.post202Retry200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LRORetrysPost202Retry200HeadersInner, Void> object
+     */
+    public Single<Void> post202Retry200Async(ProductInner product) {
+        return post202Retry200WithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LRORetrysPost202Retry200HeadersInner, Void>, Void>() { public Void call(RestResponse<LRORetrysPost202Retry200HeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -830,6 +940,7 @@ public class LRORetrysInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postAsyncRelativeRetrySucceeded() {
         postAsyncRelativeRetrySucceededAsync().toBlocking().value();
@@ -842,20 +953,32 @@ public class LRORetrysInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postAsyncRelativeRetrySucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRelativeRetrySucceededAsync(), serviceCallback);
+    public ServiceFuture<Void> postAsyncRelativeRetrySucceededAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRelativeRetrySucceededAsync(), serviceCallback);
     }
 
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LRORetrysPostAsyncRelativeRetrySucceededHeadersInner, Void> object
      */
-    public Single<Void> postAsyncRelativeRetrySucceededAsync() {
+    public Single<RestResponse<LRORetrysPostAsyncRelativeRetrySucceededHeadersInner, Void>> postAsyncRelativeRetrySucceededWithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.postAsyncRelativeRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LRORetrysPostAsyncRelativeRetrySucceededHeadersInner, Void> object
+     */
+    public Single<Void> postAsyncRelativeRetrySucceededAsync() {
+        return postAsyncRelativeRetrySucceededWithRestResponseAsync()
+            .map(new Func1<RestResponse<LRORetrysPostAsyncRelativeRetrySucceededHeadersInner, Void>, Void>() { public Void call(RestResponse<LRORetrysPostAsyncRelativeRetrySucceededHeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -864,6 +987,7 @@ public class LRORetrysInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postAsyncRelativeRetrySucceeded(ProductInner product) {
         postAsyncRelativeRetrySucceededAsync(product).toBlocking().value();
@@ -877,8 +1001,8 @@ public class LRORetrysInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postAsyncRelativeRetrySucceededAsync(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRelativeRetrySucceededAsync(product), serviceCallback);
+    public ServiceFuture<Void> postAsyncRelativeRetrySucceededAsync(ProductInner product, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRelativeRetrySucceededAsync(product), serviceCallback);
     }
 
     /**
@@ -886,12 +1010,24 @@ public class LRORetrysInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LRORetrysPostAsyncRelativeRetrySucceededHeadersInner, Void> object
      */
-    public Single<Void> postAsyncRelativeRetrySucceededAsync(ProductInner product) {
+    public Single<RestResponse<LRORetrysPostAsyncRelativeRetrySucceededHeadersInner, Void>> postAsyncRelativeRetrySucceededWithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.postAsyncRelativeRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LRORetrysPostAsyncRelativeRetrySucceededHeadersInner, Void> object
+     */
+    public Single<Void> postAsyncRelativeRetrySucceededAsync(ProductInner product) {
+        return postAsyncRelativeRetrySucceededWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LRORetrysPostAsyncRelativeRetrySucceededHeadersInner, Void>, Void>() { public Void call(RestResponse<LRORetrysPostAsyncRelativeRetrySucceededHeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azurefluent/src/main/java/fixtures/lro/implementation/LROSADsInner.java
+++ b/test/azurefluent/src/main/java/fixtures/lro/implementation/LROSADsInner.java
@@ -10,6 +10,7 @@
 
 package fixtures.lro.implementation;
 
+import com.microsoft.rest.RestResponse;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.CloudException;
 import com.microsoft.azure.OperationStatus;
@@ -69,7 +70,7 @@ public class LROSADsInner {
         @PUT("lro/nonretryerror/put/400")
         @ExpectedResponses({200, 201, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> putNonRetry400(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, ProductInner>> putNonRetry400(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginPutNonRetry201Creating400" })
         @PUT("lro/nonretryerror/put/201/creating/400")
@@ -81,7 +82,7 @@ public class LROSADsInner {
         @PUT("lro/nonretryerror/put/201/creating/400")
         @ExpectedResponses({200, 201, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> putNonRetry201Creating400(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, ProductInner>> putNonRetry201Creating400(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginPutNonRetry201Creating400InvalidJson" })
         @PUT("lro/nonretryerror/put/201/creating/400/invalidjson")
@@ -93,7 +94,7 @@ public class LROSADsInner {
         @PUT("lro/nonretryerror/put/201/creating/400/invalidjson")
         @ExpectedResponses({200, 201, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> putNonRetry201Creating400InvalidJson(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, ProductInner>> putNonRetry201Creating400InvalidJson(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginPutAsyncRelativeRetry400" })
         @PUT("lro/nonretryerror/putasync/retry/400")
@@ -105,7 +106,7 @@ public class LROSADsInner {
         @PUT("lro/nonretryerror/putasync/retry/400")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> putAsyncRelativeRetry400(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsPutAsyncRelativeRetry400HeadersInner, ProductInner>> putAsyncRelativeRetry400(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginDeleteNonRetry400" })
         @DELETE("lro/nonretryerror/delete/400")
@@ -117,7 +118,7 @@ public class LROSADsInner {
         @DELETE("lro/nonretryerror/delete/400")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> deleteNonRetry400(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsDeleteNonRetry400HeadersInner, Void>> deleteNonRetry400(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginDelete202NonRetry400" })
         @DELETE("lro/nonretryerror/delete/202/retry/400")
@@ -129,7 +130,7 @@ public class LROSADsInner {
         @DELETE("lro/nonretryerror/delete/202/retry/400")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> delete202NonRetry400(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsDelete202NonRetry400HeadersInner, Void>> delete202NonRetry400(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginDeleteAsyncRelativeRetry400" })
         @DELETE("lro/nonretryerror/deleteasync/retry/400")
@@ -141,7 +142,7 @@ public class LROSADsInner {
         @DELETE("lro/nonretryerror/deleteasync/retry/400")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> deleteAsyncRelativeRetry400(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsDeleteAsyncRelativeRetry400HeadersInner, Void>> deleteAsyncRelativeRetry400(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginPostNonRetry400" })
         @POST("lro/nonretryerror/post/400")
@@ -153,7 +154,7 @@ public class LROSADsInner {
         @POST("lro/nonretryerror/post/400")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> postNonRetry400(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsPostNonRetry400HeadersInner, Void>> postNonRetry400(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginPost202NonRetry400" })
         @POST("lro/nonretryerror/post/202/retry/400")
@@ -165,7 +166,7 @@ public class LROSADsInner {
         @POST("lro/nonretryerror/post/202/retry/400")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> post202NonRetry400(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsPost202NonRetry400HeadersInner, Void>> post202NonRetry400(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginPostAsyncRelativeRetry400" })
         @POST("lro/nonretryerror/postasync/retry/400")
@@ -177,7 +178,7 @@ public class LROSADsInner {
         @POST("lro/nonretryerror/postasync/retry/400")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> postAsyncRelativeRetry400(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsPostAsyncRelativeRetry400HeadersInner, Void>> postAsyncRelativeRetry400(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginPutError201NoProvisioningStatePayload" })
         @PUT("lro/error/put/201/noprovisioningstatepayload")
@@ -189,7 +190,7 @@ public class LROSADsInner {
         @PUT("lro/error/put/201/noprovisioningstatepayload")
         @ExpectedResponses({200, 201, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> putError201NoProvisioningStatePayload(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, ProductInner>> putError201NoProvisioningStatePayload(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginPutAsyncRelativeRetryNoStatus" })
         @PUT("lro/error/putasync/retry/nostatus")
@@ -201,7 +202,7 @@ public class LROSADsInner {
         @PUT("lro/error/putasync/retry/nostatus")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> putAsyncRelativeRetryNoStatus(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsPutAsyncRelativeRetryNoStatusHeadersInner, ProductInner>> putAsyncRelativeRetryNoStatus(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginPutAsyncRelativeRetryNoStatusPayload" })
         @PUT("lro/error/putasync/retry/nostatuspayload")
@@ -213,7 +214,7 @@ public class LROSADsInner {
         @PUT("lro/error/putasync/retry/nostatuspayload")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> putAsyncRelativeRetryNoStatusPayload(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner, ProductInner>> putAsyncRelativeRetryNoStatusPayload(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginDelete204Succeeded" })
         @DELETE("lro/error/delete/204/nolocation")
@@ -225,7 +226,7 @@ public class LROSADsInner {
         @DELETE("lro/error/delete/204/nolocation")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> delete204Succeeded(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> delete204Succeeded(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginDeleteAsyncRelativeRetryNoStatus" })
         @DELETE("lro/error/deleteasync/retry/nostatus")
@@ -237,7 +238,7 @@ public class LROSADsInner {
         @DELETE("lro/error/deleteasync/retry/nostatus")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> deleteAsyncRelativeRetryNoStatus(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsDeleteAsyncRelativeRetryNoStatusHeadersInner, Void>> deleteAsyncRelativeRetryNoStatus(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginPost202NoLocation" })
         @POST("lro/error/post/202/nolocation")
@@ -249,7 +250,7 @@ public class LROSADsInner {
         @POST("lro/error/post/202/nolocation")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> post202NoLocation(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsPost202NoLocationHeadersInner, Void>> post202NoLocation(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginPostAsyncRelativeRetryNoPayload" })
         @POST("lro/error/postasync/retry/nopayload")
@@ -261,7 +262,7 @@ public class LROSADsInner {
         @POST("lro/error/postasync/retry/nopayload")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> postAsyncRelativeRetryNoPayload(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner, Void>> postAsyncRelativeRetryNoPayload(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginPut200InvalidJson" })
         @PUT("lro/error/put/200/invalidjson")
@@ -273,7 +274,7 @@ public class LROSADsInner {
         @PUT("lro/error/put/200/invalidjson")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> put200InvalidJson(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, ProductInner>> put200InvalidJson(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginPutAsyncRelativeRetryInvalidHeader" })
         @PUT("lro/error/putasync/retry/invalidheader")
@@ -285,7 +286,7 @@ public class LROSADsInner {
         @PUT("lro/error/putasync/retry/invalidheader")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> putAsyncRelativeRetryInvalidHeader(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner, ProductInner>> putAsyncRelativeRetryInvalidHeader(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginPutAsyncRelativeRetryInvalidJsonPolling" })
         @PUT("lro/error/putasync/retry/invalidjsonpolling")
@@ -297,7 +298,7 @@ public class LROSADsInner {
         @PUT("lro/error/putasync/retry/invalidjsonpolling")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> putAsyncRelativeRetryInvalidJsonPolling(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner, ProductInner>> putAsyncRelativeRetryInvalidJsonPolling(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginDelete202RetryInvalidHeader" })
         @DELETE("lro/error/delete/202/retry/invalidheader")
@@ -309,7 +310,7 @@ public class LROSADsInner {
         @DELETE("lro/error/delete/202/retry/invalidheader")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> delete202RetryInvalidHeader(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsDelete202RetryInvalidHeaderHeadersInner, Void>> delete202RetryInvalidHeader(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginDeleteAsyncRelativeRetryInvalidHeader" })
         @DELETE("lro/error/deleteasync/retry/invalidheader")
@@ -321,7 +322,7 @@ public class LROSADsInner {
         @DELETE("lro/error/deleteasync/retry/invalidheader")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> deleteAsyncRelativeRetryInvalidHeader(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeadersInner, Void>> deleteAsyncRelativeRetryInvalidHeader(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginDeleteAsyncRelativeRetryInvalidJsonPolling" })
         @DELETE("lro/error/deleteasync/retry/invalidjsonpolling")
@@ -333,7 +334,7 @@ public class LROSADsInner {
         @DELETE("lro/error/deleteasync/retry/invalidjsonpolling")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> deleteAsyncRelativeRetryInvalidJsonPolling(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeadersInner, Void>> deleteAsyncRelativeRetryInvalidJsonPolling(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginPost202RetryInvalidHeader" })
         @POST("lro/error/post/202/retry/invalidheader")
@@ -345,7 +346,7 @@ public class LROSADsInner {
         @POST("lro/error/post/202/retry/invalidheader")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> post202RetryInvalidHeader(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsPost202RetryInvalidHeaderHeadersInner, Void>> post202RetryInvalidHeader(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginPostAsyncRelativeRetryInvalidHeader" })
         @POST("lro/error/postasync/retry/invalidheader")
@@ -357,7 +358,7 @@ public class LROSADsInner {
         @POST("lro/error/postasync/retry/invalidheader")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> postAsyncRelativeRetryInvalidHeader(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner, Void>> postAsyncRelativeRetryInvalidHeader(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROSADs beginPostAsyncRelativeRetryInvalidJsonPolling" })
         @POST("lro/error/postasync/retry/invalidjsonpolling")
@@ -369,7 +370,7 @@ public class LROSADsInner {
         @POST("lro/error/postasync/retry/invalidjsonpolling")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> postAsyncRelativeRetryInvalidJsonPolling(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner, Void>> postAsyncRelativeRetryInvalidJsonPolling(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -460,7 +461,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> putNonRetry400Async(final ServiceCallback<ProductInner> serviceCallback) {
+    public ServiceFuture<ProductInner> putNonRetry400Async(ServiceCallback<ProductInner> serviceCallback) {
         return ServiceFuture.fromBody(putNonRetry400Async(), serviceCallback);
     }
 
@@ -468,12 +469,24 @@ public class LROSADsInner {
      * Long running put request, service returns a 400 to the initial request.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
      */
-    public Single<ProductInner> putNonRetry400Async() {
+    public Single<RestResponse<Void, ProductInner>> putNonRetry400WithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.putNonRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 400 to the initial request.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
+     */
+    public Single<ProductInner> putNonRetry400Async() {
+        return putNonRetry400WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<Void, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 400 to the initial request.
@@ -496,7 +509,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> putNonRetry400Async(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
+    public ServiceFuture<ProductInner> putNonRetry400Async(ProductInner product, ServiceCallback<ProductInner> serviceCallback) {
         return ServiceFuture.fromBody(putNonRetry400Async(product), serviceCallback);
     }
 
@@ -505,12 +518,24 @@ public class LROSADsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
      */
-    public Single<ProductInner> putNonRetry400Async(ProductInner product) {
+    public Single<RestResponse<Void, ProductInner>> putNonRetry400WithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.putNonRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 400 to the initial request.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
+     */
+    public Single<ProductInner> putNonRetry400Async(ProductInner product) {
+        return putNonRetry400WithRestResponseAsync(product)
+            .map(new Func1<RestResponse<Void, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<Void, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -600,7 +625,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> putNonRetry201Creating400Async(final ServiceCallback<ProductInner> serviceCallback) {
+    public ServiceFuture<ProductInner> putNonRetry201Creating400Async(ServiceCallback<ProductInner> serviceCallback) {
         return ServiceFuture.fromBody(putNonRetry201Creating400Async(), serviceCallback);
     }
 
@@ -608,12 +633,24 @@ public class LROSADsInner {
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
      */
-    public Single<ProductInner> putNonRetry201Creating400Async() {
+    public Single<RestResponse<Void, ProductInner>> putNonRetry201Creating400WithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.putNonRetry201Creating400(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
+     */
+    public Single<ProductInner> putNonRetry201Creating400Async() {
+        return putNonRetry201Creating400WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<Void, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
@@ -636,7 +673,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> putNonRetry201Creating400Async(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
+    public ServiceFuture<ProductInner> putNonRetry201Creating400Async(ProductInner product, ServiceCallback<ProductInner> serviceCallback) {
         return ServiceFuture.fromBody(putNonRetry201Creating400Async(product), serviceCallback);
     }
 
@@ -645,12 +682,24 @@ public class LROSADsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
      */
-    public Single<ProductInner> putNonRetry201Creating400Async(ProductInner product) {
+    public Single<RestResponse<Void, ProductInner>> putNonRetry201Creating400WithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.putNonRetry201Creating400(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
+     */
+    public Single<ProductInner> putNonRetry201Creating400Async(ProductInner product) {
+        return putNonRetry201Creating400WithRestResponseAsync(product)
+            .map(new Func1<RestResponse<Void, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<Void, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -740,7 +789,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> putNonRetry201Creating400InvalidJsonAsync(final ServiceCallback<ProductInner> serviceCallback) {
+    public ServiceFuture<ProductInner> putNonRetry201Creating400InvalidJsonAsync(ServiceCallback<ProductInner> serviceCallback) {
         return ServiceFuture.fromBody(putNonRetry201Creating400InvalidJsonAsync(), serviceCallback);
     }
 
@@ -748,12 +797,24 @@ public class LROSADsInner {
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
      */
-    public Single<ProductInner> putNonRetry201Creating400InvalidJsonAsync() {
+    public Single<RestResponse<Void, ProductInner>> putNonRetry201Creating400InvalidJsonWithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.putNonRetry201Creating400InvalidJson(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
+     */
+    public Single<ProductInner> putNonRetry201Creating400InvalidJsonAsync() {
+        return putNonRetry201Creating400InvalidJsonWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<Void, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
@@ -776,7 +837,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> putNonRetry201Creating400InvalidJsonAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
+    public ServiceFuture<ProductInner> putNonRetry201Creating400InvalidJsonAsync(ProductInner product, ServiceCallback<ProductInner> serviceCallback) {
         return ServiceFuture.fromBody(putNonRetry201Creating400InvalidJsonAsync(product), serviceCallback);
     }
 
@@ -785,12 +846,24 @@ public class LROSADsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
      */
-    public Single<ProductInner> putNonRetry201Creating400InvalidJsonAsync(ProductInner product) {
+    public Single<RestResponse<Void, ProductInner>> putNonRetry201Creating400InvalidJsonWithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.putNonRetry201Creating400InvalidJson(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
+     */
+    public Single<ProductInner> putNonRetry201Creating400InvalidJsonAsync(ProductInner product) {
+        return putNonRetry201Creating400InvalidJsonWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<Void, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<Void, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -880,20 +953,32 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> putAsyncRelativeRetry400Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRelativeRetry400Async(), serviceCallback);
+    public ServiceFuture<ProductInner> putAsyncRelativeRetry400Async(ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRelativeRetry400Async(), serviceCallback);
     }
 
     /**
      * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetry400HeadersInner, ProductInner> object
      */
-    public Single<ProductInner> putAsyncRelativeRetry400Async() {
+    public Single<RestResponse<LROSADsPutAsyncRelativeRetry400HeadersInner, ProductInner>> putAsyncRelativeRetry400WithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.putAsyncRelativeRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetry400HeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> putAsyncRelativeRetry400Async() {
+        return putAsyncRelativeRetry400WithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsPutAsyncRelativeRetry400HeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROSADsPutAsyncRelativeRetry400HeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -916,8 +1001,8 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> putAsyncRelativeRetry400Async(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRelativeRetry400Async(product), serviceCallback);
+    public ServiceFuture<ProductInner> putAsyncRelativeRetry400Async(ProductInner product, ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRelativeRetry400Async(product), serviceCallback);
     }
 
     /**
@@ -925,12 +1010,24 @@ public class LROSADsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetry400HeadersInner, ProductInner> object
      */
-    public Single<ProductInner> putAsyncRelativeRetry400Async(ProductInner product) {
+    public Single<RestResponse<LROSADsPutAsyncRelativeRetry400HeadersInner, ProductInner>> putAsyncRelativeRetry400WithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.putAsyncRelativeRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetry400HeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> putAsyncRelativeRetry400Async(ProductInner product) {
+        return putAsyncRelativeRetry400WithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROSADsPutAsyncRelativeRetry400HeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROSADsPutAsyncRelativeRetry400HeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -971,6 +1068,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void deleteNonRetry400() {
         deleteNonRetry400Async().toBlocking().value();
@@ -983,19 +1081,30 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> deleteNonRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(deleteNonRetry400Async(), serviceCallback);
+    public ServiceFuture<Void> deleteNonRetry400Async(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(deleteNonRetry400Async(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 400 with an error body.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsDeleteNonRetry400HeadersInner, Void> object
      */
-    public Single<Void> deleteNonRetry400Async() {
+    public Single<RestResponse<LROSADsDeleteNonRetry400HeadersInner, Void>> deleteNonRetry400WithRestResponseAsync() {
         return service.deleteNonRetry400(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 400 with an error body.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsDeleteNonRetry400HeadersInner, Void> object
+     */
+    public Single<Void> deleteNonRetry400Async() {
+        return deleteNonRetry400WithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsDeleteNonRetry400HeadersInner, Void>, Void>() { public Void call(RestResponse<LROSADsDeleteNonRetry400HeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1036,6 +1145,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void delete202NonRetry400() {
         delete202NonRetry400Async().toBlocking().value();
@@ -1048,19 +1158,30 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> delete202NonRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(delete202NonRetry400Async(), serviceCallback);
+    public ServiceFuture<Void> delete202NonRetry400Async(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(delete202NonRetry400Async(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 202 with a location header.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsDelete202NonRetry400HeadersInner, Void> object
      */
-    public Single<Void> delete202NonRetry400Async() {
+    public Single<RestResponse<LROSADsDelete202NonRetry400HeadersInner, Void>> delete202NonRetry400WithRestResponseAsync() {
         return service.delete202NonRetry400(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 202 with a location header.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsDelete202NonRetry400HeadersInner, Void> object
+     */
+    public Single<Void> delete202NonRetry400Async() {
+        return delete202NonRetry400WithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsDelete202NonRetry400HeadersInner, Void>, Void>() { public Void call(RestResponse<LROSADsDelete202NonRetry400HeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1101,6 +1222,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void deleteAsyncRelativeRetry400() {
         deleteAsyncRelativeRetry400Async().toBlocking().value();
@@ -1113,19 +1235,30 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> deleteAsyncRelativeRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(deleteAsyncRelativeRetry400Async(), serviceCallback);
+    public ServiceFuture<Void> deleteAsyncRelativeRetry400Async(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(deleteAsyncRelativeRetry400Async(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsDeleteAsyncRelativeRetry400HeadersInner, Void> object
      */
-    public Single<Void> deleteAsyncRelativeRetry400Async() {
+    public Single<RestResponse<LROSADsDeleteAsyncRelativeRetry400HeadersInner, Void>> deleteAsyncRelativeRetry400WithRestResponseAsync() {
         return service.deleteAsyncRelativeRetry400(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsDeleteAsyncRelativeRetry400HeadersInner, Void> object
+     */
+    public Single<Void> deleteAsyncRelativeRetry400Async() {
+        return deleteAsyncRelativeRetry400WithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsDeleteAsyncRelativeRetry400HeadersInner, Void>, Void>() { public Void call(RestResponse<LROSADsDeleteAsyncRelativeRetry400HeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1200,6 +1333,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postNonRetry400() {
         postNonRetry400Async().toBlocking().value();
@@ -1212,20 +1346,32 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postNonRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postNonRetry400Async(), serviceCallback);
+    public ServiceFuture<Void> postNonRetry400Async(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postNonRetry400Async(), serviceCallback);
     }
 
     /**
      * Long running post request, service returns a 400 with no error body.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostNonRetry400HeadersInner, Void> object
      */
-    public Single<Void> postNonRetry400Async() {
+    public Single<RestResponse<LROSADsPostNonRetry400HeadersInner, Void>> postNonRetry400WithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.postNonRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 400 with no error body.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostNonRetry400HeadersInner, Void> object
+     */
+    public Single<Void> postNonRetry400Async() {
+        return postNonRetry400WithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsPostNonRetry400HeadersInner, Void>, Void>() { public Void call(RestResponse<LROSADsPostNonRetry400HeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running post request, service returns a 400 with no error body.
@@ -1234,6 +1380,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postNonRetry400(ProductInner product) {
         postNonRetry400Async(product).toBlocking().value();
@@ -1247,8 +1394,8 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postNonRetry400Async(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postNonRetry400Async(product), serviceCallback);
+    public ServiceFuture<Void> postNonRetry400Async(ProductInner product, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postNonRetry400Async(product), serviceCallback);
     }
 
     /**
@@ -1256,12 +1403,24 @@ public class LROSADsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostNonRetry400HeadersInner, Void> object
      */
-    public Single<Void> postNonRetry400Async(ProductInner product) {
+    public Single<RestResponse<LROSADsPostNonRetry400HeadersInner, Void>> postNonRetry400WithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.postNonRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 400 with no error body.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostNonRetry400HeadersInner, Void> object
+     */
+    public Single<Void> postNonRetry400Async(ProductInner product) {
+        return postNonRetry400WithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROSADsPostNonRetry400HeadersInner, Void>, Void>() { public Void call(RestResponse<LROSADsPostNonRetry400HeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1336,6 +1495,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post202NonRetry400() {
         post202NonRetry400Async().toBlocking().value();
@@ -1348,20 +1508,32 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post202NonRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(post202NonRetry400Async(), serviceCallback);
+    public ServiceFuture<Void> post202NonRetry400Async(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(post202NonRetry400Async(), serviceCallback);
     }
 
     /**
      * Long running post request, service returns a 202 with a location header.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsPost202NonRetry400HeadersInner, Void> object
      */
-    public Single<Void> post202NonRetry400Async() {
+    public Single<RestResponse<LROSADsPost202NonRetry400HeadersInner, Void>> post202NonRetry400WithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.post202NonRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 with a location header.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPost202NonRetry400HeadersInner, Void> object
+     */
+    public Single<Void> post202NonRetry400Async() {
+        return post202NonRetry400WithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsPost202NonRetry400HeadersInner, Void>, Void>() { public Void call(RestResponse<LROSADsPost202NonRetry400HeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running post request, service returns a 202 with a location header.
@@ -1370,6 +1542,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post202NonRetry400(ProductInner product) {
         post202NonRetry400Async(product).toBlocking().value();
@@ -1383,8 +1556,8 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post202NonRetry400Async(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(post202NonRetry400Async(product), serviceCallback);
+    public ServiceFuture<Void> post202NonRetry400Async(ProductInner product, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(post202NonRetry400Async(product), serviceCallback);
     }
 
     /**
@@ -1392,12 +1565,24 @@ public class LROSADsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsPost202NonRetry400HeadersInner, Void> object
      */
-    public Single<Void> post202NonRetry400Async(ProductInner product) {
+    public Single<RestResponse<LROSADsPost202NonRetry400HeadersInner, Void>> post202NonRetry400WithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.post202NonRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 with a location header.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPost202NonRetry400HeadersInner, Void> object
+     */
+    public Single<Void> post202NonRetry400Async(ProductInner product) {
+        return post202NonRetry400WithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROSADsPost202NonRetry400HeadersInner, Void>, Void>() { public Void call(RestResponse<LROSADsPost202NonRetry400HeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1472,6 +1657,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postAsyncRelativeRetry400() {
         postAsyncRelativeRetry400Async().toBlocking().value();
@@ -1484,20 +1670,32 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postAsyncRelativeRetry400Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRelativeRetry400Async(), serviceCallback);
+    public ServiceFuture<Void> postAsyncRelativeRetry400Async(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRelativeRetry400Async(), serviceCallback);
     }
 
     /**
      * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostAsyncRelativeRetry400HeadersInner, Void> object
      */
-    public Single<Void> postAsyncRelativeRetry400Async() {
+    public Single<RestResponse<LROSADsPostAsyncRelativeRetry400HeadersInner, Void>> postAsyncRelativeRetry400WithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.postAsyncRelativeRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostAsyncRelativeRetry400HeadersInner, Void> object
+     */
+    public Single<Void> postAsyncRelativeRetry400Async() {
+        return postAsyncRelativeRetry400WithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsPostAsyncRelativeRetry400HeadersInner, Void>, Void>() { public Void call(RestResponse<LROSADsPostAsyncRelativeRetry400HeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1506,6 +1704,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postAsyncRelativeRetry400(ProductInner product) {
         postAsyncRelativeRetry400Async(product).toBlocking().value();
@@ -1519,8 +1718,8 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postAsyncRelativeRetry400Async(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRelativeRetry400Async(product), serviceCallback);
+    public ServiceFuture<Void> postAsyncRelativeRetry400Async(ProductInner product, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRelativeRetry400Async(product), serviceCallback);
     }
 
     /**
@@ -1528,12 +1727,24 @@ public class LROSADsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostAsyncRelativeRetry400HeadersInner, Void> object
      */
-    public Single<Void> postAsyncRelativeRetry400Async(ProductInner product) {
+    public Single<RestResponse<LROSADsPostAsyncRelativeRetry400HeadersInner, Void>> postAsyncRelativeRetry400WithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.postAsyncRelativeRetry400(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostAsyncRelativeRetry400HeadersInner, Void> object
+     */
+    public Single<Void> postAsyncRelativeRetry400Async(ProductInner product) {
+        return postAsyncRelativeRetry400WithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROSADsPostAsyncRelativeRetry400HeadersInner, Void>, Void>() { public Void call(RestResponse<LROSADsPostAsyncRelativeRetry400HeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1623,7 +1834,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> putError201NoProvisioningStatePayloadAsync(final ServiceCallback<ProductInner> serviceCallback) {
+    public ServiceFuture<ProductInner> putError201NoProvisioningStatePayloadAsync(ServiceCallback<ProductInner> serviceCallback) {
         return ServiceFuture.fromBody(putError201NoProvisioningStatePayloadAsync(), serviceCallback);
     }
 
@@ -1631,12 +1842,24 @@ public class LROSADsInner {
      * Long running put request, service returns a 201 to the initial request with no payload.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
      */
-    public Single<ProductInner> putError201NoProvisioningStatePayloadAsync() {
+    public Single<RestResponse<Void, ProductInner>> putError201NoProvisioningStatePayloadWithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.putError201NoProvisioningStatePayload(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request with no payload.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
+     */
+    public Single<ProductInner> putError201NoProvisioningStatePayloadAsync() {
+        return putError201NoProvisioningStatePayloadWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<Void, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 201 to the initial request with no payload.
@@ -1659,7 +1882,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> putError201NoProvisioningStatePayloadAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
+    public ServiceFuture<ProductInner> putError201NoProvisioningStatePayloadAsync(ProductInner product, ServiceCallback<ProductInner> serviceCallback) {
         return ServiceFuture.fromBody(putError201NoProvisioningStatePayloadAsync(product), serviceCallback);
     }
 
@@ -1668,12 +1891,24 @@ public class LROSADsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
      */
-    public Single<ProductInner> putError201NoProvisioningStatePayloadAsync(ProductInner product) {
+    public Single<RestResponse<Void, ProductInner>> putError201NoProvisioningStatePayloadWithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.putError201NoProvisioningStatePayload(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request with no payload.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
+     */
+    public Single<ProductInner> putError201NoProvisioningStatePayloadAsync(ProductInner product) {
+        return putError201NoProvisioningStatePayloadWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<Void, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<Void, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1763,20 +1998,32 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> putAsyncRelativeRetryNoStatusAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRelativeRetryNoStatusAsync(), serviceCallback);
+    public ServiceFuture<ProductInner> putAsyncRelativeRetryNoStatusAsync(ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRelativeRetryNoStatusAsync(), serviceCallback);
     }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetryNoStatusHeadersInner, ProductInner> object
      */
-    public Single<ProductInner> putAsyncRelativeRetryNoStatusAsync() {
+    public Single<RestResponse<LROSADsPutAsyncRelativeRetryNoStatusHeadersInner, ProductInner>> putAsyncRelativeRetryNoStatusWithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.putAsyncRelativeRetryNoStatus(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetryNoStatusHeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> putAsyncRelativeRetryNoStatusAsync() {
+        return putAsyncRelativeRetryNoStatusWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsPutAsyncRelativeRetryNoStatusHeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROSADsPutAsyncRelativeRetryNoStatusHeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1799,8 +2046,8 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> putAsyncRelativeRetryNoStatusAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRelativeRetryNoStatusAsync(product), serviceCallback);
+    public ServiceFuture<ProductInner> putAsyncRelativeRetryNoStatusAsync(ProductInner product, ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRelativeRetryNoStatusAsync(product), serviceCallback);
     }
 
     /**
@@ -1808,12 +2055,24 @@ public class LROSADsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetryNoStatusHeadersInner, ProductInner> object
      */
-    public Single<ProductInner> putAsyncRelativeRetryNoStatusAsync(ProductInner product) {
+    public Single<RestResponse<LROSADsPutAsyncRelativeRetryNoStatusHeadersInner, ProductInner>> putAsyncRelativeRetryNoStatusWithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.putAsyncRelativeRetryNoStatus(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetryNoStatusHeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> putAsyncRelativeRetryNoStatusAsync(ProductInner product) {
+        return putAsyncRelativeRetryNoStatusWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROSADsPutAsyncRelativeRetryNoStatusHeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROSADsPutAsyncRelativeRetryNoStatusHeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1903,20 +2162,32 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> putAsyncRelativeRetryNoStatusPayloadAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRelativeRetryNoStatusPayloadAsync(), serviceCallback);
+    public ServiceFuture<ProductInner> putAsyncRelativeRetryNoStatusPayloadAsync(ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRelativeRetryNoStatusPayloadAsync(), serviceCallback);
     }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner, ProductInner> object
      */
-    public Single<ProductInner> putAsyncRelativeRetryNoStatusPayloadAsync() {
+    public Single<RestResponse<LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner, ProductInner>> putAsyncRelativeRetryNoStatusPayloadWithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.putAsyncRelativeRetryNoStatusPayload(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> putAsyncRelativeRetryNoStatusPayloadAsync() {
+        return putAsyncRelativeRetryNoStatusPayloadWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1939,8 +2210,8 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> putAsyncRelativeRetryNoStatusPayloadAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRelativeRetryNoStatusPayloadAsync(product), serviceCallback);
+    public ServiceFuture<ProductInner> putAsyncRelativeRetryNoStatusPayloadAsync(ProductInner product, ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRelativeRetryNoStatusPayloadAsync(product), serviceCallback);
     }
 
     /**
@@ -1948,12 +2219,24 @@ public class LROSADsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner, ProductInner> object
      */
-    public Single<ProductInner> putAsyncRelativeRetryNoStatusPayloadAsync(ProductInner product) {
+    public Single<RestResponse<LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner, ProductInner>> putAsyncRelativeRetryNoStatusPayloadWithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.putAsyncRelativeRetryNoStatusPayload(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> putAsyncRelativeRetryNoStatusPayloadAsync(ProductInner product) {
+        return putAsyncRelativeRetryNoStatusPayloadWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1994,6 +2277,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void delete204Succeeded() {
         delete204SucceededAsync().toBlocking().value();
@@ -2006,7 +2290,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> delete204SucceededAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> delete204SucceededAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(delete204SucceededAsync(), serviceCallback);
     }
 
@@ -2014,11 +2298,22 @@ public class LROSADsInner {
      * Long running delete request, service returns a 204 to the initial request, indicating success.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> delete204SucceededAsync() {
+    public Single<RestResponse<Void, Void>> delete204SucceededWithRestResponseAsync() {
         return service.delete204Succeeded(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 204 to the initial request, indicating success.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> delete204SucceededAsync() {
+        return delete204SucceededWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2059,6 +2354,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void deleteAsyncRelativeRetryNoStatus() {
         deleteAsyncRelativeRetryNoStatusAsync().toBlocking().value();
@@ -2071,19 +2367,30 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> deleteAsyncRelativeRetryNoStatusAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(deleteAsyncRelativeRetryNoStatusAsync(), serviceCallback);
+    public ServiceFuture<Void> deleteAsyncRelativeRetryNoStatusAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(deleteAsyncRelativeRetryNoStatusAsync(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsDeleteAsyncRelativeRetryNoStatusHeadersInner, Void> object
      */
-    public Single<Void> deleteAsyncRelativeRetryNoStatusAsync() {
+    public Single<RestResponse<LROSADsDeleteAsyncRelativeRetryNoStatusHeadersInner, Void>> deleteAsyncRelativeRetryNoStatusWithRestResponseAsync() {
         return service.deleteAsyncRelativeRetryNoStatus(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsDeleteAsyncRelativeRetryNoStatusHeadersInner, Void> object
+     */
+    public Single<Void> deleteAsyncRelativeRetryNoStatusAsync() {
+        return deleteAsyncRelativeRetryNoStatusWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsDeleteAsyncRelativeRetryNoStatusHeadersInner, Void>, Void>() { public Void call(RestResponse<LROSADsDeleteAsyncRelativeRetryNoStatusHeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2158,6 +2465,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post202NoLocation() {
         post202NoLocationAsync().toBlocking().value();
@@ -2170,20 +2478,32 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post202NoLocationAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(post202NoLocationAsync(), serviceCallback);
+    public ServiceFuture<Void> post202NoLocationAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(post202NoLocationAsync(), serviceCallback);
     }
 
     /**
      * Long running post request, service returns a 202 to the initial request, without a location header.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsPost202NoLocationHeadersInner, Void> object
      */
-    public Single<Void> post202NoLocationAsync() {
+    public Single<RestResponse<LROSADsPost202NoLocationHeadersInner, Void>> post202NoLocationWithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.post202NoLocation(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, without a location header.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPost202NoLocationHeadersInner, Void> object
+     */
+    public Single<Void> post202NoLocationAsync() {
+        return post202NoLocationWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsPost202NoLocationHeadersInner, Void>, Void>() { public Void call(RestResponse<LROSADsPost202NoLocationHeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running post request, service returns a 202 to the initial request, without a location header.
@@ -2192,6 +2512,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post202NoLocation(ProductInner product) {
         post202NoLocationAsync(product).toBlocking().value();
@@ -2205,8 +2526,8 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post202NoLocationAsync(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(post202NoLocationAsync(product), serviceCallback);
+    public ServiceFuture<Void> post202NoLocationAsync(ProductInner product, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(post202NoLocationAsync(product), serviceCallback);
     }
 
     /**
@@ -2214,12 +2535,24 @@ public class LROSADsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsPost202NoLocationHeadersInner, Void> object
      */
-    public Single<Void> post202NoLocationAsync(ProductInner product) {
+    public Single<RestResponse<LROSADsPost202NoLocationHeadersInner, Void>> post202NoLocationWithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.post202NoLocation(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, without a location header.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPost202NoLocationHeadersInner, Void> object
+     */
+    public Single<Void> post202NoLocationAsync(ProductInner product) {
+        return post202NoLocationWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROSADsPost202NoLocationHeadersInner, Void>, Void>() { public Void call(RestResponse<LROSADsPost202NoLocationHeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2294,6 +2627,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postAsyncRelativeRetryNoPayload() {
         postAsyncRelativeRetryNoPayloadAsync().toBlocking().value();
@@ -2306,20 +2640,32 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postAsyncRelativeRetryNoPayloadAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRelativeRetryNoPayloadAsync(), serviceCallback);
+    public ServiceFuture<Void> postAsyncRelativeRetryNoPayloadAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRelativeRetryNoPayloadAsync(), serviceCallback);
     }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner, Void> object
      */
-    public Single<Void> postAsyncRelativeRetryNoPayloadAsync() {
+    public Single<RestResponse<LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner, Void>> postAsyncRelativeRetryNoPayloadWithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.postAsyncRelativeRetryNoPayload(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner, Void> object
+     */
+    public Single<Void> postAsyncRelativeRetryNoPayloadAsync() {
+        return postAsyncRelativeRetryNoPayloadWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner, Void>, Void>() { public Void call(RestResponse<LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2328,6 +2674,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postAsyncRelativeRetryNoPayload(ProductInner product) {
         postAsyncRelativeRetryNoPayloadAsync(product).toBlocking().value();
@@ -2341,8 +2688,8 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postAsyncRelativeRetryNoPayloadAsync(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRelativeRetryNoPayloadAsync(product), serviceCallback);
+    public ServiceFuture<Void> postAsyncRelativeRetryNoPayloadAsync(ProductInner product, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRelativeRetryNoPayloadAsync(product), serviceCallback);
     }
 
     /**
@@ -2350,12 +2697,24 @@ public class LROSADsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner, Void> object
      */
-    public Single<Void> postAsyncRelativeRetryNoPayloadAsync(ProductInner product) {
+    public Single<RestResponse<LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner, Void>> postAsyncRelativeRetryNoPayloadWithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.postAsyncRelativeRetryNoPayload(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner, Void> object
+     */
+    public Single<Void> postAsyncRelativeRetryNoPayloadAsync(ProductInner product) {
+        return postAsyncRelativeRetryNoPayloadWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner, Void>, Void>() { public Void call(RestResponse<LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2445,7 +2804,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> put200InvalidJsonAsync(final ServiceCallback<ProductInner> serviceCallback) {
+    public ServiceFuture<ProductInner> put200InvalidJsonAsync(ServiceCallback<ProductInner> serviceCallback) {
         return ServiceFuture.fromBody(put200InvalidJsonAsync(), serviceCallback);
     }
 
@@ -2453,12 +2812,24 @@ public class LROSADsInner {
      * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
      */
-    public Single<ProductInner> put200InvalidJsonAsync() {
+    public Single<RestResponse<Void, ProductInner>> put200InvalidJsonWithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.put200InvalidJson(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
+     */
+    public Single<ProductInner> put200InvalidJsonAsync() {
+        return put200InvalidJsonWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<Void, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
@@ -2481,7 +2852,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> put200InvalidJsonAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
+    public ServiceFuture<ProductInner> put200InvalidJsonAsync(ProductInner product, ServiceCallback<ProductInner> serviceCallback) {
         return ServiceFuture.fromBody(put200InvalidJsonAsync(product), serviceCallback);
     }
 
@@ -2490,12 +2861,24 @@ public class LROSADsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
      */
-    public Single<ProductInner> put200InvalidJsonAsync(ProductInner product) {
+    public Single<RestResponse<Void, ProductInner>> put200InvalidJsonWithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.put200InvalidJson(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
+     */
+    public Single<ProductInner> put200InvalidJsonAsync(ProductInner product) {
+        return put200InvalidJsonWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<Void, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<Void, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2585,20 +2968,32 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> putAsyncRelativeRetryInvalidHeaderAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRelativeRetryInvalidHeaderAsync(), serviceCallback);
+    public ServiceFuture<ProductInner> putAsyncRelativeRetryInvalidHeaderAsync(ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRelativeRetryInvalidHeaderAsync(), serviceCallback);
     }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner, ProductInner> object
      */
-    public Single<ProductInner> putAsyncRelativeRetryInvalidHeaderAsync() {
+    public Single<RestResponse<LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner, ProductInner>> putAsyncRelativeRetryInvalidHeaderWithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.putAsyncRelativeRetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> putAsyncRelativeRetryInvalidHeaderAsync() {
+        return putAsyncRelativeRetryInvalidHeaderWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
@@ -2621,8 +3016,8 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> putAsyncRelativeRetryInvalidHeaderAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRelativeRetryInvalidHeaderAsync(product), serviceCallback);
+    public ServiceFuture<ProductInner> putAsyncRelativeRetryInvalidHeaderAsync(ProductInner product, ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRelativeRetryInvalidHeaderAsync(product), serviceCallback);
     }
 
     /**
@@ -2630,12 +3025,24 @@ public class LROSADsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner, ProductInner> object
      */
-    public Single<ProductInner> putAsyncRelativeRetryInvalidHeaderAsync(ProductInner product) {
+    public Single<RestResponse<LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner, ProductInner>> putAsyncRelativeRetryInvalidHeaderWithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.putAsyncRelativeRetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> putAsyncRelativeRetryInvalidHeaderAsync(ProductInner product) {
+        return putAsyncRelativeRetryInvalidHeaderWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2725,20 +3132,32 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> putAsyncRelativeRetryInvalidJsonPollingAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRelativeRetryInvalidJsonPollingAsync(), serviceCallback);
+    public ServiceFuture<ProductInner> putAsyncRelativeRetryInvalidJsonPollingAsync(ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRelativeRetryInvalidJsonPollingAsync(), serviceCallback);
     }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner, ProductInner> object
      */
-    public Single<ProductInner> putAsyncRelativeRetryInvalidJsonPollingAsync() {
+    public Single<RestResponse<LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner, ProductInner>> putAsyncRelativeRetryInvalidJsonPollingWithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.putAsyncRelativeRetryInvalidJsonPolling(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> putAsyncRelativeRetryInvalidJsonPollingAsync() {
+        return putAsyncRelativeRetryInvalidJsonPollingWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2761,8 +3180,8 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> putAsyncRelativeRetryInvalidJsonPollingAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRelativeRetryInvalidJsonPollingAsync(product), serviceCallback);
+    public ServiceFuture<ProductInner> putAsyncRelativeRetryInvalidJsonPollingAsync(ProductInner product, ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRelativeRetryInvalidJsonPollingAsync(product), serviceCallback);
     }
 
     /**
@@ -2770,12 +3189,24 @@ public class LROSADsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner, ProductInner> object
      */
-    public Single<ProductInner> putAsyncRelativeRetryInvalidJsonPollingAsync(ProductInner product) {
+    public Single<RestResponse<LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner, ProductInner>> putAsyncRelativeRetryInvalidJsonPollingWithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.putAsyncRelativeRetryInvalidJsonPolling(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> putAsyncRelativeRetryInvalidJsonPollingAsync(ProductInner product) {
+        return putAsyncRelativeRetryInvalidJsonPollingWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2816,6 +3247,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void delete202RetryInvalidHeader() {
         delete202RetryInvalidHeaderAsync().toBlocking().value();
@@ -2828,19 +3260,30 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> delete202RetryInvalidHeaderAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(delete202RetryInvalidHeaderAsync(), serviceCallback);
+    public ServiceFuture<Void> delete202RetryInvalidHeaderAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(delete202RetryInvalidHeaderAsync(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 202 to the initial request receing a reponse with an invalid 'Location' and 'Retry-After' headers.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsDelete202RetryInvalidHeaderHeadersInner, Void> object
      */
-    public Single<Void> delete202RetryInvalidHeaderAsync() {
+    public Single<RestResponse<LROSADsDelete202RetryInvalidHeaderHeadersInner, Void>> delete202RetryInvalidHeaderWithRestResponseAsync() {
         return service.delete202RetryInvalidHeader(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request receing a reponse with an invalid 'Location' and 'Retry-After' headers.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsDelete202RetryInvalidHeaderHeadersInner, Void> object
+     */
+    public Single<Void> delete202RetryInvalidHeaderAsync() {
+        return delete202RetryInvalidHeaderWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsDelete202RetryInvalidHeaderHeadersInner, Void>, Void>() { public Void call(RestResponse<LROSADsDelete202RetryInvalidHeaderHeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2881,6 +3324,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void deleteAsyncRelativeRetryInvalidHeader() {
         deleteAsyncRelativeRetryInvalidHeaderAsync().toBlocking().value();
@@ -2893,19 +3337,30 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> deleteAsyncRelativeRetryInvalidHeaderAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(deleteAsyncRelativeRetryInvalidHeaderAsync(), serviceCallback);
+    public ServiceFuture<Void> deleteAsyncRelativeRetryInvalidHeaderAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(deleteAsyncRelativeRetryInvalidHeaderAsync(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 202 to the initial request. The endpoint indicated in the Azure-AsyncOperation header is invalid.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeadersInner, Void> object
      */
-    public Single<Void> deleteAsyncRelativeRetryInvalidHeaderAsync() {
+    public Single<RestResponse<LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeadersInner, Void>> deleteAsyncRelativeRetryInvalidHeaderWithRestResponseAsync() {
         return service.deleteAsyncRelativeRetryInvalidHeader(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeadersInner, Void> object
+     */
+    public Single<Void> deleteAsyncRelativeRetryInvalidHeaderAsync() {
+        return deleteAsyncRelativeRetryInvalidHeaderWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeadersInner, Void>, Void>() { public Void call(RestResponse<LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2946,6 +3401,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void deleteAsyncRelativeRetryInvalidJsonPolling() {
         deleteAsyncRelativeRetryInvalidJsonPollingAsync().toBlocking().value();
@@ -2958,19 +3414,30 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> deleteAsyncRelativeRetryInvalidJsonPollingAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(deleteAsyncRelativeRetryInvalidJsonPollingAsync(), serviceCallback);
+    public ServiceFuture<Void> deleteAsyncRelativeRetryInvalidJsonPollingAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(deleteAsyncRelativeRetryInvalidJsonPollingAsync(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeadersInner, Void> object
      */
-    public Single<Void> deleteAsyncRelativeRetryInvalidJsonPollingAsync() {
+    public Single<RestResponse<LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeadersInner, Void>> deleteAsyncRelativeRetryInvalidJsonPollingWithRestResponseAsync() {
         return service.deleteAsyncRelativeRetryInvalidJsonPolling(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeadersInner, Void> object
+     */
+    public Single<Void> deleteAsyncRelativeRetryInvalidJsonPollingAsync() {
+        return deleteAsyncRelativeRetryInvalidJsonPollingWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeadersInner, Void>, Void>() { public Void call(RestResponse<LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -3045,6 +3512,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post202RetryInvalidHeader() {
         post202RetryInvalidHeaderAsync().toBlocking().value();
@@ -3057,20 +3525,32 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post202RetryInvalidHeaderAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(post202RetryInvalidHeaderAsync(), serviceCallback);
+    public ServiceFuture<Void> post202RetryInvalidHeaderAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(post202RetryInvalidHeaderAsync(), serviceCallback);
     }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsPost202RetryInvalidHeaderHeadersInner, Void> object
      */
-    public Single<Void> post202RetryInvalidHeaderAsync() {
+    public Single<RestResponse<LROSADsPost202RetryInvalidHeaderHeadersInner, Void>> post202RetryInvalidHeaderWithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.post202RetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPost202RetryInvalidHeaderHeadersInner, Void> object
+     */
+    public Single<Void> post202RetryInvalidHeaderAsync() {
+        return post202RetryInvalidHeaderWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsPost202RetryInvalidHeaderHeadersInner, Void>, Void>() { public Void call(RestResponse<LROSADsPost202RetryInvalidHeaderHeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
@@ -3079,6 +3559,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post202RetryInvalidHeader(ProductInner product) {
         post202RetryInvalidHeaderAsync(product).toBlocking().value();
@@ -3092,8 +3573,8 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post202RetryInvalidHeaderAsync(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(post202RetryInvalidHeaderAsync(product), serviceCallback);
+    public ServiceFuture<Void> post202RetryInvalidHeaderAsync(ProductInner product, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(post202RetryInvalidHeaderAsync(product), serviceCallback);
     }
 
     /**
@@ -3101,12 +3582,24 @@ public class LROSADsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsPost202RetryInvalidHeaderHeadersInner, Void> object
      */
-    public Single<Void> post202RetryInvalidHeaderAsync(ProductInner product) {
+    public Single<RestResponse<LROSADsPost202RetryInvalidHeaderHeadersInner, Void>> post202RetryInvalidHeaderWithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.post202RetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPost202RetryInvalidHeaderHeadersInner, Void> object
+     */
+    public Single<Void> post202RetryInvalidHeaderAsync(ProductInner product) {
+        return post202RetryInvalidHeaderWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROSADsPost202RetryInvalidHeaderHeadersInner, Void>, Void>() { public Void call(RestResponse<LROSADsPost202RetryInvalidHeaderHeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -3181,6 +3674,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postAsyncRelativeRetryInvalidHeader() {
         postAsyncRelativeRetryInvalidHeaderAsync().toBlocking().value();
@@ -3193,20 +3687,32 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postAsyncRelativeRetryInvalidHeaderAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRelativeRetryInvalidHeaderAsync(), serviceCallback);
+    public ServiceFuture<Void> postAsyncRelativeRetryInvalidHeaderAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRelativeRetryInvalidHeaderAsync(), serviceCallback);
     }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner, Void> object
      */
-    public Single<Void> postAsyncRelativeRetryInvalidHeaderAsync() {
+    public Single<RestResponse<LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner, Void>> postAsyncRelativeRetryInvalidHeaderWithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.postAsyncRelativeRetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner, Void> object
+     */
+    public Single<Void> postAsyncRelativeRetryInvalidHeaderAsync() {
+        return postAsyncRelativeRetryInvalidHeaderWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner, Void>, Void>() { public Void call(RestResponse<LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
@@ -3215,6 +3721,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postAsyncRelativeRetryInvalidHeader(ProductInner product) {
         postAsyncRelativeRetryInvalidHeaderAsync(product).toBlocking().value();
@@ -3228,8 +3735,8 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postAsyncRelativeRetryInvalidHeaderAsync(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRelativeRetryInvalidHeaderAsync(product), serviceCallback);
+    public ServiceFuture<Void> postAsyncRelativeRetryInvalidHeaderAsync(ProductInner product, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRelativeRetryInvalidHeaderAsync(product), serviceCallback);
     }
 
     /**
@@ -3237,12 +3744,24 @@ public class LROSADsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner, Void> object
      */
-    public Single<Void> postAsyncRelativeRetryInvalidHeaderAsync(ProductInner product) {
+    public Single<RestResponse<LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner, Void>> postAsyncRelativeRetryInvalidHeaderWithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.postAsyncRelativeRetryInvalidHeader(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner, Void> object
+     */
+    public Single<Void> postAsyncRelativeRetryInvalidHeaderAsync(ProductInner product) {
+        return postAsyncRelativeRetryInvalidHeaderWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner, Void>, Void>() { public Void call(RestResponse<LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -3317,6 +3836,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postAsyncRelativeRetryInvalidJsonPolling() {
         postAsyncRelativeRetryInvalidJsonPollingAsync().toBlocking().value();
@@ -3329,20 +3849,32 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postAsyncRelativeRetryInvalidJsonPollingAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRelativeRetryInvalidJsonPollingAsync(), serviceCallback);
+    public ServiceFuture<Void> postAsyncRelativeRetryInvalidJsonPollingAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRelativeRetryInvalidJsonPollingAsync(), serviceCallback);
     }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner, Void> object
      */
-    public Single<Void> postAsyncRelativeRetryInvalidJsonPollingAsync() {
+    public Single<RestResponse<LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner, Void>> postAsyncRelativeRetryInvalidJsonPollingWithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.postAsyncRelativeRetryInvalidJsonPolling(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner, Void> object
+     */
+    public Single<Void> postAsyncRelativeRetryInvalidJsonPollingAsync() {
+        return postAsyncRelativeRetryInvalidJsonPollingWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner, Void>, Void>() { public Void call(RestResponse<LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -3351,6 +3883,7 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postAsyncRelativeRetryInvalidJsonPolling(ProductInner product) {
         postAsyncRelativeRetryInvalidJsonPollingAsync(product).toBlocking().value();
@@ -3364,8 +3897,8 @@ public class LROSADsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postAsyncRelativeRetryInvalidJsonPollingAsync(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRelativeRetryInvalidJsonPollingAsync(product), serviceCallback);
+    public ServiceFuture<Void> postAsyncRelativeRetryInvalidJsonPollingAsync(ProductInner product, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRelativeRetryInvalidJsonPollingAsync(product), serviceCallback);
     }
 
     /**
@@ -3373,12 +3906,24 @@ public class LROSADsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner, Void> object
      */
-    public Single<Void> postAsyncRelativeRetryInvalidJsonPollingAsync(ProductInner product) {
+    public Single<RestResponse<LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner, Void>> postAsyncRelativeRetryInvalidJsonPollingWithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.postAsyncRelativeRetryInvalidJsonPolling(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner, Void> object
+     */
+    public Single<Void> postAsyncRelativeRetryInvalidJsonPollingAsync(ProductInner product) {
+        return postAsyncRelativeRetryInvalidJsonPollingWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner, Void>, Void>() { public Void call(RestResponse<LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azurefluent/src/main/java/fixtures/lro/implementation/LROsCustomHeadersInner.java
+++ b/test/azurefluent/src/main/java/fixtures/lro/implementation/LROsCustomHeadersInner.java
@@ -10,6 +10,7 @@
 
 package fixtures.lro.implementation;
 
+import com.microsoft.rest.RestResponse;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.CloudException;
 import com.microsoft.azure.OperationStatus;
@@ -68,7 +69,7 @@ public class LROsCustomHeadersInner {
         @PUT("lro/customheader/putasync/retry/succeeded")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> putAsyncRetrySucceeded(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsCustomHeaderPutAsyncRetrySucceededHeadersInner, ProductInner>> putAsyncRetrySucceeded(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROsCustomHeaders beginPut201CreatingSucceeded200" })
         @PUT("lro/customheader/put/201/creating/succeeded/200")
@@ -80,7 +81,7 @@ public class LROsCustomHeadersInner {
         @PUT("lro/customheader/put/201/creating/succeeded/200")
         @ExpectedResponses({200, 201, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> put201CreatingSucceeded200(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, ProductInner>> put201CreatingSucceeded200(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROsCustomHeaders beginPost202Retry200" })
         @POST("lro/customheader/post/202/retry/200")
@@ -92,7 +93,7 @@ public class LROsCustomHeadersInner {
         @POST("lro/customheader/post/202/retry/200")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> post202Retry200(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsCustomHeaderPost202Retry200HeadersInner, Void>> post202Retry200(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROsCustomHeaders beginPostAsyncRetrySucceeded" })
         @POST("lro/customheader/postasync/retry/succeeded")
@@ -104,7 +105,7 @@ public class LROsCustomHeadersInner {
         @POST("lro/customheader/postasync/retry/succeeded")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> postAsyncRetrySucceeded(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsCustomHeaderPostAsyncRetrySucceededHeadersInner, Void>> postAsyncRetrySucceeded(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -195,20 +196,32 @@ public class LROsCustomHeadersInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> putAsyncRetrySucceededAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRetrySucceededAsync(), serviceCallback);
+    public ServiceFuture<ProductInner> putAsyncRetrySucceededAsync(ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRetrySucceededAsync(), serviceCallback);
     }
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROsCustomHeaderPutAsyncRetrySucceededHeadersInner, ProductInner> object
      */
-    public Single<ProductInner> putAsyncRetrySucceededAsync() {
+    public Single<RestResponse<LROsCustomHeaderPutAsyncRetrySucceededHeadersInner, ProductInner>> putAsyncRetrySucceededWithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.putAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsCustomHeaderPutAsyncRetrySucceededHeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> putAsyncRetrySucceededAsync() {
+        return putAsyncRetrySucceededWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsCustomHeaderPutAsyncRetrySucceededHeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROsCustomHeaderPutAsyncRetrySucceededHeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -231,8 +244,8 @@ public class LROsCustomHeadersInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> putAsyncRetrySucceededAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRetrySucceededAsync(product), serviceCallback);
+    public ServiceFuture<ProductInner> putAsyncRetrySucceededAsync(ProductInner product, ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRetrySucceededAsync(product), serviceCallback);
     }
 
     /**
@@ -240,12 +253,24 @@ public class LROsCustomHeadersInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROsCustomHeaderPutAsyncRetrySucceededHeadersInner, ProductInner> object
      */
-    public Single<ProductInner> putAsyncRetrySucceededAsync(ProductInner product) {
+    public Single<RestResponse<LROsCustomHeaderPutAsyncRetrySucceededHeadersInner, ProductInner>> putAsyncRetrySucceededWithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.putAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsCustomHeaderPutAsyncRetrySucceededHeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> putAsyncRetrySucceededAsync(ProductInner product) {
+        return putAsyncRetrySucceededWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROsCustomHeaderPutAsyncRetrySucceededHeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROsCustomHeaderPutAsyncRetrySucceededHeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -335,7 +360,7 @@ public class LROsCustomHeadersInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> put201CreatingSucceeded200Async(final ServiceCallback<ProductInner> serviceCallback) {
+    public ServiceFuture<ProductInner> put201CreatingSucceeded200Async(ServiceCallback<ProductInner> serviceCallback) {
         return ServiceFuture.fromBody(put201CreatingSucceeded200Async(), serviceCallback);
     }
 
@@ -343,12 +368,24 @@ public class LROsCustomHeadersInner {
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
      */
-    public Single<ProductInner> put201CreatingSucceeded200Async() {
+    public Single<RestResponse<Void, ProductInner>> put201CreatingSucceeded200WithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.put201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
+     */
+    public Single<ProductInner> put201CreatingSucceeded200Async() {
+        return put201CreatingSucceeded200WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<Void, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -371,7 +408,7 @@ public class LROsCustomHeadersInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> put201CreatingSucceeded200Async(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
+    public ServiceFuture<ProductInner> put201CreatingSucceeded200Async(ProductInner product, ServiceCallback<ProductInner> serviceCallback) {
         return ServiceFuture.fromBody(put201CreatingSucceeded200Async(product), serviceCallback);
     }
 
@@ -380,12 +417,24 @@ public class LROsCustomHeadersInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
      */
-    public Single<ProductInner> put201CreatingSucceeded200Async(ProductInner product) {
+    public Single<RestResponse<Void, ProductInner>> put201CreatingSucceeded200WithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.put201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
+     */
+    public Single<ProductInner> put201CreatingSucceeded200Async(ProductInner product) {
+        return put201CreatingSucceeded200WithRestResponseAsync(product)
+            .map(new Func1<RestResponse<Void, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<Void, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -460,6 +509,7 @@ public class LROsCustomHeadersInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post202Retry200() {
         post202Retry200Async().toBlocking().value();
@@ -472,20 +522,32 @@ public class LROsCustomHeadersInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post202Retry200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(post202Retry200Async(), serviceCallback);
+    public ServiceFuture<Void> post202Retry200Async(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(post202Retry200Async(), serviceCallback);
     }
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROsCustomHeaderPost202Retry200HeadersInner, Void> object
      */
-    public Single<Void> post202Retry200Async() {
+    public Single<RestResponse<LROsCustomHeaderPost202Retry200HeadersInner, Void>> post202Retry200WithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.post202Retry200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsCustomHeaderPost202Retry200HeadersInner, Void> object
+     */
+    public Single<Void> post202Retry200Async() {
+        return post202Retry200WithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsCustomHeaderPost202Retry200HeadersInner, Void>, Void>() { public Void call(RestResponse<LROsCustomHeaderPost202Retry200HeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
@@ -494,6 +556,7 @@ public class LROsCustomHeadersInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post202Retry200(ProductInner product) {
         post202Retry200Async(product).toBlocking().value();
@@ -507,8 +570,8 @@ public class LROsCustomHeadersInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post202Retry200Async(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(post202Retry200Async(product), serviceCallback);
+    public ServiceFuture<Void> post202Retry200Async(ProductInner product, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(post202Retry200Async(product), serviceCallback);
     }
 
     /**
@@ -516,12 +579,24 @@ public class LROsCustomHeadersInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROsCustomHeaderPost202Retry200HeadersInner, Void> object
      */
-    public Single<Void> post202Retry200Async(ProductInner product) {
+    public Single<RestResponse<LROsCustomHeaderPost202Retry200HeadersInner, Void>> post202Retry200WithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.post202Retry200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsCustomHeaderPost202Retry200HeadersInner, Void> object
+     */
+    public Single<Void> post202Retry200Async(ProductInner product) {
+        return post202Retry200WithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROsCustomHeaderPost202Retry200HeadersInner, Void>, Void>() { public Void call(RestResponse<LROsCustomHeaderPost202Retry200HeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -596,6 +671,7 @@ public class LROsCustomHeadersInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postAsyncRetrySucceeded() {
         postAsyncRetrySucceededAsync().toBlocking().value();
@@ -608,20 +684,32 @@ public class LROsCustomHeadersInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postAsyncRetrySucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRetrySucceededAsync(), serviceCallback);
+    public ServiceFuture<Void> postAsyncRetrySucceededAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRetrySucceededAsync(), serviceCallback);
     }
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROsCustomHeaderPostAsyncRetrySucceededHeadersInner, Void> object
      */
-    public Single<Void> postAsyncRetrySucceededAsync() {
+    public Single<RestResponse<LROsCustomHeaderPostAsyncRetrySucceededHeadersInner, Void>> postAsyncRetrySucceededWithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.postAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsCustomHeaderPostAsyncRetrySucceededHeadersInner, Void> object
+     */
+    public Single<Void> postAsyncRetrySucceededAsync() {
+        return postAsyncRetrySucceededWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsCustomHeaderPostAsyncRetrySucceededHeadersInner, Void>, Void>() { public Void call(RestResponse<LROsCustomHeaderPostAsyncRetrySucceededHeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -630,6 +718,7 @@ public class LROsCustomHeadersInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postAsyncRetrySucceeded(ProductInner product) {
         postAsyncRetrySucceededAsync(product).toBlocking().value();
@@ -643,8 +732,8 @@ public class LROsCustomHeadersInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postAsyncRetrySucceededAsync(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRetrySucceededAsync(product), serviceCallback);
+    public ServiceFuture<Void> postAsyncRetrySucceededAsync(ProductInner product, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRetrySucceededAsync(product), serviceCallback);
     }
 
     /**
@@ -652,12 +741,24 @@ public class LROsCustomHeadersInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROsCustomHeaderPostAsyncRetrySucceededHeadersInner, Void> object
      */
-    public Single<Void> postAsyncRetrySucceededAsync(ProductInner product) {
+    public Single<RestResponse<LROsCustomHeaderPostAsyncRetrySucceededHeadersInner, Void>> postAsyncRetrySucceededWithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.postAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsCustomHeaderPostAsyncRetrySucceededHeadersInner, Void> object
+     */
+    public Single<Void> postAsyncRetrySucceededAsync(ProductInner product) {
+        return postAsyncRetrySucceededWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROsCustomHeaderPostAsyncRetrySucceededHeadersInner, Void>, Void>() { public Void call(RestResponse<LROsCustomHeaderPostAsyncRetrySucceededHeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azurefluent/src/main/java/fixtures/lro/implementation/LROsInner.java
+++ b/test/azurefluent/src/main/java/fixtures/lro/implementation/LROsInner.java
@@ -10,6 +10,7 @@
 
 package fixtures.lro.implementation;
 
+import com.microsoft.rest.RestResponse;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.CloudException;
 import com.microsoft.azure.OperationStatus;
@@ -69,7 +70,7 @@ public class LROsInner {
         @PUT("lro/put/200/succeeded")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> put200Succeeded(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, ProductInner>> put200Succeeded(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPut200SucceededNoState" })
         @PUT("lro/put/200/succeeded/nostate")
@@ -81,7 +82,7 @@ public class LROsInner {
         @PUT("lro/put/200/succeeded/nostate")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> put200SucceededNoState(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, ProductInner>> put200SucceededNoState(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPut202Retry200" })
         @PUT("lro/put/202/retry/200")
@@ -93,7 +94,7 @@ public class LROsInner {
         @PUT("lro/put/202/retry/200")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> put202Retry200(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, ProductInner>> put202Retry200(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPut201CreatingSucceeded200" })
         @PUT("lro/put/201/creating/succeeded/200")
@@ -105,7 +106,7 @@ public class LROsInner {
         @PUT("lro/put/201/creating/succeeded/200")
         @ExpectedResponses({200, 201, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> put201CreatingSucceeded200(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, ProductInner>> put201CreatingSucceeded200(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPut200UpdatingSucceeded204" })
         @PUT("lro/put/200/updating/succeeded/200")
@@ -117,7 +118,7 @@ public class LROsInner {
         @PUT("lro/put/200/updating/succeeded/200")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> put200UpdatingSucceeded204(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, ProductInner>> put200UpdatingSucceeded204(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPut201CreatingFailed200" })
         @PUT("lro/put/201/created/failed/200")
@@ -129,7 +130,7 @@ public class LROsInner {
         @PUT("lro/put/201/created/failed/200")
         @ExpectedResponses({200, 201, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> put201CreatingFailed200(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, ProductInner>> put201CreatingFailed200(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPut200Acceptedcanceled200" })
         @PUT("lro/put/200/accepted/canceled/200")
@@ -141,7 +142,7 @@ public class LROsInner {
         @PUT("lro/put/200/accepted/canceled/200")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> put200Acceptedcanceled200(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, ProductInner>> put200Acceptedcanceled200(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPutNoHeaderInRetry" })
         @PUT("lro/put/noheader/202/200")
@@ -153,7 +154,7 @@ public class LROsInner {
         @PUT("lro/put/noheader/202/200")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> putNoHeaderInRetry(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsPutNoHeaderInRetryHeadersInner, ProductInner>> putNoHeaderInRetry(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPutAsyncRetrySucceeded" })
         @PUT("lro/putasync/retry/succeeded")
@@ -165,7 +166,7 @@ public class LROsInner {
         @PUT("lro/putasync/retry/succeeded")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> putAsyncRetrySucceeded(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsPutAsyncRetrySucceededHeadersInner, ProductInner>> putAsyncRetrySucceeded(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPutAsyncNoRetrySucceeded" })
         @PUT("lro/putasync/noretry/succeeded")
@@ -177,7 +178,7 @@ public class LROsInner {
         @PUT("lro/putasync/noretry/succeeded")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> putAsyncNoRetrySucceeded(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsPutAsyncNoRetrySucceededHeadersInner, ProductInner>> putAsyncNoRetrySucceeded(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPutAsyncRetryFailed" })
         @PUT("lro/putasync/retry/failed")
@@ -189,7 +190,7 @@ public class LROsInner {
         @PUT("lro/putasync/retry/failed")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> putAsyncRetryFailed(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsPutAsyncRetryFailedHeadersInner, ProductInner>> putAsyncRetryFailed(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPutAsyncNoRetrycanceled" })
         @PUT("lro/putasync/noretry/canceled")
@@ -201,7 +202,7 @@ public class LROsInner {
         @PUT("lro/putasync/noretry/canceled")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> putAsyncNoRetrycanceled(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsPutAsyncNoRetrycanceledHeadersInner, ProductInner>> putAsyncNoRetrycanceled(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPutAsyncNoHeaderInRetry" })
         @PUT("lro/putasync/noheader/201/200")
@@ -213,7 +214,7 @@ public class LROsInner {
         @PUT("lro/putasync/noheader/201/200")
         @ExpectedResponses({200, 201, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> putAsyncNoHeaderInRetry(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsPutAsyncNoHeaderInRetryHeadersInner, ProductInner>> putAsyncNoHeaderInRetry(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPutNonResource" })
         @PUT("lro/putnonresource/202/200")
@@ -225,7 +226,7 @@ public class LROsInner {
         @PUT("lro/putnonresource/202/200")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<SkuInner> putNonResource(@BodyParam("application/json; charset=utf-8") SkuInner sku, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, SkuInner>> putNonResource(@BodyParam("application/json; charset=utf-8") SkuInner sku, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPutAsyncNonResource" })
         @PUT("lro/putnonresourceasync/202/200")
@@ -237,7 +238,7 @@ public class LROsInner {
         @PUT("lro/putnonresourceasync/202/200")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<SkuInner> putAsyncNonResource(@BodyParam("application/json; charset=utf-8") SkuInner sku, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, SkuInner>> putAsyncNonResource(@BodyParam("application/json; charset=utf-8") SkuInner sku, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPutSubResource" })
         @PUT("lro/putsubresource/202/200")
@@ -249,7 +250,7 @@ public class LROsInner {
         @PUT("lro/putsubresource/202/200")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<SubProductInner> putSubResource(@BodyParam("application/json; charset=utf-8") SubProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, SubProductInner>> putSubResource(@BodyParam("application/json; charset=utf-8") SubProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPutAsyncSubResource" })
         @PUT("lro/putsubresourceasync/202/200")
@@ -261,7 +262,7 @@ public class LROsInner {
         @PUT("lro/putsubresourceasync/202/200")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<SubProductInner> putAsyncSubResource(@BodyParam("application/json; charset=utf-8") SubProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, SubProductInner>> putAsyncSubResource(@BodyParam("application/json; charset=utf-8") SubProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginDeleteProvisioning202Accepted200Succeeded" })
         @DELETE("lro/delete/provisioning/202/accepted/200/succeeded")
@@ -273,7 +274,7 @@ public class LROsInner {
         @DELETE("lro/delete/provisioning/202/accepted/200/succeeded")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> deleteProvisioning202Accepted200Succeeded(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsDeleteProvisioning202Accepted200SucceededHeadersInner, ProductInner>> deleteProvisioning202Accepted200Succeeded(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginDeleteProvisioning202DeletingFailed200" })
         @DELETE("lro/delete/provisioning/202/deleting/200/failed")
@@ -285,7 +286,7 @@ public class LROsInner {
         @DELETE("lro/delete/provisioning/202/deleting/200/failed")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> deleteProvisioning202DeletingFailed200(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsDeleteProvisioning202DeletingFailed200HeadersInner, ProductInner>> deleteProvisioning202DeletingFailed200(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginDeleteProvisioning202Deletingcanceled200" })
         @DELETE("lro/delete/provisioning/202/deleting/200/canceled")
@@ -297,7 +298,7 @@ public class LROsInner {
         @DELETE("lro/delete/provisioning/202/deleting/200/canceled")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> deleteProvisioning202Deletingcanceled200(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsDeleteProvisioning202Deletingcanceled200HeadersInner, ProductInner>> deleteProvisioning202Deletingcanceled200(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginDelete204Succeeded" })
         @DELETE("lro/delete/204/succeeded")
@@ -309,7 +310,7 @@ public class LROsInner {
         @DELETE("lro/delete/204/succeeded")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> delete204Succeeded(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> delete204Succeeded(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginDelete202Retry200" })
         @DELETE("lro/delete/202/retry/200")
@@ -321,7 +322,7 @@ public class LROsInner {
         @DELETE("lro/delete/202/retry/200")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> delete202Retry200(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsDelete202Retry200HeadersInner, ProductInner>> delete202Retry200(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginDelete202NoRetry204" })
         @DELETE("lro/delete/202/noretry/204")
@@ -333,7 +334,7 @@ public class LROsInner {
         @DELETE("lro/delete/202/noretry/204")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> delete202NoRetry204(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsDelete202NoRetry204HeadersInner, ProductInner>> delete202NoRetry204(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginDeleteNoHeaderInRetry" })
         @DELETE("lro/delete/noheader")
@@ -345,7 +346,7 @@ public class LROsInner {
         @DELETE("lro/delete/noheader")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> deleteNoHeaderInRetry(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsDeleteNoHeaderInRetryHeadersInner, Void>> deleteNoHeaderInRetry(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginDeleteAsyncNoHeaderInRetry" })
         @DELETE("lro/deleteasync/noheader/202/204")
@@ -357,7 +358,7 @@ public class LROsInner {
         @DELETE("lro/deleteasync/noheader/202/204")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> deleteAsyncNoHeaderInRetry(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsDeleteAsyncNoHeaderInRetryHeadersInner, Void>> deleteAsyncNoHeaderInRetry(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginDeleteAsyncRetrySucceeded" })
         @DELETE("lro/deleteasync/retry/succeeded")
@@ -369,7 +370,7 @@ public class LROsInner {
         @DELETE("lro/deleteasync/retry/succeeded")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> deleteAsyncRetrySucceeded(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsDeleteAsyncRetrySucceededHeadersInner, Void>> deleteAsyncRetrySucceeded(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginDeleteAsyncNoRetrySucceeded" })
         @DELETE("lro/deleteasync/noretry/succeeded")
@@ -381,7 +382,7 @@ public class LROsInner {
         @DELETE("lro/deleteasync/noretry/succeeded")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> deleteAsyncNoRetrySucceeded(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsDeleteAsyncNoRetrySucceededHeadersInner, Void>> deleteAsyncNoRetrySucceeded(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginDeleteAsyncRetryFailed" })
         @DELETE("lro/deleteasync/retry/failed")
@@ -393,7 +394,7 @@ public class LROsInner {
         @DELETE("lro/deleteasync/retry/failed")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> deleteAsyncRetryFailed(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsDeleteAsyncRetryFailedHeadersInner, Void>> deleteAsyncRetryFailed(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginDeleteAsyncRetrycanceled" })
         @DELETE("lro/deleteasync/retry/canceled")
@@ -405,7 +406,7 @@ public class LROsInner {
         @DELETE("lro/deleteasync/retry/canceled")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> deleteAsyncRetrycanceled(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsDeleteAsyncRetrycanceledHeadersInner, Void>> deleteAsyncRetrycanceled(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPost200WithPayload" })
         @POST("lro/post/payload/200")
@@ -417,7 +418,7 @@ public class LROsInner {
         @POST("lro/post/payload/200")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<SkuInner> post200WithPayload(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, SkuInner>> post200WithPayload(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPost202Retry200" })
         @POST("lro/post/202/retry/200")
@@ -429,7 +430,7 @@ public class LROsInner {
         @POST("lro/post/202/retry/200")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> post202Retry200(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsPost202Retry200HeadersInner, Void>> post202Retry200(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPost202NoRetry204" })
         @POST("lro/post/202/noretry/204")
@@ -441,7 +442,7 @@ public class LROsInner {
         @POST("lro/post/202/noretry/204")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> post202NoRetry204(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsPost202NoRetry204HeadersInner, ProductInner>> post202NoRetry204(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPostAsyncRetrySucceeded" })
         @POST("lro/postasync/retry/succeeded")
@@ -453,7 +454,7 @@ public class LROsInner {
         @POST("lro/postasync/retry/succeeded")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> postAsyncRetrySucceeded(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsPostAsyncRetrySucceededHeadersInner, ProductInner>> postAsyncRetrySucceeded(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPostAsyncNoRetrySucceeded" })
         @POST("lro/postasync/noretry/succeeded")
@@ -465,7 +466,7 @@ public class LROsInner {
         @POST("lro/postasync/noretry/succeeded")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<ProductInner> postAsyncNoRetrySucceeded(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsPostAsyncNoRetrySucceededHeadersInner, ProductInner>> postAsyncNoRetrySucceeded(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPostAsyncRetryFailed" })
         @POST("lro/postasync/retry/failed")
@@ -477,7 +478,7 @@ public class LROsInner {
         @POST("lro/postasync/retry/failed")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> postAsyncRetryFailed(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsPostAsyncRetryFailedHeadersInner, Void>> postAsyncRetryFailed(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.lro.LROs beginPostAsyncRetrycanceled" })
         @POST("lro/postasync/retry/canceled")
@@ -489,7 +490,7 @@ public class LROsInner {
         @POST("lro/postasync/retry/canceled")
         @ExpectedResponses({200, 202, 204})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<Void> postAsyncRetrycanceled(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<LROsPostAsyncRetrycanceledHeadersInner, Void>> postAsyncRetrycanceled(@BodyParam("application/json; charset=utf-8") ProductInner product, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -580,7 +581,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> put200SucceededAsync(final ServiceCallback<ProductInner> serviceCallback) {
+    public ServiceFuture<ProductInner> put200SucceededAsync(ServiceCallback<ProductInner> serviceCallback) {
         return ServiceFuture.fromBody(put200SucceededAsync(), serviceCallback);
     }
 
@@ -588,12 +589,24 @@ public class LROsInner {
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
      */
-    public Single<ProductInner> put200SucceededAsync() {
+    public Single<RestResponse<Void, ProductInner>> put200SucceededWithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.put200Succeeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
+     */
+    public Single<ProductInner> put200SucceededAsync() {
+        return put200SucceededWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<Void, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
@@ -616,7 +629,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> put200SucceededAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
+    public ServiceFuture<ProductInner> put200SucceededAsync(ProductInner product, ServiceCallback<ProductInner> serviceCallback) {
         return ServiceFuture.fromBody(put200SucceededAsync(product), serviceCallback);
     }
 
@@ -625,12 +638,24 @@ public class LROsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
      */
-    public Single<ProductInner> put200SucceededAsync(ProductInner product) {
+    public Single<RestResponse<Void, ProductInner>> put200SucceededWithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.put200Succeeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
+     */
+    public Single<ProductInner> put200SucceededAsync(ProductInner product) {
+        return put200SucceededWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<Void, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<Void, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -720,7 +745,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> put200SucceededNoStateAsync(final ServiceCallback<ProductInner> serviceCallback) {
+    public ServiceFuture<ProductInner> put200SucceededNoStateAsync(ServiceCallback<ProductInner> serviceCallback) {
         return ServiceFuture.fromBody(put200SucceededNoStateAsync(), serviceCallback);
     }
 
@@ -728,12 +753,24 @@ public class LROsInner {
      * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
      */
-    public Single<ProductInner> put200SucceededNoStateAsync() {
+    public Single<RestResponse<Void, ProductInner>> put200SucceededNoStateWithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.put200SucceededNoState(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
+     */
+    public Single<ProductInner> put200SucceededNoStateAsync() {
+        return put200SucceededNoStateWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<Void, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
@@ -756,7 +793,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> put200SucceededNoStateAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
+    public ServiceFuture<ProductInner> put200SucceededNoStateAsync(ProductInner product, ServiceCallback<ProductInner> serviceCallback) {
         return ServiceFuture.fromBody(put200SucceededNoStateAsync(product), serviceCallback);
     }
 
@@ -765,12 +802,24 @@ public class LROsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
      */
-    public Single<ProductInner> put200SucceededNoStateAsync(ProductInner product) {
+    public Single<RestResponse<Void, ProductInner>> put200SucceededNoStateWithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.put200SucceededNoState(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
+     */
+    public Single<ProductInner> put200SucceededNoStateAsync(ProductInner product) {
+        return put200SucceededNoStateWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<Void, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<Void, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -860,7 +909,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> put202Retry200Async(final ServiceCallback<ProductInner> serviceCallback) {
+    public ServiceFuture<ProductInner> put202Retry200Async(ServiceCallback<ProductInner> serviceCallback) {
         return ServiceFuture.fromBody(put202Retry200Async(), serviceCallback);
     }
 
@@ -868,12 +917,24 @@ public class LROsInner {
      * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
      */
-    public Single<ProductInner> put202Retry200Async() {
+    public Single<RestResponse<Void, ProductInner>> put202Retry200WithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.put202Retry200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
+     */
+    public Single<ProductInner> put202Retry200Async() {
+        return put202Retry200WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<Void, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
@@ -896,7 +957,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> put202Retry200Async(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
+    public ServiceFuture<ProductInner> put202Retry200Async(ProductInner product, ServiceCallback<ProductInner> serviceCallback) {
         return ServiceFuture.fromBody(put202Retry200Async(product), serviceCallback);
     }
 
@@ -905,12 +966,24 @@ public class LROsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
      */
-    public Single<ProductInner> put202Retry200Async(ProductInner product) {
+    public Single<RestResponse<Void, ProductInner>> put202Retry200WithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.put202Retry200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
+     */
+    public Single<ProductInner> put202Retry200Async(ProductInner product) {
+        return put202Retry200WithRestResponseAsync(product)
+            .map(new Func1<RestResponse<Void, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<Void, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1000,7 +1073,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> put201CreatingSucceeded200Async(final ServiceCallback<ProductInner> serviceCallback) {
+    public ServiceFuture<ProductInner> put201CreatingSucceeded200Async(ServiceCallback<ProductInner> serviceCallback) {
         return ServiceFuture.fromBody(put201CreatingSucceeded200Async(), serviceCallback);
     }
 
@@ -1008,12 +1081,24 @@ public class LROsInner {
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
      */
-    public Single<ProductInner> put201CreatingSucceeded200Async() {
+    public Single<RestResponse<Void, ProductInner>> put201CreatingSucceeded200WithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.put201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
+     */
+    public Single<ProductInner> put201CreatingSucceeded200Async() {
+        return put201CreatingSucceeded200WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<Void, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -1036,7 +1121,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> put201CreatingSucceeded200Async(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
+    public ServiceFuture<ProductInner> put201CreatingSucceeded200Async(ProductInner product, ServiceCallback<ProductInner> serviceCallback) {
         return ServiceFuture.fromBody(put201CreatingSucceeded200Async(product), serviceCallback);
     }
 
@@ -1045,12 +1130,24 @@ public class LROsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
      */
-    public Single<ProductInner> put201CreatingSucceeded200Async(ProductInner product) {
+    public Single<RestResponse<Void, ProductInner>> put201CreatingSucceeded200WithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.put201CreatingSucceeded200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
+     */
+    public Single<ProductInner> put201CreatingSucceeded200Async(ProductInner product) {
+        return put201CreatingSucceeded200WithRestResponseAsync(product)
+            .map(new Func1<RestResponse<Void, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<Void, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1140,7 +1237,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> put200UpdatingSucceeded204Async(final ServiceCallback<ProductInner> serviceCallback) {
+    public ServiceFuture<ProductInner> put200UpdatingSucceeded204Async(ServiceCallback<ProductInner> serviceCallback) {
         return ServiceFuture.fromBody(put200UpdatingSucceeded204Async(), serviceCallback);
     }
 
@@ -1148,12 +1245,24 @@ public class LROsInner {
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
      */
-    public Single<ProductInner> put200UpdatingSucceeded204Async() {
+    public Single<RestResponse<Void, ProductInner>> put200UpdatingSucceeded204WithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.put200UpdatingSucceeded204(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
+     */
+    public Single<ProductInner> put200UpdatingSucceeded204Async() {
+        return put200UpdatingSucceeded204WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<Void, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -1176,7 +1285,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> put200UpdatingSucceeded204Async(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
+    public ServiceFuture<ProductInner> put200UpdatingSucceeded204Async(ProductInner product, ServiceCallback<ProductInner> serviceCallback) {
         return ServiceFuture.fromBody(put200UpdatingSucceeded204Async(product), serviceCallback);
     }
 
@@ -1185,12 +1294,24 @@ public class LROsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
      */
-    public Single<ProductInner> put200UpdatingSucceeded204Async(ProductInner product) {
+    public Single<RestResponse<Void, ProductInner>> put200UpdatingSucceeded204WithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.put200UpdatingSucceeded204(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
+     */
+    public Single<ProductInner> put200UpdatingSucceeded204Async(ProductInner product) {
+        return put200UpdatingSucceeded204WithRestResponseAsync(product)
+            .map(new Func1<RestResponse<Void, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<Void, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1280,7 +1401,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> put201CreatingFailed200Async(final ServiceCallback<ProductInner> serviceCallback) {
+    public ServiceFuture<ProductInner> put201CreatingFailed200Async(ServiceCallback<ProductInner> serviceCallback) {
         return ServiceFuture.fromBody(put201CreatingFailed200Async(), serviceCallback);
     }
 
@@ -1288,12 +1409,24 @@ public class LROsInner {
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
      */
-    public Single<ProductInner> put201CreatingFailed200Async() {
+    public Single<RestResponse<Void, ProductInner>> put201CreatingFailed200WithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.put201CreatingFailed200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
+     */
+    public Single<ProductInner> put201CreatingFailed200Async() {
+        return put201CreatingFailed200WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<Void, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
@@ -1316,7 +1449,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> put201CreatingFailed200Async(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
+    public ServiceFuture<ProductInner> put201CreatingFailed200Async(ProductInner product, ServiceCallback<ProductInner> serviceCallback) {
         return ServiceFuture.fromBody(put201CreatingFailed200Async(product), serviceCallback);
     }
 
@@ -1325,12 +1458,24 @@ public class LROsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
      */
-    public Single<ProductInner> put201CreatingFailed200Async(ProductInner product) {
+    public Single<RestResponse<Void, ProductInner>> put201CreatingFailed200WithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.put201CreatingFailed200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
+     */
+    public Single<ProductInner> put201CreatingFailed200Async(ProductInner product) {
+        return put201CreatingFailed200WithRestResponseAsync(product)
+            .map(new Func1<RestResponse<Void, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<Void, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1420,7 +1565,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> put200Acceptedcanceled200Async(final ServiceCallback<ProductInner> serviceCallback) {
+    public ServiceFuture<ProductInner> put200Acceptedcanceled200Async(ServiceCallback<ProductInner> serviceCallback) {
         return ServiceFuture.fromBody(put200Acceptedcanceled200Async(), serviceCallback);
     }
 
@@ -1428,12 +1573,24 @@ public class LROsInner {
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
      */
-    public Single<ProductInner> put200Acceptedcanceled200Async() {
+    public Single<RestResponse<Void, ProductInner>> put200Acceptedcanceled200WithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.put200Acceptedcanceled200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
+     */
+    public Single<ProductInner> put200Acceptedcanceled200Async() {
+        return put200Acceptedcanceled200WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<Void, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
@@ -1456,7 +1613,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> put200Acceptedcanceled200Async(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
+    public ServiceFuture<ProductInner> put200Acceptedcanceled200Async(ProductInner product, ServiceCallback<ProductInner> serviceCallback) {
         return ServiceFuture.fromBody(put200Acceptedcanceled200Async(product), serviceCallback);
     }
 
@@ -1465,12 +1622,24 @@ public class LROsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
      */
-    public Single<ProductInner> put200Acceptedcanceled200Async(ProductInner product) {
+    public Single<RestResponse<Void, ProductInner>> put200Acceptedcanceled200WithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.put200Acceptedcanceled200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ProductInner> object
+     */
+    public Single<ProductInner> put200Acceptedcanceled200Async(ProductInner product) {
+        return put200Acceptedcanceled200WithRestResponseAsync(product)
+            .map(new Func1<RestResponse<Void, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<Void, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1560,20 +1729,32 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> putNoHeaderInRetryAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putNoHeaderInRetryAsync(), serviceCallback);
+    public ServiceFuture<ProductInner> putNoHeaderInRetryAsync(ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(putNoHeaderInRetryAsync(), serviceCallback);
     }
 
     /**
      * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROsPutNoHeaderInRetryHeadersInner, ProductInner> object
      */
-    public Single<ProductInner> putNoHeaderInRetryAsync() {
+    public Single<RestResponse<LROsPutNoHeaderInRetryHeadersInner, ProductInner>> putNoHeaderInRetryWithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.putNoHeaderInRetry(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPutNoHeaderInRetryHeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> putNoHeaderInRetryAsync() {
+        return putNoHeaderInRetryWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsPutNoHeaderInRetryHeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROsPutNoHeaderInRetryHeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
@@ -1596,8 +1777,8 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> putNoHeaderInRetryAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putNoHeaderInRetryAsync(product), serviceCallback);
+    public ServiceFuture<ProductInner> putNoHeaderInRetryAsync(ProductInner product, ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(putNoHeaderInRetryAsync(product), serviceCallback);
     }
 
     /**
@@ -1605,12 +1786,24 @@ public class LROsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROsPutNoHeaderInRetryHeadersInner, ProductInner> object
      */
-    public Single<ProductInner> putNoHeaderInRetryAsync(ProductInner product) {
+    public Single<RestResponse<LROsPutNoHeaderInRetryHeadersInner, ProductInner>> putNoHeaderInRetryWithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.putNoHeaderInRetry(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPutNoHeaderInRetryHeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> putNoHeaderInRetryAsync(ProductInner product) {
+        return putNoHeaderInRetryWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROsPutNoHeaderInRetryHeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROsPutNoHeaderInRetryHeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1700,20 +1893,32 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> putAsyncRetrySucceededAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRetrySucceededAsync(), serviceCallback);
+    public ServiceFuture<ProductInner> putAsyncRetrySucceededAsync(ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRetrySucceededAsync(), serviceCallback);
     }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncRetrySucceededHeadersInner, ProductInner> object
      */
-    public Single<ProductInner> putAsyncRetrySucceededAsync() {
+    public Single<RestResponse<LROsPutAsyncRetrySucceededHeadersInner, ProductInner>> putAsyncRetrySucceededWithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.putAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncRetrySucceededHeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> putAsyncRetrySucceededAsync() {
+        return putAsyncRetrySucceededWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsPutAsyncRetrySucceededHeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROsPutAsyncRetrySucceededHeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1736,8 +1941,8 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> putAsyncRetrySucceededAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRetrySucceededAsync(product), serviceCallback);
+    public ServiceFuture<ProductInner> putAsyncRetrySucceededAsync(ProductInner product, ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRetrySucceededAsync(product), serviceCallback);
     }
 
     /**
@@ -1745,12 +1950,24 @@ public class LROsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncRetrySucceededHeadersInner, ProductInner> object
      */
-    public Single<ProductInner> putAsyncRetrySucceededAsync(ProductInner product) {
+    public Single<RestResponse<LROsPutAsyncRetrySucceededHeadersInner, ProductInner>> putAsyncRetrySucceededWithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.putAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncRetrySucceededHeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> putAsyncRetrySucceededAsync(ProductInner product) {
+        return putAsyncRetrySucceededWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROsPutAsyncRetrySucceededHeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROsPutAsyncRetrySucceededHeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1840,20 +2057,32 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> putAsyncNoRetrySucceededAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncNoRetrySucceededAsync(), serviceCallback);
+    public ServiceFuture<ProductInner> putAsyncNoRetrySucceededAsync(ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncNoRetrySucceededAsync(), serviceCallback);
     }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncNoRetrySucceededHeadersInner, ProductInner> object
      */
-    public Single<ProductInner> putAsyncNoRetrySucceededAsync() {
+    public Single<RestResponse<LROsPutAsyncNoRetrySucceededHeadersInner, ProductInner>> putAsyncNoRetrySucceededWithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.putAsyncNoRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncNoRetrySucceededHeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> putAsyncNoRetrySucceededAsync() {
+        return putAsyncNoRetrySucceededWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsPutAsyncNoRetrySucceededHeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROsPutAsyncNoRetrySucceededHeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -1876,8 +2105,8 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> putAsyncNoRetrySucceededAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncNoRetrySucceededAsync(product), serviceCallback);
+    public ServiceFuture<ProductInner> putAsyncNoRetrySucceededAsync(ProductInner product, ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncNoRetrySucceededAsync(product), serviceCallback);
     }
 
     /**
@@ -1885,12 +2114,24 @@ public class LROsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncNoRetrySucceededHeadersInner, ProductInner> object
      */
-    public Single<ProductInner> putAsyncNoRetrySucceededAsync(ProductInner product) {
+    public Single<RestResponse<LROsPutAsyncNoRetrySucceededHeadersInner, ProductInner>> putAsyncNoRetrySucceededWithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.putAsyncNoRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncNoRetrySucceededHeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> putAsyncNoRetrySucceededAsync(ProductInner product) {
+        return putAsyncNoRetrySucceededWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROsPutAsyncNoRetrySucceededHeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROsPutAsyncNoRetrySucceededHeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1980,20 +2221,32 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> putAsyncRetryFailedAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRetryFailedAsync(), serviceCallback);
+    public ServiceFuture<ProductInner> putAsyncRetryFailedAsync(ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRetryFailedAsync(), serviceCallback);
     }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncRetryFailedHeadersInner, ProductInner> object
      */
-    public Single<ProductInner> putAsyncRetryFailedAsync() {
+    public Single<RestResponse<LROsPutAsyncRetryFailedHeadersInner, ProductInner>> putAsyncRetryFailedWithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.putAsyncRetryFailed(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncRetryFailedHeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> putAsyncRetryFailedAsync() {
+        return putAsyncRetryFailedWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsPutAsyncRetryFailedHeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROsPutAsyncRetryFailedHeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2016,8 +2269,8 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> putAsyncRetryFailedAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncRetryFailedAsync(product), serviceCallback);
+    public ServiceFuture<ProductInner> putAsyncRetryFailedAsync(ProductInner product, ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncRetryFailedAsync(product), serviceCallback);
     }
 
     /**
@@ -2025,12 +2278,24 @@ public class LROsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncRetryFailedHeadersInner, ProductInner> object
      */
-    public Single<ProductInner> putAsyncRetryFailedAsync(ProductInner product) {
+    public Single<RestResponse<LROsPutAsyncRetryFailedHeadersInner, ProductInner>> putAsyncRetryFailedWithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.putAsyncRetryFailed(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncRetryFailedHeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> putAsyncRetryFailedAsync(ProductInner product) {
+        return putAsyncRetryFailedWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROsPutAsyncRetryFailedHeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROsPutAsyncRetryFailedHeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2120,20 +2385,32 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> putAsyncNoRetrycanceledAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncNoRetrycanceledAsync(), serviceCallback);
+    public ServiceFuture<ProductInner> putAsyncNoRetrycanceledAsync(ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncNoRetrycanceledAsync(), serviceCallback);
     }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncNoRetrycanceledHeadersInner, ProductInner> object
      */
-    public Single<ProductInner> putAsyncNoRetrycanceledAsync() {
+    public Single<RestResponse<LROsPutAsyncNoRetrycanceledHeadersInner, ProductInner>> putAsyncNoRetrycanceledWithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.putAsyncNoRetrycanceled(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncNoRetrycanceledHeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> putAsyncNoRetrycanceledAsync() {
+        return putAsyncNoRetrycanceledWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsPutAsyncNoRetrycanceledHeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROsPutAsyncNoRetrycanceledHeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -2156,8 +2433,8 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> putAsyncNoRetrycanceledAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncNoRetrycanceledAsync(product), serviceCallback);
+    public ServiceFuture<ProductInner> putAsyncNoRetrycanceledAsync(ProductInner product, ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncNoRetrycanceledAsync(product), serviceCallback);
     }
 
     /**
@@ -2165,12 +2442,24 @@ public class LROsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncNoRetrycanceledHeadersInner, ProductInner> object
      */
-    public Single<ProductInner> putAsyncNoRetrycanceledAsync(ProductInner product) {
+    public Single<RestResponse<LROsPutAsyncNoRetrycanceledHeadersInner, ProductInner>> putAsyncNoRetrycanceledWithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.putAsyncNoRetrycanceled(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncNoRetrycanceledHeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> putAsyncNoRetrycanceledAsync(ProductInner product) {
+        return putAsyncNoRetrycanceledWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROsPutAsyncNoRetrycanceledHeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROsPutAsyncNoRetrycanceledHeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2260,20 +2549,32 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> putAsyncNoHeaderInRetryAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncNoHeaderInRetryAsync(), serviceCallback);
+    public ServiceFuture<ProductInner> putAsyncNoHeaderInRetryAsync(ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncNoHeaderInRetryAsync(), serviceCallback);
     }
 
     /**
      * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncNoHeaderInRetryHeadersInner, ProductInner> object
      */
-    public Single<ProductInner> putAsyncNoHeaderInRetryAsync() {
+    public Single<RestResponse<LROsPutAsyncNoHeaderInRetryHeadersInner, ProductInner>> putAsyncNoHeaderInRetryWithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.putAsyncNoHeaderInRetry(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncNoHeaderInRetryHeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> putAsyncNoHeaderInRetryAsync() {
+        return putAsyncNoHeaderInRetryWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsPutAsyncNoHeaderInRetryHeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROsPutAsyncNoHeaderInRetryHeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
@@ -2296,8 +2597,8 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> putAsyncNoHeaderInRetryAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(putAsyncNoHeaderInRetryAsync(product), serviceCallback);
+    public ServiceFuture<ProductInner> putAsyncNoHeaderInRetryAsync(ProductInner product, ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(putAsyncNoHeaderInRetryAsync(product), serviceCallback);
     }
 
     /**
@@ -2305,12 +2606,24 @@ public class LROsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncNoHeaderInRetryHeadersInner, ProductInner> object
      */
-    public Single<ProductInner> putAsyncNoHeaderInRetryAsync(ProductInner product) {
+    public Single<RestResponse<LROsPutAsyncNoHeaderInRetryHeadersInner, ProductInner>> putAsyncNoHeaderInRetryWithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.putAsyncNoHeaderInRetry(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPutAsyncNoHeaderInRetryHeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> putAsyncNoHeaderInRetryAsync(ProductInner product) {
+        return putAsyncNoHeaderInRetryWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROsPutAsyncNoHeaderInRetryHeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROsPutAsyncNoHeaderInRetryHeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2400,7 +2713,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<SkuInner> putNonResourceAsync(final ServiceCallback<SkuInner> serviceCallback) {
+    public ServiceFuture<SkuInner> putNonResourceAsync(ServiceCallback<SkuInner> serviceCallback) {
         return ServiceFuture.fromBody(putNonResourceAsync(), serviceCallback);
     }
 
@@ -2408,12 +2721,24 @@ public class LROsInner {
      * Long running put request with non resource.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the SkuInner object
+     * @return a {@link Single} emitting the RestResponse<Void, SkuInner> object
      */
-    public Single<SkuInner> putNonResourceAsync() {
+    public Single<RestResponse<Void, SkuInner>> putNonResourceWithRestResponseAsync() {
         final SkuInner sku = null;
+        Validator.validate(sku);
         return service.putNonResource(sku, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, SkuInner> object
+     */
+    public Single<SkuInner> putNonResourceAsync() {
+        return putNonResourceWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, SkuInner>, SkuInner>() { public SkuInner call(RestResponse<Void, SkuInner> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request with non resource.
@@ -2436,7 +2761,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<SkuInner> putNonResourceAsync(SkuInner sku, final ServiceCallback<SkuInner> serviceCallback) {
+    public ServiceFuture<SkuInner> putNonResourceAsync(SkuInner sku, ServiceCallback<SkuInner> serviceCallback) {
         return ServiceFuture.fromBody(putNonResourceAsync(sku), serviceCallback);
     }
 
@@ -2445,12 +2770,24 @@ public class LROsInner {
      *
      * @param sku sku to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the SkuInner object
+     * @return a {@link Single} emitting the RestResponse<Void, SkuInner> object
      */
-    public Single<SkuInner> putNonResourceAsync(SkuInner sku) {
+    public Single<RestResponse<Void, SkuInner>> putNonResourceWithRestResponseAsync(SkuInner sku) {
         Validator.validate(sku);
         return service.putNonResource(sku, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @param sku sku to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, SkuInner> object
+     */
+    public Single<SkuInner> putNonResourceAsync(SkuInner sku) {
+        return putNonResourceWithRestResponseAsync(sku)
+            .map(new Func1<RestResponse<Void, SkuInner>, SkuInner>() { public SkuInner call(RestResponse<Void, SkuInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2540,7 +2877,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<SkuInner> putAsyncNonResourceAsync(final ServiceCallback<SkuInner> serviceCallback) {
+    public ServiceFuture<SkuInner> putAsyncNonResourceAsync(ServiceCallback<SkuInner> serviceCallback) {
         return ServiceFuture.fromBody(putAsyncNonResourceAsync(), serviceCallback);
     }
 
@@ -2548,12 +2885,24 @@ public class LROsInner {
      * Long running put request with non resource.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the SkuInner object
+     * @return a {@link Single} emitting the RestResponse<Void, SkuInner> object
      */
-    public Single<SkuInner> putAsyncNonResourceAsync() {
+    public Single<RestResponse<Void, SkuInner>> putAsyncNonResourceWithRestResponseAsync() {
         final SkuInner sku = null;
+        Validator.validate(sku);
         return service.putAsyncNonResource(sku, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, SkuInner> object
+     */
+    public Single<SkuInner> putAsyncNonResourceAsync() {
+        return putAsyncNonResourceWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, SkuInner>, SkuInner>() { public SkuInner call(RestResponse<Void, SkuInner> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request with non resource.
@@ -2576,7 +2925,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<SkuInner> putAsyncNonResourceAsync(SkuInner sku, final ServiceCallback<SkuInner> serviceCallback) {
+    public ServiceFuture<SkuInner> putAsyncNonResourceAsync(SkuInner sku, ServiceCallback<SkuInner> serviceCallback) {
         return ServiceFuture.fromBody(putAsyncNonResourceAsync(sku), serviceCallback);
     }
 
@@ -2585,12 +2934,24 @@ public class LROsInner {
      *
      * @param sku Sku to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the SkuInner object
+     * @return a {@link Single} emitting the RestResponse<Void, SkuInner> object
      */
-    public Single<SkuInner> putAsyncNonResourceAsync(SkuInner sku) {
+    public Single<RestResponse<Void, SkuInner>> putAsyncNonResourceWithRestResponseAsync(SkuInner sku) {
         Validator.validate(sku);
         return service.putAsyncNonResource(sku, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request with non resource.
+     *
+     * @param sku Sku to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, SkuInner> object
+     */
+    public Single<SkuInner> putAsyncNonResourceAsync(SkuInner sku) {
+        return putAsyncNonResourceWithRestResponseAsync(sku)
+            .map(new Func1<RestResponse<Void, SkuInner>, SkuInner>() { public SkuInner call(RestResponse<Void, SkuInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2680,7 +3041,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<SubProductInner> putSubResourceAsync(final ServiceCallback<SubProductInner> serviceCallback) {
+    public ServiceFuture<SubProductInner> putSubResourceAsync(ServiceCallback<SubProductInner> serviceCallback) {
         return ServiceFuture.fromBody(putSubResourceAsync(), serviceCallback);
     }
 
@@ -2688,12 +3049,24 @@ public class LROsInner {
      * Long running put request with sub resource.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the SubProductInner object
+     * @return a {@link Single} emitting the RestResponse<Void, SubProductInner> object
      */
-    public Single<SubProductInner> putSubResourceAsync() {
+    public Single<RestResponse<Void, SubProductInner>> putSubResourceWithRestResponseAsync() {
         final SubProductInner product = null;
+        Validator.validate(product);
         return service.putSubResource(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, SubProductInner> object
+     */
+    public Single<SubProductInner> putSubResourceAsync() {
+        return putSubResourceWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, SubProductInner>, SubProductInner>() { public SubProductInner call(RestResponse<Void, SubProductInner> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request with sub resource.
@@ -2716,7 +3089,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<SubProductInner> putSubResourceAsync(SubProductInner product, final ServiceCallback<SubProductInner> serviceCallback) {
+    public ServiceFuture<SubProductInner> putSubResourceAsync(SubProductInner product, ServiceCallback<SubProductInner> serviceCallback) {
         return ServiceFuture.fromBody(putSubResourceAsync(product), serviceCallback);
     }
 
@@ -2725,12 +3098,24 @@ public class LROsInner {
      *
      * @param product Sub Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the SubProductInner object
+     * @return a {@link Single} emitting the RestResponse<Void, SubProductInner> object
      */
-    public Single<SubProductInner> putSubResourceAsync(SubProductInner product) {
+    public Single<RestResponse<Void, SubProductInner>> putSubResourceWithRestResponseAsync(SubProductInner product) {
         Validator.validate(product);
         return service.putSubResource(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @param product Sub Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, SubProductInner> object
+     */
+    public Single<SubProductInner> putSubResourceAsync(SubProductInner product) {
+        return putSubResourceWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<Void, SubProductInner>, SubProductInner>() { public SubProductInner call(RestResponse<Void, SubProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2820,7 +3205,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<SubProductInner> putAsyncSubResourceAsync(final ServiceCallback<SubProductInner> serviceCallback) {
+    public ServiceFuture<SubProductInner> putAsyncSubResourceAsync(ServiceCallback<SubProductInner> serviceCallback) {
         return ServiceFuture.fromBody(putAsyncSubResourceAsync(), serviceCallback);
     }
 
@@ -2828,12 +3213,24 @@ public class LROsInner {
      * Long running put request with sub resource.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the SubProductInner object
+     * @return a {@link Single} emitting the RestResponse<Void, SubProductInner> object
      */
-    public Single<SubProductInner> putAsyncSubResourceAsync() {
+    public Single<RestResponse<Void, SubProductInner>> putAsyncSubResourceWithRestResponseAsync() {
         final SubProductInner product = null;
+        Validator.validate(product);
         return service.putAsyncSubResource(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, SubProductInner> object
+     */
+    public Single<SubProductInner> putAsyncSubResourceAsync() {
+        return putAsyncSubResourceWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, SubProductInner>, SubProductInner>() { public SubProductInner call(RestResponse<Void, SubProductInner> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running put request with sub resource.
@@ -2856,7 +3253,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<SubProductInner> putAsyncSubResourceAsync(SubProductInner product, final ServiceCallback<SubProductInner> serviceCallback) {
+    public ServiceFuture<SubProductInner> putAsyncSubResourceAsync(SubProductInner product, ServiceCallback<SubProductInner> serviceCallback) {
         return ServiceFuture.fromBody(putAsyncSubResourceAsync(product), serviceCallback);
     }
 
@@ -2865,12 +3262,24 @@ public class LROsInner {
      *
      * @param product Sub Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the SubProductInner object
+     * @return a {@link Single} emitting the RestResponse<Void, SubProductInner> object
      */
-    public Single<SubProductInner> putAsyncSubResourceAsync(SubProductInner product) {
+    public Single<RestResponse<Void, SubProductInner>> putAsyncSubResourceWithRestResponseAsync(SubProductInner product) {
         Validator.validate(product);
         return service.putAsyncSubResource(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running put request with sub resource.
+     *
+     * @param product Sub Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, SubProductInner> object
+     */
+    public Single<SubProductInner> putAsyncSubResourceAsync(SubProductInner product) {
+        return putAsyncSubResourceWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<Void, SubProductInner>, SubProductInner>() { public SubProductInner call(RestResponse<Void, SubProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2925,19 +3334,30 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> deleteProvisioning202Accepted200SucceededAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(deleteProvisioning202Accepted200SucceededAsync(), serviceCallback);
+    public ServiceFuture<ProductInner> deleteProvisioning202Accepted200SucceededAsync(ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(deleteProvisioning202Accepted200SucceededAsync(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteProvisioning202Accepted200SucceededHeadersInner, ProductInner> object
      */
-    public Single<ProductInner> deleteProvisioning202Accepted200SucceededAsync() {
+    public Single<RestResponse<LROsDeleteProvisioning202Accepted200SucceededHeadersInner, ProductInner>> deleteProvisioning202Accepted200SucceededWithRestResponseAsync() {
         return service.deleteProvisioning202Accepted200Succeeded(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteProvisioning202Accepted200SucceededHeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> deleteProvisioning202Accepted200SucceededAsync() {
+        return deleteProvisioning202Accepted200SucceededWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsDeleteProvisioning202Accepted200SucceededHeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROsDeleteProvisioning202Accepted200SucceededHeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2992,19 +3412,30 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> deleteProvisioning202DeletingFailed200Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(deleteProvisioning202DeletingFailed200Async(), serviceCallback);
+    public ServiceFuture<ProductInner> deleteProvisioning202DeletingFailed200Async(ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(deleteProvisioning202DeletingFailed200Async(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteProvisioning202DeletingFailed200HeadersInner, ProductInner> object
      */
-    public Single<ProductInner> deleteProvisioning202DeletingFailed200Async() {
+    public Single<RestResponse<LROsDeleteProvisioning202DeletingFailed200HeadersInner, ProductInner>> deleteProvisioning202DeletingFailed200WithRestResponseAsync() {
         return service.deleteProvisioning202DeletingFailed200(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteProvisioning202DeletingFailed200HeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> deleteProvisioning202DeletingFailed200Async() {
+        return deleteProvisioning202DeletingFailed200WithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsDeleteProvisioning202DeletingFailed200HeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROsDeleteProvisioning202DeletingFailed200HeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -3059,19 +3490,30 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> deleteProvisioning202Deletingcanceled200Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(deleteProvisioning202Deletingcanceled200Async(), serviceCallback);
+    public ServiceFuture<ProductInner> deleteProvisioning202Deletingcanceled200Async(ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(deleteProvisioning202Deletingcanceled200Async(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteProvisioning202Deletingcanceled200HeadersInner, ProductInner> object
      */
-    public Single<ProductInner> deleteProvisioning202Deletingcanceled200Async() {
+    public Single<RestResponse<LROsDeleteProvisioning202Deletingcanceled200HeadersInner, ProductInner>> deleteProvisioning202Deletingcanceled200WithRestResponseAsync() {
         return service.deleteProvisioning202Deletingcanceled200(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteProvisioning202Deletingcanceled200HeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> deleteProvisioning202Deletingcanceled200Async() {
+        return deleteProvisioning202Deletingcanceled200WithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsDeleteProvisioning202Deletingcanceled200HeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROsDeleteProvisioning202Deletingcanceled200HeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -3112,6 +3554,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void delete204Succeeded() {
         delete204SucceededAsync().toBlocking().value();
@@ -3124,7 +3567,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> delete204SucceededAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> delete204SucceededAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(delete204SucceededAsync(), serviceCallback);
     }
 
@@ -3132,11 +3575,22 @@ public class LROsInner {
      * Long running delete succeeds and returns right away.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> delete204SucceededAsync() {
+    public Single<RestResponse<Void, Void>> delete204SucceededWithRestResponseAsync() {
         return service.delete204Succeeded(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete succeeds and returns right away.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> delete204SucceededAsync() {
+        return delete204SucceededWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -3191,19 +3645,30 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> delete202Retry200Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(delete202Retry200Async(), serviceCallback);
+    public ServiceFuture<ProductInner> delete202Retry200Async(ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(delete202Retry200Async(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROsDelete202Retry200HeadersInner, ProductInner> object
      */
-    public Single<ProductInner> delete202Retry200Async() {
+    public Single<RestResponse<LROsDelete202Retry200HeadersInner, ProductInner>> delete202Retry200WithRestResponseAsync() {
         return service.delete202Retry200(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsDelete202Retry200HeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> delete202Retry200Async() {
+        return delete202Retry200WithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsDelete202Retry200HeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROsDelete202Retry200HeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -3258,19 +3723,30 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> delete202NoRetry204Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(delete202NoRetry204Async(), serviceCallback);
+    public ServiceFuture<ProductInner> delete202NoRetry204Async(ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(delete202NoRetry204Async(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROsDelete202NoRetry204HeadersInner, ProductInner> object
      */
-    public Single<ProductInner> delete202NoRetry204Async() {
+    public Single<RestResponse<LROsDelete202NoRetry204HeadersInner, ProductInner>> delete202NoRetry204WithRestResponseAsync() {
         return service.delete202NoRetry204(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsDelete202NoRetry204HeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> delete202NoRetry204Async() {
+        return delete202NoRetry204WithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsDelete202NoRetry204HeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROsDelete202NoRetry204HeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -3311,6 +3787,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void deleteNoHeaderInRetry() {
         deleteNoHeaderInRetryAsync().toBlocking().value();
@@ -3323,19 +3800,30 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> deleteNoHeaderInRetryAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(deleteNoHeaderInRetryAsync(), serviceCallback);
+    public ServiceFuture<Void> deleteNoHeaderInRetryAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(deleteNoHeaderInRetryAsync(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a location header in the initial request. Subsequent calls to operation status do not contain location header.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteNoHeaderInRetryHeadersInner, Void> object
      */
-    public Single<Void> deleteNoHeaderInRetryAsync() {
+    public Single<RestResponse<LROsDeleteNoHeaderInRetryHeadersInner, Void>> deleteNoHeaderInRetryWithRestResponseAsync() {
         return service.deleteNoHeaderInRetry(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a location header in the initial request. Subsequent calls to operation status do not contain location header.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteNoHeaderInRetryHeadersInner, Void> object
+     */
+    public Single<Void> deleteNoHeaderInRetryAsync() {
+        return deleteNoHeaderInRetryWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsDeleteNoHeaderInRetryHeadersInner, Void>, Void>() { public Void call(RestResponse<LROsDeleteNoHeaderInRetryHeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -3376,6 +3864,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void deleteAsyncNoHeaderInRetry() {
         deleteAsyncNoHeaderInRetryAsync().toBlocking().value();
@@ -3388,19 +3877,30 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> deleteAsyncNoHeaderInRetryAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(deleteAsyncNoHeaderInRetryAsync(), serviceCallback);
+    public ServiceFuture<Void> deleteAsyncNoHeaderInRetryAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(deleteAsyncNoHeaderInRetryAsync(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns an Azure-AsyncOperation header in the initial request. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteAsyncNoHeaderInRetryHeadersInner, Void> object
      */
-    public Single<Void> deleteAsyncNoHeaderInRetryAsync() {
+    public Single<RestResponse<LROsDeleteAsyncNoHeaderInRetryHeadersInner, Void>> deleteAsyncNoHeaderInRetryWithRestResponseAsync() {
         return service.deleteAsyncNoHeaderInRetry(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns an Azure-AsyncOperation header in the initial request. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteAsyncNoHeaderInRetryHeadersInner, Void> object
+     */
+    public Single<Void> deleteAsyncNoHeaderInRetryAsync() {
+        return deleteAsyncNoHeaderInRetryWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsDeleteAsyncNoHeaderInRetryHeadersInner, Void>, Void>() { public Void call(RestResponse<LROsDeleteAsyncNoHeaderInRetryHeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -3441,6 +3941,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void deleteAsyncRetrySucceeded() {
         deleteAsyncRetrySucceededAsync().toBlocking().value();
@@ -3453,19 +3954,30 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> deleteAsyncRetrySucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(deleteAsyncRetrySucceededAsync(), serviceCallback);
+    public ServiceFuture<Void> deleteAsyncRetrySucceededAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(deleteAsyncRetrySucceededAsync(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteAsyncRetrySucceededHeadersInner, Void> object
      */
-    public Single<Void> deleteAsyncRetrySucceededAsync() {
+    public Single<RestResponse<LROsDeleteAsyncRetrySucceededHeadersInner, Void>> deleteAsyncRetrySucceededWithRestResponseAsync() {
         return service.deleteAsyncRetrySucceeded(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteAsyncRetrySucceededHeadersInner, Void> object
+     */
+    public Single<Void> deleteAsyncRetrySucceededAsync() {
+        return deleteAsyncRetrySucceededWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsDeleteAsyncRetrySucceededHeadersInner, Void>, Void>() { public Void call(RestResponse<LROsDeleteAsyncRetrySucceededHeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -3506,6 +4018,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void deleteAsyncNoRetrySucceeded() {
         deleteAsyncNoRetrySucceededAsync().toBlocking().value();
@@ -3518,19 +4031,30 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> deleteAsyncNoRetrySucceededAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(deleteAsyncNoRetrySucceededAsync(), serviceCallback);
+    public ServiceFuture<Void> deleteAsyncNoRetrySucceededAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(deleteAsyncNoRetrySucceededAsync(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteAsyncNoRetrySucceededHeadersInner, Void> object
      */
-    public Single<Void> deleteAsyncNoRetrySucceededAsync() {
+    public Single<RestResponse<LROsDeleteAsyncNoRetrySucceededHeadersInner, Void>> deleteAsyncNoRetrySucceededWithRestResponseAsync() {
         return service.deleteAsyncNoRetrySucceeded(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteAsyncNoRetrySucceededHeadersInner, Void> object
+     */
+    public Single<Void> deleteAsyncNoRetrySucceededAsync() {
+        return deleteAsyncNoRetrySucceededWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsDeleteAsyncNoRetrySucceededHeadersInner, Void>, Void>() { public Void call(RestResponse<LROsDeleteAsyncNoRetrySucceededHeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -3571,6 +4095,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void deleteAsyncRetryFailed() {
         deleteAsyncRetryFailedAsync().toBlocking().value();
@@ -3583,19 +4108,30 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> deleteAsyncRetryFailedAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(deleteAsyncRetryFailedAsync(), serviceCallback);
+    public ServiceFuture<Void> deleteAsyncRetryFailedAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(deleteAsyncRetryFailedAsync(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteAsyncRetryFailedHeadersInner, Void> object
      */
-    public Single<Void> deleteAsyncRetryFailedAsync() {
+    public Single<RestResponse<LROsDeleteAsyncRetryFailedHeadersInner, Void>> deleteAsyncRetryFailedWithRestResponseAsync() {
         return service.deleteAsyncRetryFailed(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteAsyncRetryFailedHeadersInner, Void> object
+     */
+    public Single<Void> deleteAsyncRetryFailedAsync() {
+        return deleteAsyncRetryFailedWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsDeleteAsyncRetryFailedHeadersInner, Void>, Void>() { public Void call(RestResponse<LROsDeleteAsyncRetryFailedHeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -3636,6 +4172,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void deleteAsyncRetrycanceled() {
         deleteAsyncRetrycanceledAsync().toBlocking().value();
@@ -3648,19 +4185,30 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> deleteAsyncRetrycanceledAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(deleteAsyncRetrycanceledAsync(), serviceCallback);
+    public ServiceFuture<Void> deleteAsyncRetrycanceledAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(deleteAsyncRetrycanceledAsync(), serviceCallback);
     }
 
     /**
      * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteAsyncRetrycanceledHeadersInner, Void> object
      */
-    public Single<Void> deleteAsyncRetrycanceledAsync() {
+    public Single<RestResponse<LROsDeleteAsyncRetrycanceledHeadersInner, Void>> deleteAsyncRetrycanceledWithRestResponseAsync() {
         return service.deleteAsyncRetrycanceled(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsDeleteAsyncRetrycanceledHeadersInner, Void> object
+     */
+    public Single<Void> deleteAsyncRetrycanceledAsync() {
+        return deleteAsyncRetrycanceledWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsDeleteAsyncRetrycanceledHeadersInner, Void>, Void>() { public Void call(RestResponse<LROsDeleteAsyncRetrycanceledHeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -3715,7 +4263,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<SkuInner> post200WithPayloadAsync(final ServiceCallback<SkuInner> serviceCallback) {
+    public ServiceFuture<SkuInner> post200WithPayloadAsync(ServiceCallback<SkuInner> serviceCallback) {
         return ServiceFuture.fromBody(post200WithPayloadAsync(), serviceCallback);
     }
 
@@ -3723,11 +4271,22 @@ public class LROsInner {
      * Long running post request, service returns a 202 to the initial request, with 'Location' header. Poll returns a 200 with a response body after success.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the SkuInner object
+     * @return a {@link Single} emitting the RestResponse<Void, SkuInner> object
      */
-    public Single<SkuInner> post200WithPayloadAsync() {
+    public Single<RestResponse<Void, SkuInner>> post200WithPayloadWithRestResponseAsync() {
         return service.post200WithPayload(this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' header. Poll returns a 200 with a response body after success.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, SkuInner> object
+     */
+    public Single<SkuInner> post200WithPayloadAsync() {
+        return post200WithPayloadWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, SkuInner>, SkuInner>() { public SkuInner call(RestResponse<Void, SkuInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -3802,6 +4361,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post202Retry200() {
         post202Retry200Async().toBlocking().value();
@@ -3814,20 +4374,32 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post202Retry200Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(post202Retry200Async(), serviceCallback);
+    public ServiceFuture<Void> post202Retry200Async(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(post202Retry200Async(), serviceCallback);
     }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROsPost202Retry200HeadersInner, Void> object
      */
-    public Single<Void> post202Retry200Async() {
+    public Single<RestResponse<LROsPost202Retry200HeadersInner, Void>> post202Retry200WithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.post202Retry200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPost202Retry200HeadersInner, Void> object
+     */
+    public Single<Void> post202Retry200Async() {
+        return post202Retry200WithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsPost202Retry200HeadersInner, Void>, Void>() { public Void call(RestResponse<LROsPost202Retry200HeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
@@ -3836,6 +4408,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post202Retry200(ProductInner product) {
         post202Retry200Async(product).toBlocking().value();
@@ -3849,8 +4422,8 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post202Retry200Async(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(post202Retry200Async(product), serviceCallback);
+    public ServiceFuture<Void> post202Retry200Async(ProductInner product, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(post202Retry200Async(product), serviceCallback);
     }
 
     /**
@@ -3858,12 +4431,24 @@ public class LROsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROsPost202Retry200HeadersInner, Void> object
      */
-    public Single<Void> post202Retry200Async(ProductInner product) {
+    public Single<RestResponse<LROsPost202Retry200HeadersInner, Void>> post202Retry200WithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.post202Retry200(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPost202Retry200HeadersInner, Void> object
+     */
+    public Single<Void> post202Retry200Async(ProductInner product) {
+        return post202Retry200WithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROsPost202Retry200HeadersInner, Void>, Void>() { public Void call(RestResponse<LROsPost202Retry200HeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -3953,20 +4538,32 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> post202NoRetry204Async(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(post202NoRetry204Async(), serviceCallback);
+    public ServiceFuture<ProductInner> post202NoRetry204Async(ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(post202NoRetry204Async(), serviceCallback);
     }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROsPost202NoRetry204HeadersInner, ProductInner> object
      */
-    public Single<ProductInner> post202NoRetry204Async() {
+    public Single<RestResponse<LROsPost202NoRetry204HeadersInner, ProductInner>> post202NoRetry204WithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.post202NoRetry204(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPost202NoRetry204HeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> post202NoRetry204Async() {
+        return post202NoRetry204WithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsPost202NoRetry204HeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROsPost202NoRetry204HeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
@@ -3989,8 +4586,8 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> post202NoRetry204Async(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(post202NoRetry204Async(product), serviceCallback);
+    public ServiceFuture<ProductInner> post202NoRetry204Async(ProductInner product, ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(post202NoRetry204Async(product), serviceCallback);
     }
 
     /**
@@ -3998,12 +4595,24 @@ public class LROsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROsPost202NoRetry204HeadersInner, ProductInner> object
      */
-    public Single<ProductInner> post202NoRetry204Async(ProductInner product) {
+    public Single<RestResponse<LROsPost202NoRetry204HeadersInner, ProductInner>> post202NoRetry204WithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.post202NoRetry204(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPost202NoRetry204HeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> post202NoRetry204Async(ProductInner product) {
+        return post202NoRetry204WithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROsPost202NoRetry204HeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROsPost202NoRetry204HeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -4093,20 +4702,32 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> postAsyncRetrySucceededAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRetrySucceededAsync(), serviceCallback);
+    public ServiceFuture<ProductInner> postAsyncRetrySucceededAsync(ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRetrySucceededAsync(), serviceCallback);
     }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROsPostAsyncRetrySucceededHeadersInner, ProductInner> object
      */
-    public Single<ProductInner> postAsyncRetrySucceededAsync() {
+    public Single<RestResponse<LROsPostAsyncRetrySucceededHeadersInner, ProductInner>> postAsyncRetrySucceededWithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.postAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPostAsyncRetrySucceededHeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> postAsyncRetrySucceededAsync() {
+        return postAsyncRetrySucceededWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsPostAsyncRetrySucceededHeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROsPostAsyncRetrySucceededHeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -4129,8 +4750,8 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> postAsyncRetrySucceededAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRetrySucceededAsync(product), serviceCallback);
+    public ServiceFuture<ProductInner> postAsyncRetrySucceededAsync(ProductInner product, ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRetrySucceededAsync(product), serviceCallback);
     }
 
     /**
@@ -4138,12 +4759,24 @@ public class LROsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROsPostAsyncRetrySucceededHeadersInner, ProductInner> object
      */
-    public Single<ProductInner> postAsyncRetrySucceededAsync(ProductInner product) {
+    public Single<RestResponse<LROsPostAsyncRetrySucceededHeadersInner, ProductInner>> postAsyncRetrySucceededWithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.postAsyncRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPostAsyncRetrySucceededHeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> postAsyncRetrySucceededAsync(ProductInner product) {
+        return postAsyncRetrySucceededWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROsPostAsyncRetrySucceededHeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROsPostAsyncRetrySucceededHeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -4233,20 +4866,32 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> postAsyncNoRetrySucceededAsync(final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncNoRetrySucceededAsync(), serviceCallback);
+    public ServiceFuture<ProductInner> postAsyncNoRetrySucceededAsync(ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncNoRetrySucceededAsync(), serviceCallback);
     }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROsPostAsyncNoRetrySucceededHeadersInner, ProductInner> object
      */
-    public Single<ProductInner> postAsyncNoRetrySucceededAsync() {
+    public Single<RestResponse<LROsPostAsyncNoRetrySucceededHeadersInner, ProductInner>> postAsyncNoRetrySucceededWithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.postAsyncNoRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPostAsyncNoRetrySucceededHeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> postAsyncNoRetrySucceededAsync() {
+        return postAsyncNoRetrySucceededWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsPostAsyncNoRetrySucceededHeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROsPostAsyncNoRetrySucceededHeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -4269,8 +4914,8 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ProductInner> postAsyncNoRetrySucceededAsync(ProductInner product, final ServiceCallback<ProductInner> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncNoRetrySucceededAsync(product), serviceCallback);
+    public ServiceFuture<ProductInner> postAsyncNoRetrySucceededAsync(ProductInner product, ServiceCallback<ProductInner> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncNoRetrySucceededAsync(product), serviceCallback);
     }
 
     /**
@@ -4278,12 +4923,24 @@ public class LROsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ProductInner object
+     * @return a {@link Single} emitting the RestResponse<LROsPostAsyncNoRetrySucceededHeadersInner, ProductInner> object
      */
-    public Single<ProductInner> postAsyncNoRetrySucceededAsync(ProductInner product) {
+    public Single<RestResponse<LROsPostAsyncNoRetrySucceededHeadersInner, ProductInner>> postAsyncNoRetrySucceededWithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.postAsyncNoRetrySucceeded(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPostAsyncNoRetrySucceededHeadersInner, ProductInner> object
+     */
+    public Single<ProductInner> postAsyncNoRetrySucceededAsync(ProductInner product) {
+        return postAsyncNoRetrySucceededWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROsPostAsyncNoRetrySucceededHeadersInner, ProductInner>, ProductInner>() { public ProductInner call(RestResponse<LROsPostAsyncNoRetrySucceededHeadersInner, ProductInner> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -4358,6 +5015,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postAsyncRetryFailed() {
         postAsyncRetryFailedAsync().toBlocking().value();
@@ -4370,20 +5028,32 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postAsyncRetryFailedAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRetryFailedAsync(), serviceCallback);
+    public ServiceFuture<Void> postAsyncRetryFailedAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRetryFailedAsync(), serviceCallback);
     }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROsPostAsyncRetryFailedHeadersInner, Void> object
      */
-    public Single<Void> postAsyncRetryFailedAsync() {
+    public Single<RestResponse<LROsPostAsyncRetryFailedHeadersInner, Void>> postAsyncRetryFailedWithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.postAsyncRetryFailed(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPostAsyncRetryFailedHeadersInner, Void> object
+     */
+    public Single<Void> postAsyncRetryFailedAsync() {
+        return postAsyncRetryFailedWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsPostAsyncRetryFailedHeadersInner, Void>, Void>() { public Void call(RestResponse<LROsPostAsyncRetryFailedHeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -4392,6 +5062,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postAsyncRetryFailed(ProductInner product) {
         postAsyncRetryFailedAsync(product).toBlocking().value();
@@ -4405,8 +5076,8 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postAsyncRetryFailedAsync(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRetryFailedAsync(product), serviceCallback);
+    public ServiceFuture<Void> postAsyncRetryFailedAsync(ProductInner product, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRetryFailedAsync(product), serviceCallback);
     }
 
     /**
@@ -4414,12 +5085,24 @@ public class LROsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROsPostAsyncRetryFailedHeadersInner, Void> object
      */
-    public Single<Void> postAsyncRetryFailedAsync(ProductInner product) {
+    public Single<RestResponse<LROsPostAsyncRetryFailedHeadersInner, Void>> postAsyncRetryFailedWithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.postAsyncRetryFailed(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPostAsyncRetryFailedHeadersInner, Void> object
+     */
+    public Single<Void> postAsyncRetryFailedAsync(ProductInner product) {
+        return postAsyncRetryFailedWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROsPostAsyncRetryFailedHeadersInner, Void>, Void>() { public Void call(RestResponse<LROsPostAsyncRetryFailedHeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -4494,6 +5177,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postAsyncRetrycanceled() {
         postAsyncRetrycanceledAsync().toBlocking().value();
@@ -4506,20 +5190,32 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postAsyncRetrycanceledAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRetrycanceledAsync(), serviceCallback);
+    public ServiceFuture<Void> postAsyncRetrycanceledAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRetrycanceledAsync(), serviceCallback);
     }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROsPostAsyncRetrycanceledHeadersInner, Void> object
      */
-    public Single<Void> postAsyncRetrycanceledAsync() {
+    public Single<RestResponse<LROsPostAsyncRetrycanceledHeadersInner, Void>> postAsyncRetrycanceledWithRestResponseAsync() {
         final ProductInner product = null;
+        Validator.validate(product);
         return service.postAsyncRetrycanceled(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPostAsyncRetrycanceledHeadersInner, Void> object
+     */
+    public Single<Void> postAsyncRetrycanceledAsync() {
+        return postAsyncRetrycanceledWithRestResponseAsync()
+            .map(new Func1<RestResponse<LROsPostAsyncRetrycanceledHeadersInner, Void>, Void>() { public Void call(RestResponse<LROsPostAsyncRetrycanceledHeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
@@ -4528,6 +5224,7 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws CloudException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postAsyncRetrycanceled(ProductInner product) {
         postAsyncRetrycanceledAsync(product).toBlocking().value();
@@ -4541,8 +5238,8 @@ public class LROsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postAsyncRetrycanceledAsync(ProductInner product, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(postAsyncRetrycanceledAsync(product), serviceCallback);
+    public ServiceFuture<Void> postAsyncRetrycanceledAsync(ProductInner product, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(postAsyncRetrycanceledAsync(product), serviceCallback);
     }
 
     /**
@@ -4550,12 +5247,24 @@ public class LROsInner {
      *
      * @param product Product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<LROsPostAsyncRetrycanceledHeadersInner, Void> object
      */
-    public Single<Void> postAsyncRetrycanceledAsync(ProductInner product) {
+    public Single<RestResponse<LROsPostAsyncRetrycanceledHeadersInner, Void>> postAsyncRetrycanceledWithRestResponseAsync(ProductInner product) {
         Validator.validate(product);
         return service.postAsyncRetrycanceled(product, this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status.
+     *
+     * @param product Product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<LROsPostAsyncRetrycanceledHeadersInner, Void> object
+     */
+    public Single<Void> postAsyncRetrycanceledAsync(ProductInner product) {
+        return postAsyncRetrycanceledWithRestResponseAsync(product)
+            .map(new Func1<RestResponse<LROsPostAsyncRetrycanceledHeadersInner, Void>, Void>() { public Void call(RestResponse<LROsPostAsyncRetrycanceledHeadersInner, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azurefluent/src/main/java/fixtures/paging/implementation/AutoRestPagingTestServiceImpl.java
+++ b/test/azurefluent/src/main/java/fixtures/paging/implementation/AutoRestPagingTestServiceImpl.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.AzureProxy;
 import com.microsoft.azure.AzureServiceClient;
 import com.microsoft.rest.credentials.ServiceClientCredentials;
 import com.microsoft.rest.RestClient;
+import com.microsoft.rest.RestResponse;
 import rx.Single;
 
 /**

--- a/test/azurefluent/src/main/java/fixtures/paging/implementation/PagingsInner.java
+++ b/test/azurefluent/src/main/java/fixtures/paging/implementation/PagingsInner.java
@@ -10,6 +10,7 @@
 
 package fixtures.paging.implementation;
 
+import com.microsoft.rest.RestResponse;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.CloudException;
 import com.microsoft.azure.ListOperationCallback;
@@ -63,133 +64,133 @@ public class PagingsInner {
         @GET("paging/single")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl<ProductInner>> getSinglePages(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl<ProductInner>>> getSinglePages(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getMultiplePages" })
         @GET("paging/multiple")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl<ProductInner>> getMultiplePages(@HeaderParam("client-request-id") String clientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("maxresults") Integer maxresults, @HeaderParam("timeout") Integer timeout, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl<ProductInner>>> getMultiplePages(@HeaderParam("client-request-id") String clientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("maxresults") Integer maxresults, @HeaderParam("timeout") Integer timeout, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getOdataMultiplePages" })
         @GET("paging/multiple/odata")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl1<ProductInner>> getOdataMultiplePages(@HeaderParam("client-request-id") String clientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("maxresults") Integer maxresults, @HeaderParam("timeout") Integer timeout, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl1<ProductInner>>> getOdataMultiplePages(@HeaderParam("client-request-id") String clientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("maxresults") Integer maxresults, @HeaderParam("timeout") Integer timeout, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getMultiplePagesWithOffset" })
         @GET("paging/multiple/withpath/{offset}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl<ProductInner>> getMultiplePagesWithOffset(@PathParam("offset") int offset, @HeaderParam("client-request-id") String clientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("maxresults") Integer maxresults, @HeaderParam("timeout") Integer timeout, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl<ProductInner>>> getMultiplePagesWithOffset(@PathParam("offset") int offset, @HeaderParam("client-request-id") String clientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("maxresults") Integer maxresults, @HeaderParam("timeout") Integer timeout, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getMultiplePagesRetryFirst" })
         @GET("paging/multiple/retryfirst")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl<ProductInner>> getMultiplePagesRetryFirst(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl<ProductInner>>> getMultiplePagesRetryFirst(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getMultiplePagesRetrySecond" })
         @GET("paging/multiple/retrysecond")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl<ProductInner>> getMultiplePagesRetrySecond(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl<ProductInner>>> getMultiplePagesRetrySecond(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getSinglePagesFailure" })
         @GET("paging/single/failure")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl<ProductInner>> getSinglePagesFailure(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl<ProductInner>>> getSinglePagesFailure(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getMultiplePagesFailure" })
         @GET("paging/multiple/failure")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl<ProductInner>> getMultiplePagesFailure(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl<ProductInner>>> getMultiplePagesFailure(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getMultiplePagesFailureUri" })
         @GET("paging/multiple/failureuri")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl<ProductInner>> getMultiplePagesFailureUri(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl<ProductInner>>> getMultiplePagesFailureUri(@HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getMultiplePagesFragmentNextLink" })
         @GET("paging/multiple/fragment/{tenant}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl1<ProductInner>> getMultiplePagesFragmentNextLink(@PathParam("tenant") String tenant, @QueryParam("api_version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl1<ProductInner>>> getMultiplePagesFragmentNextLink(@PathParam("tenant") String tenant, @QueryParam("api_version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getMultiplePagesFragmentWithGroupingNextLink" })
         @GET("paging/multiple/fragmentwithgrouping/{tenant}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl1<ProductInner>> getMultiplePagesFragmentWithGroupingNextLink(@PathParam("tenant") String tenant, @HeaderParam("accept-language") String acceptLanguage, @QueryParam("api_version") String apiVersion, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl1<ProductInner>>> getMultiplePagesFragmentWithGroupingNextLink(@PathParam("tenant") String tenant, @HeaderParam("accept-language") String acceptLanguage, @QueryParam("api_version") String apiVersion, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings nextFragment" })
         @GET("{nextUrl}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl1<ProductInner>> nextFragment(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @QueryParam("api_version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl1<ProductInner>>> nextFragment(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @QueryParam("api_version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings nextFragmentWithGrouping" })
         @GET("{nextUrl}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl1<ProductInner>> nextFragmentWithGrouping(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("accept-language") String acceptLanguage, @QueryParam("api_version") String apiVersion, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl1<ProductInner>>> nextFragmentWithGrouping(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("accept-language") String acceptLanguage, @QueryParam("api_version") String apiVersion, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getSinglePagesNext" })
         @GET("{nextUrl}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl<ProductInner>> getSinglePagesNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl<ProductInner>>> getSinglePagesNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getMultiplePagesNext" })
         @GET("{nextUrl}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl<ProductInner>> getMultiplePagesNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("client-request-id") String clientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("maxresults") Integer maxresults, @HeaderParam("timeout") Integer timeout, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl<ProductInner>>> getMultiplePagesNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("client-request-id") String clientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("maxresults") Integer maxresults, @HeaderParam("timeout") Integer timeout, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getOdataMultiplePagesNext" })
         @GET("{nextUrl}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl1<ProductInner>> getOdataMultiplePagesNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("client-request-id") String clientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("maxresults") Integer maxresults, @HeaderParam("timeout") Integer timeout, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl1<ProductInner>>> getOdataMultiplePagesNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("client-request-id") String clientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("maxresults") Integer maxresults, @HeaderParam("timeout") Integer timeout, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getMultiplePagesWithOffsetNext" })
         @GET("{nextUrl}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl<ProductInner>> getMultiplePagesWithOffsetNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("client-request-id") String clientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("maxresults") Integer maxresults, @HeaderParam("timeout") Integer timeout, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl<ProductInner>>> getMultiplePagesWithOffsetNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("client-request-id") String clientRequestId, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("maxresults") Integer maxresults, @HeaderParam("timeout") Integer timeout, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getMultiplePagesRetryFirstNext" })
         @GET("{nextUrl}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl<ProductInner>> getMultiplePagesRetryFirstNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl<ProductInner>>> getMultiplePagesRetryFirstNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getMultiplePagesRetrySecondNext" })
         @GET("{nextUrl}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl<ProductInner>> getMultiplePagesRetrySecondNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl<ProductInner>>> getMultiplePagesRetrySecondNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getSinglePagesFailureNext" })
         @GET("{nextUrl}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl<ProductInner>> getSinglePagesFailureNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl<ProductInner>>> getSinglePagesFailureNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getMultiplePagesFailureNext" })
         @GET("{nextUrl}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl<ProductInner>> getMultiplePagesFailureNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl<ProductInner>>> getMultiplePagesFailureNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.paging.Pagings getMultiplePagesFailureUriNext" })
         @GET("{nextUrl}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudException.class)
-        Single<PageImpl<ProductInner>> getMultiplePagesFailureUriNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, PageImpl<ProductInner>>> getMultiplePagesFailureUriNext(@PathParam(value = "nextUrl", encoded = true) String nextUrl, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -239,10 +240,10 @@ public class PagingsInner {
      * @return the PagedList<ProductInner> object if successful.
      */
     public Single<Page<ProductInner>> getSinglePagesSinglePageAsync() {
-        return service.getSinglePages(this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<PageImpl<ProductInner>, Page<ProductInner>>() {
+        return service.getSinglePages(this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<ProductInner>>, Page<ProductInner>>() {
                 @Override
-                public Page<ProductInner> call(PageImpl<ProductInner> productPage) {
-                    return productPage;
+                public Page<ProductInner> call(RestResponse<Void, PageImpl<ProductInner>> response) {
+                    return response.body();
                 }
             });
     }
@@ -298,10 +299,10 @@ public class PagingsInner {
         final PagingGetMultiplePagesOptionsInner pagingGetMultiplePagesOptions = null;
         Integer maxresults = null;
         Integer timeout = null;
-        return service.getMultiplePages(clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<PageImpl<ProductInner>, Page<ProductInner>>() {
+        return service.getMultiplePages(clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<ProductInner>>, Page<ProductInner>>() {
                 @Override
-                public Page<ProductInner> call(PageImpl<ProductInner> productPage) {
-                    return productPage;
+                public Page<ProductInner> call(RestResponse<Void, PageImpl<ProductInner>> response) {
+                    return response.body();
                 }
             });
     }
@@ -367,10 +368,10 @@ public class PagingsInner {
         if (pagingGetMultiplePagesOptions != null) {
             timeout = pagingGetMultiplePagesOptions.timeout();
         }
-        return service.getMultiplePages(clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<PageImpl<ProductInner>, Page<ProductInner>>() {
+        return service.getMultiplePages(clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<ProductInner>>, Page<ProductInner>>() {
                 @Override
-                public Page<ProductInner> call(PageImpl<ProductInner> productPage) {
-                    return productPage;
+                public Page<ProductInner> call(RestResponse<Void, PageImpl<ProductInner>> response) {
+                    return response.body();
                 }
             });
     }
@@ -426,10 +427,10 @@ public class PagingsInner {
         final PagingGetOdataMultiplePagesOptionsInner pagingGetOdataMultiplePagesOptions = null;
         Integer maxresults = null;
         Integer timeout = null;
-        return service.getOdataMultiplePages(clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<PageImpl1<ProductInner>, Page<ProductInner>>() {
+        return service.getOdataMultiplePages(clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl1<ProductInner>>, Page<ProductInner>>() {
                 @Override
-                public Page<ProductInner> call(PageImpl1<ProductInner> productPage) {
-                    return productPage;
+                public Page<ProductInner> call(RestResponse<Void, PageImpl1<ProductInner>> response) {
+                    return response.body();
                 }
             });
     }
@@ -495,10 +496,10 @@ public class PagingsInner {
         if (pagingGetOdataMultiplePagesOptions != null) {
             timeout = pagingGetOdataMultiplePagesOptions.timeout();
         }
-        return service.getOdataMultiplePages(clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<PageImpl1<ProductInner>, Page<ProductInner>>() {
+        return service.getOdataMultiplePages(clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl1<ProductInner>>, Page<ProductInner>>() {
                 @Override
-                public Page<ProductInner> call(PageImpl1<ProductInner> productPage) {
-                    return productPage;
+                public Page<ProductInner> call(RestResponse<Void, PageImpl1<ProductInner>> response) {
+                    return response.body();
                 }
             });
     }
@@ -567,10 +568,10 @@ public class PagingsInner {
         Integer maxresults = pagingGetMultiplePagesWithOffsetOptions.maxresults();
         int offset = pagingGetMultiplePagesWithOffsetOptions.offset();
         Integer timeout = pagingGetMultiplePagesWithOffsetOptions.timeout();
-        return service.getMultiplePagesWithOffset(offset, clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<PageImpl<ProductInner>, Page<ProductInner>>() {
+        return service.getMultiplePagesWithOffset(offset, clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<ProductInner>>, Page<ProductInner>>() {
                 @Override
-                public Page<ProductInner> call(PageImpl<ProductInner> productPage) {
-                    return productPage;
+                public Page<ProductInner> call(RestResponse<Void, PageImpl<ProductInner>> response) {
+                    return response.body();
                 }
             });
     }
@@ -640,10 +641,10 @@ public class PagingsInner {
         Integer maxresults = pagingGetMultiplePagesWithOffsetOptions.maxresults();
         int offset = pagingGetMultiplePagesWithOffsetOptions.offset();
         Integer timeout = pagingGetMultiplePagesWithOffsetOptions.timeout();
-        return service.getMultiplePagesWithOffset(offset, clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<PageImpl<ProductInner>, Page<ProductInner>>() {
+        return service.getMultiplePagesWithOffset(offset, clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<ProductInner>>, Page<ProductInner>>() {
                 @Override
-                public Page<ProductInner> call(PageImpl<ProductInner> productPage) {
-                    return productPage;
+                public Page<ProductInner> call(RestResponse<Void, PageImpl<ProductInner>> response) {
+                    return response.body();
                 }
             });
     }
@@ -695,10 +696,10 @@ public class PagingsInner {
      * @return the PagedList<ProductInner> object if successful.
      */
     public Single<Page<ProductInner>> getMultiplePagesRetryFirstSinglePageAsync() {
-        return service.getMultiplePagesRetryFirst(this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<PageImpl<ProductInner>, Page<ProductInner>>() {
+        return service.getMultiplePagesRetryFirst(this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<ProductInner>>, Page<ProductInner>>() {
                 @Override
-                public Page<ProductInner> call(PageImpl<ProductInner> productPage) {
-                    return productPage;
+                public Page<ProductInner> call(RestResponse<Void, PageImpl<ProductInner>> response) {
+                    return response.body();
                 }
             });
     }
@@ -750,10 +751,10 @@ public class PagingsInner {
      * @return the PagedList<ProductInner> object if successful.
      */
     public Single<Page<ProductInner>> getMultiplePagesRetrySecondSinglePageAsync() {
-        return service.getMultiplePagesRetrySecond(this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<PageImpl<ProductInner>, Page<ProductInner>>() {
+        return service.getMultiplePagesRetrySecond(this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<ProductInner>>, Page<ProductInner>>() {
                 @Override
-                public Page<ProductInner> call(PageImpl<ProductInner> productPage) {
-                    return productPage;
+                public Page<ProductInner> call(RestResponse<Void, PageImpl<ProductInner>> response) {
+                    return response.body();
                 }
             });
     }
@@ -805,10 +806,10 @@ public class PagingsInner {
      * @return the PagedList<ProductInner> object if successful.
      */
     public Single<Page<ProductInner>> getSinglePagesFailureSinglePageAsync() {
-        return service.getSinglePagesFailure(this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<PageImpl<ProductInner>, Page<ProductInner>>() {
+        return service.getSinglePagesFailure(this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<ProductInner>>, Page<ProductInner>>() {
                 @Override
-                public Page<ProductInner> call(PageImpl<ProductInner> productPage) {
-                    return productPage;
+                public Page<ProductInner> call(RestResponse<Void, PageImpl<ProductInner>> response) {
+                    return response.body();
                 }
             });
     }
@@ -860,10 +861,10 @@ public class PagingsInner {
      * @return the PagedList<ProductInner> object if successful.
      */
     public Single<Page<ProductInner>> getMultiplePagesFailureSinglePageAsync() {
-        return service.getMultiplePagesFailure(this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<PageImpl<ProductInner>, Page<ProductInner>>() {
+        return service.getMultiplePagesFailure(this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<ProductInner>>, Page<ProductInner>>() {
                 @Override
-                public Page<ProductInner> call(PageImpl<ProductInner> productPage) {
-                    return productPage;
+                public Page<ProductInner> call(RestResponse<Void, PageImpl<ProductInner>> response) {
+                    return response.body();
                 }
             });
     }
@@ -915,10 +916,10 @@ public class PagingsInner {
      * @return the PagedList<ProductInner> object if successful.
      */
     public Single<Page<ProductInner>> getMultiplePagesFailureUriSinglePageAsync() {
-        return service.getMultiplePagesFailureUri(this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<PageImpl<ProductInner>, Page<ProductInner>>() {
+        return service.getMultiplePagesFailureUri(this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<ProductInner>>, Page<ProductInner>>() {
                 @Override
-                public Page<ProductInner> call(PageImpl<ProductInner> productPage) {
-                    return productPage;
+                public Page<ProductInner> call(RestResponse<Void, PageImpl<ProductInner>> response) {
+                    return response.body();
                 }
             });
     }
@@ -982,10 +983,10 @@ public class PagingsInner {
         if (apiVersion == null) {
             throw new IllegalArgumentException("Parameter apiVersion is required and cannot be null.");
         }
-        return service.getMultiplePagesFragmentNextLink(tenant, apiVersion, this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<PageImpl1<ProductInner>, Page<ProductInner>>() {
+        return service.getMultiplePagesFragmentNextLink(tenant, apiVersion, this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl1<ProductInner>>, Page<ProductInner>>() {
                 @Override
-                public Page<ProductInner> call(PageImpl1<ProductInner> productPage) {
-                    return productPage;
+                public Page<ProductInner> call(RestResponse<Void, PageImpl1<ProductInner>> response) {
+                    return response.body();
                 }
             });
     }
@@ -1046,10 +1047,10 @@ public class PagingsInner {
         Validator.validate(customParameterGroup);
         String apiVersion = customParameterGroup.apiVersion();
         String tenant = customParameterGroup.tenant();
-        return service.getMultiplePagesFragmentWithGroupingNextLink(tenant, this.client.acceptLanguage(), apiVersion, this.client.userAgent()).map(new Func1<PageImpl1<ProductInner>, Page<ProductInner>>() {
+        return service.getMultiplePagesFragmentWithGroupingNextLink(tenant, this.client.acceptLanguage(), apiVersion, this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl1<ProductInner>>, Page<ProductInner>>() {
                 @Override
-                public Page<ProductInner> call(PageImpl1<ProductInner> productPage) {
-                    return productPage;
+                public Page<ProductInner> call(RestResponse<Void, PageImpl1<ProductInner>> response) {
+                    return response.body();
                 }
             });
     }
@@ -1120,10 +1121,10 @@ public class PagingsInner {
             throw new IllegalArgumentException("Parameter apiVersion is required and cannot be null.");
         }
         String nextUrl = String.format("paging/multiple/fragment/%s/%s", tenant, nextLink);
-        return service.nextFragment(nextUrl, apiVersion, this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<PageImpl1<ProductInner>, Page<ProductInner>>() {
+        return service.nextFragment(nextUrl, apiVersion, this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl1<ProductInner>>, Page<ProductInner>>() {
                 @Override
-                public Page<ProductInner> call(PageImpl1<ProductInner> productPage) {
-                    return productPage;
+                public Page<ProductInner> call(RestResponse<Void, PageImpl1<ProductInner>> response) {
+                    return response.body();
                 }
             });
     }
@@ -1191,10 +1192,10 @@ public class PagingsInner {
         String apiVersion = customParameterGroup.apiVersion();
         String tenant = customParameterGroup.tenant();
         String nextUrl = String.format("paging/multiple/fragmentwithgrouping/%s/%s", tenant, nextLink);
-        return service.nextFragmentWithGrouping(nextUrl, this.client.acceptLanguage(), apiVersion, this.client.userAgent()).map(new Func1<PageImpl1<ProductInner>, Page<ProductInner>>() {
+        return service.nextFragmentWithGrouping(nextUrl, this.client.acceptLanguage(), apiVersion, this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl1<ProductInner>>, Page<ProductInner>>() {
                 @Override
-                public Page<ProductInner> call(PageImpl1<ProductInner> productPage) {
-                    return productPage;
+                public Page<ProductInner> call(RestResponse<Void, PageImpl1<ProductInner>> response) {
+                    return response.body();
                 }
             });
     }
@@ -1253,10 +1254,10 @@ public class PagingsInner {
             throw new IllegalArgumentException("Parameter nextPageLink is required and cannot be null.");
         }
         String nextUrl = String.format("%s", nextPageLink);
-        return service.getSinglePagesNext(nextUrl, this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<PageImpl<ProductInner>, Page<ProductInner>>() {
+        return service.getSinglePagesNext(nextUrl, this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<ProductInner>>, Page<ProductInner>>() {
                 @Override
-                public Page<ProductInner> call(PageImpl<ProductInner> productPage) {
-                    return productPage;
+                public Page<ProductInner> call(RestResponse<Void, PageImpl<ProductInner>> response) {
+                    return response.body();
                 }
             });
     }
@@ -1319,10 +1320,10 @@ public class PagingsInner {
         Integer maxresults = null;
         Integer timeout = null;
         String nextUrl = String.format("%s", nextPageLink);
-        return service.getMultiplePagesNext(nextUrl, clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<PageImpl<ProductInner>, Page<ProductInner>>() {
+        return service.getMultiplePagesNext(nextUrl, clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<ProductInner>>, Page<ProductInner>>() {
                 @Override
-                public Page<ProductInner> call(PageImpl<ProductInner> productPage) {
-                    return productPage;
+                public Page<ProductInner> call(RestResponse<Void, PageImpl<ProductInner>> response) {
+                    return response.body();
                 }
             });
     }
@@ -1395,10 +1396,10 @@ public class PagingsInner {
             timeout = pagingGetMultiplePagesOptions.timeout();
         }
         String nextUrl = String.format("%s", nextPageLink);
-        return service.getMultiplePagesNext(nextUrl, clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<PageImpl<ProductInner>, Page<ProductInner>>() {
+        return service.getMultiplePagesNext(nextUrl, clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<ProductInner>>, Page<ProductInner>>() {
                 @Override
-                public Page<ProductInner> call(PageImpl<ProductInner> productPage) {
-                    return productPage;
+                public Page<ProductInner> call(RestResponse<Void, PageImpl<ProductInner>> response) {
+                    return response.body();
                 }
             });
     }
@@ -1461,10 +1462,10 @@ public class PagingsInner {
         Integer maxresults = null;
         Integer timeout = null;
         String nextUrl = String.format("%s", nextPageLink);
-        return service.getOdataMultiplePagesNext(nextUrl, clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<PageImpl1<ProductInner>, Page<ProductInner>>() {
+        return service.getOdataMultiplePagesNext(nextUrl, clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl1<ProductInner>>, Page<ProductInner>>() {
                 @Override
-                public Page<ProductInner> call(PageImpl1<ProductInner> productPage) {
-                    return productPage;
+                public Page<ProductInner> call(RestResponse<Void, PageImpl1<ProductInner>> response) {
+                    return response.body();
                 }
             });
     }
@@ -1537,10 +1538,10 @@ public class PagingsInner {
             timeout = pagingGetOdataMultiplePagesOptions.timeout();
         }
         String nextUrl = String.format("%s", nextPageLink);
-        return service.getOdataMultiplePagesNext(nextUrl, clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<PageImpl1<ProductInner>, Page<ProductInner>>() {
+        return service.getOdataMultiplePagesNext(nextUrl, clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl1<ProductInner>>, Page<ProductInner>>() {
                 @Override
-                public Page<ProductInner> call(PageImpl1<ProductInner> productPage) {
-                    return productPage;
+                public Page<ProductInner> call(RestResponse<Void, PageImpl1<ProductInner>> response) {
+                    return response.body();
                 }
             });
     }
@@ -1603,10 +1604,10 @@ public class PagingsInner {
         Integer maxresults = null;
         Integer timeout = null;
         String nextUrl = String.format("%s", nextPageLink);
-        return service.getMultiplePagesWithOffsetNext(nextUrl, clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<PageImpl<ProductInner>, Page<ProductInner>>() {
+        return service.getMultiplePagesWithOffsetNext(nextUrl, clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<ProductInner>>, Page<ProductInner>>() {
                 @Override
-                public Page<ProductInner> call(PageImpl<ProductInner> productPage) {
-                    return productPage;
+                public Page<ProductInner> call(RestResponse<Void, PageImpl<ProductInner>> response) {
+                    return response.body();
                 }
             });
     }
@@ -1679,10 +1680,10 @@ public class PagingsInner {
             timeout = pagingGetMultiplePagesWithOffsetNextOptions.timeout();
         }
         String nextUrl = String.format("%s", nextPageLink);
-        return service.getMultiplePagesWithOffsetNext(nextUrl, clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<PageImpl<ProductInner>, Page<ProductInner>>() {
+        return service.getMultiplePagesWithOffsetNext(nextUrl, clientRequestId, this.client.acceptLanguage(), maxresults, timeout, this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<ProductInner>>, Page<ProductInner>>() {
                 @Override
-                public Page<ProductInner> call(PageImpl<ProductInner> productPage) {
-                    return productPage;
+                public Page<ProductInner> call(RestResponse<Void, PageImpl<ProductInner>> response) {
+                    return response.body();
                 }
             });
     }
@@ -1741,10 +1742,10 @@ public class PagingsInner {
             throw new IllegalArgumentException("Parameter nextPageLink is required and cannot be null.");
         }
         String nextUrl = String.format("%s", nextPageLink);
-        return service.getMultiplePagesRetryFirstNext(nextUrl, this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<PageImpl<ProductInner>, Page<ProductInner>>() {
+        return service.getMultiplePagesRetryFirstNext(nextUrl, this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<ProductInner>>, Page<ProductInner>>() {
                 @Override
-                public Page<ProductInner> call(PageImpl<ProductInner> productPage) {
-                    return productPage;
+                public Page<ProductInner> call(RestResponse<Void, PageImpl<ProductInner>> response) {
+                    return response.body();
                 }
             });
     }
@@ -1803,10 +1804,10 @@ public class PagingsInner {
             throw new IllegalArgumentException("Parameter nextPageLink is required and cannot be null.");
         }
         String nextUrl = String.format("%s", nextPageLink);
-        return service.getMultiplePagesRetrySecondNext(nextUrl, this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<PageImpl<ProductInner>, Page<ProductInner>>() {
+        return service.getMultiplePagesRetrySecondNext(nextUrl, this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<ProductInner>>, Page<ProductInner>>() {
                 @Override
-                public Page<ProductInner> call(PageImpl<ProductInner> productPage) {
-                    return productPage;
+                public Page<ProductInner> call(RestResponse<Void, PageImpl<ProductInner>> response) {
+                    return response.body();
                 }
             });
     }
@@ -1865,10 +1866,10 @@ public class PagingsInner {
             throw new IllegalArgumentException("Parameter nextPageLink is required and cannot be null.");
         }
         String nextUrl = String.format("%s", nextPageLink);
-        return service.getSinglePagesFailureNext(nextUrl, this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<PageImpl<ProductInner>, Page<ProductInner>>() {
+        return service.getSinglePagesFailureNext(nextUrl, this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<ProductInner>>, Page<ProductInner>>() {
                 @Override
-                public Page<ProductInner> call(PageImpl<ProductInner> productPage) {
-                    return productPage;
+                public Page<ProductInner> call(RestResponse<Void, PageImpl<ProductInner>> response) {
+                    return response.body();
                 }
             });
     }
@@ -1927,10 +1928,10 @@ public class PagingsInner {
             throw new IllegalArgumentException("Parameter nextPageLink is required and cannot be null.");
         }
         String nextUrl = String.format("%s", nextPageLink);
-        return service.getMultiplePagesFailureNext(nextUrl, this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<PageImpl<ProductInner>, Page<ProductInner>>() {
+        return service.getMultiplePagesFailureNext(nextUrl, this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<ProductInner>>, Page<ProductInner>>() {
                 @Override
-                public Page<ProductInner> call(PageImpl<ProductInner> productPage) {
-                    return productPage;
+                public Page<ProductInner> call(RestResponse<Void, PageImpl<ProductInner>> response) {
+                    return response.body();
                 }
             });
     }
@@ -1989,10 +1990,10 @@ public class PagingsInner {
             throw new IllegalArgumentException("Parameter nextPageLink is required and cannot be null.");
         }
         String nextUrl = String.format("%s", nextPageLink);
-        return service.getMultiplePagesFailureUriNext(nextUrl, this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<PageImpl<ProductInner>, Page<ProductInner>>() {
+        return service.getMultiplePagesFailureUriNext(nextUrl, this.client.acceptLanguage(), this.client.userAgent()).map(new Func1<RestResponse<Void, PageImpl<ProductInner>>, Page<ProductInner>>() {
                 @Override
-                public Page<ProductInner> call(PageImpl<ProductInner> productPage) {
-                    return productPage;
+                public Page<ProductInner> call(RestResponse<Void, PageImpl<ProductInner>> response) {
+                    return response.body();
                 }
             });
     }

--- a/test/azurefluent/src/main/java/fixtures/subscriptionidapiversion/implementation/GroupsInner.java
+++ b/test/azurefluent/src/main/java/fixtures/subscriptionidapiversion/implementation/GroupsInner.java
@@ -10,6 +10,7 @@
 
 package fixtures.subscriptionidapiversion.implementation;
 
+import com.microsoft.rest.RestResponse;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.ExpectedResponses;
 import com.microsoft.rest.annotations.GET;
@@ -59,7 +60,7 @@ public class GroupsInner {
         @GET("subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<SampleResourceGroupInner> getSampleResourceGroup(@PathParam("subscriptionId") String subscriptionId, @PathParam("resourceGroupName") String resourceGroupName, @QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, SampleResourceGroupInner>> getSampleResourceGroup(@PathParam("subscriptionId") String subscriptionId, @PathParam("resourceGroupName") String resourceGroupName, @QueryParam("api-version") String apiVersion, @HeaderParam("accept-language") String acceptLanguage, @HeaderParam("User-Agent") String userAgent);
 
     }
 
@@ -84,7 +85,7 @@ public class GroupsInner {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<SampleResourceGroupInner> getSampleResourceGroupAsync(String resourceGroupName, final ServiceCallback<SampleResourceGroupInner> serviceCallback) {
+    public ServiceFuture<SampleResourceGroupInner> getSampleResourceGroupAsync(String resourceGroupName, ServiceCallback<SampleResourceGroupInner> serviceCallback) {
         return ServiceFuture.fromBody(getSampleResourceGroupAsync(resourceGroupName), serviceCallback);
     }
 
@@ -93,9 +94,9 @@ public class GroupsInner {
      *
      * @param resourceGroupName Resource Group name 'testgroup101'.
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the SampleResourceGroupInner object
+     * @return a {@link Single} emitting the RestResponse<Void, SampleResourceGroupInner> object
      */
-    public Single<SampleResourceGroupInner> getSampleResourceGroupAsync(String resourceGroupName) {
+    public Single<RestResponse<Void, SampleResourceGroupInner>> getSampleResourceGroupWithRestResponseAsync(String resourceGroupName) {
         if (this.client.subscriptionId() == null) {
             throw new IllegalArgumentException("Parameter this.client.subscriptionId() is required and cannot be null.");
         }
@@ -107,6 +108,18 @@ public class GroupsInner {
         }
         return service.getSampleResourceGroup(this.client.subscriptionId(), resourceGroupName, this.client.apiVersion(), this.client.acceptLanguage(), this.client.userAgent());
     }
+
+    /**
+     * Provides a resouce group with name 'testgroup101' and location 'West US'.
+     *
+     * @param resourceGroupName Resource Group name 'testgroup101'.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, SampleResourceGroupInner> object
+     */
+    public Single<SampleResourceGroupInner> getSampleResourceGroupAsync(String resourceGroupName) {
+        return getSampleResourceGroupWithRestResponseAsync(resourceGroupName)
+            .map(new Func1<RestResponse<Void, SampleResourceGroupInner>, SampleResourceGroupInner>() { public SampleResourceGroupInner call(RestResponse<Void, SampleResourceGroupInner> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/azurefluent/src/main/java/fixtures/subscriptionidapiversion/implementation/MicrosoftAzureTestUrlImpl.java
+++ b/test/azurefluent/src/main/java/fixtures/subscriptionidapiversion/implementation/MicrosoftAzureTestUrlImpl.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.AzureProxy;
 import com.microsoft.azure.AzureServiceClient;
 import com.microsoft.rest.credentials.ServiceClientCredentials;
 import com.microsoft.rest.RestClient;
+import com.microsoft.rest.RestResponse;
 import rx.Single;
 
 /**

--- a/test/vanilla/src/main/java/fixtures/bodyarray/Arrays.java
+++ b/test/vanilla/src/main/java/fixtures/bodyarray/Arrays.java
@@ -10,6 +10,7 @@
 
 package fixtures.bodyarray;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.bodyarray.models.ErrorException;
@@ -55,6 +56,13 @@ public interface Arrays {
      * @return the observable to the List&lt;Integer&gt; object
      */
     Single<List<Integer>> getNullAsync();
+    /**
+     * Get null array value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;Integer&gt; object
+     */
+    Single<RestResponse<Void, List<Integer>>> getNullWithRestResponseAsync();
 
 
     /**
@@ -83,6 +91,13 @@ public interface Arrays {
      * @return the observable to the List&lt;Integer&gt; object
      */
     Single<List<Integer>> getInvalidAsync();
+    /**
+     * Get invalid array [1, 2, 3.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;Integer&gt; object
+     */
+    Single<RestResponse<Void, List<Integer>>> getInvalidWithRestResponseAsync();
 
 
     /**
@@ -111,6 +126,13 @@ public interface Arrays {
      * @return the observable to the List&lt;Integer&gt; object
      */
     Single<List<Integer>> getEmptyAsync();
+    /**
+     * Get empty array value [].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;Integer&gt; object
+     */
+    Single<RestResponse<Void, List<Integer>>> getEmptyWithRestResponseAsync();
 
 
     /**
@@ -141,6 +163,14 @@ public interface Arrays {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putEmptyAsync(List<String> arrayBody);
+    /**
+     * Set array value empty [].
+     *
+     * @param arrayBody the List&lt;String&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putEmptyWithRestResponseAsync(List<String> arrayBody);
 
 
     /**
@@ -169,6 +199,13 @@ public interface Arrays {
      * @return the observable to the List&lt;Boolean&gt; object
      */
     Single<List<Boolean>> getBooleanTfftAsync();
+    /**
+     * Get boolean array value [true, false, false, true].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;Boolean&gt; object
+     */
+    Single<RestResponse<Void, List<Boolean>>> getBooleanTfftWithRestResponseAsync();
 
 
     /**
@@ -199,6 +236,14 @@ public interface Arrays {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putBooleanTfftAsync(List<Boolean> arrayBody);
+    /**
+     * Set array value empty [true, false, false, true].
+     *
+     * @param arrayBody the List&lt;Boolean&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putBooleanTfftWithRestResponseAsync(List<Boolean> arrayBody);
 
 
     /**
@@ -227,6 +272,13 @@ public interface Arrays {
      * @return the observable to the List&lt;Boolean&gt; object
      */
     Single<List<Boolean>> getBooleanInvalidNullAsync();
+    /**
+     * Get boolean array value [true, null, false].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;Boolean&gt; object
+     */
+    Single<RestResponse<Void, List<Boolean>>> getBooleanInvalidNullWithRestResponseAsync();
 
 
     /**
@@ -255,6 +307,13 @@ public interface Arrays {
      * @return the observable to the List&lt;Boolean&gt; object
      */
     Single<List<Boolean>> getBooleanInvalidStringAsync();
+    /**
+     * Get boolean array value [true, 'boolean', false].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;Boolean&gt; object
+     */
+    Single<RestResponse<Void, List<Boolean>>> getBooleanInvalidStringWithRestResponseAsync();
 
 
     /**
@@ -283,6 +342,13 @@ public interface Arrays {
      * @return the observable to the List&lt;Integer&gt; object
      */
     Single<List<Integer>> getIntegerValidAsync();
+    /**
+     * Get integer array value [1, -1, 3, 300].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;Integer&gt; object
+     */
+    Single<RestResponse<Void, List<Integer>>> getIntegerValidWithRestResponseAsync();
 
 
     /**
@@ -313,6 +379,14 @@ public interface Arrays {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putIntegerValidAsync(List<Integer> arrayBody);
+    /**
+     * Set array value empty [1, -1, 3, 300].
+     *
+     * @param arrayBody the List&lt;Integer&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putIntegerValidWithRestResponseAsync(List<Integer> arrayBody);
 
 
     /**
@@ -341,6 +415,13 @@ public interface Arrays {
      * @return the observable to the List&lt;Integer&gt; object
      */
     Single<List<Integer>> getIntInvalidNullAsync();
+    /**
+     * Get integer array value [1, null, 0].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;Integer&gt; object
+     */
+    Single<RestResponse<Void, List<Integer>>> getIntInvalidNullWithRestResponseAsync();
 
 
     /**
@@ -369,6 +450,13 @@ public interface Arrays {
      * @return the observable to the List&lt;Integer&gt; object
      */
     Single<List<Integer>> getIntInvalidStringAsync();
+    /**
+     * Get integer array value [1, 'integer', 0].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;Integer&gt; object
+     */
+    Single<RestResponse<Void, List<Integer>>> getIntInvalidStringWithRestResponseAsync();
 
 
     /**
@@ -397,6 +485,13 @@ public interface Arrays {
      * @return the observable to the List&lt;Long&gt; object
      */
     Single<List<Long>> getLongValidAsync();
+    /**
+     * Get integer array value [1, -1, 3, 300].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;Long&gt; object
+     */
+    Single<RestResponse<Void, List<Long>>> getLongValidWithRestResponseAsync();
 
 
     /**
@@ -427,6 +522,14 @@ public interface Arrays {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putLongValidAsync(List<Long> arrayBody);
+    /**
+     * Set array value empty [1, -1, 3, 300].
+     *
+     * @param arrayBody the List&lt;Long&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putLongValidWithRestResponseAsync(List<Long> arrayBody);
 
 
     /**
@@ -455,6 +558,13 @@ public interface Arrays {
      * @return the observable to the List&lt;Long&gt; object
      */
     Single<List<Long>> getLongInvalidNullAsync();
+    /**
+     * Get long array value [1, null, 0].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;Long&gt; object
+     */
+    Single<RestResponse<Void, List<Long>>> getLongInvalidNullWithRestResponseAsync();
 
 
     /**
@@ -483,6 +593,13 @@ public interface Arrays {
      * @return the observable to the List&lt;Long&gt; object
      */
     Single<List<Long>> getLongInvalidStringAsync();
+    /**
+     * Get long array value [1, 'integer', 0].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;Long&gt; object
+     */
+    Single<RestResponse<Void, List<Long>>> getLongInvalidStringWithRestResponseAsync();
 
 
     /**
@@ -511,6 +628,13 @@ public interface Arrays {
      * @return the observable to the List&lt;Double&gt; object
      */
     Single<List<Double>> getFloatValidAsync();
+    /**
+     * Get float array value [0, -0.01, 1.2e20].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;Double&gt; object
+     */
+    Single<RestResponse<Void, List<Double>>> getFloatValidWithRestResponseAsync();
 
 
     /**
@@ -541,6 +665,14 @@ public interface Arrays {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putFloatValidAsync(List<Double> arrayBody);
+    /**
+     * Set array value [0, -0.01, 1.2e20].
+     *
+     * @param arrayBody the List&lt;Double&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putFloatValidWithRestResponseAsync(List<Double> arrayBody);
 
 
     /**
@@ -569,6 +701,13 @@ public interface Arrays {
      * @return the observable to the List&lt;Double&gt; object
      */
     Single<List<Double>> getFloatInvalidNullAsync();
+    /**
+     * Get float array value [0.0, null, -1.2e20].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;Double&gt; object
+     */
+    Single<RestResponse<Void, List<Double>>> getFloatInvalidNullWithRestResponseAsync();
 
 
     /**
@@ -597,6 +736,13 @@ public interface Arrays {
      * @return the observable to the List&lt;Double&gt; object
      */
     Single<List<Double>> getFloatInvalidStringAsync();
+    /**
+     * Get boolean array value [1.0, 'number', 0.0].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;Double&gt; object
+     */
+    Single<RestResponse<Void, List<Double>>> getFloatInvalidStringWithRestResponseAsync();
 
 
     /**
@@ -625,6 +771,13 @@ public interface Arrays {
      * @return the observable to the List&lt;Double&gt; object
      */
     Single<List<Double>> getDoubleValidAsync();
+    /**
+     * Get float array value [0, -0.01, 1.2e20].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;Double&gt; object
+     */
+    Single<RestResponse<Void, List<Double>>> getDoubleValidWithRestResponseAsync();
 
 
     /**
@@ -655,6 +808,14 @@ public interface Arrays {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putDoubleValidAsync(List<Double> arrayBody);
+    /**
+     * Set array value [0, -0.01, 1.2e20].
+     *
+     * @param arrayBody the List&lt;Double&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putDoubleValidWithRestResponseAsync(List<Double> arrayBody);
 
 
     /**
@@ -683,6 +844,13 @@ public interface Arrays {
      * @return the observable to the List&lt;Double&gt; object
      */
     Single<List<Double>> getDoubleInvalidNullAsync();
+    /**
+     * Get float array value [0.0, null, -1.2e20].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;Double&gt; object
+     */
+    Single<RestResponse<Void, List<Double>>> getDoubleInvalidNullWithRestResponseAsync();
 
 
     /**
@@ -711,6 +879,13 @@ public interface Arrays {
      * @return the observable to the List&lt;Double&gt; object
      */
     Single<List<Double>> getDoubleInvalidStringAsync();
+    /**
+     * Get boolean array value [1.0, 'number', 0.0].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;Double&gt; object
+     */
+    Single<RestResponse<Void, List<Double>>> getDoubleInvalidStringWithRestResponseAsync();
 
 
     /**
@@ -739,6 +914,13 @@ public interface Arrays {
      * @return the observable to the List&lt;String&gt; object
      */
     Single<List<String>> getStringValidAsync();
+    /**
+     * Get string array value ['foo1', 'foo2', 'foo3'].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;String&gt; object
+     */
+    Single<RestResponse<Void, List<String>>> getStringValidWithRestResponseAsync();
 
 
     /**
@@ -769,6 +951,14 @@ public interface Arrays {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putStringValidAsync(List<String> arrayBody);
+    /**
+     * Set array value ['foo1', 'foo2', 'foo3'].
+     *
+     * @param arrayBody the List&lt;String&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putStringValidWithRestResponseAsync(List<String> arrayBody);
 
 
     /**
@@ -797,6 +987,13 @@ public interface Arrays {
      * @return the observable to the List&lt;String&gt; object
      */
     Single<List<String>> getStringWithNullAsync();
+    /**
+     * Get string array value ['foo', null, 'foo2'].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;String&gt; object
+     */
+    Single<RestResponse<Void, List<String>>> getStringWithNullWithRestResponseAsync();
 
 
     /**
@@ -825,6 +1022,13 @@ public interface Arrays {
      * @return the observable to the List&lt;String&gt; object
      */
     Single<List<String>> getStringWithInvalidAsync();
+    /**
+     * Get string array value ['foo', 123, 'foo2'].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;String&gt; object
+     */
+    Single<RestResponse<Void, List<String>>> getStringWithInvalidWithRestResponseAsync();
 
 
     /**
@@ -853,6 +1057,13 @@ public interface Arrays {
      * @return the observable to the List&lt;UUID&gt; object
      */
     Single<List<UUID>> getUuidValidAsync();
+    /**
+     * Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205'].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;UUID&gt; object
+     */
+    Single<RestResponse<Void, List<UUID>>> getUuidValidWithRestResponseAsync();
 
 
     /**
@@ -883,6 +1094,14 @@ public interface Arrays {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putUuidValidAsync(List<UUID> arrayBody);
+    /**
+     * Set array value  ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205'].
+     *
+     * @param arrayBody the List&lt;UUID&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putUuidValidWithRestResponseAsync(List<UUID> arrayBody);
 
 
     /**
@@ -911,6 +1130,13 @@ public interface Arrays {
      * @return the observable to the List&lt;UUID&gt; object
      */
     Single<List<UUID>> getUuidInvalidCharsAsync();
+    /**
+     * Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'foo'].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;UUID&gt; object
+     */
+    Single<RestResponse<Void, List<UUID>>> getUuidInvalidCharsWithRestResponseAsync();
 
 
     /**
@@ -939,6 +1165,13 @@ public interface Arrays {
      * @return the observable to the List&lt;LocalDate&gt; object
      */
     Single<List<LocalDate>> getDateValidAsync();
+    /**
+     * Get integer array value ['2000-12-01', '1980-01-02', '1492-10-12'].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;LocalDate&gt; object
+     */
+    Single<RestResponse<Void, List<LocalDate>>> getDateValidWithRestResponseAsync();
 
 
     /**
@@ -969,6 +1202,14 @@ public interface Arrays {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putDateValidAsync(List<LocalDate> arrayBody);
+    /**
+     * Set array value  ['2000-12-01', '1980-01-02', '1492-10-12'].
+     *
+     * @param arrayBody the List&lt;LocalDate&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putDateValidWithRestResponseAsync(List<LocalDate> arrayBody);
 
 
     /**
@@ -997,6 +1238,13 @@ public interface Arrays {
      * @return the observable to the List&lt;LocalDate&gt; object
      */
     Single<List<LocalDate>> getDateInvalidNullAsync();
+    /**
+     * Get date array value ['2012-01-01', null, '1776-07-04'].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;LocalDate&gt; object
+     */
+    Single<RestResponse<Void, List<LocalDate>>> getDateInvalidNullWithRestResponseAsync();
 
 
     /**
@@ -1025,6 +1273,13 @@ public interface Arrays {
      * @return the observable to the List&lt;LocalDate&gt; object
      */
     Single<List<LocalDate>> getDateInvalidCharsAsync();
+    /**
+     * Get date array value ['2011-03-22', 'date'].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;LocalDate&gt; object
+     */
+    Single<RestResponse<Void, List<LocalDate>>> getDateInvalidCharsWithRestResponseAsync();
 
 
     /**
@@ -1053,6 +1308,13 @@ public interface Arrays {
      * @return the observable to the List&lt;DateTime&gt; object
      */
     Single<List<DateTime>> getDateTimeValidAsync();
+    /**
+     * Get date-time array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00'].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;DateTime&gt; object
+     */
+    Single<RestResponse<Void, List<DateTime>>> getDateTimeValidWithRestResponseAsync();
 
 
     /**
@@ -1083,6 +1345,14 @@ public interface Arrays {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putDateTimeValidAsync(List<DateTime> arrayBody);
+    /**
+     * Set array value  ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00'].
+     *
+     * @param arrayBody the List&lt;DateTime&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putDateTimeValidWithRestResponseAsync(List<DateTime> arrayBody);
 
 
     /**
@@ -1111,6 +1381,13 @@ public interface Arrays {
      * @return the observable to the List&lt;DateTime&gt; object
      */
     Single<List<DateTime>> getDateTimeInvalidNullAsync();
+    /**
+     * Get date array value ['2000-12-01t00:00:01z', null].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;DateTime&gt; object
+     */
+    Single<RestResponse<Void, List<DateTime>>> getDateTimeInvalidNullWithRestResponseAsync();
 
 
     /**
@@ -1139,6 +1416,13 @@ public interface Arrays {
      * @return the observable to the List&lt;DateTime&gt; object
      */
     Single<List<DateTime>> getDateTimeInvalidCharsAsync();
+    /**
+     * Get date array value ['2000-12-01t00:00:01z', 'date-time'].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;DateTime&gt; object
+     */
+    Single<RestResponse<Void, List<DateTime>>> getDateTimeInvalidCharsWithRestResponseAsync();
 
 
     /**
@@ -1167,6 +1451,13 @@ public interface Arrays {
      * @return the observable to the List&lt;DateTime&gt; object
      */
     Single<List<DateTime>> getDateTimeRfc1123ValidAsync();
+    /**
+     * Get date-time array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01 GMT'].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;DateTime&gt; object
+     */
+    Single<RestResponse<Void, List<DateTime>>> getDateTimeRfc1123ValidWithRestResponseAsync();
 
 
     /**
@@ -1197,6 +1488,14 @@ public interface Arrays {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putDateTimeRfc1123ValidAsync(List<DateTime> arrayBody);
+    /**
+     * Set array value  ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01 GMT'].
+     *
+     * @param arrayBody the List&lt;DateTimeRfc1123&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putDateTimeRfc1123ValidWithRestResponseAsync(List<DateTime> arrayBody);
 
 
     /**
@@ -1225,6 +1524,13 @@ public interface Arrays {
      * @return the observable to the List&lt;Period&gt; object
      */
     Single<List<Period>> getDurationValidAsync();
+    /**
+     * Get duration array value ['P123DT22H14M12.011S', 'P5DT1H0M0S'].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;Period&gt; object
+     */
+    Single<RestResponse<Void, List<Period>>> getDurationValidWithRestResponseAsync();
 
 
     /**
@@ -1255,6 +1561,14 @@ public interface Arrays {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putDurationValidAsync(List<Period> arrayBody);
+    /**
+     * Set array value  ['P123DT22H14M12.011S', 'P5DT1H0M0S'].
+     *
+     * @param arrayBody the List&lt;Period&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putDurationValidWithRestResponseAsync(List<Period> arrayBody);
 
 
     /**
@@ -1283,6 +1597,13 @@ public interface Arrays {
      * @return the observable to the List&lt;byte[]&gt; object
      */
     Single<List<byte[]>> getByteValidAsync();
+    /**
+     * Get byte array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each item encoded in base64.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;byte[]&gt; object
+     */
+    Single<RestResponse<Void, List<byte[]>>> getByteValidWithRestResponseAsync();
 
 
     /**
@@ -1313,6 +1634,14 @@ public interface Arrays {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putByteValidAsync(List<byte[]> arrayBody);
+    /**
+     * Put the array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64.
+     *
+     * @param arrayBody the List&lt;byte[]&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putByteValidWithRestResponseAsync(List<byte[]> arrayBody);
 
 
     /**
@@ -1341,6 +1670,13 @@ public interface Arrays {
      * @return the observable to the List&lt;byte[]&gt; object
      */
     Single<List<byte[]>> getByteInvalidNullAsync();
+    /**
+     * Get byte array value [hex(AB, AC, AD), null] with the first item base64 encoded.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;byte[]&gt; object
+     */
+    Single<RestResponse<Void, List<byte[]>>> getByteInvalidNullWithRestResponseAsync();
 
 
     /**
@@ -1369,6 +1705,13 @@ public interface Arrays {
      * @return the observable to the List&lt;byte[]&gt; object
      */
     Single<List<byte[]>> getBase64UrlAsync();
+    /**
+     * Get array value ['a string that gets encoded with base64url', 'test string' 'Lorem ipsum'] with the items base64url encoded.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;byte[]&gt; object
+     */
+    Single<RestResponse<Void, List<byte[]>>> getBase64UrlWithRestResponseAsync();
 
 
     /**
@@ -1397,6 +1740,13 @@ public interface Arrays {
      * @return the observable to the List&lt;Product&gt; object
      */
     Single<List<Product>> getComplexNullAsync();
+    /**
+     * Get array of complex type null value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Single<RestResponse<Void, List<Product>>> getComplexNullWithRestResponseAsync();
 
 
     /**
@@ -1425,6 +1775,13 @@ public interface Arrays {
      * @return the observable to the List&lt;Product&gt; object
      */
     Single<List<Product>> getComplexEmptyAsync();
+    /**
+     * Get empty array of complex type [].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Single<RestResponse<Void, List<Product>>> getComplexEmptyWithRestResponseAsync();
 
 
     /**
@@ -1453,6 +1810,13 @@ public interface Arrays {
      * @return the observable to the List&lt;Product&gt; object
      */
     Single<List<Product>> getComplexItemNullAsync();
+    /**
+     * Get array of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5, 'string': '6'}].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Single<RestResponse<Void, List<Product>>> getComplexItemNullWithRestResponseAsync();
 
 
     /**
@@ -1481,6 +1845,13 @@ public interface Arrays {
      * @return the observable to the List&lt;Product&gt; object
      */
     Single<List<Product>> getComplexItemEmptyAsync();
+    /**
+     * Get array of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5, 'string': '6'}].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Single<RestResponse<Void, List<Product>>> getComplexItemEmptyWithRestResponseAsync();
 
 
     /**
@@ -1509,6 +1880,13 @@ public interface Arrays {
      * @return the observable to the List&lt;Product&gt; object
      */
     Single<List<Product>> getComplexValidAsync();
+    /**
+     * Get array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;Product&gt; object
+     */
+    Single<RestResponse<Void, List<Product>>> getComplexValidWithRestResponseAsync();
 
 
     /**
@@ -1539,6 +1917,14 @@ public interface Arrays {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putComplexValidAsync(List<Product> arrayBody);
+    /**
+     * Put an array of complex type with values [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}].
+     *
+     * @param arrayBody the List&lt;Product&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putComplexValidWithRestResponseAsync(List<Product> arrayBody);
 
 
     /**
@@ -1567,6 +1953,13 @@ public interface Arrays {
      * @return the observable to the List&lt;List&lt;String&gt;&gt; object
      */
     Single<List<List<String>>> getArrayNullAsync();
+    /**
+     * Get a null array.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;List&lt;String&gt;&gt; object
+     */
+    Single<RestResponse<Void, List<List<String>>>> getArrayNullWithRestResponseAsync();
 
 
     /**
@@ -1595,6 +1988,13 @@ public interface Arrays {
      * @return the observable to the List&lt;List&lt;String&gt;&gt; object
      */
     Single<List<List<String>>> getArrayEmptyAsync();
+    /**
+     * Get an empty array [].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;List&lt;String&gt;&gt; object
+     */
+    Single<RestResponse<Void, List<List<String>>>> getArrayEmptyWithRestResponseAsync();
 
 
     /**
@@ -1623,6 +2023,13 @@ public interface Arrays {
      * @return the observable to the List&lt;List&lt;String&gt;&gt; object
      */
     Single<List<List<String>>> getArrayItemNullAsync();
+    /**
+     * Get an array of array of strings [['1', '2', '3'], null, ['7', '8', '9']].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;List&lt;String&gt;&gt; object
+     */
+    Single<RestResponse<Void, List<List<String>>>> getArrayItemNullWithRestResponseAsync();
 
 
     /**
@@ -1651,6 +2058,13 @@ public interface Arrays {
      * @return the observable to the List&lt;List&lt;String&gt;&gt; object
      */
     Single<List<List<String>>> getArrayItemEmptyAsync();
+    /**
+     * Get an array of array of strings [['1', '2', '3'], [], ['7', '8', '9']].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;List&lt;String&gt;&gt; object
+     */
+    Single<RestResponse<Void, List<List<String>>>> getArrayItemEmptyWithRestResponseAsync();
 
 
     /**
@@ -1679,6 +2093,13 @@ public interface Arrays {
      * @return the observable to the List&lt;List&lt;String&gt;&gt; object
      */
     Single<List<List<String>>> getArrayValidAsync();
+    /**
+     * Get an array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;List&lt;String&gt;&gt; object
+     */
+    Single<RestResponse<Void, List<List<String>>>> getArrayValidWithRestResponseAsync();
 
 
     /**
@@ -1709,6 +2130,14 @@ public interface Arrays {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putArrayValidAsync(List<List<String>> arrayBody);
+    /**
+     * Put An array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']].
+     *
+     * @param arrayBody the List&lt;List&lt;String&gt;&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putArrayValidWithRestResponseAsync(List<List<String>> arrayBody);
 
 
     /**
@@ -1737,6 +2166,13 @@ public interface Arrays {
      * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
      */
     Single<List<Map<String, String>>> getDictionaryNullAsync();
+    /**
+     * Get an array of Dictionaries with value null.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
+     */
+    Single<RestResponse<Void, List<Map<String, String>>>> getDictionaryNullWithRestResponseAsync();
 
 
     /**
@@ -1765,6 +2201,13 @@ public interface Arrays {
      * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
      */
     Single<List<Map<String, String>>> getDictionaryEmptyAsync();
+    /**
+     * Get an array of Dictionaries of type &lt;string, string&gt; with value [].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
+     */
+    Single<RestResponse<Void, List<Map<String, String>>>> getDictionaryEmptyWithRestResponseAsync();
 
 
     /**
@@ -1793,6 +2236,13 @@ public interface Arrays {
      * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
      */
     Single<List<Map<String, String>>> getDictionaryItemNullAsync();
+    /**
+     * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'}, null, {'7': 'seven', '8': 'eight', '9': 'nine'}].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
+     */
+    Single<RestResponse<Void, List<Map<String, String>>>> getDictionaryItemNullWithRestResponseAsync();
 
 
     /**
@@ -1821,6 +2271,13 @@ public interface Arrays {
      * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
      */
     Single<List<Map<String, String>>> getDictionaryItemEmptyAsync();
+    /**
+     * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'}, {}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
+     */
+    Single<RestResponse<Void, List<Map<String, String>>>> getDictionaryItemEmptyWithRestResponseAsync();
 
 
     /**
@@ -1849,6 +2306,13 @@ public interface Arrays {
      * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
      */
     Single<List<Map<String, String>>> getDictionaryValidAsync();
+    /**
+     * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
+     */
+    Single<RestResponse<Void, List<Map<String, String>>>> getDictionaryValidWithRestResponseAsync();
 
 
     /**
@@ -1879,6 +2343,14 @@ public interface Arrays {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putDictionaryValidAsync(List<Map<String, String>> arrayBody);
+    /**
+     * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
+     *
+     * @param arrayBody the List&lt;Map&lt;String, String&gt;&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putDictionaryValidWithRestResponseAsync(List<Map<String, String>> arrayBody);
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodyarray/implementation/ArraysImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodyarray/implementation/ArraysImpl.java
@@ -11,6 +11,7 @@
 package fixtures.bodyarray.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.bodyarray.Arrays;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.BodyParam;
@@ -71,393 +72,393 @@ public class ArraysImpl implements Arrays {
         @GET("array/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<Integer>> getNull();
+        Single<RestResponse<Void, List<Integer>>> getNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getInvalid" })
         @GET("array/invalid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<Integer>> getInvalid();
+        Single<RestResponse<Void, List<Integer>>> getInvalid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getEmpty" })
         @GET("array/empty")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<Integer>> getEmpty();
+        Single<RestResponse<Void, List<Integer>>> getEmpty();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays putEmpty" })
         @PUT("array/empty")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putEmpty(@BodyParam("application/json; charset=utf-8") List<String> arrayBody);
+        Single<RestResponse<Void, Void>> putEmpty(@BodyParam("application/json; charset=utf-8") List<String> arrayBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getBooleanTfft" })
         @GET("array/prim/boolean/tfft")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<Boolean>> getBooleanTfft();
+        Single<RestResponse<Void, List<Boolean>>> getBooleanTfft();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays putBooleanTfft" })
         @PUT("array/prim/boolean/tfft")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putBooleanTfft(@BodyParam("application/json; charset=utf-8") List<Boolean> arrayBody);
+        Single<RestResponse<Void, Void>> putBooleanTfft(@BodyParam("application/json; charset=utf-8") List<Boolean> arrayBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getBooleanInvalidNull" })
         @GET("array/prim/boolean/true.null.false")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<Boolean>> getBooleanInvalidNull();
+        Single<RestResponse<Void, List<Boolean>>> getBooleanInvalidNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getBooleanInvalidString" })
         @GET("array/prim/boolean/true.boolean.false")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<Boolean>> getBooleanInvalidString();
+        Single<RestResponse<Void, List<Boolean>>> getBooleanInvalidString();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getIntegerValid" })
         @GET("array/prim/integer/1.-1.3.300")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<Integer>> getIntegerValid();
+        Single<RestResponse<Void, List<Integer>>> getIntegerValid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays putIntegerValid" })
         @PUT("array/prim/integer/1.-1.3.300")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putIntegerValid(@BodyParam("application/json; charset=utf-8") List<Integer> arrayBody);
+        Single<RestResponse<Void, Void>> putIntegerValid(@BodyParam("application/json; charset=utf-8") List<Integer> arrayBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getIntInvalidNull" })
         @GET("array/prim/integer/1.null.zero")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<Integer>> getIntInvalidNull();
+        Single<RestResponse<Void, List<Integer>>> getIntInvalidNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getIntInvalidString" })
         @GET("array/prim/integer/1.integer.0")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<Integer>> getIntInvalidString();
+        Single<RestResponse<Void, List<Integer>>> getIntInvalidString();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getLongValid" })
         @GET("array/prim/long/1.-1.3.300")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<Long>> getLongValid();
+        Single<RestResponse<Void, List<Long>>> getLongValid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays putLongValid" })
         @PUT("array/prim/long/1.-1.3.300")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putLongValid(@BodyParam("application/json; charset=utf-8") List<Long> arrayBody);
+        Single<RestResponse<Void, Void>> putLongValid(@BodyParam("application/json; charset=utf-8") List<Long> arrayBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getLongInvalidNull" })
         @GET("array/prim/long/1.null.zero")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<Long>> getLongInvalidNull();
+        Single<RestResponse<Void, List<Long>>> getLongInvalidNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getLongInvalidString" })
         @GET("array/prim/long/1.integer.0")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<Long>> getLongInvalidString();
+        Single<RestResponse<Void, List<Long>>> getLongInvalidString();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getFloatValid" })
         @GET("array/prim/float/0--0.01-1.2e20")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<Double>> getFloatValid();
+        Single<RestResponse<Void, List<Double>>> getFloatValid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays putFloatValid" })
         @PUT("array/prim/float/0--0.01-1.2e20")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putFloatValid(@BodyParam("application/json; charset=utf-8") List<Double> arrayBody);
+        Single<RestResponse<Void, Void>> putFloatValid(@BodyParam("application/json; charset=utf-8") List<Double> arrayBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getFloatInvalidNull" })
         @GET("array/prim/float/0.0-null-1.2e20")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<Double>> getFloatInvalidNull();
+        Single<RestResponse<Void, List<Double>>> getFloatInvalidNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getFloatInvalidString" })
         @GET("array/prim/float/1.number.0")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<Double>> getFloatInvalidString();
+        Single<RestResponse<Void, List<Double>>> getFloatInvalidString();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getDoubleValid" })
         @GET("array/prim/double/0--0.01-1.2e20")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<Double>> getDoubleValid();
+        Single<RestResponse<Void, List<Double>>> getDoubleValid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays putDoubleValid" })
         @PUT("array/prim/double/0--0.01-1.2e20")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putDoubleValid(@BodyParam("application/json; charset=utf-8") List<Double> arrayBody);
+        Single<RestResponse<Void, Void>> putDoubleValid(@BodyParam("application/json; charset=utf-8") List<Double> arrayBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getDoubleInvalidNull" })
         @GET("array/prim/double/0.0-null-1.2e20")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<Double>> getDoubleInvalidNull();
+        Single<RestResponse<Void, List<Double>>> getDoubleInvalidNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getDoubleInvalidString" })
         @GET("array/prim/double/1.number.0")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<Double>> getDoubleInvalidString();
+        Single<RestResponse<Void, List<Double>>> getDoubleInvalidString();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getStringValid" })
         @GET("array/prim/string/foo1.foo2.foo3")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<String>> getStringValid();
+        Single<RestResponse<Void, List<String>>> getStringValid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays putStringValid" })
         @PUT("array/prim/string/foo1.foo2.foo3")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putStringValid(@BodyParam("application/json; charset=utf-8") List<String> arrayBody);
+        Single<RestResponse<Void, Void>> putStringValid(@BodyParam("application/json; charset=utf-8") List<String> arrayBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getStringWithNull" })
         @GET("array/prim/string/foo.null.foo2")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<String>> getStringWithNull();
+        Single<RestResponse<Void, List<String>>> getStringWithNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getStringWithInvalid" })
         @GET("array/prim/string/foo.123.foo2")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<String>> getStringWithInvalid();
+        Single<RestResponse<Void, List<String>>> getStringWithInvalid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getUuidValid" })
         @GET("array/prim/uuid/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<UUID>> getUuidValid();
+        Single<RestResponse<Void, List<UUID>>> getUuidValid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays putUuidValid" })
         @PUT("array/prim/uuid/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putUuidValid(@BodyParam("application/json; charset=utf-8") List<UUID> arrayBody);
+        Single<RestResponse<Void, Void>> putUuidValid(@BodyParam("application/json; charset=utf-8") List<UUID> arrayBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getUuidInvalidChars" })
         @GET("array/prim/uuid/invalidchars")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<UUID>> getUuidInvalidChars();
+        Single<RestResponse<Void, List<UUID>>> getUuidInvalidChars();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getDateValid" })
         @GET("array/prim/date/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<LocalDate>> getDateValid();
+        Single<RestResponse<Void, List<LocalDate>>> getDateValid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays putDateValid" })
         @PUT("array/prim/date/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putDateValid(@BodyParam("application/json; charset=utf-8") List<LocalDate> arrayBody);
+        Single<RestResponse<Void, Void>> putDateValid(@BodyParam("application/json; charset=utf-8") List<LocalDate> arrayBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getDateInvalidNull" })
         @GET("array/prim/date/invalidnull")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<LocalDate>> getDateInvalidNull();
+        Single<RestResponse<Void, List<LocalDate>>> getDateInvalidNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getDateInvalidChars" })
         @GET("array/prim/date/invalidchars")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<LocalDate>> getDateInvalidChars();
+        Single<RestResponse<Void, List<LocalDate>>> getDateInvalidChars();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getDateTimeValid" })
         @GET("array/prim/date-time/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<DateTime>> getDateTimeValid();
+        Single<RestResponse<Void, List<DateTime>>> getDateTimeValid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays putDateTimeValid" })
         @PUT("array/prim/date-time/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putDateTimeValid(@BodyParam("application/json; charset=utf-8") List<DateTime> arrayBody);
+        Single<RestResponse<Void, Void>> putDateTimeValid(@BodyParam("application/json; charset=utf-8") List<DateTime> arrayBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getDateTimeInvalidNull" })
         @GET("array/prim/date-time/invalidnull")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<DateTime>> getDateTimeInvalidNull();
+        Single<RestResponse<Void, List<DateTime>>> getDateTimeInvalidNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getDateTimeInvalidChars" })
         @GET("array/prim/date-time/invalidchars")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<DateTime>> getDateTimeInvalidChars();
+        Single<RestResponse<Void, List<DateTime>>> getDateTimeInvalidChars();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getDateTimeRfc1123Valid" })
         @GET("array/prim/date-time-rfc1123/valid")
         @ExpectedResponses({200})
         @ReturnValueWireType(DateTimeRfc1123.class)
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<DateTime>> getDateTimeRfc1123Valid();
+        Single<RestResponse<Void, List<DateTime>>> getDateTimeRfc1123Valid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays putDateTimeRfc1123Valid" })
         @PUT("array/prim/date-time-rfc1123/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putDateTimeRfc1123Valid(@BodyParam("application/json; charset=utf-8") List<DateTimeRfc1123> arrayBody);
+        Single<RestResponse<Void, Void>> putDateTimeRfc1123Valid(@BodyParam("application/json; charset=utf-8") List<DateTimeRfc1123> arrayBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getDurationValid" })
         @GET("array/prim/duration/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<Period>> getDurationValid();
+        Single<RestResponse<Void, List<Period>>> getDurationValid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays putDurationValid" })
         @PUT("array/prim/duration/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putDurationValid(@BodyParam("application/json; charset=utf-8") List<Period> arrayBody);
+        Single<RestResponse<Void, Void>> putDurationValid(@BodyParam("application/json; charset=utf-8") List<Period> arrayBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getByteValid" })
         @GET("array/prim/byte/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<byte[]>> getByteValid();
+        Single<RestResponse<Void, List<byte[]>>> getByteValid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays putByteValid" })
         @PUT("array/prim/byte/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putByteValid(@BodyParam("application/json; charset=utf-8") List<byte[]> arrayBody);
+        Single<RestResponse<Void, Void>> putByteValid(@BodyParam("application/json; charset=utf-8") List<byte[]> arrayBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getByteInvalidNull" })
         @GET("array/prim/byte/invalidnull")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<byte[]>> getByteInvalidNull();
+        Single<RestResponse<Void, List<byte[]>>> getByteInvalidNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getBase64Url" })
         @GET("array/prim/base64url/valid")
         @ExpectedResponses({200})
         @ReturnValueWireType(Base64Url.class)
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<byte[]>> getBase64Url();
+        Single<RestResponse<Void, List<byte[]>>> getBase64Url();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getComplexNull" })
         @GET("array/complex/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<Product>> getComplexNull();
+        Single<RestResponse<Void, List<Product>>> getComplexNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getComplexEmpty" })
         @GET("array/complex/empty")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<Product>> getComplexEmpty();
+        Single<RestResponse<Void, List<Product>>> getComplexEmpty();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getComplexItemNull" })
         @GET("array/complex/itemnull")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<Product>> getComplexItemNull();
+        Single<RestResponse<Void, List<Product>>> getComplexItemNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getComplexItemEmpty" })
         @GET("array/complex/itemempty")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<Product>> getComplexItemEmpty();
+        Single<RestResponse<Void, List<Product>>> getComplexItemEmpty();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getComplexValid" })
         @GET("array/complex/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<Product>> getComplexValid();
+        Single<RestResponse<Void, List<Product>>> getComplexValid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays putComplexValid" })
         @PUT("array/complex/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putComplexValid(@BodyParam("application/json; charset=utf-8") List<Product> arrayBody);
+        Single<RestResponse<Void, Void>> putComplexValid(@BodyParam("application/json; charset=utf-8") List<Product> arrayBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getArrayNull" })
         @GET("array/array/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<List<String>>> getArrayNull();
+        Single<RestResponse<Void, List<List<String>>>> getArrayNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getArrayEmpty" })
         @GET("array/array/empty")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<List<String>>> getArrayEmpty();
+        Single<RestResponse<Void, List<List<String>>>> getArrayEmpty();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getArrayItemNull" })
         @GET("array/array/itemnull")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<List<String>>> getArrayItemNull();
+        Single<RestResponse<Void, List<List<String>>>> getArrayItemNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getArrayItemEmpty" })
         @GET("array/array/itemempty")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<List<String>>> getArrayItemEmpty();
+        Single<RestResponse<Void, List<List<String>>>> getArrayItemEmpty();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getArrayValid" })
         @GET("array/array/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<List<String>>> getArrayValid();
+        Single<RestResponse<Void, List<List<String>>>> getArrayValid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays putArrayValid" })
         @PUT("array/array/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putArrayValid(@BodyParam("application/json; charset=utf-8") List<List<String>> arrayBody);
+        Single<RestResponse<Void, Void>> putArrayValid(@BodyParam("application/json; charset=utf-8") List<List<String>> arrayBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getDictionaryNull" })
         @GET("array/dictionary/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<Map<String, String>>> getDictionaryNull();
+        Single<RestResponse<Void, List<Map<String, String>>>> getDictionaryNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getDictionaryEmpty" })
         @GET("array/dictionary/empty")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<Map<String, String>>> getDictionaryEmpty();
+        Single<RestResponse<Void, List<Map<String, String>>>> getDictionaryEmpty();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getDictionaryItemNull" })
         @GET("array/dictionary/itemnull")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<Map<String, String>>> getDictionaryItemNull();
+        Single<RestResponse<Void, List<Map<String, String>>>> getDictionaryItemNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getDictionaryItemEmpty" })
         @GET("array/dictionary/itemempty")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<Map<String, String>>> getDictionaryItemEmpty();
+        Single<RestResponse<Void, List<Map<String, String>>>> getDictionaryItemEmpty();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays getDictionaryValid" })
         @GET("array/dictionary/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<Map<String, String>>> getDictionaryValid();
+        Single<RestResponse<Void, List<Map<String, String>>>> getDictionaryValid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyarray.Arrays putDictionaryValid" })
         @PUT("array/dictionary/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putDictionaryValid(@BodyParam("application/json; charset=utf-8") List<Map<String, String>> arrayBody);
+        Single<RestResponse<Void, Void>> putDictionaryValid(@BodyParam("application/json; charset=utf-8") List<Map<String, String>> arrayBody);
 
     }
 
@@ -480,7 +481,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<Integer>> getNullAsync(final ServiceCallback<List<Integer>> serviceCallback) {
+    public ServiceFuture<List<Integer>> getNullAsync(ServiceCallback<List<Integer>> serviceCallback) {
         return ServiceFuture.fromBody(getNullAsync(), serviceCallback);
     }
 
@@ -488,11 +489,22 @@ public class ArraysImpl implements Arrays {
      * Get null array value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;Integer&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<Integer>> object
      */
-    public Single<List<Integer>> getNullAsync() {
+    public Single<RestResponse<Void, List<Integer>>> getNullWithRestResponseAsync() {
         return service.getNull();
     }
+
+    /**
+     * Get null array value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<Integer>> object
+     */
+    public Single<List<Integer>> getNullAsync() {
+        return getNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<Integer>>, List<Integer>>() { public List<Integer> call(RestResponse<Void, List<Integer>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -514,7 +526,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<Integer>> getInvalidAsync(final ServiceCallback<List<Integer>> serviceCallback) {
+    public ServiceFuture<List<Integer>> getInvalidAsync(ServiceCallback<List<Integer>> serviceCallback) {
         return ServiceFuture.fromBody(getInvalidAsync(), serviceCallback);
     }
 
@@ -522,11 +534,22 @@ public class ArraysImpl implements Arrays {
      * Get invalid array [1, 2, 3.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;Integer&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<Integer>> object
      */
-    public Single<List<Integer>> getInvalidAsync() {
+    public Single<RestResponse<Void, List<Integer>>> getInvalidWithRestResponseAsync() {
         return service.getInvalid();
     }
+
+    /**
+     * Get invalid array [1, 2, 3.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<Integer>> object
+     */
+    public Single<List<Integer>> getInvalidAsync() {
+        return getInvalidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<Integer>>, List<Integer>>() { public List<Integer> call(RestResponse<Void, List<Integer>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -548,7 +571,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<Integer>> getEmptyAsync(final ServiceCallback<List<Integer>> serviceCallback) {
+    public ServiceFuture<List<Integer>> getEmptyAsync(ServiceCallback<List<Integer>> serviceCallback) {
         return ServiceFuture.fromBody(getEmptyAsync(), serviceCallback);
     }
 
@@ -556,11 +579,22 @@ public class ArraysImpl implements Arrays {
      * Get empty array value [].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;Integer&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<Integer>> object
      */
-    public Single<List<Integer>> getEmptyAsync() {
+    public Single<RestResponse<Void, List<Integer>>> getEmptyWithRestResponseAsync() {
         return service.getEmpty();
     }
+
+    /**
+     * Get empty array value [].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<Integer>> object
+     */
+    public Single<List<Integer>> getEmptyAsync() {
+        return getEmptyWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<Integer>>, List<Integer>>() { public List<Integer> call(RestResponse<Void, List<Integer>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -570,6 +604,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putEmpty(List<String> arrayBody) {
         putEmptyAsync(arrayBody).toBlocking().value();
@@ -583,7 +618,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putEmptyAsync(List<String> arrayBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putEmptyAsync(List<String> arrayBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putEmptyAsync(arrayBody), serviceCallback);
     }
 
@@ -592,15 +627,27 @@ public class ArraysImpl implements Arrays {
      *
      * @param arrayBody the List&lt;String&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putEmptyAsync(List<String> arrayBody) {
+    public Single<RestResponse<Void, Void>> putEmptyWithRestResponseAsync(List<String> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
         Validator.validate(arrayBody);
         return service.putEmpty(arrayBody);
     }
+
+    /**
+     * Set array value empty [].
+     *
+     * @param arrayBody the List&lt;String&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putEmptyAsync(List<String> arrayBody) {
+        return putEmptyWithRestResponseAsync(arrayBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -622,7 +669,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<Boolean>> getBooleanTfftAsync(final ServiceCallback<List<Boolean>> serviceCallback) {
+    public ServiceFuture<List<Boolean>> getBooleanTfftAsync(ServiceCallback<List<Boolean>> serviceCallback) {
         return ServiceFuture.fromBody(getBooleanTfftAsync(), serviceCallback);
     }
 
@@ -630,11 +677,22 @@ public class ArraysImpl implements Arrays {
      * Get boolean array value [true, false, false, true].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;Boolean&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<Boolean>> object
      */
-    public Single<List<Boolean>> getBooleanTfftAsync() {
+    public Single<RestResponse<Void, List<Boolean>>> getBooleanTfftWithRestResponseAsync() {
         return service.getBooleanTfft();
     }
+
+    /**
+     * Get boolean array value [true, false, false, true].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<Boolean>> object
+     */
+    public Single<List<Boolean>> getBooleanTfftAsync() {
+        return getBooleanTfftWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<Boolean>>, List<Boolean>>() { public List<Boolean> call(RestResponse<Void, List<Boolean>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -644,6 +702,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putBooleanTfft(List<Boolean> arrayBody) {
         putBooleanTfftAsync(arrayBody).toBlocking().value();
@@ -657,7 +716,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putBooleanTfftAsync(List<Boolean> arrayBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putBooleanTfftAsync(List<Boolean> arrayBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putBooleanTfftAsync(arrayBody), serviceCallback);
     }
 
@@ -666,15 +725,27 @@ public class ArraysImpl implements Arrays {
      *
      * @param arrayBody the List&lt;Boolean&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putBooleanTfftAsync(List<Boolean> arrayBody) {
+    public Single<RestResponse<Void, Void>> putBooleanTfftWithRestResponseAsync(List<Boolean> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
         Validator.validate(arrayBody);
         return service.putBooleanTfft(arrayBody);
     }
+
+    /**
+     * Set array value empty [true, false, false, true].
+     *
+     * @param arrayBody the List&lt;Boolean&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putBooleanTfftAsync(List<Boolean> arrayBody) {
+        return putBooleanTfftWithRestResponseAsync(arrayBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -696,7 +767,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<Boolean>> getBooleanInvalidNullAsync(final ServiceCallback<List<Boolean>> serviceCallback) {
+    public ServiceFuture<List<Boolean>> getBooleanInvalidNullAsync(ServiceCallback<List<Boolean>> serviceCallback) {
         return ServiceFuture.fromBody(getBooleanInvalidNullAsync(), serviceCallback);
     }
 
@@ -704,11 +775,22 @@ public class ArraysImpl implements Arrays {
      * Get boolean array value [true, null, false].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;Boolean&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<Boolean>> object
      */
-    public Single<List<Boolean>> getBooleanInvalidNullAsync() {
+    public Single<RestResponse<Void, List<Boolean>>> getBooleanInvalidNullWithRestResponseAsync() {
         return service.getBooleanInvalidNull();
     }
+
+    /**
+     * Get boolean array value [true, null, false].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<Boolean>> object
+     */
+    public Single<List<Boolean>> getBooleanInvalidNullAsync() {
+        return getBooleanInvalidNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<Boolean>>, List<Boolean>>() { public List<Boolean> call(RestResponse<Void, List<Boolean>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -730,7 +812,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<Boolean>> getBooleanInvalidStringAsync(final ServiceCallback<List<Boolean>> serviceCallback) {
+    public ServiceFuture<List<Boolean>> getBooleanInvalidStringAsync(ServiceCallback<List<Boolean>> serviceCallback) {
         return ServiceFuture.fromBody(getBooleanInvalidStringAsync(), serviceCallback);
     }
 
@@ -738,11 +820,22 @@ public class ArraysImpl implements Arrays {
      * Get boolean array value [true, 'boolean', false].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;Boolean&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<Boolean>> object
      */
-    public Single<List<Boolean>> getBooleanInvalidStringAsync() {
+    public Single<RestResponse<Void, List<Boolean>>> getBooleanInvalidStringWithRestResponseAsync() {
         return service.getBooleanInvalidString();
     }
+
+    /**
+     * Get boolean array value [true, 'boolean', false].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<Boolean>> object
+     */
+    public Single<List<Boolean>> getBooleanInvalidStringAsync() {
+        return getBooleanInvalidStringWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<Boolean>>, List<Boolean>>() { public List<Boolean> call(RestResponse<Void, List<Boolean>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -764,7 +857,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<Integer>> getIntegerValidAsync(final ServiceCallback<List<Integer>> serviceCallback) {
+    public ServiceFuture<List<Integer>> getIntegerValidAsync(ServiceCallback<List<Integer>> serviceCallback) {
         return ServiceFuture.fromBody(getIntegerValidAsync(), serviceCallback);
     }
 
@@ -772,11 +865,22 @@ public class ArraysImpl implements Arrays {
      * Get integer array value [1, -1, 3, 300].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;Integer&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<Integer>> object
      */
-    public Single<List<Integer>> getIntegerValidAsync() {
+    public Single<RestResponse<Void, List<Integer>>> getIntegerValidWithRestResponseAsync() {
         return service.getIntegerValid();
     }
+
+    /**
+     * Get integer array value [1, -1, 3, 300].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<Integer>> object
+     */
+    public Single<List<Integer>> getIntegerValidAsync() {
+        return getIntegerValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<Integer>>, List<Integer>>() { public List<Integer> call(RestResponse<Void, List<Integer>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -786,6 +890,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putIntegerValid(List<Integer> arrayBody) {
         putIntegerValidAsync(arrayBody).toBlocking().value();
@@ -799,7 +904,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putIntegerValidAsync(List<Integer> arrayBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putIntegerValidAsync(List<Integer> arrayBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putIntegerValidAsync(arrayBody), serviceCallback);
     }
 
@@ -808,15 +913,27 @@ public class ArraysImpl implements Arrays {
      *
      * @param arrayBody the List&lt;Integer&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putIntegerValidAsync(List<Integer> arrayBody) {
+    public Single<RestResponse<Void, Void>> putIntegerValidWithRestResponseAsync(List<Integer> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
         Validator.validate(arrayBody);
         return service.putIntegerValid(arrayBody);
     }
+
+    /**
+     * Set array value empty [1, -1, 3, 300].
+     *
+     * @param arrayBody the List&lt;Integer&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putIntegerValidAsync(List<Integer> arrayBody) {
+        return putIntegerValidWithRestResponseAsync(arrayBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -838,7 +955,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<Integer>> getIntInvalidNullAsync(final ServiceCallback<List<Integer>> serviceCallback) {
+    public ServiceFuture<List<Integer>> getIntInvalidNullAsync(ServiceCallback<List<Integer>> serviceCallback) {
         return ServiceFuture.fromBody(getIntInvalidNullAsync(), serviceCallback);
     }
 
@@ -846,11 +963,22 @@ public class ArraysImpl implements Arrays {
      * Get integer array value [1, null, 0].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;Integer&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<Integer>> object
      */
-    public Single<List<Integer>> getIntInvalidNullAsync() {
+    public Single<RestResponse<Void, List<Integer>>> getIntInvalidNullWithRestResponseAsync() {
         return service.getIntInvalidNull();
     }
+
+    /**
+     * Get integer array value [1, null, 0].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<Integer>> object
+     */
+    public Single<List<Integer>> getIntInvalidNullAsync() {
+        return getIntInvalidNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<Integer>>, List<Integer>>() { public List<Integer> call(RestResponse<Void, List<Integer>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -872,7 +1000,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<Integer>> getIntInvalidStringAsync(final ServiceCallback<List<Integer>> serviceCallback) {
+    public ServiceFuture<List<Integer>> getIntInvalidStringAsync(ServiceCallback<List<Integer>> serviceCallback) {
         return ServiceFuture.fromBody(getIntInvalidStringAsync(), serviceCallback);
     }
 
@@ -880,11 +1008,22 @@ public class ArraysImpl implements Arrays {
      * Get integer array value [1, 'integer', 0].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;Integer&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<Integer>> object
      */
-    public Single<List<Integer>> getIntInvalidStringAsync() {
+    public Single<RestResponse<Void, List<Integer>>> getIntInvalidStringWithRestResponseAsync() {
         return service.getIntInvalidString();
     }
+
+    /**
+     * Get integer array value [1, 'integer', 0].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<Integer>> object
+     */
+    public Single<List<Integer>> getIntInvalidStringAsync() {
+        return getIntInvalidStringWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<Integer>>, List<Integer>>() { public List<Integer> call(RestResponse<Void, List<Integer>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -906,7 +1045,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<Long>> getLongValidAsync(final ServiceCallback<List<Long>> serviceCallback) {
+    public ServiceFuture<List<Long>> getLongValidAsync(ServiceCallback<List<Long>> serviceCallback) {
         return ServiceFuture.fromBody(getLongValidAsync(), serviceCallback);
     }
 
@@ -914,11 +1053,22 @@ public class ArraysImpl implements Arrays {
      * Get integer array value [1, -1, 3, 300].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;Long&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<Long>> object
      */
-    public Single<List<Long>> getLongValidAsync() {
+    public Single<RestResponse<Void, List<Long>>> getLongValidWithRestResponseAsync() {
         return service.getLongValid();
     }
+
+    /**
+     * Get integer array value [1, -1, 3, 300].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<Long>> object
+     */
+    public Single<List<Long>> getLongValidAsync() {
+        return getLongValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<Long>>, List<Long>>() { public List<Long> call(RestResponse<Void, List<Long>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -928,6 +1078,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putLongValid(List<Long> arrayBody) {
         putLongValidAsync(arrayBody).toBlocking().value();
@@ -941,7 +1092,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putLongValidAsync(List<Long> arrayBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putLongValidAsync(List<Long> arrayBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putLongValidAsync(arrayBody), serviceCallback);
     }
 
@@ -950,15 +1101,27 @@ public class ArraysImpl implements Arrays {
      *
      * @param arrayBody the List&lt;Long&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putLongValidAsync(List<Long> arrayBody) {
+    public Single<RestResponse<Void, Void>> putLongValidWithRestResponseAsync(List<Long> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
         Validator.validate(arrayBody);
         return service.putLongValid(arrayBody);
     }
+
+    /**
+     * Set array value empty [1, -1, 3, 300].
+     *
+     * @param arrayBody the List&lt;Long&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putLongValidAsync(List<Long> arrayBody) {
+        return putLongValidWithRestResponseAsync(arrayBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -980,7 +1143,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<Long>> getLongInvalidNullAsync(final ServiceCallback<List<Long>> serviceCallback) {
+    public ServiceFuture<List<Long>> getLongInvalidNullAsync(ServiceCallback<List<Long>> serviceCallback) {
         return ServiceFuture.fromBody(getLongInvalidNullAsync(), serviceCallback);
     }
 
@@ -988,11 +1151,22 @@ public class ArraysImpl implements Arrays {
      * Get long array value [1, null, 0].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;Long&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<Long>> object
      */
-    public Single<List<Long>> getLongInvalidNullAsync() {
+    public Single<RestResponse<Void, List<Long>>> getLongInvalidNullWithRestResponseAsync() {
         return service.getLongInvalidNull();
     }
+
+    /**
+     * Get long array value [1, null, 0].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<Long>> object
+     */
+    public Single<List<Long>> getLongInvalidNullAsync() {
+        return getLongInvalidNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<Long>>, List<Long>>() { public List<Long> call(RestResponse<Void, List<Long>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1014,7 +1188,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<Long>> getLongInvalidStringAsync(final ServiceCallback<List<Long>> serviceCallback) {
+    public ServiceFuture<List<Long>> getLongInvalidStringAsync(ServiceCallback<List<Long>> serviceCallback) {
         return ServiceFuture.fromBody(getLongInvalidStringAsync(), serviceCallback);
     }
 
@@ -1022,11 +1196,22 @@ public class ArraysImpl implements Arrays {
      * Get long array value [1, 'integer', 0].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;Long&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<Long>> object
      */
-    public Single<List<Long>> getLongInvalidStringAsync() {
+    public Single<RestResponse<Void, List<Long>>> getLongInvalidStringWithRestResponseAsync() {
         return service.getLongInvalidString();
     }
+
+    /**
+     * Get long array value [1, 'integer', 0].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<Long>> object
+     */
+    public Single<List<Long>> getLongInvalidStringAsync() {
+        return getLongInvalidStringWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<Long>>, List<Long>>() { public List<Long> call(RestResponse<Void, List<Long>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1048,7 +1233,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<Double>> getFloatValidAsync(final ServiceCallback<List<Double>> serviceCallback) {
+    public ServiceFuture<List<Double>> getFloatValidAsync(ServiceCallback<List<Double>> serviceCallback) {
         return ServiceFuture.fromBody(getFloatValidAsync(), serviceCallback);
     }
 
@@ -1056,11 +1241,22 @@ public class ArraysImpl implements Arrays {
      * Get float array value [0, -0.01, 1.2e20].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;Double&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<Double>> object
      */
-    public Single<List<Double>> getFloatValidAsync() {
+    public Single<RestResponse<Void, List<Double>>> getFloatValidWithRestResponseAsync() {
         return service.getFloatValid();
     }
+
+    /**
+     * Get float array value [0, -0.01, 1.2e20].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<Double>> object
+     */
+    public Single<List<Double>> getFloatValidAsync() {
+        return getFloatValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<Double>>, List<Double>>() { public List<Double> call(RestResponse<Void, List<Double>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1070,6 +1266,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putFloatValid(List<Double> arrayBody) {
         putFloatValidAsync(arrayBody).toBlocking().value();
@@ -1083,7 +1280,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putFloatValidAsync(List<Double> arrayBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putFloatValidAsync(List<Double> arrayBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putFloatValidAsync(arrayBody), serviceCallback);
     }
 
@@ -1092,15 +1289,27 @@ public class ArraysImpl implements Arrays {
      *
      * @param arrayBody the List&lt;Double&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putFloatValidAsync(List<Double> arrayBody) {
+    public Single<RestResponse<Void, Void>> putFloatValidWithRestResponseAsync(List<Double> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
         Validator.validate(arrayBody);
         return service.putFloatValid(arrayBody);
     }
+
+    /**
+     * Set array value [0, -0.01, 1.2e20].
+     *
+     * @param arrayBody the List&lt;Double&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putFloatValidAsync(List<Double> arrayBody) {
+        return putFloatValidWithRestResponseAsync(arrayBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1122,7 +1331,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<Double>> getFloatInvalidNullAsync(final ServiceCallback<List<Double>> serviceCallback) {
+    public ServiceFuture<List<Double>> getFloatInvalidNullAsync(ServiceCallback<List<Double>> serviceCallback) {
         return ServiceFuture.fromBody(getFloatInvalidNullAsync(), serviceCallback);
     }
 
@@ -1130,11 +1339,22 @@ public class ArraysImpl implements Arrays {
      * Get float array value [0.0, null, -1.2e20].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;Double&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<Double>> object
      */
-    public Single<List<Double>> getFloatInvalidNullAsync() {
+    public Single<RestResponse<Void, List<Double>>> getFloatInvalidNullWithRestResponseAsync() {
         return service.getFloatInvalidNull();
     }
+
+    /**
+     * Get float array value [0.0, null, -1.2e20].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<Double>> object
+     */
+    public Single<List<Double>> getFloatInvalidNullAsync() {
+        return getFloatInvalidNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<Double>>, List<Double>>() { public List<Double> call(RestResponse<Void, List<Double>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1156,7 +1376,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<Double>> getFloatInvalidStringAsync(final ServiceCallback<List<Double>> serviceCallback) {
+    public ServiceFuture<List<Double>> getFloatInvalidStringAsync(ServiceCallback<List<Double>> serviceCallback) {
         return ServiceFuture.fromBody(getFloatInvalidStringAsync(), serviceCallback);
     }
 
@@ -1164,11 +1384,22 @@ public class ArraysImpl implements Arrays {
      * Get boolean array value [1.0, 'number', 0.0].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;Double&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<Double>> object
      */
-    public Single<List<Double>> getFloatInvalidStringAsync() {
+    public Single<RestResponse<Void, List<Double>>> getFloatInvalidStringWithRestResponseAsync() {
         return service.getFloatInvalidString();
     }
+
+    /**
+     * Get boolean array value [1.0, 'number', 0.0].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<Double>> object
+     */
+    public Single<List<Double>> getFloatInvalidStringAsync() {
+        return getFloatInvalidStringWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<Double>>, List<Double>>() { public List<Double> call(RestResponse<Void, List<Double>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1190,7 +1421,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<Double>> getDoubleValidAsync(final ServiceCallback<List<Double>> serviceCallback) {
+    public ServiceFuture<List<Double>> getDoubleValidAsync(ServiceCallback<List<Double>> serviceCallback) {
         return ServiceFuture.fromBody(getDoubleValidAsync(), serviceCallback);
     }
 
@@ -1198,11 +1429,22 @@ public class ArraysImpl implements Arrays {
      * Get float array value [0, -0.01, 1.2e20].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;Double&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<Double>> object
      */
-    public Single<List<Double>> getDoubleValidAsync() {
+    public Single<RestResponse<Void, List<Double>>> getDoubleValidWithRestResponseAsync() {
         return service.getDoubleValid();
     }
+
+    /**
+     * Get float array value [0, -0.01, 1.2e20].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<Double>> object
+     */
+    public Single<List<Double>> getDoubleValidAsync() {
+        return getDoubleValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<Double>>, List<Double>>() { public List<Double> call(RestResponse<Void, List<Double>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1212,6 +1454,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putDoubleValid(List<Double> arrayBody) {
         putDoubleValidAsync(arrayBody).toBlocking().value();
@@ -1225,7 +1468,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putDoubleValidAsync(List<Double> arrayBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putDoubleValidAsync(List<Double> arrayBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putDoubleValidAsync(arrayBody), serviceCallback);
     }
 
@@ -1234,15 +1477,27 @@ public class ArraysImpl implements Arrays {
      *
      * @param arrayBody the List&lt;Double&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putDoubleValidAsync(List<Double> arrayBody) {
+    public Single<RestResponse<Void, Void>> putDoubleValidWithRestResponseAsync(List<Double> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
         Validator.validate(arrayBody);
         return service.putDoubleValid(arrayBody);
     }
+
+    /**
+     * Set array value [0, -0.01, 1.2e20].
+     *
+     * @param arrayBody the List&lt;Double&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putDoubleValidAsync(List<Double> arrayBody) {
+        return putDoubleValidWithRestResponseAsync(arrayBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1264,7 +1519,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<Double>> getDoubleInvalidNullAsync(final ServiceCallback<List<Double>> serviceCallback) {
+    public ServiceFuture<List<Double>> getDoubleInvalidNullAsync(ServiceCallback<List<Double>> serviceCallback) {
         return ServiceFuture.fromBody(getDoubleInvalidNullAsync(), serviceCallback);
     }
 
@@ -1272,11 +1527,22 @@ public class ArraysImpl implements Arrays {
      * Get float array value [0.0, null, -1.2e20].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;Double&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<Double>> object
      */
-    public Single<List<Double>> getDoubleInvalidNullAsync() {
+    public Single<RestResponse<Void, List<Double>>> getDoubleInvalidNullWithRestResponseAsync() {
         return service.getDoubleInvalidNull();
     }
+
+    /**
+     * Get float array value [0.0, null, -1.2e20].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<Double>> object
+     */
+    public Single<List<Double>> getDoubleInvalidNullAsync() {
+        return getDoubleInvalidNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<Double>>, List<Double>>() { public List<Double> call(RestResponse<Void, List<Double>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1298,7 +1564,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<Double>> getDoubleInvalidStringAsync(final ServiceCallback<List<Double>> serviceCallback) {
+    public ServiceFuture<List<Double>> getDoubleInvalidStringAsync(ServiceCallback<List<Double>> serviceCallback) {
         return ServiceFuture.fromBody(getDoubleInvalidStringAsync(), serviceCallback);
     }
 
@@ -1306,11 +1572,22 @@ public class ArraysImpl implements Arrays {
      * Get boolean array value [1.0, 'number', 0.0].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;Double&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<Double>> object
      */
-    public Single<List<Double>> getDoubleInvalidStringAsync() {
+    public Single<RestResponse<Void, List<Double>>> getDoubleInvalidStringWithRestResponseAsync() {
         return service.getDoubleInvalidString();
     }
+
+    /**
+     * Get boolean array value [1.0, 'number', 0.0].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<Double>> object
+     */
+    public Single<List<Double>> getDoubleInvalidStringAsync() {
+        return getDoubleInvalidStringWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<Double>>, List<Double>>() { public List<Double> call(RestResponse<Void, List<Double>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1332,7 +1609,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<String>> getStringValidAsync(final ServiceCallback<List<String>> serviceCallback) {
+    public ServiceFuture<List<String>> getStringValidAsync(ServiceCallback<List<String>> serviceCallback) {
         return ServiceFuture.fromBody(getStringValidAsync(), serviceCallback);
     }
 
@@ -1340,11 +1617,22 @@ public class ArraysImpl implements Arrays {
      * Get string array value ['foo1', 'foo2', 'foo3'].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;String&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<String>> object
      */
-    public Single<List<String>> getStringValidAsync() {
+    public Single<RestResponse<Void, List<String>>> getStringValidWithRestResponseAsync() {
         return service.getStringValid();
     }
+
+    /**
+     * Get string array value ['foo1', 'foo2', 'foo3'].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<String>> object
+     */
+    public Single<List<String>> getStringValidAsync() {
+        return getStringValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<String>>, List<String>>() { public List<String> call(RestResponse<Void, List<String>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1354,6 +1642,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putStringValid(List<String> arrayBody) {
         putStringValidAsync(arrayBody).toBlocking().value();
@@ -1367,7 +1656,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putStringValidAsync(List<String> arrayBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putStringValidAsync(List<String> arrayBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putStringValidAsync(arrayBody), serviceCallback);
     }
 
@@ -1376,15 +1665,27 @@ public class ArraysImpl implements Arrays {
      *
      * @param arrayBody the List&lt;String&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putStringValidAsync(List<String> arrayBody) {
+    public Single<RestResponse<Void, Void>> putStringValidWithRestResponseAsync(List<String> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
         Validator.validate(arrayBody);
         return service.putStringValid(arrayBody);
     }
+
+    /**
+     * Set array value ['foo1', 'foo2', 'foo3'].
+     *
+     * @param arrayBody the List&lt;String&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putStringValidAsync(List<String> arrayBody) {
+        return putStringValidWithRestResponseAsync(arrayBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1406,7 +1707,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<String>> getStringWithNullAsync(final ServiceCallback<List<String>> serviceCallback) {
+    public ServiceFuture<List<String>> getStringWithNullAsync(ServiceCallback<List<String>> serviceCallback) {
         return ServiceFuture.fromBody(getStringWithNullAsync(), serviceCallback);
     }
 
@@ -1414,11 +1715,22 @@ public class ArraysImpl implements Arrays {
      * Get string array value ['foo', null, 'foo2'].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;String&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<String>> object
      */
-    public Single<List<String>> getStringWithNullAsync() {
+    public Single<RestResponse<Void, List<String>>> getStringWithNullWithRestResponseAsync() {
         return service.getStringWithNull();
     }
+
+    /**
+     * Get string array value ['foo', null, 'foo2'].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<String>> object
+     */
+    public Single<List<String>> getStringWithNullAsync() {
+        return getStringWithNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<String>>, List<String>>() { public List<String> call(RestResponse<Void, List<String>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1440,7 +1752,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<String>> getStringWithInvalidAsync(final ServiceCallback<List<String>> serviceCallback) {
+    public ServiceFuture<List<String>> getStringWithInvalidAsync(ServiceCallback<List<String>> serviceCallback) {
         return ServiceFuture.fromBody(getStringWithInvalidAsync(), serviceCallback);
     }
 
@@ -1448,11 +1760,22 @@ public class ArraysImpl implements Arrays {
      * Get string array value ['foo', 123, 'foo2'].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;String&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<String>> object
      */
-    public Single<List<String>> getStringWithInvalidAsync() {
+    public Single<RestResponse<Void, List<String>>> getStringWithInvalidWithRestResponseAsync() {
         return service.getStringWithInvalid();
     }
+
+    /**
+     * Get string array value ['foo', 123, 'foo2'].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<String>> object
+     */
+    public Single<List<String>> getStringWithInvalidAsync() {
+        return getStringWithInvalidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<String>>, List<String>>() { public List<String> call(RestResponse<Void, List<String>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1474,7 +1797,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<UUID>> getUuidValidAsync(final ServiceCallback<List<UUID>> serviceCallback) {
+    public ServiceFuture<List<UUID>> getUuidValidAsync(ServiceCallback<List<UUID>> serviceCallback) {
         return ServiceFuture.fromBody(getUuidValidAsync(), serviceCallback);
     }
 
@@ -1482,11 +1805,22 @@ public class ArraysImpl implements Arrays {
      * Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205'].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;UUID&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<UUID>> object
      */
-    public Single<List<UUID>> getUuidValidAsync() {
+    public Single<RestResponse<Void, List<UUID>>> getUuidValidWithRestResponseAsync() {
         return service.getUuidValid();
     }
+
+    /**
+     * Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205'].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<UUID>> object
+     */
+    public Single<List<UUID>> getUuidValidAsync() {
+        return getUuidValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<UUID>>, List<UUID>>() { public List<UUID> call(RestResponse<Void, List<UUID>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1496,6 +1830,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putUuidValid(List<UUID> arrayBody) {
         putUuidValidAsync(arrayBody).toBlocking().value();
@@ -1509,7 +1844,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putUuidValidAsync(List<UUID> arrayBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putUuidValidAsync(List<UUID> arrayBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putUuidValidAsync(arrayBody), serviceCallback);
     }
 
@@ -1518,15 +1853,27 @@ public class ArraysImpl implements Arrays {
      *
      * @param arrayBody the List&lt;UUID&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putUuidValidAsync(List<UUID> arrayBody) {
+    public Single<RestResponse<Void, Void>> putUuidValidWithRestResponseAsync(List<UUID> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
         Validator.validate(arrayBody);
         return service.putUuidValid(arrayBody);
     }
+
+    /**
+     * Set array value  ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205'].
+     *
+     * @param arrayBody the List&lt;UUID&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putUuidValidAsync(List<UUID> arrayBody) {
+        return putUuidValidWithRestResponseAsync(arrayBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1548,7 +1895,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<UUID>> getUuidInvalidCharsAsync(final ServiceCallback<List<UUID>> serviceCallback) {
+    public ServiceFuture<List<UUID>> getUuidInvalidCharsAsync(ServiceCallback<List<UUID>> serviceCallback) {
         return ServiceFuture.fromBody(getUuidInvalidCharsAsync(), serviceCallback);
     }
 
@@ -1556,11 +1903,22 @@ public class ArraysImpl implements Arrays {
      * Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'foo'].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;UUID&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<UUID>> object
      */
-    public Single<List<UUID>> getUuidInvalidCharsAsync() {
+    public Single<RestResponse<Void, List<UUID>>> getUuidInvalidCharsWithRestResponseAsync() {
         return service.getUuidInvalidChars();
     }
+
+    /**
+     * Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'foo'].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<UUID>> object
+     */
+    public Single<List<UUID>> getUuidInvalidCharsAsync() {
+        return getUuidInvalidCharsWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<UUID>>, List<UUID>>() { public List<UUID> call(RestResponse<Void, List<UUID>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1582,7 +1940,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<LocalDate>> getDateValidAsync(final ServiceCallback<List<LocalDate>> serviceCallback) {
+    public ServiceFuture<List<LocalDate>> getDateValidAsync(ServiceCallback<List<LocalDate>> serviceCallback) {
         return ServiceFuture.fromBody(getDateValidAsync(), serviceCallback);
     }
 
@@ -1590,11 +1948,22 @@ public class ArraysImpl implements Arrays {
      * Get integer array value ['2000-12-01', '1980-01-02', '1492-10-12'].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;LocalDate&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<LocalDate>> object
      */
-    public Single<List<LocalDate>> getDateValidAsync() {
+    public Single<RestResponse<Void, List<LocalDate>>> getDateValidWithRestResponseAsync() {
         return service.getDateValid();
     }
+
+    /**
+     * Get integer array value ['2000-12-01', '1980-01-02', '1492-10-12'].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<LocalDate>> object
+     */
+    public Single<List<LocalDate>> getDateValidAsync() {
+        return getDateValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<LocalDate>>, List<LocalDate>>() { public List<LocalDate> call(RestResponse<Void, List<LocalDate>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1604,6 +1973,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putDateValid(List<LocalDate> arrayBody) {
         putDateValidAsync(arrayBody).toBlocking().value();
@@ -1617,7 +1987,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putDateValidAsync(List<LocalDate> arrayBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putDateValidAsync(List<LocalDate> arrayBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putDateValidAsync(arrayBody), serviceCallback);
     }
 
@@ -1626,15 +1996,27 @@ public class ArraysImpl implements Arrays {
      *
      * @param arrayBody the List&lt;LocalDate&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putDateValidAsync(List<LocalDate> arrayBody) {
+    public Single<RestResponse<Void, Void>> putDateValidWithRestResponseAsync(List<LocalDate> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
         Validator.validate(arrayBody);
         return service.putDateValid(arrayBody);
     }
+
+    /**
+     * Set array value  ['2000-12-01', '1980-01-02', '1492-10-12'].
+     *
+     * @param arrayBody the List&lt;LocalDate&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putDateValidAsync(List<LocalDate> arrayBody) {
+        return putDateValidWithRestResponseAsync(arrayBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1656,7 +2038,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<LocalDate>> getDateInvalidNullAsync(final ServiceCallback<List<LocalDate>> serviceCallback) {
+    public ServiceFuture<List<LocalDate>> getDateInvalidNullAsync(ServiceCallback<List<LocalDate>> serviceCallback) {
         return ServiceFuture.fromBody(getDateInvalidNullAsync(), serviceCallback);
     }
 
@@ -1664,11 +2046,22 @@ public class ArraysImpl implements Arrays {
      * Get date array value ['2012-01-01', null, '1776-07-04'].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;LocalDate&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<LocalDate>> object
      */
-    public Single<List<LocalDate>> getDateInvalidNullAsync() {
+    public Single<RestResponse<Void, List<LocalDate>>> getDateInvalidNullWithRestResponseAsync() {
         return service.getDateInvalidNull();
     }
+
+    /**
+     * Get date array value ['2012-01-01', null, '1776-07-04'].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<LocalDate>> object
+     */
+    public Single<List<LocalDate>> getDateInvalidNullAsync() {
+        return getDateInvalidNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<LocalDate>>, List<LocalDate>>() { public List<LocalDate> call(RestResponse<Void, List<LocalDate>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1690,7 +2083,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<LocalDate>> getDateInvalidCharsAsync(final ServiceCallback<List<LocalDate>> serviceCallback) {
+    public ServiceFuture<List<LocalDate>> getDateInvalidCharsAsync(ServiceCallback<List<LocalDate>> serviceCallback) {
         return ServiceFuture.fromBody(getDateInvalidCharsAsync(), serviceCallback);
     }
 
@@ -1698,11 +2091,22 @@ public class ArraysImpl implements Arrays {
      * Get date array value ['2011-03-22', 'date'].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;LocalDate&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<LocalDate>> object
      */
-    public Single<List<LocalDate>> getDateInvalidCharsAsync() {
+    public Single<RestResponse<Void, List<LocalDate>>> getDateInvalidCharsWithRestResponseAsync() {
         return service.getDateInvalidChars();
     }
+
+    /**
+     * Get date array value ['2011-03-22', 'date'].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<LocalDate>> object
+     */
+    public Single<List<LocalDate>> getDateInvalidCharsAsync() {
+        return getDateInvalidCharsWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<LocalDate>>, List<LocalDate>>() { public List<LocalDate> call(RestResponse<Void, List<LocalDate>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1724,7 +2128,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<DateTime>> getDateTimeValidAsync(final ServiceCallback<List<DateTime>> serviceCallback) {
+    public ServiceFuture<List<DateTime>> getDateTimeValidAsync(ServiceCallback<List<DateTime>> serviceCallback) {
         return ServiceFuture.fromBody(getDateTimeValidAsync(), serviceCallback);
     }
 
@@ -1732,11 +2136,22 @@ public class ArraysImpl implements Arrays {
      * Get date-time array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00'].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;DateTime&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<DateTime>> object
      */
-    public Single<List<DateTime>> getDateTimeValidAsync() {
+    public Single<RestResponse<Void, List<DateTime>>> getDateTimeValidWithRestResponseAsync() {
         return service.getDateTimeValid();
     }
+
+    /**
+     * Get date-time array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00'].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<DateTime>> object
+     */
+    public Single<List<DateTime>> getDateTimeValidAsync() {
+        return getDateTimeValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<DateTime>>, List<DateTime>>() { public List<DateTime> call(RestResponse<Void, List<DateTime>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1746,6 +2161,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putDateTimeValid(List<DateTime> arrayBody) {
         putDateTimeValidAsync(arrayBody).toBlocking().value();
@@ -1759,7 +2175,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putDateTimeValidAsync(List<DateTime> arrayBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putDateTimeValidAsync(List<DateTime> arrayBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putDateTimeValidAsync(arrayBody), serviceCallback);
     }
 
@@ -1768,15 +2184,27 @@ public class ArraysImpl implements Arrays {
      *
      * @param arrayBody the List&lt;DateTime&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putDateTimeValidAsync(List<DateTime> arrayBody) {
+    public Single<RestResponse<Void, Void>> putDateTimeValidWithRestResponseAsync(List<DateTime> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
         Validator.validate(arrayBody);
         return service.putDateTimeValid(arrayBody);
     }
+
+    /**
+     * Set array value  ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00'].
+     *
+     * @param arrayBody the List&lt;DateTime&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putDateTimeValidAsync(List<DateTime> arrayBody) {
+        return putDateTimeValidWithRestResponseAsync(arrayBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1798,7 +2226,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<DateTime>> getDateTimeInvalidNullAsync(final ServiceCallback<List<DateTime>> serviceCallback) {
+    public ServiceFuture<List<DateTime>> getDateTimeInvalidNullAsync(ServiceCallback<List<DateTime>> serviceCallback) {
         return ServiceFuture.fromBody(getDateTimeInvalidNullAsync(), serviceCallback);
     }
 
@@ -1806,11 +2234,22 @@ public class ArraysImpl implements Arrays {
      * Get date array value ['2000-12-01t00:00:01z', null].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;DateTime&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<DateTime>> object
      */
-    public Single<List<DateTime>> getDateTimeInvalidNullAsync() {
+    public Single<RestResponse<Void, List<DateTime>>> getDateTimeInvalidNullWithRestResponseAsync() {
         return service.getDateTimeInvalidNull();
     }
+
+    /**
+     * Get date array value ['2000-12-01t00:00:01z', null].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<DateTime>> object
+     */
+    public Single<List<DateTime>> getDateTimeInvalidNullAsync() {
+        return getDateTimeInvalidNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<DateTime>>, List<DateTime>>() { public List<DateTime> call(RestResponse<Void, List<DateTime>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1832,7 +2271,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<DateTime>> getDateTimeInvalidCharsAsync(final ServiceCallback<List<DateTime>> serviceCallback) {
+    public ServiceFuture<List<DateTime>> getDateTimeInvalidCharsAsync(ServiceCallback<List<DateTime>> serviceCallback) {
         return ServiceFuture.fromBody(getDateTimeInvalidCharsAsync(), serviceCallback);
     }
 
@@ -1840,11 +2279,22 @@ public class ArraysImpl implements Arrays {
      * Get date array value ['2000-12-01t00:00:01z', 'date-time'].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;DateTime&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<DateTime>> object
      */
-    public Single<List<DateTime>> getDateTimeInvalidCharsAsync() {
+    public Single<RestResponse<Void, List<DateTime>>> getDateTimeInvalidCharsWithRestResponseAsync() {
         return service.getDateTimeInvalidChars();
     }
+
+    /**
+     * Get date array value ['2000-12-01t00:00:01z', 'date-time'].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<DateTime>> object
+     */
+    public Single<List<DateTime>> getDateTimeInvalidCharsAsync() {
+        return getDateTimeInvalidCharsWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<DateTime>>, List<DateTime>>() { public List<DateTime> call(RestResponse<Void, List<DateTime>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1866,7 +2316,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<DateTime>> getDateTimeRfc1123ValidAsync(final ServiceCallback<List<DateTime>> serviceCallback) {
+    public ServiceFuture<List<DateTime>> getDateTimeRfc1123ValidAsync(ServiceCallback<List<DateTime>> serviceCallback) {
         return ServiceFuture.fromBody(getDateTimeRfc1123ValidAsync(), serviceCallback);
     }
 
@@ -1874,11 +2324,22 @@ public class ArraysImpl implements Arrays {
      * Get date-time array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01 GMT'].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;DateTime&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<DateTime>> object
      */
-    public Single<List<DateTime>> getDateTimeRfc1123ValidAsync() {
+    public Single<RestResponse<Void, List<DateTime>>> getDateTimeRfc1123ValidWithRestResponseAsync() {
         return service.getDateTimeRfc1123Valid();
     }
+
+    /**
+     * Get date-time array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01 GMT'].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<DateTime>> object
+     */
+    public Single<List<DateTime>> getDateTimeRfc1123ValidAsync() {
+        return getDateTimeRfc1123ValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<DateTime>>, List<DateTime>>() { public List<DateTime> call(RestResponse<Void, List<DateTime>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1888,6 +2349,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putDateTimeRfc1123Valid(List<DateTime> arrayBody) {
         putDateTimeRfc1123ValidAsync(arrayBody).toBlocking().value();
@@ -1901,7 +2363,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putDateTimeRfc1123ValidAsync(List<DateTime> arrayBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putDateTimeRfc1123ValidAsync(List<DateTime> arrayBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putDateTimeRfc1123ValidAsync(arrayBody), serviceCallback);
     }
 
@@ -1910,20 +2372,32 @@ public class ArraysImpl implements Arrays {
      *
      * @param arrayBody the List&lt;DateTimeRfc1123&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putDateTimeRfc1123ValidAsync(List<DateTime> arrayBody) {
+    public Single<RestResponse<Void, Void>> putDateTimeRfc1123ValidWithRestResponseAsync(List<DateTime> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
         Validator.validate(arrayBody);
-        List<DateTimeRfc1123> arrayBodyConverted = new ArrayList<DateTimeRfc1123>();
-        for (DateTime item : arrayBody) {
-            DateTimeRfc1123 value = new DateTimeRfc1123(item);
-            arrayBodyConverted.add(value);
-        }
+    List<DateTimeRfc1123> arrayBodyConverted = new ArrayList<DateTimeRfc1123>();
+    for (DateTime item : arrayBody) {
+        DateTimeRfc1123 value = new DateTimeRfc1123(item);
+        arrayBodyConverted.add(value);
+    }
         return service.putDateTimeRfc1123Valid(arrayBodyConverted);
     }
+
+    /**
+     * Set array value  ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01 GMT'].
+     *
+     * @param arrayBody the List&lt;DateTimeRfc1123&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putDateTimeRfc1123ValidAsync(List<DateTime> arrayBody) {
+        return putDateTimeRfc1123ValidWithRestResponseAsync(arrayBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1945,7 +2419,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<Period>> getDurationValidAsync(final ServiceCallback<List<Period>> serviceCallback) {
+    public ServiceFuture<List<Period>> getDurationValidAsync(ServiceCallback<List<Period>> serviceCallback) {
         return ServiceFuture.fromBody(getDurationValidAsync(), serviceCallback);
     }
 
@@ -1953,11 +2427,22 @@ public class ArraysImpl implements Arrays {
      * Get duration array value ['P123DT22H14M12.011S', 'P5DT1H0M0S'].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;Period&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<Period>> object
      */
-    public Single<List<Period>> getDurationValidAsync() {
+    public Single<RestResponse<Void, List<Period>>> getDurationValidWithRestResponseAsync() {
         return service.getDurationValid();
     }
+
+    /**
+     * Get duration array value ['P123DT22H14M12.011S', 'P5DT1H0M0S'].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<Period>> object
+     */
+    public Single<List<Period>> getDurationValidAsync() {
+        return getDurationValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<Period>>, List<Period>>() { public List<Period> call(RestResponse<Void, List<Period>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1967,6 +2452,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putDurationValid(List<Period> arrayBody) {
         putDurationValidAsync(arrayBody).toBlocking().value();
@@ -1980,7 +2466,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putDurationValidAsync(List<Period> arrayBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putDurationValidAsync(List<Period> arrayBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putDurationValidAsync(arrayBody), serviceCallback);
     }
 
@@ -1989,15 +2475,27 @@ public class ArraysImpl implements Arrays {
      *
      * @param arrayBody the List&lt;Period&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putDurationValidAsync(List<Period> arrayBody) {
+    public Single<RestResponse<Void, Void>> putDurationValidWithRestResponseAsync(List<Period> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
         Validator.validate(arrayBody);
         return service.putDurationValid(arrayBody);
     }
+
+    /**
+     * Set array value  ['P123DT22H14M12.011S', 'P5DT1H0M0S'].
+     *
+     * @param arrayBody the List&lt;Period&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putDurationValidAsync(List<Period> arrayBody) {
+        return putDurationValidWithRestResponseAsync(arrayBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2019,7 +2517,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<byte[]>> getByteValidAsync(final ServiceCallback<List<byte[]>> serviceCallback) {
+    public ServiceFuture<List<byte[]>> getByteValidAsync(ServiceCallback<List<byte[]>> serviceCallback) {
         return ServiceFuture.fromBody(getByteValidAsync(), serviceCallback);
     }
 
@@ -2027,11 +2525,22 @@ public class ArraysImpl implements Arrays {
      * Get byte array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each item encoded in base64.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;byte[]&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<byte[]>> object
      */
-    public Single<List<byte[]>> getByteValidAsync() {
+    public Single<RestResponse<Void, List<byte[]>>> getByteValidWithRestResponseAsync() {
         return service.getByteValid();
     }
+
+    /**
+     * Get byte array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each item encoded in base64.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<byte[]>> object
+     */
+    public Single<List<byte[]>> getByteValidAsync() {
+        return getByteValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<byte[]>>, List<byte[]>>() { public List<byte[]> call(RestResponse<Void, List<byte[]>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2041,6 +2550,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putByteValid(List<byte[]> arrayBody) {
         putByteValidAsync(arrayBody).toBlocking().value();
@@ -2054,7 +2564,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putByteValidAsync(List<byte[]> arrayBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putByteValidAsync(List<byte[]> arrayBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putByteValidAsync(arrayBody), serviceCallback);
     }
 
@@ -2063,15 +2573,27 @@ public class ArraysImpl implements Arrays {
      *
      * @param arrayBody the List&lt;byte[]&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putByteValidAsync(List<byte[]> arrayBody) {
+    public Single<RestResponse<Void, Void>> putByteValidWithRestResponseAsync(List<byte[]> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
         Validator.validate(arrayBody);
         return service.putByteValid(arrayBody);
     }
+
+    /**
+     * Put the array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64.
+     *
+     * @param arrayBody the List&lt;byte[]&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putByteValidAsync(List<byte[]> arrayBody) {
+        return putByteValidWithRestResponseAsync(arrayBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2093,7 +2615,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<byte[]>> getByteInvalidNullAsync(final ServiceCallback<List<byte[]>> serviceCallback) {
+    public ServiceFuture<List<byte[]>> getByteInvalidNullAsync(ServiceCallback<List<byte[]>> serviceCallback) {
         return ServiceFuture.fromBody(getByteInvalidNullAsync(), serviceCallback);
     }
 
@@ -2101,11 +2623,22 @@ public class ArraysImpl implements Arrays {
      * Get byte array value [hex(AB, AC, AD), null] with the first item base64 encoded.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;byte[]&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<byte[]>> object
      */
-    public Single<List<byte[]>> getByteInvalidNullAsync() {
+    public Single<RestResponse<Void, List<byte[]>>> getByteInvalidNullWithRestResponseAsync() {
         return service.getByteInvalidNull();
     }
+
+    /**
+     * Get byte array value [hex(AB, AC, AD), null] with the first item base64 encoded.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<byte[]>> object
+     */
+    public Single<List<byte[]>> getByteInvalidNullAsync() {
+        return getByteInvalidNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<byte[]>>, List<byte[]>>() { public List<byte[]> call(RestResponse<Void, List<byte[]>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2127,7 +2660,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<byte[]>> getBase64UrlAsync(final ServiceCallback<List<byte[]>> serviceCallback) {
+    public ServiceFuture<List<byte[]>> getBase64UrlAsync(ServiceCallback<List<byte[]>> serviceCallback) {
         return ServiceFuture.fromBody(getBase64UrlAsync(), serviceCallback);
     }
 
@@ -2135,11 +2668,22 @@ public class ArraysImpl implements Arrays {
      * Get array value ['a string that gets encoded with base64url', 'test string' 'Lorem ipsum'] with the items base64url encoded.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;byte[]&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<byte[]>> object
      */
-    public Single<List<byte[]>> getBase64UrlAsync() {
+    public Single<RestResponse<Void, List<byte[]>>> getBase64UrlWithRestResponseAsync() {
         return service.getBase64Url();
     }
+
+    /**
+     * Get array value ['a string that gets encoded with base64url', 'test string' 'Lorem ipsum'] with the items base64url encoded.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<byte[]>> object
+     */
+    public Single<List<byte[]>> getBase64UrlAsync() {
+        return getBase64UrlWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<byte[]>>, List<byte[]>>() { public List<byte[]> call(RestResponse<Void, List<byte[]>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2161,7 +2705,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<Product>> getComplexNullAsync(final ServiceCallback<List<Product>> serviceCallback) {
+    public ServiceFuture<List<Product>> getComplexNullAsync(ServiceCallback<List<Product>> serviceCallback) {
         return ServiceFuture.fromBody(getComplexNullAsync(), serviceCallback);
     }
 
@@ -2169,11 +2713,22 @@ public class ArraysImpl implements Arrays {
      * Get array of complex type null value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<Product>> object
      */
-    public Single<List<Product>> getComplexNullAsync() {
+    public Single<RestResponse<Void, List<Product>>> getComplexNullWithRestResponseAsync() {
         return service.getComplexNull();
     }
+
+    /**
+     * Get array of complex type null value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<Product>> object
+     */
+    public Single<List<Product>> getComplexNullAsync() {
+        return getComplexNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<Product>>, List<Product>>() { public List<Product> call(RestResponse<Void, List<Product>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2195,7 +2750,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<Product>> getComplexEmptyAsync(final ServiceCallback<List<Product>> serviceCallback) {
+    public ServiceFuture<List<Product>> getComplexEmptyAsync(ServiceCallback<List<Product>> serviceCallback) {
         return ServiceFuture.fromBody(getComplexEmptyAsync(), serviceCallback);
     }
 
@@ -2203,11 +2758,22 @@ public class ArraysImpl implements Arrays {
      * Get empty array of complex type [].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<Product>> object
      */
-    public Single<List<Product>> getComplexEmptyAsync() {
+    public Single<RestResponse<Void, List<Product>>> getComplexEmptyWithRestResponseAsync() {
         return service.getComplexEmpty();
     }
+
+    /**
+     * Get empty array of complex type [].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<Product>> object
+     */
+    public Single<List<Product>> getComplexEmptyAsync() {
+        return getComplexEmptyWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<Product>>, List<Product>>() { public List<Product> call(RestResponse<Void, List<Product>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2229,7 +2795,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<Product>> getComplexItemNullAsync(final ServiceCallback<List<Product>> serviceCallback) {
+    public ServiceFuture<List<Product>> getComplexItemNullAsync(ServiceCallback<List<Product>> serviceCallback) {
         return ServiceFuture.fromBody(getComplexItemNullAsync(), serviceCallback);
     }
 
@@ -2237,11 +2803,22 @@ public class ArraysImpl implements Arrays {
      * Get array of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5, 'string': '6'}].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<Product>> object
      */
-    public Single<List<Product>> getComplexItemNullAsync() {
+    public Single<RestResponse<Void, List<Product>>> getComplexItemNullWithRestResponseAsync() {
         return service.getComplexItemNull();
     }
+
+    /**
+     * Get array of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5, 'string': '6'}].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<Product>> object
+     */
+    public Single<List<Product>> getComplexItemNullAsync() {
+        return getComplexItemNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<Product>>, List<Product>>() { public List<Product> call(RestResponse<Void, List<Product>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2263,7 +2840,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<Product>> getComplexItemEmptyAsync(final ServiceCallback<List<Product>> serviceCallback) {
+    public ServiceFuture<List<Product>> getComplexItemEmptyAsync(ServiceCallback<List<Product>> serviceCallback) {
         return ServiceFuture.fromBody(getComplexItemEmptyAsync(), serviceCallback);
     }
 
@@ -2271,11 +2848,22 @@ public class ArraysImpl implements Arrays {
      * Get array of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5, 'string': '6'}].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<Product>> object
      */
-    public Single<List<Product>> getComplexItemEmptyAsync() {
+    public Single<RestResponse<Void, List<Product>>> getComplexItemEmptyWithRestResponseAsync() {
         return service.getComplexItemEmpty();
     }
+
+    /**
+     * Get array of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5, 'string': '6'}].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<Product>> object
+     */
+    public Single<List<Product>> getComplexItemEmptyAsync() {
+        return getComplexItemEmptyWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<Product>>, List<Product>>() { public List<Product> call(RestResponse<Void, List<Product>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2297,7 +2885,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<Product>> getComplexValidAsync(final ServiceCallback<List<Product>> serviceCallback) {
+    public ServiceFuture<List<Product>> getComplexValidAsync(ServiceCallback<List<Product>> serviceCallback) {
         return ServiceFuture.fromBody(getComplexValidAsync(), serviceCallback);
     }
 
@@ -2305,11 +2893,22 @@ public class ArraysImpl implements Arrays {
      * Get array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;Product&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<Product>> object
      */
-    public Single<List<Product>> getComplexValidAsync() {
+    public Single<RestResponse<Void, List<Product>>> getComplexValidWithRestResponseAsync() {
         return service.getComplexValid();
     }
+
+    /**
+     * Get array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<Product>> object
+     */
+    public Single<List<Product>> getComplexValidAsync() {
+        return getComplexValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<Product>>, List<Product>>() { public List<Product> call(RestResponse<Void, List<Product>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2319,6 +2918,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putComplexValid(List<Product> arrayBody) {
         putComplexValidAsync(arrayBody).toBlocking().value();
@@ -2332,7 +2932,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putComplexValidAsync(List<Product> arrayBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putComplexValidAsync(List<Product> arrayBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putComplexValidAsync(arrayBody), serviceCallback);
     }
 
@@ -2341,15 +2941,27 @@ public class ArraysImpl implements Arrays {
      *
      * @param arrayBody the List&lt;Product&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putComplexValidAsync(List<Product> arrayBody) {
+    public Single<RestResponse<Void, Void>> putComplexValidWithRestResponseAsync(List<Product> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
         Validator.validate(arrayBody);
         return service.putComplexValid(arrayBody);
     }
+
+    /**
+     * Put an array of complex type with values [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}].
+     *
+     * @param arrayBody the List&lt;Product&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putComplexValidAsync(List<Product> arrayBody) {
+        return putComplexValidWithRestResponseAsync(arrayBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2371,7 +2983,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<List<String>>> getArrayNullAsync(final ServiceCallback<List<List<String>>> serviceCallback) {
+    public ServiceFuture<List<List<String>>> getArrayNullAsync(ServiceCallback<List<List<String>>> serviceCallback) {
         return ServiceFuture.fromBody(getArrayNullAsync(), serviceCallback);
     }
 
@@ -2379,11 +2991,22 @@ public class ArraysImpl implements Arrays {
      * Get a null array.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;List&lt;String&gt;&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<List<String>>> object
      */
-    public Single<List<List<String>>> getArrayNullAsync() {
+    public Single<RestResponse<Void, List<List<String>>>> getArrayNullWithRestResponseAsync() {
         return service.getArrayNull();
     }
+
+    /**
+     * Get a null array.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<List<String>>> object
+     */
+    public Single<List<List<String>>> getArrayNullAsync() {
+        return getArrayNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<List<String>>>, List<List<String>>>() { public List<List<String>> call(RestResponse<Void, List<List<String>>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2405,7 +3028,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<List<String>>> getArrayEmptyAsync(final ServiceCallback<List<List<String>>> serviceCallback) {
+    public ServiceFuture<List<List<String>>> getArrayEmptyAsync(ServiceCallback<List<List<String>>> serviceCallback) {
         return ServiceFuture.fromBody(getArrayEmptyAsync(), serviceCallback);
     }
 
@@ -2413,11 +3036,22 @@ public class ArraysImpl implements Arrays {
      * Get an empty array [].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;List&lt;String&gt;&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<List<String>>> object
      */
-    public Single<List<List<String>>> getArrayEmptyAsync() {
+    public Single<RestResponse<Void, List<List<String>>>> getArrayEmptyWithRestResponseAsync() {
         return service.getArrayEmpty();
     }
+
+    /**
+     * Get an empty array [].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<List<String>>> object
+     */
+    public Single<List<List<String>>> getArrayEmptyAsync() {
+        return getArrayEmptyWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<List<String>>>, List<List<String>>>() { public List<List<String>> call(RestResponse<Void, List<List<String>>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2439,7 +3073,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<List<String>>> getArrayItemNullAsync(final ServiceCallback<List<List<String>>> serviceCallback) {
+    public ServiceFuture<List<List<String>>> getArrayItemNullAsync(ServiceCallback<List<List<String>>> serviceCallback) {
         return ServiceFuture.fromBody(getArrayItemNullAsync(), serviceCallback);
     }
 
@@ -2447,11 +3081,22 @@ public class ArraysImpl implements Arrays {
      * Get an array of array of strings [['1', '2', '3'], null, ['7', '8', '9']].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;List&lt;String&gt;&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<List<String>>> object
      */
-    public Single<List<List<String>>> getArrayItemNullAsync() {
+    public Single<RestResponse<Void, List<List<String>>>> getArrayItemNullWithRestResponseAsync() {
         return service.getArrayItemNull();
     }
+
+    /**
+     * Get an array of array of strings [['1', '2', '3'], null, ['7', '8', '9']].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<List<String>>> object
+     */
+    public Single<List<List<String>>> getArrayItemNullAsync() {
+        return getArrayItemNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<List<String>>>, List<List<String>>>() { public List<List<String>> call(RestResponse<Void, List<List<String>>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2473,7 +3118,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<List<String>>> getArrayItemEmptyAsync(final ServiceCallback<List<List<String>>> serviceCallback) {
+    public ServiceFuture<List<List<String>>> getArrayItemEmptyAsync(ServiceCallback<List<List<String>>> serviceCallback) {
         return ServiceFuture.fromBody(getArrayItemEmptyAsync(), serviceCallback);
     }
 
@@ -2481,11 +3126,22 @@ public class ArraysImpl implements Arrays {
      * Get an array of array of strings [['1', '2', '3'], [], ['7', '8', '9']].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;List&lt;String&gt;&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<List<String>>> object
      */
-    public Single<List<List<String>>> getArrayItemEmptyAsync() {
+    public Single<RestResponse<Void, List<List<String>>>> getArrayItemEmptyWithRestResponseAsync() {
         return service.getArrayItemEmpty();
     }
+
+    /**
+     * Get an array of array of strings [['1', '2', '3'], [], ['7', '8', '9']].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<List<String>>> object
+     */
+    public Single<List<List<String>>> getArrayItemEmptyAsync() {
+        return getArrayItemEmptyWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<List<String>>>, List<List<String>>>() { public List<List<String>> call(RestResponse<Void, List<List<String>>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2507,7 +3163,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<List<String>>> getArrayValidAsync(final ServiceCallback<List<List<String>>> serviceCallback) {
+    public ServiceFuture<List<List<String>>> getArrayValidAsync(ServiceCallback<List<List<String>>> serviceCallback) {
         return ServiceFuture.fromBody(getArrayValidAsync(), serviceCallback);
     }
 
@@ -2515,11 +3171,22 @@ public class ArraysImpl implements Arrays {
      * Get an array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;List&lt;String&gt;&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<List<String>>> object
      */
-    public Single<List<List<String>>> getArrayValidAsync() {
+    public Single<RestResponse<Void, List<List<String>>>> getArrayValidWithRestResponseAsync() {
         return service.getArrayValid();
     }
+
+    /**
+     * Get an array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<List<String>>> object
+     */
+    public Single<List<List<String>>> getArrayValidAsync() {
+        return getArrayValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<List<String>>>, List<List<String>>>() { public List<List<String>> call(RestResponse<Void, List<List<String>>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2529,6 +3196,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putArrayValid(List<List<String>> arrayBody) {
         putArrayValidAsync(arrayBody).toBlocking().value();
@@ -2542,7 +3210,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putArrayValidAsync(List<List<String>> arrayBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putArrayValidAsync(List<List<String>> arrayBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putArrayValidAsync(arrayBody), serviceCallback);
     }
 
@@ -2551,15 +3219,27 @@ public class ArraysImpl implements Arrays {
      *
      * @param arrayBody the List&lt;List&lt;String&gt;&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putArrayValidAsync(List<List<String>> arrayBody) {
+    public Single<RestResponse<Void, Void>> putArrayValidWithRestResponseAsync(List<List<String>> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
         Validator.validate(arrayBody);
         return service.putArrayValid(arrayBody);
     }
+
+    /**
+     * Put An array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']].
+     *
+     * @param arrayBody the List&lt;List&lt;String&gt;&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putArrayValidAsync(List<List<String>> arrayBody) {
+        return putArrayValidWithRestResponseAsync(arrayBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2581,7 +3261,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<Map<String, String>>> getDictionaryNullAsync(final ServiceCallback<List<Map<String, String>>> serviceCallback) {
+    public ServiceFuture<List<Map<String, String>>> getDictionaryNullAsync(ServiceCallback<List<Map<String, String>>> serviceCallback) {
         return ServiceFuture.fromBody(getDictionaryNullAsync(), serviceCallback);
     }
 
@@ -2589,11 +3269,22 @@ public class ArraysImpl implements Arrays {
      * Get an array of Dictionaries with value null.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<Map<String, String>>> object
      */
-    public Single<List<Map<String, String>>> getDictionaryNullAsync() {
+    public Single<RestResponse<Void, List<Map<String, String>>>> getDictionaryNullWithRestResponseAsync() {
         return service.getDictionaryNull();
     }
+
+    /**
+     * Get an array of Dictionaries with value null.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<Map<String, String>>> object
+     */
+    public Single<List<Map<String, String>>> getDictionaryNullAsync() {
+        return getDictionaryNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<Map<String, String>>>, List<Map<String, String>>>() { public List<Map<String, String>> call(RestResponse<Void, List<Map<String, String>>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2615,7 +3306,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<Map<String, String>>> getDictionaryEmptyAsync(final ServiceCallback<List<Map<String, String>>> serviceCallback) {
+    public ServiceFuture<List<Map<String, String>>> getDictionaryEmptyAsync(ServiceCallback<List<Map<String, String>>> serviceCallback) {
         return ServiceFuture.fromBody(getDictionaryEmptyAsync(), serviceCallback);
     }
 
@@ -2623,11 +3314,22 @@ public class ArraysImpl implements Arrays {
      * Get an array of Dictionaries of type &lt;string, string&gt; with value [].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<Map<String, String>>> object
      */
-    public Single<List<Map<String, String>>> getDictionaryEmptyAsync() {
+    public Single<RestResponse<Void, List<Map<String, String>>>> getDictionaryEmptyWithRestResponseAsync() {
         return service.getDictionaryEmpty();
     }
+
+    /**
+     * Get an array of Dictionaries of type &lt;string, string&gt; with value [].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<Map<String, String>>> object
+     */
+    public Single<List<Map<String, String>>> getDictionaryEmptyAsync() {
+        return getDictionaryEmptyWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<Map<String, String>>>, List<Map<String, String>>>() { public List<Map<String, String>> call(RestResponse<Void, List<Map<String, String>>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2649,7 +3351,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<Map<String, String>>> getDictionaryItemNullAsync(final ServiceCallback<List<Map<String, String>>> serviceCallback) {
+    public ServiceFuture<List<Map<String, String>>> getDictionaryItemNullAsync(ServiceCallback<List<Map<String, String>>> serviceCallback) {
         return ServiceFuture.fromBody(getDictionaryItemNullAsync(), serviceCallback);
     }
 
@@ -2657,11 +3359,22 @@ public class ArraysImpl implements Arrays {
      * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'}, null, {'7': 'seven', '8': 'eight', '9': 'nine'}].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<Map<String, String>>> object
      */
-    public Single<List<Map<String, String>>> getDictionaryItemNullAsync() {
+    public Single<RestResponse<Void, List<Map<String, String>>>> getDictionaryItemNullWithRestResponseAsync() {
         return service.getDictionaryItemNull();
     }
+
+    /**
+     * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'}, null, {'7': 'seven', '8': 'eight', '9': 'nine'}].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<Map<String, String>>> object
+     */
+    public Single<List<Map<String, String>>> getDictionaryItemNullAsync() {
+        return getDictionaryItemNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<Map<String, String>>>, List<Map<String, String>>>() { public List<Map<String, String>> call(RestResponse<Void, List<Map<String, String>>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2683,7 +3396,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<Map<String, String>>> getDictionaryItemEmptyAsync(final ServiceCallback<List<Map<String, String>>> serviceCallback) {
+    public ServiceFuture<List<Map<String, String>>> getDictionaryItemEmptyAsync(ServiceCallback<List<Map<String, String>>> serviceCallback) {
         return ServiceFuture.fromBody(getDictionaryItemEmptyAsync(), serviceCallback);
     }
 
@@ -2691,11 +3404,22 @@ public class ArraysImpl implements Arrays {
      * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'}, {}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<Map<String, String>>> object
      */
-    public Single<List<Map<String, String>>> getDictionaryItemEmptyAsync() {
+    public Single<RestResponse<Void, List<Map<String, String>>>> getDictionaryItemEmptyWithRestResponseAsync() {
         return service.getDictionaryItemEmpty();
     }
+
+    /**
+     * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'}, {}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<Map<String, String>>> object
+     */
+    public Single<List<Map<String, String>>> getDictionaryItemEmptyAsync() {
+        return getDictionaryItemEmptyWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<Map<String, String>>>, List<Map<String, String>>>() { public List<Map<String, String>> call(RestResponse<Void, List<Map<String, String>>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2717,7 +3441,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<Map<String, String>>> getDictionaryValidAsync(final ServiceCallback<List<Map<String, String>>> serviceCallback) {
+    public ServiceFuture<List<Map<String, String>>> getDictionaryValidAsync(ServiceCallback<List<Map<String, String>>> serviceCallback) {
         return ServiceFuture.fromBody(getDictionaryValidAsync(), serviceCallback);
     }
 
@@ -2725,11 +3449,22 @@ public class ArraysImpl implements Arrays {
      * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;Map&lt;String, String&gt;&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<Map<String, String>>> object
      */
-    public Single<List<Map<String, String>>> getDictionaryValidAsync() {
+    public Single<RestResponse<Void, List<Map<String, String>>>> getDictionaryValidWithRestResponseAsync() {
         return service.getDictionaryValid();
     }
+
+    /**
+     * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<Map<String, String>>> object
+     */
+    public Single<List<Map<String, String>>> getDictionaryValidAsync() {
+        return getDictionaryValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<Map<String, String>>>, List<Map<String, String>>>() { public List<Map<String, String>> call(RestResponse<Void, List<Map<String, String>>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2739,6 +3474,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putDictionaryValid(List<Map<String, String>> arrayBody) {
         putDictionaryValidAsync(arrayBody).toBlocking().value();
@@ -2752,7 +3488,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putDictionaryValidAsync(List<Map<String, String>> arrayBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putDictionaryValidAsync(List<Map<String, String>> arrayBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putDictionaryValidAsync(arrayBody), serviceCallback);
     }
 
@@ -2761,15 +3497,27 @@ public class ArraysImpl implements Arrays {
      *
      * @param arrayBody the List&lt;Map&lt;String, String&gt;&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putDictionaryValidAsync(List<Map<String, String>> arrayBody) {
+    public Single<RestResponse<Void, Void>> putDictionaryValidWithRestResponseAsync(List<Map<String, String>> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
         Validator.validate(arrayBody);
         return service.putDictionaryValid(arrayBody);
     }
+
+    /**
+     * Get an array of Dictionaries of type &lt;string, string&gt; with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}].
+     *
+     * @param arrayBody the List&lt;Map&lt;String, String&gt;&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putDictionaryValidAsync(List<Map<String, String>> arrayBody) {
+        return putDictionaryValidWithRestResponseAsync(arrayBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodyarray/implementation/AutoRestSwaggerBATArrayServiceImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodyarray/implementation/AutoRestSwaggerBATArrayServiceImpl.java
@@ -13,6 +13,7 @@ package fixtures.bodyarray.implementation;
 import fixtures.bodyarray.AutoRestSwaggerBATArrayService;
 import fixtures.bodyarray.Arrays;
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceClient;
 import com.microsoft.rest.RestClient;
 import rx.Single;

--- a/test/vanilla/src/main/java/fixtures/bodyboolean/Bools.java
+++ b/test/vanilla/src/main/java/fixtures/bodyboolean/Bools.java
@@ -10,6 +10,7 @@
 
 package fixtures.bodyboolean;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.bodyboolean.models.ErrorException;
@@ -48,6 +49,13 @@ public interface Bools {
      * @return the observable to the boolean object
      */
     Single<Boolean> getTrueAsync();
+    /**
+     * Get true Boolean value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the boolean object
+     */
+    Single<RestResponse<Void, Boolean>> getTrueWithRestResponseAsync();
 
 
     /**
@@ -78,6 +86,14 @@ public interface Bools {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putTrueAsync(boolean boolBody);
+    /**
+     * Set Boolean value true.
+     *
+     * @param boolBody the boolean value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putTrueWithRestResponseAsync(boolean boolBody);
 
 
     /**
@@ -106,6 +122,13 @@ public interface Bools {
      * @return the observable to the boolean object
      */
     Single<Boolean> getFalseAsync();
+    /**
+     * Get false Boolean value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the boolean object
+     */
+    Single<RestResponse<Void, Boolean>> getFalseWithRestResponseAsync();
 
 
     /**
@@ -136,6 +159,14 @@ public interface Bools {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putFalseAsync(boolean boolBody);
+    /**
+     * Set Boolean value false.
+     *
+     * @param boolBody the boolean value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putFalseWithRestResponseAsync(boolean boolBody);
 
 
     /**
@@ -164,6 +195,13 @@ public interface Bools {
      * @return the observable to the boolean object
      */
     Single<Boolean> getNullAsync();
+    /**
+     * Get null Boolean value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the boolean object
+     */
+    Single<RestResponse<Void, Boolean>> getNullWithRestResponseAsync();
 
 
     /**
@@ -192,6 +230,13 @@ public interface Bools {
      * @return the observable to the boolean object
      */
     Single<Boolean> getInvalidAsync();
+    /**
+     * Get invalid Boolean value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the boolean object
+     */
+    Single<RestResponse<Void, Boolean>> getInvalidWithRestResponseAsync();
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodyboolean/implementation/AutoRestBoolTestServiceImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodyboolean/implementation/AutoRestBoolTestServiceImpl.java
@@ -13,6 +13,7 @@ package fixtures.bodyboolean.implementation;
 import fixtures.bodyboolean.AutoRestBoolTestService;
 import fixtures.bodyboolean.Bools;
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceClient;
 import com.microsoft.rest.RestClient;
 import rx.Single;

--- a/test/vanilla/src/main/java/fixtures/bodyboolean/implementation/BoolsImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodyboolean/implementation/BoolsImpl.java
@@ -11,6 +11,7 @@
 package fixtures.bodyboolean.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.bodyboolean.Bools;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.BodyParam;
@@ -59,37 +60,37 @@ public class BoolsImpl implements Bools {
         @GET("bool/true")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Boolean> getTrue();
+        Single<RestResponse<Void, Boolean>> getTrue();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyboolean.Bools putTrue" })
         @PUT("bool/true")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putTrue(@BodyParam("application/json; charset=utf-8") boolean boolBody);
+        Single<RestResponse<Void, Void>> putTrue(@BodyParam("application/json; charset=utf-8") boolean boolBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodyboolean.Bools getFalse" })
         @GET("bool/false")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Boolean> getFalse();
+        Single<RestResponse<Void, Boolean>> getFalse();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyboolean.Bools putFalse" })
         @PUT("bool/false")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putFalse(@BodyParam("application/json; charset=utf-8") boolean boolBody);
+        Single<RestResponse<Void, Void>> putFalse(@BodyParam("application/json; charset=utf-8") boolean boolBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodyboolean.Bools getNull" })
         @GET("bool/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Boolean> getNull();
+        Single<RestResponse<Void, Boolean>> getNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyboolean.Bools getInvalid" })
         @GET("bool/invalid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Boolean> getInvalid();
+        Single<RestResponse<Void, Boolean>> getInvalid();
 
     }
 
@@ -112,7 +113,7 @@ public class BoolsImpl implements Bools {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Boolean> getTrueAsync(final ServiceCallback<Boolean> serviceCallback) {
+    public ServiceFuture<Boolean> getTrueAsync(ServiceCallback<Boolean> serviceCallback) {
         return ServiceFuture.fromBody(getTrueAsync(), serviceCallback);
     }
 
@@ -120,11 +121,22 @@ public class BoolsImpl implements Bools {
      * Get true Boolean value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Boolean object
+     * @return a {@link Single} emitting the RestResponse<Void, Boolean> object
      */
-    public Single<Boolean> getTrueAsync() {
+    public Single<RestResponse<Void, Boolean>> getTrueWithRestResponseAsync() {
         return service.getTrue();
     }
+
+    /**
+     * Get true Boolean value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Boolean> object
+     */
+    public Single<Boolean> getTrueAsync() {
+        return getTrueWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Boolean>, Boolean>() { public Boolean call(RestResponse<Void, Boolean> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -134,6 +146,7 @@ public class BoolsImpl implements Bools {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putTrue(boolean boolBody) {
         putTrueAsync(boolBody).toBlocking().value();
@@ -147,7 +160,7 @@ public class BoolsImpl implements Bools {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putTrueAsync(boolean boolBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putTrueAsync(boolean boolBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putTrueAsync(boolBody), serviceCallback);
     }
 
@@ -156,11 +169,23 @@ public class BoolsImpl implements Bools {
      *
      * @param boolBody the boolean value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putTrueAsync(boolean boolBody) {
+    public Single<RestResponse<Void, Void>> putTrueWithRestResponseAsync(boolean boolBody) {
         return service.putTrue(boolBody);
     }
+
+    /**
+     * Set Boolean value true.
+     *
+     * @param boolBody the boolean value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putTrueAsync(boolean boolBody) {
+        return putTrueWithRestResponseAsync(boolBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -182,7 +207,7 @@ public class BoolsImpl implements Bools {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Boolean> getFalseAsync(final ServiceCallback<Boolean> serviceCallback) {
+    public ServiceFuture<Boolean> getFalseAsync(ServiceCallback<Boolean> serviceCallback) {
         return ServiceFuture.fromBody(getFalseAsync(), serviceCallback);
     }
 
@@ -190,11 +215,22 @@ public class BoolsImpl implements Bools {
      * Get false Boolean value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Boolean object
+     * @return a {@link Single} emitting the RestResponse<Void, Boolean> object
      */
-    public Single<Boolean> getFalseAsync() {
+    public Single<RestResponse<Void, Boolean>> getFalseWithRestResponseAsync() {
         return service.getFalse();
     }
+
+    /**
+     * Get false Boolean value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Boolean> object
+     */
+    public Single<Boolean> getFalseAsync() {
+        return getFalseWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Boolean>, Boolean>() { public Boolean call(RestResponse<Void, Boolean> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -204,6 +240,7 @@ public class BoolsImpl implements Bools {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putFalse(boolean boolBody) {
         putFalseAsync(boolBody).toBlocking().value();
@@ -217,7 +254,7 @@ public class BoolsImpl implements Bools {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putFalseAsync(boolean boolBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putFalseAsync(boolean boolBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putFalseAsync(boolBody), serviceCallback);
     }
 
@@ -226,11 +263,23 @@ public class BoolsImpl implements Bools {
      *
      * @param boolBody the boolean value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putFalseAsync(boolean boolBody) {
+    public Single<RestResponse<Void, Void>> putFalseWithRestResponseAsync(boolean boolBody) {
         return service.putFalse(boolBody);
     }
+
+    /**
+     * Set Boolean value false.
+     *
+     * @param boolBody the boolean value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putFalseAsync(boolean boolBody) {
+        return putFalseWithRestResponseAsync(boolBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -252,7 +301,7 @@ public class BoolsImpl implements Bools {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Boolean> getNullAsync(final ServiceCallback<Boolean> serviceCallback) {
+    public ServiceFuture<Boolean> getNullAsync(ServiceCallback<Boolean> serviceCallback) {
         return ServiceFuture.fromBody(getNullAsync(), serviceCallback);
     }
 
@@ -260,11 +309,22 @@ public class BoolsImpl implements Bools {
      * Get null Boolean value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Boolean object
+     * @return a {@link Single} emitting the RestResponse<Void, Boolean> object
      */
-    public Single<Boolean> getNullAsync() {
+    public Single<RestResponse<Void, Boolean>> getNullWithRestResponseAsync() {
         return service.getNull();
     }
+
+    /**
+     * Get null Boolean value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Boolean> object
+     */
+    public Single<Boolean> getNullAsync() {
+        return getNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Boolean>, Boolean>() { public Boolean call(RestResponse<Void, Boolean> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -286,7 +346,7 @@ public class BoolsImpl implements Bools {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Boolean> getInvalidAsync(final ServiceCallback<Boolean> serviceCallback) {
+    public ServiceFuture<Boolean> getInvalidAsync(ServiceCallback<Boolean> serviceCallback) {
         return ServiceFuture.fromBody(getInvalidAsync(), serviceCallback);
     }
 
@@ -294,11 +354,22 @@ public class BoolsImpl implements Bools {
      * Get invalid Boolean value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Boolean object
+     * @return a {@link Single} emitting the RestResponse<Void, Boolean> object
      */
-    public Single<Boolean> getInvalidAsync() {
+    public Single<RestResponse<Void, Boolean>> getInvalidWithRestResponseAsync() {
         return service.getInvalid();
     }
+
+    /**
+     * Get invalid Boolean value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Boolean> object
+     */
+    public Single<Boolean> getInvalidAsync() {
+        return getInvalidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Boolean>, Boolean>() { public Boolean call(RestResponse<Void, Boolean> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodybyte/Bytes.java
+++ b/test/vanilla/src/main/java/fixtures/bodybyte/Bytes.java
@@ -10,6 +10,7 @@
 
 package fixtures.bodybyte;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.bodybyte.models.ErrorException;
@@ -48,6 +49,13 @@ public interface Bytes {
      * @return the observable to the byte[] object
      */
     Single<byte[]> getNullAsync();
+    /**
+     * Get null byte value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the byte[] object
+     */
+    Single<RestResponse<Void, byte[]>> getNullWithRestResponseAsync();
 
 
     /**
@@ -76,6 +84,13 @@ public interface Bytes {
      * @return the observable to the byte[] object
      */
     Single<byte[]> getEmptyAsync();
+    /**
+     * Get empty byte value ''.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the byte[] object
+     */
+    Single<RestResponse<Void, byte[]>> getEmptyWithRestResponseAsync();
 
 
     /**
@@ -104,6 +119,13 @@ public interface Bytes {
      * @return the observable to the byte[] object
      */
     Single<byte[]> getNonAsciiAsync();
+    /**
+     * Get non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the byte[] object
+     */
+    Single<RestResponse<Void, byte[]>> getNonAsciiWithRestResponseAsync();
 
 
     /**
@@ -134,6 +156,14 @@ public interface Bytes {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putNonAsciiAsync(byte[] byteBody);
+    /**
+     * Put non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
+     *
+     * @param byteBody Base64-encoded non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putNonAsciiWithRestResponseAsync(byte[] byteBody);
 
 
     /**
@@ -162,6 +192,13 @@ public interface Bytes {
      * @return the observable to the byte[] object
      */
     Single<byte[]> getInvalidAsync();
+    /**
+     * Get invalid byte value ':::SWAGGER::::'.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the byte[] object
+     */
+    Single<RestResponse<Void, byte[]>> getInvalidWithRestResponseAsync();
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodybyte/implementation/AutoRestSwaggerBATByteServiceImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodybyte/implementation/AutoRestSwaggerBATByteServiceImpl.java
@@ -13,6 +13,7 @@ package fixtures.bodybyte.implementation;
 import fixtures.bodybyte.AutoRestSwaggerBATByteService;
 import fixtures.bodybyte.Bytes;
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceClient;
 import com.microsoft.rest.RestClient;
 import rx.Single;

--- a/test/vanilla/src/main/java/fixtures/bodybyte/implementation/BytesImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodybyte/implementation/BytesImpl.java
@@ -11,6 +11,7 @@
 package fixtures.bodybyte.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.bodybyte.Bytes;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.BodyParam;
@@ -59,31 +60,31 @@ public class BytesImpl implements Bytes {
         @GET("byte/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<byte[]> getNull();
+        Single<RestResponse<Void, byte[]>> getNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodybyte.Bytes getEmpty" })
         @GET("byte/empty")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<byte[]> getEmpty();
+        Single<RestResponse<Void, byte[]>> getEmpty();
 
         @Headers({ "x-ms-logging-context: fixtures.bodybyte.Bytes getNonAscii" })
         @GET("byte/nonAscii")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<byte[]> getNonAscii();
+        Single<RestResponse<Void, byte[]>> getNonAscii();
 
         @Headers({ "x-ms-logging-context: fixtures.bodybyte.Bytes putNonAscii" })
         @PUT("byte/nonAscii")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putNonAscii(@BodyParam("application/json; charset=utf-8") byte[] byteBody);
+        Single<RestResponse<Void, Void>> putNonAscii(@BodyParam("application/json; charset=utf-8") byte[] byteBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodybyte.Bytes getInvalid" })
         @GET("byte/invalid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<byte[]> getInvalid();
+        Single<RestResponse<Void, byte[]>> getInvalid();
 
     }
 
@@ -106,7 +107,7 @@ public class BytesImpl implements Bytes {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<byte[]> getNullAsync(final ServiceCallback<byte[]> serviceCallback) {
+    public ServiceFuture<byte[]> getNullAsync(ServiceCallback<byte[]> serviceCallback) {
         return ServiceFuture.fromBody(getNullAsync(), serviceCallback);
     }
 
@@ -114,11 +115,22 @@ public class BytesImpl implements Bytes {
      * Get null byte value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the byte[] object
+     * @return a {@link Single} emitting the RestResponse<Void, byte[]> object
      */
-    public Single<byte[]> getNullAsync() {
+    public Single<RestResponse<Void, byte[]>> getNullWithRestResponseAsync() {
         return service.getNull();
     }
+
+    /**
+     * Get null byte value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, byte[]> object
+     */
+    public Single<byte[]> getNullAsync() {
+        return getNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, byte[]>, byte[]>() { public byte[] call(RestResponse<Void, byte[]> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -140,7 +152,7 @@ public class BytesImpl implements Bytes {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<byte[]> getEmptyAsync(final ServiceCallback<byte[]> serviceCallback) {
+    public ServiceFuture<byte[]> getEmptyAsync(ServiceCallback<byte[]> serviceCallback) {
         return ServiceFuture.fromBody(getEmptyAsync(), serviceCallback);
     }
 
@@ -148,11 +160,22 @@ public class BytesImpl implements Bytes {
      * Get empty byte value ''.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the byte[] object
+     * @return a {@link Single} emitting the RestResponse<Void, byte[]> object
      */
-    public Single<byte[]> getEmptyAsync() {
+    public Single<RestResponse<Void, byte[]>> getEmptyWithRestResponseAsync() {
         return service.getEmpty();
     }
+
+    /**
+     * Get empty byte value ''.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, byte[]> object
+     */
+    public Single<byte[]> getEmptyAsync() {
+        return getEmptyWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, byte[]>, byte[]>() { public byte[] call(RestResponse<Void, byte[]> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -174,7 +197,7 @@ public class BytesImpl implements Bytes {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<byte[]> getNonAsciiAsync(final ServiceCallback<byte[]> serviceCallback) {
+    public ServiceFuture<byte[]> getNonAsciiAsync(ServiceCallback<byte[]> serviceCallback) {
         return ServiceFuture.fromBody(getNonAsciiAsync(), serviceCallback);
     }
 
@@ -182,11 +205,22 @@ public class BytesImpl implements Bytes {
      * Get non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the byte[] object
+     * @return a {@link Single} emitting the RestResponse<Void, byte[]> object
      */
-    public Single<byte[]> getNonAsciiAsync() {
+    public Single<RestResponse<Void, byte[]>> getNonAsciiWithRestResponseAsync() {
         return service.getNonAscii();
     }
+
+    /**
+     * Get non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, byte[]> object
+     */
+    public Single<byte[]> getNonAsciiAsync() {
+        return getNonAsciiWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, byte[]>, byte[]>() { public byte[] call(RestResponse<Void, byte[]> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -196,6 +230,7 @@ public class BytesImpl implements Bytes {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putNonAscii(byte[] byteBody) {
         putNonAsciiAsync(byteBody).toBlocking().value();
@@ -209,7 +244,7 @@ public class BytesImpl implements Bytes {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putNonAsciiAsync(byte[] byteBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putNonAsciiAsync(byte[] byteBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putNonAsciiAsync(byteBody), serviceCallback);
     }
 
@@ -218,14 +253,26 @@ public class BytesImpl implements Bytes {
      *
      * @param byteBody Base64-encoded non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putNonAsciiAsync(byte[] byteBody) {
+    public Single<RestResponse<Void, Void>> putNonAsciiWithRestResponseAsync(byte[] byteBody) {
         if (byteBody == null) {
             throw new IllegalArgumentException("Parameter byteBody is required and cannot be null.");
         }
         return service.putNonAscii(byteBody);
     }
+
+    /**
+     * Put non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
+     *
+     * @param byteBody Base64-encoded non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putNonAsciiAsync(byte[] byteBody) {
+        return putNonAsciiWithRestResponseAsync(byteBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -247,7 +294,7 @@ public class BytesImpl implements Bytes {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<byte[]> getInvalidAsync(final ServiceCallback<byte[]> serviceCallback) {
+    public ServiceFuture<byte[]> getInvalidAsync(ServiceCallback<byte[]> serviceCallback) {
         return ServiceFuture.fromBody(getInvalidAsync(), serviceCallback);
     }
 
@@ -255,11 +302,22 @@ public class BytesImpl implements Bytes {
      * Get invalid byte value ':::SWAGGER::::'.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the byte[] object
+     * @return a {@link Single} emitting the RestResponse<Void, byte[]> object
      */
-    public Single<byte[]> getInvalidAsync() {
+    public Single<RestResponse<Void, byte[]>> getInvalidWithRestResponseAsync() {
         return service.getInvalid();
     }
+
+    /**
+     * Get invalid byte value ':::SWAGGER::::'.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, byte[]> object
+     */
+    public Single<byte[]> getInvalidAsync() {
+        return getInvalidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, byte[]>, byte[]>() { public byte[] call(RestResponse<Void, byte[]> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/Arrays.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/Arrays.java
@@ -10,6 +10,7 @@
 
 package fixtures.bodycomplex;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.bodycomplex.models.ArrayWrapper;
@@ -49,6 +50,13 @@ public interface Arrays {
      * @return the observable to the ArrayWrapper object
      */
     Single<ArrayWrapper> getValidAsync();
+    /**
+     * Get complex types with array property.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the ArrayWrapper object
+     */
+    Single<RestResponse<Void, ArrayWrapper>> getValidWithRestResponseAsync();
 
 
     /**
@@ -79,6 +87,14 @@ public interface Arrays {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putValidAsync(ArrayWrapper complexBody);
+    /**
+     * Put complex types with array property.
+     *
+     * @param complexBody Please put an array with 4 items: "1, 2, 3, 4", "", null, "&amp;S#$(*Y", "The quick brown fox jumps over the lazy dog"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putValidWithRestResponseAsync(ArrayWrapper complexBody);
 
 
     /**
@@ -107,6 +123,13 @@ public interface Arrays {
      * @return the observable to the ArrayWrapper object
      */
     Single<ArrayWrapper> getEmptyAsync();
+    /**
+     * Get complex types with array property which is empty.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the ArrayWrapper object
+     */
+    Single<RestResponse<Void, ArrayWrapper>> getEmptyWithRestResponseAsync();
 
 
     /**
@@ -137,6 +160,14 @@ public interface Arrays {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putEmptyAsync(ArrayWrapper complexBody);
+    /**
+     * Put complex types with array property which is empty.
+     *
+     * @param complexBody Please put an empty array
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putEmptyWithRestResponseAsync(ArrayWrapper complexBody);
 
 
     /**
@@ -165,6 +196,13 @@ public interface Arrays {
      * @return the observable to the ArrayWrapper object
      */
     Single<ArrayWrapper> getNotProvidedAsync();
+    /**
+     * Get complex types with array property while server doesn't provide a response payload.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the ArrayWrapper object
+     */
+    Single<RestResponse<Void, ArrayWrapper>> getNotProvidedWithRestResponseAsync();
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/Basics.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/Basics.java
@@ -10,6 +10,7 @@
 
 package fixtures.bodycomplex;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.bodycomplex.models.Basic;
@@ -49,6 +50,13 @@ public interface Basics {
      * @return the observable to the Basic object
      */
     Single<Basic> getValidAsync();
+    /**
+     * Get complex type {id: 2, name: 'abc', color: 'YELLOW'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Basic object
+     */
+    Single<RestResponse<Void, Basic>> getValidWithRestResponseAsync();
 
 
     /**
@@ -79,6 +87,14 @@ public interface Basics {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putValidAsync(Basic complexBody);
+    /**
+     * Please put {id: 2, name: 'abc', color: 'Magenta'}.
+     *
+     * @param complexBody Please put {id: 2, name: 'abc', color: 'Magenta'}
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putValidWithRestResponseAsync(Basic complexBody);
 
 
     /**
@@ -107,6 +123,13 @@ public interface Basics {
      * @return the observable to the Basic object
      */
     Single<Basic> getInvalidAsync();
+    /**
+     * Get a basic complex type that is invalid for the local strong type.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Basic object
+     */
+    Single<RestResponse<Void, Basic>> getInvalidWithRestResponseAsync();
 
 
     /**
@@ -135,6 +158,13 @@ public interface Basics {
      * @return the observable to the Basic object
      */
     Single<Basic> getEmptyAsync();
+    /**
+     * Get a basic complex type that is empty.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Basic object
+     */
+    Single<RestResponse<Void, Basic>> getEmptyWithRestResponseAsync();
 
 
     /**
@@ -163,6 +193,13 @@ public interface Basics {
      * @return the observable to the Basic object
      */
     Single<Basic> getNullAsync();
+    /**
+     * Get a basic complex type whose properties are null.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Basic object
+     */
+    Single<RestResponse<Void, Basic>> getNullWithRestResponseAsync();
 
 
     /**
@@ -191,6 +228,13 @@ public interface Basics {
      * @return the observable to the Basic object
      */
     Single<Basic> getNotProvidedAsync();
+    /**
+     * Get a basic complex type while the server doesn't provide a response payload.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Basic object
+     */
+    Single<RestResponse<Void, Basic>> getNotProvidedWithRestResponseAsync();
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/Dictionarys.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/Dictionarys.java
@@ -10,6 +10,7 @@
 
 package fixtures.bodycomplex;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.bodycomplex.models.DictionaryWrapper;
@@ -49,6 +50,13 @@ public interface Dictionarys {
      * @return the observable to the DictionaryWrapper object
      */
     Single<DictionaryWrapper> getValidAsync();
+    /**
+     * Get complex types with dictionary property.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the DictionaryWrapper object
+     */
+    Single<RestResponse<Void, DictionaryWrapper>> getValidWithRestResponseAsync();
 
 
     /**
@@ -79,6 +87,14 @@ public interface Dictionarys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putValidAsync(DictionaryWrapper complexBody);
+    /**
+     * Put complex types with dictionary property.
+     *
+     * @param complexBody Please put a dictionary with 5 key-value pairs: "txt":"notepad", "bmp":"mspaint", "xls":"excel", "exe":"", "":null
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putValidWithRestResponseAsync(DictionaryWrapper complexBody);
 
 
     /**
@@ -107,6 +123,13 @@ public interface Dictionarys {
      * @return the observable to the DictionaryWrapper object
      */
     Single<DictionaryWrapper> getEmptyAsync();
+    /**
+     * Get complex types with dictionary property which is empty.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the DictionaryWrapper object
+     */
+    Single<RestResponse<Void, DictionaryWrapper>> getEmptyWithRestResponseAsync();
 
 
     /**
@@ -137,6 +160,14 @@ public interface Dictionarys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putEmptyAsync(DictionaryWrapper complexBody);
+    /**
+     * Put complex types with dictionary property which is empty.
+     *
+     * @param complexBody Please put an empty dictionary
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putEmptyWithRestResponseAsync(DictionaryWrapper complexBody);
 
 
     /**
@@ -165,6 +196,13 @@ public interface Dictionarys {
      * @return the observable to the DictionaryWrapper object
      */
     Single<DictionaryWrapper> getNullAsync();
+    /**
+     * Get complex types with dictionary property which is null.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the DictionaryWrapper object
+     */
+    Single<RestResponse<Void, DictionaryWrapper>> getNullWithRestResponseAsync();
 
 
     /**
@@ -193,6 +231,13 @@ public interface Dictionarys {
      * @return the observable to the DictionaryWrapper object
      */
     Single<DictionaryWrapper> getNotProvidedAsync();
+    /**
+     * Get complex types with dictionary property while server doesn't provide a response payload.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the DictionaryWrapper object
+     */
+    Single<RestResponse<Void, DictionaryWrapper>> getNotProvidedWithRestResponseAsync();
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/Inheritances.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/Inheritances.java
@@ -10,6 +10,7 @@
 
 package fixtures.bodycomplex;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.bodycomplex.models.ErrorException;
@@ -49,6 +50,13 @@ public interface Inheritances {
      * @return the observable to the Siamese object
      */
     Single<Siamese> getValidAsync();
+    /**
+     * Get complex types that extend others.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Siamese object
+     */
+    Single<RestResponse<Void, Siamese>> getValidWithRestResponseAsync();
 
 
     /**
@@ -79,6 +87,14 @@ public interface Inheritances {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putValidAsync(Siamese complexBody);
+    /**
+     * Put complex types that extend others.
+     *
+     * @param complexBody Please put a siamese with id=2, name="Siameee", color=green, breed=persion, which hates 2 dogs, the 1st one named "Potato" with id=1 and food="tomato", and the 2nd one named "Tomato" with id=-1 and food="french fries".
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putValidWithRestResponseAsync(Siamese complexBody);
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/Polymorphicrecursives.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/Polymorphicrecursives.java
@@ -10,6 +10,7 @@
 
 package fixtures.bodycomplex;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.bodycomplex.models.ErrorException;
@@ -49,6 +50,13 @@ public interface Polymorphicrecursives {
      * @return the observable to the Fish object
      */
     Single<Fish> getValidAsync();
+    /**
+     * Get complex types that are polymorphic and have recursive references.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Fish object
+     */
+    Single<RestResponse<Void, Fish>> getValidWithRestResponseAsync();
 
 
     /**
@@ -235,6 +243,66 @@ public interface Polymorphicrecursives {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putValidAsync(Fish complexBody);
+    /**
+     * Put complex types that are polymorphic and have recursive references.
+     *
+     * @param complexBody Please put a salmon that looks like this:
+     {
+         "fishtype": "salmon",
+         "species": "king",
+         "length": 1,
+         "age": 1,
+         "location": "alaska",
+         "iswild": true,
+         "siblings": [
+             {
+                 "fishtype": "shark",
+                 "species": "predator",
+                 "length": 20,
+                 "age": 6,
+                 "siblings": [
+                     {
+                         "fishtype": "salmon",
+                         "species": "coho",
+                         "length": 2,
+                         "age": 2,
+                         "location": "atlantic",
+                         "iswild": true,
+                         "siblings": [
+                             {
+                                 "fishtype": "shark",
+                                 "species": "predator",
+                                 "length": 20,
+                                 "age": 6
+                             },
+                             {
+                                 "fishtype": "sawshark",
+                                 "species": "dangerous",
+                                 "length": 10,
+                                 "age": 105
+                             }
+                         ]
+                     },
+                     {
+                         "fishtype": "sawshark",
+                         "species": "dangerous",
+                         "length": 10,
+                         "age": 105
+                     }
+                 ]
+             },
+             {
+                 "fishtype": "sawshark",
+                 "species": "dangerous",
+                 "length": 10,
+                 "age": 105
+             }
+         ]
+     }
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putValidWithRestResponseAsync(Fish complexBody);
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/Polymorphisms.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/Polymorphisms.java
@@ -10,6 +10,7 @@
 
 package fixtures.bodycomplex;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.bodycomplex.models.ErrorException;
@@ -49,6 +50,13 @@ public interface Polymorphisms {
      * @return the observable to the Fish object
      */
     Single<Fish> getValidAsync();
+    /**
+     * Get complex types that are polymorphic.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Fish object
+     */
+    Single<RestResponse<Void, Fish>> getValidWithRestResponseAsync();
 
 
     /**
@@ -175,6 +183,46 @@ public interface Polymorphisms {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putValidAsync(Fish complexBody);
+    /**
+     * Put complex types that are polymorphic.
+     *
+     * @param complexBody Please put a salmon that looks like this:
+     {
+             'fishtype':'Salmon',
+             'location':'alaska',
+             'iswild':true,
+             'species':'king',
+             'length':1.0,
+             'siblings':[
+               {
+                 'fishtype':'Shark',
+                 'age':6,
+                 'birthday': '2012-01-05T01:00:00Z',
+                 'length':20.0,
+                 'species':'predator',
+               },
+               {
+                 'fishtype':'Sawshark',
+                 'age':105,
+                 'birthday': '1900-01-05T01:00:00Z',
+                 'length':10.0,
+                 'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
+                 'species':'dangerous',
+               },
+               {
+                 'fishtype': 'goblin',
+                 'age': 1,
+                 'birthday': '2015-08-08T00:00:00Z',
+                 'length': 30.0,
+                 'species': 'scary',
+                 'jawsize': 5
+               }
+             ]
+           };
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putValidWithRestResponseAsync(Fish complexBody);
 
 
     /**
@@ -280,6 +328,39 @@ public interface Polymorphisms {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putValidMissingRequiredAsync(Fish complexBody);
+    /**
+     * Put complex types that are polymorphic, attempting to omit required 'birthday' field - the request should not be allowed from the client.
+     *
+     * @param complexBody Please attempt put a sawshark that looks like this, the client should not allow this data to be sent:
+     {
+         "fishtype": "sawshark",
+         "species": "snaggle toothed",
+         "length": 18.5,
+         "age": 2,
+         "birthday": "2013-06-01T01:00:00Z",
+         "location": "alaska",
+         "picture": base64(FF FF FF FF FE),
+         "siblings": [
+             {
+                 "fishtype": "shark",
+                 "species": "predator",
+                 "birthday": "2012-01-05T01:00:00Z",
+                 "length": 20,
+                 "age": 6
+             },
+             {
+                 "fishtype": "sawshark",
+                 "species": "dangerous",
+                 "picture": base64(FF FF FF FF FE),
+                 "length": 10,
+                 "age": 105
+             }
+         ]
+     }
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putValidMissingRequiredWithRestResponseAsync(Fish complexBody);
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/Primitives.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/Primitives.java
@@ -10,6 +10,7 @@
 
 package fixtures.bodycomplex;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.bodycomplex.models.BooleanWrapper;
@@ -59,6 +60,13 @@ public interface Primitives {
      * @return the observable to the IntWrapper object
      */
     Single<IntWrapper> getIntAsync();
+    /**
+     * Get complex types with integer properties.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the IntWrapper object
+     */
+    Single<RestResponse<Void, IntWrapper>> getIntWithRestResponseAsync();
 
 
     /**
@@ -89,6 +97,14 @@ public interface Primitives {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putIntAsync(IntWrapper complexBody);
+    /**
+     * Put complex types with integer properties.
+     *
+     * @param complexBody Please put -1 and 2
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putIntWithRestResponseAsync(IntWrapper complexBody);
 
 
     /**
@@ -117,6 +133,13 @@ public interface Primitives {
      * @return the observable to the LongWrapper object
      */
     Single<LongWrapper> getLongAsync();
+    /**
+     * Get complex types with long properties.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the LongWrapper object
+     */
+    Single<RestResponse<Void, LongWrapper>> getLongWithRestResponseAsync();
 
 
     /**
@@ -147,6 +170,14 @@ public interface Primitives {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putLongAsync(LongWrapper complexBody);
+    /**
+     * Put complex types with long properties.
+     *
+     * @param complexBody Please put 1099511627775 and -999511627788
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putLongWithRestResponseAsync(LongWrapper complexBody);
 
 
     /**
@@ -175,6 +206,13 @@ public interface Primitives {
      * @return the observable to the FloatWrapper object
      */
     Single<FloatWrapper> getFloatAsync();
+    /**
+     * Get complex types with float properties.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the FloatWrapper object
+     */
+    Single<RestResponse<Void, FloatWrapper>> getFloatWithRestResponseAsync();
 
 
     /**
@@ -205,6 +243,14 @@ public interface Primitives {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putFloatAsync(FloatWrapper complexBody);
+    /**
+     * Put complex types with float properties.
+     *
+     * @param complexBody Please put 1.05 and -0.003
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putFloatWithRestResponseAsync(FloatWrapper complexBody);
 
 
     /**
@@ -233,6 +279,13 @@ public interface Primitives {
      * @return the observable to the DoubleWrapper object
      */
     Single<DoubleWrapper> getDoubleAsync();
+    /**
+     * Get complex types with double properties.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the DoubleWrapper object
+     */
+    Single<RestResponse<Void, DoubleWrapper>> getDoubleWithRestResponseAsync();
 
 
     /**
@@ -263,6 +316,14 @@ public interface Primitives {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putDoubleAsync(DoubleWrapper complexBody);
+    /**
+     * Put complex types with double properties.
+     *
+     * @param complexBody Please put 3e-100 and -0.000000000000000000000000000000000000000000000000000000005
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putDoubleWithRestResponseAsync(DoubleWrapper complexBody);
 
 
     /**
@@ -291,6 +352,13 @@ public interface Primitives {
      * @return the observable to the BooleanWrapper object
      */
     Single<BooleanWrapper> getBoolAsync();
+    /**
+     * Get complex types with bool properties.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the BooleanWrapper object
+     */
+    Single<RestResponse<Void, BooleanWrapper>> getBoolWithRestResponseAsync();
 
 
     /**
@@ -321,6 +389,14 @@ public interface Primitives {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putBoolAsync(BooleanWrapper complexBody);
+    /**
+     * Put complex types with bool properties.
+     *
+     * @param complexBody Please put true and false
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putBoolWithRestResponseAsync(BooleanWrapper complexBody);
 
 
     /**
@@ -349,6 +425,13 @@ public interface Primitives {
      * @return the observable to the StringWrapper object
      */
     Single<StringWrapper> getStringAsync();
+    /**
+     * Get complex types with string properties.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the StringWrapper object
+     */
+    Single<RestResponse<Void, StringWrapper>> getStringWithRestResponseAsync();
 
 
     /**
@@ -379,6 +462,14 @@ public interface Primitives {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putStringAsync(StringWrapper complexBody);
+    /**
+     * Put complex types with string properties.
+     *
+     * @param complexBody Please put 'goodrequest', '', and null
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putStringWithRestResponseAsync(StringWrapper complexBody);
 
 
     /**
@@ -407,6 +498,13 @@ public interface Primitives {
      * @return the observable to the DateWrapper object
      */
     Single<DateWrapper> getDateAsync();
+    /**
+     * Get complex types with date properties.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the DateWrapper object
+     */
+    Single<RestResponse<Void, DateWrapper>> getDateWithRestResponseAsync();
 
 
     /**
@@ -437,6 +535,14 @@ public interface Primitives {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putDateAsync(DateWrapper complexBody);
+    /**
+     * Put complex types with date properties.
+     *
+     * @param complexBody Please put '0001-01-01' and '2016-02-29'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putDateWithRestResponseAsync(DateWrapper complexBody);
 
 
     /**
@@ -465,6 +571,13 @@ public interface Primitives {
      * @return the observable to the DatetimeWrapper object
      */
     Single<DatetimeWrapper> getDateTimeAsync();
+    /**
+     * Get complex types with datetime properties.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the DatetimeWrapper object
+     */
+    Single<RestResponse<Void, DatetimeWrapper>> getDateTimeWithRestResponseAsync();
 
 
     /**
@@ -495,6 +608,14 @@ public interface Primitives {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putDateTimeAsync(DatetimeWrapper complexBody);
+    /**
+     * Put complex types with datetime properties.
+     *
+     * @param complexBody Please put '0001-01-01T12:00:00-04:00' and '2015-05-18T11:38:00-08:00'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putDateTimeWithRestResponseAsync(DatetimeWrapper complexBody);
 
 
     /**
@@ -523,6 +644,13 @@ public interface Primitives {
      * @return the observable to the Datetimerfc1123Wrapper object
      */
     Single<Datetimerfc1123Wrapper> getDateTimeRfc1123Async();
+    /**
+     * Get complex types with datetimeRfc1123 properties.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Datetimerfc1123Wrapper object
+     */
+    Single<RestResponse<Void, Datetimerfc1123Wrapper>> getDateTimeRfc1123WithRestResponseAsync();
 
 
     /**
@@ -553,6 +681,14 @@ public interface Primitives {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putDateTimeRfc1123Async(Datetimerfc1123Wrapper complexBody);
+    /**
+     * Put complex types with datetimeRfc1123 properties.
+     *
+     * @param complexBody Please put 'Mon, 01 Jan 0001 12:00:00 GMT' and 'Mon, 18 May 2015 11:38:00 GMT'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putDateTimeRfc1123WithRestResponseAsync(Datetimerfc1123Wrapper complexBody);
 
 
     /**
@@ -581,6 +717,13 @@ public interface Primitives {
      * @return the observable to the DurationWrapper object
      */
     Single<DurationWrapper> getDurationAsync();
+    /**
+     * Get complex types with duration properties.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the DurationWrapper object
+     */
+    Single<RestResponse<Void, DurationWrapper>> getDurationWithRestResponseAsync();
 
 
     /**
@@ -611,6 +754,14 @@ public interface Primitives {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putDurationAsync(DurationWrapper complexBody);
+    /**
+     * Put complex types with duration properties.
+     *
+     * @param complexBody Please put 'P123DT22H14M12.011S'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putDurationWithRestResponseAsync(DurationWrapper complexBody);
 
 
     /**
@@ -639,6 +790,13 @@ public interface Primitives {
      * @return the observable to the ByteWrapper object
      */
     Single<ByteWrapper> getByteAsync();
+    /**
+     * Get complex types with byte properties.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the ByteWrapper object
+     */
+    Single<RestResponse<Void, ByteWrapper>> getByteWithRestResponseAsync();
 
 
     /**
@@ -669,6 +827,14 @@ public interface Primitives {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putByteAsync(ByteWrapper complexBody);
+    /**
+     * Put complex types with byte properties.
+     *
+     * @param complexBody Please put non-ascii byte string hex(FF FE FD FC 00 FA F9 F8 F7 F6)
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putByteWithRestResponseAsync(ByteWrapper complexBody);
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/Readonlypropertys.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/Readonlypropertys.java
@@ -10,6 +10,7 @@
 
 package fixtures.bodycomplex;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.bodycomplex.models.ErrorException;
@@ -49,6 +50,13 @@ public interface Readonlypropertys {
      * @return the observable to the ReadonlyObj object
      */
     Single<ReadonlyObj> getValidAsync();
+    /**
+     * Get complex types that have readonly properties.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the ReadonlyObj object
+     */
+    Single<RestResponse<Void, ReadonlyObj>> getValidWithRestResponseAsync();
 
 
     /**
@@ -79,6 +87,14 @@ public interface Readonlypropertys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putValidAsync(ReadonlyObj complexBody);
+    /**
+     * Put complex types that have readonly properties.
+     *
+     * @param complexBody the ReadonlyObj value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putValidWithRestResponseAsync(ReadonlyObj complexBody);
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/ArraysImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/ArraysImpl.java
@@ -11,6 +11,7 @@
 package fixtures.bodycomplex.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.bodycomplex.Arrays;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.BodyParam;
@@ -61,31 +62,31 @@ public class ArraysImpl implements Arrays {
         @GET("complex/array/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<ArrayWrapper> getValid();
+        Single<RestResponse<Void, ArrayWrapper>> getValid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Arrays putValid" })
         @PUT("complex/array/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putValid(@BodyParam("application/json; charset=utf-8") ArrayWrapper complexBody);
+        Single<RestResponse<Void, Void>> putValid(@BodyParam("application/json; charset=utf-8") ArrayWrapper complexBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Arrays getEmpty" })
         @GET("complex/array/empty")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<ArrayWrapper> getEmpty();
+        Single<RestResponse<Void, ArrayWrapper>> getEmpty();
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Arrays putEmpty" })
         @PUT("complex/array/empty")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putEmpty(@BodyParam("application/json; charset=utf-8") ArrayWrapper complexBody);
+        Single<RestResponse<Void, Void>> putEmpty(@BodyParam("application/json; charset=utf-8") ArrayWrapper complexBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Arrays getNotProvided" })
         @GET("complex/array/notprovided")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<ArrayWrapper> getNotProvided();
+        Single<RestResponse<Void, ArrayWrapper>> getNotProvided();
 
     }
 
@@ -108,7 +109,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ArrayWrapper> getValidAsync(final ServiceCallback<ArrayWrapper> serviceCallback) {
+    public ServiceFuture<ArrayWrapper> getValidAsync(ServiceCallback<ArrayWrapper> serviceCallback) {
         return ServiceFuture.fromBody(getValidAsync(), serviceCallback);
     }
 
@@ -116,11 +117,22 @@ public class ArraysImpl implements Arrays {
      * Get complex types with array property.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ArrayWrapper object
+     * @return a {@link Single} emitting the RestResponse<Void, ArrayWrapper> object
      */
-    public Single<ArrayWrapper> getValidAsync() {
+    public Single<RestResponse<Void, ArrayWrapper>> getValidWithRestResponseAsync() {
         return service.getValid();
     }
+
+    /**
+     * Get complex types with array property.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ArrayWrapper> object
+     */
+    public Single<ArrayWrapper> getValidAsync() {
+        return getValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, ArrayWrapper>, ArrayWrapper>() { public ArrayWrapper call(RestResponse<Void, ArrayWrapper> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -130,6 +142,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putValid(ArrayWrapper complexBody) {
         putValidAsync(complexBody).toBlocking().value();
@@ -143,7 +156,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putValidAsync(ArrayWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putValidAsync(ArrayWrapper complexBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putValidAsync(complexBody), serviceCallback);
     }
 
@@ -152,15 +165,27 @@ public class ArraysImpl implements Arrays {
      *
      * @param complexBody Please put an array with 4 items: "1, 2, 3, 4", "", null, "&amp;S#$(*Y", "The quick brown fox jumps over the lazy dog"
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putValidAsync(ArrayWrapper complexBody) {
+    public Single<RestResponse<Void, Void>> putValidWithRestResponseAsync(ArrayWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
         Validator.validate(complexBody);
         return service.putValid(complexBody);
     }
+
+    /**
+     * Put complex types with array property.
+     *
+     * @param complexBody Please put an array with 4 items: "1, 2, 3, 4", "", null, "&amp;S#$(*Y", "The quick brown fox jumps over the lazy dog"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putValidAsync(ArrayWrapper complexBody) {
+        return putValidWithRestResponseAsync(complexBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -182,7 +207,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ArrayWrapper> getEmptyAsync(final ServiceCallback<ArrayWrapper> serviceCallback) {
+    public ServiceFuture<ArrayWrapper> getEmptyAsync(ServiceCallback<ArrayWrapper> serviceCallback) {
         return ServiceFuture.fromBody(getEmptyAsync(), serviceCallback);
     }
 
@@ -190,11 +215,22 @@ public class ArraysImpl implements Arrays {
      * Get complex types with array property which is empty.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ArrayWrapper object
+     * @return a {@link Single} emitting the RestResponse<Void, ArrayWrapper> object
      */
-    public Single<ArrayWrapper> getEmptyAsync() {
+    public Single<RestResponse<Void, ArrayWrapper>> getEmptyWithRestResponseAsync() {
         return service.getEmpty();
     }
+
+    /**
+     * Get complex types with array property which is empty.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ArrayWrapper> object
+     */
+    public Single<ArrayWrapper> getEmptyAsync() {
+        return getEmptyWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, ArrayWrapper>, ArrayWrapper>() { public ArrayWrapper call(RestResponse<Void, ArrayWrapper> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -204,6 +240,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putEmpty(ArrayWrapper complexBody) {
         putEmptyAsync(complexBody).toBlocking().value();
@@ -217,7 +254,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putEmptyAsync(ArrayWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putEmptyAsync(ArrayWrapper complexBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putEmptyAsync(complexBody), serviceCallback);
     }
 
@@ -226,15 +263,27 @@ public class ArraysImpl implements Arrays {
      *
      * @param complexBody Please put an empty array
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putEmptyAsync(ArrayWrapper complexBody) {
+    public Single<RestResponse<Void, Void>> putEmptyWithRestResponseAsync(ArrayWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
         Validator.validate(complexBody);
         return service.putEmpty(complexBody);
     }
+
+    /**
+     * Put complex types with array property which is empty.
+     *
+     * @param complexBody Please put an empty array
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putEmptyAsync(ArrayWrapper complexBody) {
+        return putEmptyWithRestResponseAsync(complexBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -256,7 +305,7 @@ public class ArraysImpl implements Arrays {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ArrayWrapper> getNotProvidedAsync(final ServiceCallback<ArrayWrapper> serviceCallback) {
+    public ServiceFuture<ArrayWrapper> getNotProvidedAsync(ServiceCallback<ArrayWrapper> serviceCallback) {
         return ServiceFuture.fromBody(getNotProvidedAsync(), serviceCallback);
     }
 
@@ -264,11 +313,22 @@ public class ArraysImpl implements Arrays {
      * Get complex types with array property while server doesn't provide a response payload.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ArrayWrapper object
+     * @return a {@link Single} emitting the RestResponse<Void, ArrayWrapper> object
      */
-    public Single<ArrayWrapper> getNotProvidedAsync() {
+    public Single<RestResponse<Void, ArrayWrapper>> getNotProvidedWithRestResponseAsync() {
         return service.getNotProvided();
     }
+
+    /**
+     * Get complex types with array property while server doesn't provide a response payload.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ArrayWrapper> object
+     */
+    public Single<ArrayWrapper> getNotProvidedAsync() {
+        return getNotProvidedWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, ArrayWrapper>, ArrayWrapper>() { public ArrayWrapper call(RestResponse<Void, ArrayWrapper> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/AutoRestComplexTestServiceImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/AutoRestComplexTestServiceImpl.java
@@ -20,6 +20,7 @@ import fixtures.bodycomplex.Polymorphisms;
 import fixtures.bodycomplex.Polymorphicrecursives;
 import fixtures.bodycomplex.Readonlypropertys;
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceClient;
 import com.microsoft.rest.RestClient;
 import rx.Single;

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/BasicsImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/BasicsImpl.java
@@ -11,6 +11,7 @@
 package fixtures.bodycomplex.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.bodycomplex.Basics;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.BodyParam;
@@ -62,37 +63,37 @@ public class BasicsImpl implements Basics {
         @GET("complex/basic/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Basic> getValid();
+        Single<RestResponse<Void, Basic>> getValid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Basics putValid" })
         @PUT("complex/basic/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putValid(@BodyParam("application/json; charset=utf-8") Basic complexBody, @QueryParam("api-version") String apiVersion);
+        Single<RestResponse<Void, Void>> putValid(@BodyParam("application/json; charset=utf-8") Basic complexBody, @QueryParam("api-version") String apiVersion);
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Basics getInvalid" })
         @GET("complex/basic/invalid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Basic> getInvalid();
+        Single<RestResponse<Void, Basic>> getInvalid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Basics getEmpty" })
         @GET("complex/basic/empty")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Basic> getEmpty();
+        Single<RestResponse<Void, Basic>> getEmpty();
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Basics getNull" })
         @GET("complex/basic/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Basic> getNull();
+        Single<RestResponse<Void, Basic>> getNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Basics getNotProvided" })
         @GET("complex/basic/notprovided")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Basic> getNotProvided();
+        Single<RestResponse<Void, Basic>> getNotProvided();
 
     }
 
@@ -115,7 +116,7 @@ public class BasicsImpl implements Basics {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Basic> getValidAsync(final ServiceCallback<Basic> serviceCallback) {
+    public ServiceFuture<Basic> getValidAsync(ServiceCallback<Basic> serviceCallback) {
         return ServiceFuture.fromBody(getValidAsync(), serviceCallback);
     }
 
@@ -123,11 +124,22 @@ public class BasicsImpl implements Basics {
      * Get complex type {id: 2, name: 'abc', color: 'YELLOW'}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Basic object
+     * @return a {@link Single} emitting the RestResponse<Void, Basic> object
      */
-    public Single<Basic> getValidAsync() {
+    public Single<RestResponse<Void, Basic>> getValidWithRestResponseAsync() {
         return service.getValid();
     }
+
+    /**
+     * Get complex type {id: 2, name: 'abc', color: 'YELLOW'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Basic> object
+     */
+    public Single<Basic> getValidAsync() {
+        return getValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Basic>, Basic>() { public Basic call(RestResponse<Void, Basic> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -137,6 +149,7 @@ public class BasicsImpl implements Basics {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putValid(Basic complexBody) {
         putValidAsync(complexBody).toBlocking().value();
@@ -150,7 +163,7 @@ public class BasicsImpl implements Basics {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putValidAsync(Basic complexBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putValidAsync(Basic complexBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putValidAsync(complexBody), serviceCallback);
     }
 
@@ -159,15 +172,27 @@ public class BasicsImpl implements Basics {
      *
      * @param complexBody Please put {id: 2, name: 'abc', color: 'Magenta'}
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putValidAsync(Basic complexBody) {
+    public Single<RestResponse<Void, Void>> putValidWithRestResponseAsync(Basic complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
         Validator.validate(complexBody);
         return service.putValid(complexBody, this.client.apiVersion());
     }
+
+    /**
+     * Please put {id: 2, name: 'abc', color: 'Magenta'}.
+     *
+     * @param complexBody Please put {id: 2, name: 'abc', color: 'Magenta'}
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putValidAsync(Basic complexBody) {
+        return putValidWithRestResponseAsync(complexBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -189,7 +214,7 @@ public class BasicsImpl implements Basics {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Basic> getInvalidAsync(final ServiceCallback<Basic> serviceCallback) {
+    public ServiceFuture<Basic> getInvalidAsync(ServiceCallback<Basic> serviceCallback) {
         return ServiceFuture.fromBody(getInvalidAsync(), serviceCallback);
     }
 
@@ -197,11 +222,22 @@ public class BasicsImpl implements Basics {
      * Get a basic complex type that is invalid for the local strong type.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Basic object
+     * @return a {@link Single} emitting the RestResponse<Void, Basic> object
      */
-    public Single<Basic> getInvalidAsync() {
+    public Single<RestResponse<Void, Basic>> getInvalidWithRestResponseAsync() {
         return service.getInvalid();
     }
+
+    /**
+     * Get a basic complex type that is invalid for the local strong type.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Basic> object
+     */
+    public Single<Basic> getInvalidAsync() {
+        return getInvalidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Basic>, Basic>() { public Basic call(RestResponse<Void, Basic> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -223,7 +259,7 @@ public class BasicsImpl implements Basics {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Basic> getEmptyAsync(final ServiceCallback<Basic> serviceCallback) {
+    public ServiceFuture<Basic> getEmptyAsync(ServiceCallback<Basic> serviceCallback) {
         return ServiceFuture.fromBody(getEmptyAsync(), serviceCallback);
     }
 
@@ -231,11 +267,22 @@ public class BasicsImpl implements Basics {
      * Get a basic complex type that is empty.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Basic object
+     * @return a {@link Single} emitting the RestResponse<Void, Basic> object
      */
-    public Single<Basic> getEmptyAsync() {
+    public Single<RestResponse<Void, Basic>> getEmptyWithRestResponseAsync() {
         return service.getEmpty();
     }
+
+    /**
+     * Get a basic complex type that is empty.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Basic> object
+     */
+    public Single<Basic> getEmptyAsync() {
+        return getEmptyWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Basic>, Basic>() { public Basic call(RestResponse<Void, Basic> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -257,7 +304,7 @@ public class BasicsImpl implements Basics {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Basic> getNullAsync(final ServiceCallback<Basic> serviceCallback) {
+    public ServiceFuture<Basic> getNullAsync(ServiceCallback<Basic> serviceCallback) {
         return ServiceFuture.fromBody(getNullAsync(), serviceCallback);
     }
 
@@ -265,11 +312,22 @@ public class BasicsImpl implements Basics {
      * Get a basic complex type whose properties are null.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Basic object
+     * @return a {@link Single} emitting the RestResponse<Void, Basic> object
      */
-    public Single<Basic> getNullAsync() {
+    public Single<RestResponse<Void, Basic>> getNullWithRestResponseAsync() {
         return service.getNull();
     }
+
+    /**
+     * Get a basic complex type whose properties are null.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Basic> object
+     */
+    public Single<Basic> getNullAsync() {
+        return getNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Basic>, Basic>() { public Basic call(RestResponse<Void, Basic> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -291,7 +349,7 @@ public class BasicsImpl implements Basics {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Basic> getNotProvidedAsync(final ServiceCallback<Basic> serviceCallback) {
+    public ServiceFuture<Basic> getNotProvidedAsync(ServiceCallback<Basic> serviceCallback) {
         return ServiceFuture.fromBody(getNotProvidedAsync(), serviceCallback);
     }
 
@@ -299,11 +357,22 @@ public class BasicsImpl implements Basics {
      * Get a basic complex type while the server doesn't provide a response payload.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Basic object
+     * @return a {@link Single} emitting the RestResponse<Void, Basic> object
      */
-    public Single<Basic> getNotProvidedAsync() {
+    public Single<RestResponse<Void, Basic>> getNotProvidedWithRestResponseAsync() {
         return service.getNotProvided();
     }
+
+    /**
+     * Get a basic complex type while the server doesn't provide a response payload.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Basic> object
+     */
+    public Single<Basic> getNotProvidedAsync() {
+        return getNotProvidedWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Basic>, Basic>() { public Basic call(RestResponse<Void, Basic> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/DictionarysImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/DictionarysImpl.java
@@ -11,6 +11,7 @@
 package fixtures.bodycomplex.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.bodycomplex.Dictionarys;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.BodyParam;
@@ -61,37 +62,37 @@ public class DictionarysImpl implements Dictionarys {
         @GET("complex/dictionary/typed/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<DictionaryWrapper> getValid();
+        Single<RestResponse<Void, DictionaryWrapper>> getValid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Dictionarys putValid" })
         @PUT("complex/dictionary/typed/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putValid(@BodyParam("application/json; charset=utf-8") DictionaryWrapper complexBody);
+        Single<RestResponse<Void, Void>> putValid(@BodyParam("application/json; charset=utf-8") DictionaryWrapper complexBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Dictionarys getEmpty" })
         @GET("complex/dictionary/typed/empty")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<DictionaryWrapper> getEmpty();
+        Single<RestResponse<Void, DictionaryWrapper>> getEmpty();
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Dictionarys putEmpty" })
         @PUT("complex/dictionary/typed/empty")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putEmpty(@BodyParam("application/json; charset=utf-8") DictionaryWrapper complexBody);
+        Single<RestResponse<Void, Void>> putEmpty(@BodyParam("application/json; charset=utf-8") DictionaryWrapper complexBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Dictionarys getNull" })
         @GET("complex/dictionary/typed/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<DictionaryWrapper> getNull();
+        Single<RestResponse<Void, DictionaryWrapper>> getNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Dictionarys getNotProvided" })
         @GET("complex/dictionary/typed/notprovided")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<DictionaryWrapper> getNotProvided();
+        Single<RestResponse<Void, DictionaryWrapper>> getNotProvided();
 
     }
 
@@ -114,7 +115,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<DictionaryWrapper> getValidAsync(final ServiceCallback<DictionaryWrapper> serviceCallback) {
+    public ServiceFuture<DictionaryWrapper> getValidAsync(ServiceCallback<DictionaryWrapper> serviceCallback) {
         return ServiceFuture.fromBody(getValidAsync(), serviceCallback);
     }
 
@@ -122,11 +123,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get complex types with dictionary property.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the DictionaryWrapper object
+     * @return a {@link Single} emitting the RestResponse<Void, DictionaryWrapper> object
      */
-    public Single<DictionaryWrapper> getValidAsync() {
+    public Single<RestResponse<Void, DictionaryWrapper>> getValidWithRestResponseAsync() {
         return service.getValid();
     }
+
+    /**
+     * Get complex types with dictionary property.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, DictionaryWrapper> object
+     */
+    public Single<DictionaryWrapper> getValidAsync() {
+        return getValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, DictionaryWrapper>, DictionaryWrapper>() { public DictionaryWrapper call(RestResponse<Void, DictionaryWrapper> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -136,6 +148,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putValid(DictionaryWrapper complexBody) {
         putValidAsync(complexBody).toBlocking().value();
@@ -149,7 +162,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putValidAsync(DictionaryWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putValidAsync(DictionaryWrapper complexBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putValidAsync(complexBody), serviceCallback);
     }
 
@@ -158,15 +171,27 @@ public class DictionarysImpl implements Dictionarys {
      *
      * @param complexBody Please put a dictionary with 5 key-value pairs: "txt":"notepad", "bmp":"mspaint", "xls":"excel", "exe":"", "":null
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putValidAsync(DictionaryWrapper complexBody) {
+    public Single<RestResponse<Void, Void>> putValidWithRestResponseAsync(DictionaryWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
         Validator.validate(complexBody);
         return service.putValid(complexBody);
     }
+
+    /**
+     * Put complex types with dictionary property.
+     *
+     * @param complexBody Please put a dictionary with 5 key-value pairs: "txt":"notepad", "bmp":"mspaint", "xls":"excel", "exe":"", "":null
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putValidAsync(DictionaryWrapper complexBody) {
+        return putValidWithRestResponseAsync(complexBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -188,7 +213,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<DictionaryWrapper> getEmptyAsync(final ServiceCallback<DictionaryWrapper> serviceCallback) {
+    public ServiceFuture<DictionaryWrapper> getEmptyAsync(ServiceCallback<DictionaryWrapper> serviceCallback) {
         return ServiceFuture.fromBody(getEmptyAsync(), serviceCallback);
     }
 
@@ -196,11 +221,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get complex types with dictionary property which is empty.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the DictionaryWrapper object
+     * @return a {@link Single} emitting the RestResponse<Void, DictionaryWrapper> object
      */
-    public Single<DictionaryWrapper> getEmptyAsync() {
+    public Single<RestResponse<Void, DictionaryWrapper>> getEmptyWithRestResponseAsync() {
         return service.getEmpty();
     }
+
+    /**
+     * Get complex types with dictionary property which is empty.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, DictionaryWrapper> object
+     */
+    public Single<DictionaryWrapper> getEmptyAsync() {
+        return getEmptyWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, DictionaryWrapper>, DictionaryWrapper>() { public DictionaryWrapper call(RestResponse<Void, DictionaryWrapper> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -210,6 +246,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putEmpty(DictionaryWrapper complexBody) {
         putEmptyAsync(complexBody).toBlocking().value();
@@ -223,7 +260,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putEmptyAsync(DictionaryWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putEmptyAsync(DictionaryWrapper complexBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putEmptyAsync(complexBody), serviceCallback);
     }
 
@@ -232,15 +269,27 @@ public class DictionarysImpl implements Dictionarys {
      *
      * @param complexBody Please put an empty dictionary
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putEmptyAsync(DictionaryWrapper complexBody) {
+    public Single<RestResponse<Void, Void>> putEmptyWithRestResponseAsync(DictionaryWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
         Validator.validate(complexBody);
         return service.putEmpty(complexBody);
     }
+
+    /**
+     * Put complex types with dictionary property which is empty.
+     *
+     * @param complexBody Please put an empty dictionary
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putEmptyAsync(DictionaryWrapper complexBody) {
+        return putEmptyWithRestResponseAsync(complexBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -262,7 +311,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<DictionaryWrapper> getNullAsync(final ServiceCallback<DictionaryWrapper> serviceCallback) {
+    public ServiceFuture<DictionaryWrapper> getNullAsync(ServiceCallback<DictionaryWrapper> serviceCallback) {
         return ServiceFuture.fromBody(getNullAsync(), serviceCallback);
     }
 
@@ -270,11 +319,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get complex types with dictionary property which is null.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the DictionaryWrapper object
+     * @return a {@link Single} emitting the RestResponse<Void, DictionaryWrapper> object
      */
-    public Single<DictionaryWrapper> getNullAsync() {
+    public Single<RestResponse<Void, DictionaryWrapper>> getNullWithRestResponseAsync() {
         return service.getNull();
     }
+
+    /**
+     * Get complex types with dictionary property which is null.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, DictionaryWrapper> object
+     */
+    public Single<DictionaryWrapper> getNullAsync() {
+        return getNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, DictionaryWrapper>, DictionaryWrapper>() { public DictionaryWrapper call(RestResponse<Void, DictionaryWrapper> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -296,7 +356,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<DictionaryWrapper> getNotProvidedAsync(final ServiceCallback<DictionaryWrapper> serviceCallback) {
+    public ServiceFuture<DictionaryWrapper> getNotProvidedAsync(ServiceCallback<DictionaryWrapper> serviceCallback) {
         return ServiceFuture.fromBody(getNotProvidedAsync(), serviceCallback);
     }
 
@@ -304,11 +364,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get complex types with dictionary property while server doesn't provide a response payload.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the DictionaryWrapper object
+     * @return a {@link Single} emitting the RestResponse<Void, DictionaryWrapper> object
      */
-    public Single<DictionaryWrapper> getNotProvidedAsync() {
+    public Single<RestResponse<Void, DictionaryWrapper>> getNotProvidedWithRestResponseAsync() {
         return service.getNotProvided();
     }
+
+    /**
+     * Get complex types with dictionary property while server doesn't provide a response payload.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, DictionaryWrapper> object
+     */
+    public Single<DictionaryWrapper> getNotProvidedAsync() {
+        return getNotProvidedWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, DictionaryWrapper>, DictionaryWrapper>() { public DictionaryWrapper call(RestResponse<Void, DictionaryWrapper> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/InheritancesImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/InheritancesImpl.java
@@ -11,6 +11,7 @@
 package fixtures.bodycomplex.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.bodycomplex.Inheritances;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.BodyParam;
@@ -61,13 +62,13 @@ public class InheritancesImpl implements Inheritances {
         @GET("complex/inheritance/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Siamese> getValid();
+        Single<RestResponse<Void, Siamese>> getValid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Inheritances putValid" })
         @PUT("complex/inheritance/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putValid(@BodyParam("application/json; charset=utf-8") Siamese complexBody);
+        Single<RestResponse<Void, Void>> putValid(@BodyParam("application/json; charset=utf-8") Siamese complexBody);
 
     }
 
@@ -90,7 +91,7 @@ public class InheritancesImpl implements Inheritances {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Siamese> getValidAsync(final ServiceCallback<Siamese> serviceCallback) {
+    public ServiceFuture<Siamese> getValidAsync(ServiceCallback<Siamese> serviceCallback) {
         return ServiceFuture.fromBody(getValidAsync(), serviceCallback);
     }
 
@@ -98,11 +99,22 @@ public class InheritancesImpl implements Inheritances {
      * Get complex types that extend others.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Siamese object
+     * @return a {@link Single} emitting the RestResponse<Void, Siamese> object
      */
-    public Single<Siamese> getValidAsync() {
+    public Single<RestResponse<Void, Siamese>> getValidWithRestResponseAsync() {
         return service.getValid();
     }
+
+    /**
+     * Get complex types that extend others.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Siamese> object
+     */
+    public Single<Siamese> getValidAsync() {
+        return getValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Siamese>, Siamese>() { public Siamese call(RestResponse<Void, Siamese> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -112,6 +124,7 @@ public class InheritancesImpl implements Inheritances {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putValid(Siamese complexBody) {
         putValidAsync(complexBody).toBlocking().value();
@@ -125,7 +138,7 @@ public class InheritancesImpl implements Inheritances {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putValidAsync(Siamese complexBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putValidAsync(Siamese complexBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putValidAsync(complexBody), serviceCallback);
     }
 
@@ -134,15 +147,27 @@ public class InheritancesImpl implements Inheritances {
      *
      * @param complexBody Please put a siamese with id=2, name="Siameee", color=green, breed=persion, which hates 2 dogs, the 1st one named "Potato" with id=1 and food="tomato", and the 2nd one named "Tomato" with id=-1 and food="french fries".
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putValidAsync(Siamese complexBody) {
+    public Single<RestResponse<Void, Void>> putValidWithRestResponseAsync(Siamese complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
         Validator.validate(complexBody);
         return service.putValid(complexBody);
     }
+
+    /**
+     * Put complex types that extend others.
+     *
+     * @param complexBody Please put a siamese with id=2, name="Siameee", color=green, breed=persion, which hates 2 dogs, the 1st one named "Potato" with id=1 and food="tomato", and the 2nd one named "Tomato" with id=-1 and food="french fries".
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putValidAsync(Siamese complexBody) {
+        return putValidWithRestResponseAsync(complexBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/PolymorphicrecursivesImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/PolymorphicrecursivesImpl.java
@@ -109,58 +109,58 @@ public class PolymorphicrecursivesImpl implements Polymorphicrecursives {
      * Put complex types that are polymorphic and have recursive references.
      *
      * @param complexBody Please put a salmon that looks like this:
-     {
-         "fishtype": "salmon",
-         "species": "king",
-         "length": 1,
-         "age": 1,
-         "location": "alaska",
-         "iswild": true,
-         "siblings": [
-             {
-                 "fishtype": "shark",
-                 "species": "predator",
-                 "length": 20,
-                 "age": 6,
-                 "siblings": [
-                     {
-                         "fishtype": "salmon",
-                         "species": "coho",
-                         "length": 2,
-                         "age": 2,
-                         "location": "atlantic",
-                         "iswild": true,
-                         "siblings": [
-                             {
-                                 "fishtype": "shark",
-                                 "species": "predator",
-                                 "length": 20,
-                                 "age": 6
-                             },
-                             {
-                                 "fishtype": "sawshark",
-                                 "species": "dangerous",
-                                 "length": 10,
-                                 "age": 105
-                             }
-                         ]
-                     },
-                     {
-                         "fishtype": "sawshark",
-                         "species": "dangerous",
-                         "length": 10,
-                         "age": 105
-                     }
-                 ]
-             },
-             {
-                 "fishtype": "sawshark",
-                 "species": "dangerous",
-                 "length": 10,
-                 "age": 105
-             }
-         ]
-     }
+    {
+        "fishtype": "salmon",
+        "species": "king",
+        "length": 1,
+        "age": 1,
+        "location": "alaska",
+        "iswild": true,
+        "siblings": [
+            {
+                "fishtype": "shark",
+                "species": "predator",
+                "length": 20,
+                "age": 6,
+                "siblings": [
+                    {
+                        "fishtype": "salmon",
+                        "species": "coho",
+                        "length": 2,
+                        "age": 2,
+                        "location": "atlantic",
+                        "iswild": true,
+                        "siblings": [
+                            {
+                                "fishtype": "shark",
+                                "species": "predator",
+                                "length": 20,
+                                "age": 6
+                            },
+                            {
+                                "fishtype": "sawshark",
+                                "species": "dangerous",
+                                "length": 10,
+                                "age": 105
+                            }
+                        ]
+                    },
+                    {
+                        "fishtype": "sawshark",
+                        "species": "dangerous",
+                        "length": 10,
+                        "age": 105
+                    }
+                ]
+            },
+            {
+                "fishtype": "sawshark",
+                "species": "dangerous",
+                "length": 10,
+                "age": 105
+            }
+        ]
+    }
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/PolymorphicrecursivesImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/PolymorphicrecursivesImpl.java
@@ -11,6 +11,7 @@
 package fixtures.bodycomplex.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.bodycomplex.Polymorphicrecursives;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.BodyParam;
@@ -61,13 +62,13 @@ public class PolymorphicrecursivesImpl implements Polymorphicrecursives {
         @GET("complex/polymorphicrecursive/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Fish> getValid();
+        Single<RestResponse<Void, Fish>> getValid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Polymorphicrecursives putValid" })
         @PUT("complex/polymorphicrecursive/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putValid(@BodyParam("application/json; charset=utf-8") Fish complexBody);
+        Single<RestResponse<Void, Void>> putValid(@BodyParam("application/json; charset=utf-8") Fish complexBody);
 
     }
 
@@ -90,7 +91,7 @@ public class PolymorphicrecursivesImpl implements Polymorphicrecursives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Fish> getValidAsync(final ServiceCallback<Fish> serviceCallback) {
+    public ServiceFuture<Fish> getValidAsync(ServiceCallback<Fish> serviceCallback) {
         return ServiceFuture.fromBody(getValidAsync(), serviceCallback);
     }
 
@@ -98,11 +99,22 @@ public class PolymorphicrecursivesImpl implements Polymorphicrecursives {
      * Get complex types that are polymorphic and have recursive references.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Fish object
+     * @return a {@link Single} emitting the RestResponse<Void, Fish> object
      */
-    public Single<Fish> getValidAsync() {
+    public Single<RestResponse<Void, Fish>> getValidWithRestResponseAsync() {
         return service.getValid();
     }
+
+    /**
+     * Get complex types that are polymorphic and have recursive references.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Fish> object
+     */
+    public Single<Fish> getValidAsync() {
+        return getValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Fish>, Fish>() { public Fish call(RestResponse<Void, Fish> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -164,6 +176,7 @@ public class PolymorphicrecursivesImpl implements Polymorphicrecursives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putValid(Fish complexBody) {
         putValidAsync(complexBody).toBlocking().value();
@@ -173,63 +186,63 @@ public class PolymorphicrecursivesImpl implements Polymorphicrecursives {
      * Put complex types that are polymorphic and have recursive references.
      *
      * @param complexBody Please put a salmon that looks like this:
-     {
-         "fishtype": "salmon",
-         "species": "king",
-         "length": 1,
-         "age": 1,
-         "location": "alaska",
-         "iswild": true,
-         "siblings": [
-             {
-                 "fishtype": "shark",
-                 "species": "predator",
-                 "length": 20,
-                 "age": 6,
-                 "siblings": [
-                     {
-                         "fishtype": "salmon",
-                         "species": "coho",
-                         "length": 2,
-                         "age": 2,
-                         "location": "atlantic",
-                         "iswild": true,
-                         "siblings": [
-                             {
-                                 "fishtype": "shark",
-                                 "species": "predator",
-                                 "length": 20,
-                                 "age": 6
-                             },
-                             {
-                                 "fishtype": "sawshark",
-                                 "species": "dangerous",
-                                 "length": 10,
-                                 "age": 105
-                             }
-                         ]
-                     },
-                     {
-                         "fishtype": "sawshark",
-                         "species": "dangerous",
-                         "length": 10,
-                         "age": 105
-                     }
-                 ]
-             },
-             {
-                 "fishtype": "sawshark",
-                 "species": "dangerous",
-                 "length": 10,
-                 "age": 105
-             }
-         ]
-     }
+    {
+        "fishtype": "salmon",
+        "species": "king",
+        "length": 1,
+        "age": 1,
+        "location": "alaska",
+        "iswild": true,
+        "siblings": [
+            {
+                "fishtype": "shark",
+                "species": "predator",
+                "length": 20,
+                "age": 6,
+                "siblings": [
+                    {
+                        "fishtype": "salmon",
+                        "species": "coho",
+                        "length": 2,
+                        "age": 2,
+                        "location": "atlantic",
+                        "iswild": true,
+                        "siblings": [
+                            {
+                                "fishtype": "shark",
+                                "species": "predator",
+                                "length": 20,
+                                "age": 6
+                            },
+                            {
+                                "fishtype": "sawshark",
+                                "species": "dangerous",
+                                "length": 10,
+                                "age": 105
+                            }
+                        ]
+                    },
+                    {
+                        "fishtype": "sawshark",
+                        "species": "dangerous",
+                        "length": 10,
+                        "age": 105
+                    }
+                ]
+            },
+            {
+                "fishtype": "sawshark",
+                "species": "dangerous",
+                "length": 10,
+                "age": 105
+            }
+        ]
+    }
      * @param serviceCallback the async ServiceCallback to handle successful and failed responses.
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putValidAsync(Fish complexBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putValidAsync(Fish complexBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putValidAsync(complexBody), serviceCallback);
     }
 
@@ -237,68 +250,132 @@ public class PolymorphicrecursivesImpl implements Polymorphicrecursives {
      * Put complex types that are polymorphic and have recursive references.
      *
      * @param complexBody Please put a salmon that looks like this:
-     {
-         "fishtype": "salmon",
-         "species": "king",
-         "length": 1,
-         "age": 1,
-         "location": "alaska",
-         "iswild": true,
-         "siblings": [
-             {
-                 "fishtype": "shark",
-                 "species": "predator",
-                 "length": 20,
-                 "age": 6,
-                 "siblings": [
-                     {
-                         "fishtype": "salmon",
-                         "species": "coho",
-                         "length": 2,
-                         "age": 2,
-                         "location": "atlantic",
-                         "iswild": true,
-                         "siblings": [
-                             {
-                                 "fishtype": "shark",
-                                 "species": "predator",
-                                 "length": 20,
-                                 "age": 6
-                             },
-                             {
-                                 "fishtype": "sawshark",
-                                 "species": "dangerous",
-                                 "length": 10,
-                                 "age": 105
-                             }
-                         ]
-                     },
-                     {
-                         "fishtype": "sawshark",
-                         "species": "dangerous",
-                         "length": 10,
-                         "age": 105
-                     }
-                 ]
-             },
-             {
-                 "fishtype": "sawshark",
-                 "species": "dangerous",
-                 "length": 10,
-                 "age": 105
-             }
-         ]
-     }
+    {
+        "fishtype": "salmon",
+        "species": "king",
+        "length": 1,
+        "age": 1,
+        "location": "alaska",
+        "iswild": true,
+        "siblings": [
+            {
+                "fishtype": "shark",
+                "species": "predator",
+                "length": 20,
+                "age": 6,
+                "siblings": [
+                    {
+                        "fishtype": "salmon",
+                        "species": "coho",
+                        "length": 2,
+                        "age": 2,
+                        "location": "atlantic",
+                        "iswild": true,
+                        "siblings": [
+                            {
+                                "fishtype": "shark",
+                                "species": "predator",
+                                "length": 20,
+                                "age": 6
+                            },
+                            {
+                                "fishtype": "sawshark",
+                                "species": "dangerous",
+                                "length": 10,
+                                "age": 105
+                            }
+                        ]
+                    },
+                    {
+                        "fishtype": "sawshark",
+                        "species": "dangerous",
+                        "length": 10,
+                        "age": 105
+                    }
+                ]
+            },
+            {
+                "fishtype": "sawshark",
+                "species": "dangerous",
+                "length": 10,
+                "age": 105
+            }
+        ]
+    }
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putValidAsync(Fish complexBody) {
+    public Single<RestResponse<Void, Void>> putValidWithRestResponseAsync(Fish complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
         Validator.validate(complexBody);
         return service.putValid(complexBody);
     }
+
+    /**
+     * Put complex types that are polymorphic and have recursive references.
+     *
+     * @param complexBody Please put a salmon that looks like this:
+    {
+        "fishtype": "salmon",
+        "species": "king",
+        "length": 1,
+        "age": 1,
+        "location": "alaska",
+        "iswild": true,
+        "siblings": [
+            {
+                "fishtype": "shark",
+                "species": "predator",
+                "length": 20,
+                "age": 6,
+                "siblings": [
+                    {
+                        "fishtype": "salmon",
+                        "species": "coho",
+                        "length": 2,
+                        "age": 2,
+                        "location": "atlantic",
+                        "iswild": true,
+                        "siblings": [
+                            {
+                                "fishtype": "shark",
+                                "species": "predator",
+                                "length": 20,
+                                "age": 6
+                            },
+                            {
+                                "fishtype": "sawshark",
+                                "species": "dangerous",
+                                "length": 10,
+                                "age": 105
+                            }
+                        ]
+                    },
+                    {
+                        "fishtype": "sawshark",
+                        "species": "dangerous",
+                        "length": 10,
+                        "age": 105
+                    }
+                ]
+            },
+            {
+                "fishtype": "sawshark",
+                "species": "dangerous",
+                "length": 10,
+                "age": 105
+            }
+        ]
+    }
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putValidAsync(Fish complexBody) {
+        return putValidWithRestResponseAsync(complexBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/PolymorphismsImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/PolymorphismsImpl.java
@@ -11,6 +11,7 @@
 package fixtures.bodycomplex.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.bodycomplex.Polymorphisms;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.BodyParam;
@@ -61,19 +62,19 @@ public class PolymorphismsImpl implements Polymorphisms {
         @GET("complex/polymorphism/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Fish> getValid();
+        Single<RestResponse<Void, Fish>> getValid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Polymorphisms putValid" })
         @PUT("complex/polymorphism/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putValid(@BodyParam("application/json; charset=utf-8") Fish complexBody);
+        Single<RestResponse<Void, Void>> putValid(@BodyParam("application/json; charset=utf-8") Fish complexBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Polymorphisms putValidMissingRequired" })
         @PUT("complex/polymorphism/missingrequired/invalid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putValidMissingRequired(@BodyParam("application/json; charset=utf-8") Fish complexBody);
+        Single<RestResponse<Void, Void>> putValidMissingRequired(@BodyParam("application/json; charset=utf-8") Fish complexBody);
 
     }
 
@@ -96,7 +97,7 @@ public class PolymorphismsImpl implements Polymorphisms {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Fish> getValidAsync(final ServiceCallback<Fish> serviceCallback) {
+    public ServiceFuture<Fish> getValidAsync(ServiceCallback<Fish> serviceCallback) {
         return ServiceFuture.fromBody(getValidAsync(), serviceCallback);
     }
 
@@ -104,11 +105,22 @@ public class PolymorphismsImpl implements Polymorphisms {
      * Get complex types that are polymorphic.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Fish object
+     * @return a {@link Single} emitting the RestResponse<Void, Fish> object
      */
-    public Single<Fish> getValidAsync() {
+    public Single<RestResponse<Void, Fish>> getValidWithRestResponseAsync() {
         return service.getValid();
     }
+
+    /**
+     * Get complex types that are polymorphic.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Fish> object
+     */
+    public Single<Fish> getValidAsync() {
+        return getValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Fish>, Fish>() { public Fish call(RestResponse<Void, Fish> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -150,6 +162,7 @@ public class PolymorphismsImpl implements Polymorphisms {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putValid(Fish complexBody) {
         putValidAsync(complexBody).toBlocking().value();
@@ -159,43 +172,43 @@ public class PolymorphismsImpl implements Polymorphisms {
      * Put complex types that are polymorphic.
      *
      * @param complexBody Please put a salmon that looks like this:
-     {
-             'fishtype':'Salmon',
-             'location':'alaska',
-             'iswild':true,
-             'species':'king',
-             'length':1.0,
-             'siblings':[
-               {
-                 'fishtype':'Shark',
-                 'age':6,
-                 'birthday': '2012-01-05T01:00:00Z',
-                 'length':20.0,
-                 'species':'predator',
-               },
-               {
-                 'fishtype':'Sawshark',
-                 'age':105,
-                 'birthday': '1900-01-05T01:00:00Z',
-                 'length':10.0,
-                 'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
-                 'species':'dangerous',
-               },
-               {
-                 'fishtype': 'goblin',
-                 'age': 1,
-                 'birthday': '2015-08-08T00:00:00Z',
-                 'length': 30.0,
-                 'species': 'scary',
-                 'jawsize': 5
-               }
-             ]
-           };
+    {
+            'fishtype':'Salmon',
+            'location':'alaska',
+            'iswild':true,
+            'species':'king',
+            'length':1.0,
+            'siblings':[
+              {
+                'fishtype':'Shark',
+                'age':6,
+                'birthday': '2012-01-05T01:00:00Z',
+                'length':20.0,
+                'species':'predator',
+              },
+              {
+                'fishtype':'Sawshark',
+                'age':105,
+                'birthday': '1900-01-05T01:00:00Z',
+                'length':10.0,
+                'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
+                'species':'dangerous',
+              },
+              {
+                'fishtype': 'goblin',
+                'age': 1,
+                'birthday': '2015-08-08T00:00:00Z',
+                'length': 30.0,
+                'species': 'scary',
+                'jawsize': 5
+              }
+            ]
+          };
      * @param serviceCallback the async ServiceCallback to handle successful and failed responses.
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putValidAsync(Fish complexBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putValidAsync(Fish complexBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putValidAsync(complexBody), serviceCallback);
     }
 
@@ -203,48 +216,92 @@ public class PolymorphismsImpl implements Polymorphisms {
      * Put complex types that are polymorphic.
      *
      * @param complexBody Please put a salmon that looks like this:
-     {
-             'fishtype':'Salmon',
-             'location':'alaska',
-             'iswild':true,
-             'species':'king',
-             'length':1.0,
-             'siblings':[
-               {
-                 'fishtype':'Shark',
-                 'age':6,
-                 'birthday': '2012-01-05T01:00:00Z',
-                 'length':20.0,
-                 'species':'predator',
-               },
-               {
-                 'fishtype':'Sawshark',
-                 'age':105,
-                 'birthday': '1900-01-05T01:00:00Z',
-                 'length':10.0,
-                 'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
-                 'species':'dangerous',
-               },
-               {
-                 'fishtype': 'goblin',
-                 'age': 1,
-                 'birthday': '2015-08-08T00:00:00Z',
-                 'length': 30.0,
-                 'species': 'scary',
-                 'jawsize': 5
-               }
-             ]
-           };
+    {
+            'fishtype':'Salmon',
+            'location':'alaska',
+            'iswild':true,
+            'species':'king',
+            'length':1.0,
+            'siblings':[
+              {
+                'fishtype':'Shark',
+                'age':6,
+                'birthday': '2012-01-05T01:00:00Z',
+                'length':20.0,
+                'species':'predator',
+              },
+              {
+                'fishtype':'Sawshark',
+                'age':105,
+                'birthday': '1900-01-05T01:00:00Z',
+                'length':10.0,
+                'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
+                'species':'dangerous',
+              },
+              {
+                'fishtype': 'goblin',
+                'age': 1,
+                'birthday': '2015-08-08T00:00:00Z',
+                'length': 30.0,
+                'species': 'scary',
+                'jawsize': 5
+              }
+            ]
+          };
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putValidAsync(Fish complexBody) {
+    public Single<RestResponse<Void, Void>> putValidWithRestResponseAsync(Fish complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
         Validator.validate(complexBody);
         return service.putValid(complexBody);
     }
+
+    /**
+     * Put complex types that are polymorphic.
+     *
+     * @param complexBody Please put a salmon that looks like this:
+    {
+            'fishtype':'Salmon',
+            'location':'alaska',
+            'iswild':true,
+            'species':'king',
+            'length':1.0,
+            'siblings':[
+              {
+                'fishtype':'Shark',
+                'age':6,
+                'birthday': '2012-01-05T01:00:00Z',
+                'length':20.0,
+                'species':'predator',
+              },
+              {
+                'fishtype':'Sawshark',
+                'age':105,
+                'birthday': '1900-01-05T01:00:00Z',
+                'length':10.0,
+                'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
+                'species':'dangerous',
+              },
+              {
+                'fishtype': 'goblin',
+                'age': 1,
+                'birthday': '2015-08-08T00:00:00Z',
+                'length': 30.0,
+                'species': 'scary',
+                'jawsize': 5
+              }
+            ]
+          };
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putValidAsync(Fish complexBody) {
+        return putValidWithRestResponseAsync(complexBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -279,6 +336,7 @@ public class PolymorphismsImpl implements Polymorphisms {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putValidMissingRequired(Fish complexBody) {
         putValidMissingRequiredAsync(complexBody).toBlocking().value();
@@ -288,36 +346,36 @@ public class PolymorphismsImpl implements Polymorphisms {
      * Put complex types that are polymorphic, attempting to omit required 'birthday' field - the request should not be allowed from the client.
      *
      * @param complexBody Please attempt put a sawshark that looks like this, the client should not allow this data to be sent:
-     {
-         "fishtype": "sawshark",
-         "species": "snaggle toothed",
-         "length": 18.5,
-         "age": 2,
-         "birthday": "2013-06-01T01:00:00Z",
-         "location": "alaska",
-         "picture": base64(FF FF FF FF FE),
-         "siblings": [
-             {
-                 "fishtype": "shark",
-                 "species": "predator",
-                 "birthday": "2012-01-05T01:00:00Z",
-                 "length": 20,
-                 "age": 6
-             },
-             {
-                 "fishtype": "sawshark",
-                 "species": "dangerous",
-                 "picture": base64(FF FF FF FF FE),
-                 "length": 10,
-                 "age": 105
-             }
-         ]
-     }
+    {
+        "fishtype": "sawshark",
+        "species": "snaggle toothed",
+        "length": 18.5,
+        "age": 2,
+        "birthday": "2013-06-01T01:00:00Z",
+        "location": "alaska",
+        "picture": base64(FF FF FF FF FE),
+        "siblings": [
+            {
+                "fishtype": "shark",
+                "species": "predator",
+                "birthday": "2012-01-05T01:00:00Z",
+                "length": 20,
+                "age": 6
+            },
+            {
+                "fishtype": "sawshark",
+                "species": "dangerous",
+                "picture": base64(FF FF FF FF FE),
+                "length": 10,
+                "age": 105
+            }
+        ]
+    }
      * @param serviceCallback the async ServiceCallback to handle successful and failed responses.
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putValidMissingRequiredAsync(Fish complexBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putValidMissingRequiredAsync(Fish complexBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putValidMissingRequiredAsync(complexBody), serviceCallback);
     }
 
@@ -325,41 +383,78 @@ public class PolymorphismsImpl implements Polymorphisms {
      * Put complex types that are polymorphic, attempting to omit required 'birthday' field - the request should not be allowed from the client.
      *
      * @param complexBody Please attempt put a sawshark that looks like this, the client should not allow this data to be sent:
-     {
-         "fishtype": "sawshark",
-         "species": "snaggle toothed",
-         "length": 18.5,
-         "age": 2,
-         "birthday": "2013-06-01T01:00:00Z",
-         "location": "alaska",
-         "picture": base64(FF FF FF FF FE),
-         "siblings": [
-             {
-                 "fishtype": "shark",
-                 "species": "predator",
-                 "birthday": "2012-01-05T01:00:00Z",
-                 "length": 20,
-                 "age": 6
-             },
-             {
-                 "fishtype": "sawshark",
-                 "species": "dangerous",
-                 "picture": base64(FF FF FF FF FE),
-                 "length": 10,
-                 "age": 105
-             }
-         ]
-     }
+    {
+        "fishtype": "sawshark",
+        "species": "snaggle toothed",
+        "length": 18.5,
+        "age": 2,
+        "birthday": "2013-06-01T01:00:00Z",
+        "location": "alaska",
+        "picture": base64(FF FF FF FF FE),
+        "siblings": [
+            {
+                "fishtype": "shark",
+                "species": "predator",
+                "birthday": "2012-01-05T01:00:00Z",
+                "length": 20,
+                "age": 6
+            },
+            {
+                "fishtype": "sawshark",
+                "species": "dangerous",
+                "picture": base64(FF FF FF FF FE),
+                "length": 10,
+                "age": 105
+            }
+        ]
+    }
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putValidMissingRequiredAsync(Fish complexBody) {
+    public Single<RestResponse<Void, Void>> putValidMissingRequiredWithRestResponseAsync(Fish complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
         Validator.validate(complexBody);
         return service.putValidMissingRequired(complexBody);
     }
+
+    /**
+     * Put complex types that are polymorphic, attempting to omit required 'birthday' field - the request should not be allowed from the client.
+     *
+     * @param complexBody Please attempt put a sawshark that looks like this, the client should not allow this data to be sent:
+    {
+        "fishtype": "sawshark",
+        "species": "snaggle toothed",
+        "length": 18.5,
+        "age": 2,
+        "birthday": "2013-06-01T01:00:00Z",
+        "location": "alaska",
+        "picture": base64(FF FF FF FF FE),
+        "siblings": [
+            {
+                "fishtype": "shark",
+                "species": "predator",
+                "birthday": "2012-01-05T01:00:00Z",
+                "length": 20,
+                "age": 6
+            },
+            {
+                "fishtype": "sawshark",
+                "species": "dangerous",
+                "picture": base64(FF FF FF FF FE),
+                "length": 10,
+                "age": 105
+            }
+        ]
+    }
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putValidMissingRequiredAsync(Fish complexBody) {
+        return putValidMissingRequiredWithRestResponseAsync(complexBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/PolymorphismsImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/PolymorphismsImpl.java
@@ -115,38 +115,38 @@ public class PolymorphismsImpl implements Polymorphisms {
      * Put complex types that are polymorphic.
      *
      * @param complexBody Please put a salmon that looks like this:
-     {
-             'fishtype':'Salmon',
-             'location':'alaska',
-             'iswild':true,
-             'species':'king',
-             'length':1.0,
-             'siblings':[
-               {
-                 'fishtype':'Shark',
-                 'age':6,
-                 'birthday': '2012-01-05T01:00:00Z',
-                 'length':20.0,
-                 'species':'predator',
-               },
-               {
-                 'fishtype':'Sawshark',
-                 'age':105,
-                 'birthday': '1900-01-05T01:00:00Z',
-                 'length':10.0,
-                 'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
-                 'species':'dangerous',
-               },
-               {
-                 'fishtype': 'goblin',
-                 'age': 1,
-                 'birthday': '2015-08-08T00:00:00Z',
-                 'length': 30.0,
-                 'species': 'scary',
-                 'jawsize': 5
-               }
-             ]
-           };
+    {
+            'fishtype':'Salmon',
+            'location':'alaska',
+            'iswild':true,
+            'species':'king',
+            'length':1.0,
+            'siblings':[
+              {
+                'fishtype':'Shark',
+                'age':6,
+                'birthday': '2012-01-05T01:00:00Z',
+                'length':20.0,
+                'species':'predator',
+              },
+              {
+                'fishtype':'Sawshark',
+                'age':105,
+                'birthday': '1900-01-05T01:00:00Z',
+                'length':10.0,
+                'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
+                'species':'dangerous',
+              },
+              {
+                'fishtype': 'goblin',
+                'age': 1,
+                'birthday': '2015-08-08T00:00:00Z',
+                'length': 30.0,
+                'species': 'scary',
+                'jawsize': 5
+              }
+            ]
+          };
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
@@ -251,31 +251,31 @@ public class PolymorphismsImpl implements Polymorphisms {
      * Put complex types that are polymorphic, attempting to omit required 'birthday' field - the request should not be allowed from the client.
      *
      * @param complexBody Please attempt put a sawshark that looks like this, the client should not allow this data to be sent:
-     {
-         "fishtype": "sawshark",
-         "species": "snaggle toothed",
-         "length": 18.5,
-         "age": 2,
-         "birthday": "2013-06-01T01:00:00Z",
-         "location": "alaska",
-         "picture": base64(FF FF FF FF FE),
-         "siblings": [
-             {
-                 "fishtype": "shark",
-                 "species": "predator",
-                 "birthday": "2012-01-05T01:00:00Z",
-                 "length": 20,
-                 "age": 6
-             },
-             {
-                 "fishtype": "sawshark",
-                 "species": "dangerous",
-                 "picture": base64(FF FF FF FF FE),
-                 "length": 10,
-                 "age": 105
-             }
-         ]
-     }
+    {
+        "fishtype": "sawshark",
+        "species": "snaggle toothed",
+        "length": 18.5,
+        "age": 2,
+        "birthday": "2013-06-01T01:00:00Z",
+        "location": "alaska",
+        "picture": base64(FF FF FF FF FE),
+        "siblings": [
+            {
+                "fishtype": "shark",
+                "species": "predator",
+                "birthday": "2012-01-05T01:00:00Z",
+                "length": 20,
+                "age": 6
+            },
+            {
+                "fishtype": "sawshark",
+                "species": "dangerous",
+                "picture": base64(FF FF FF FF FE),
+                "length": 10,
+                "age": 105
+            }
+        ]
+    }
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/PrimitivesImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/PrimitivesImpl.java
@@ -11,6 +11,7 @@
 package fixtures.bodycomplex.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.bodycomplex.Primitives;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.BodyParam;
@@ -71,133 +72,133 @@ public class PrimitivesImpl implements Primitives {
         @GET("complex/primitive/integer")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<IntWrapper> getInt();
+        Single<RestResponse<Void, IntWrapper>> getInt();
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Primitives putInt" })
         @PUT("complex/primitive/integer")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putInt(@BodyParam("application/json; charset=utf-8") IntWrapper complexBody);
+        Single<RestResponse<Void, Void>> putInt(@BodyParam("application/json; charset=utf-8") IntWrapper complexBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Primitives getLong" })
         @GET("complex/primitive/long")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<LongWrapper> getLong();
+        Single<RestResponse<Void, LongWrapper>> getLong();
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Primitives putLong" })
         @PUT("complex/primitive/long")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putLong(@BodyParam("application/json; charset=utf-8") LongWrapper complexBody);
+        Single<RestResponse<Void, Void>> putLong(@BodyParam("application/json; charset=utf-8") LongWrapper complexBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Primitives getFloat" })
         @GET("complex/primitive/float")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<FloatWrapper> getFloat();
+        Single<RestResponse<Void, FloatWrapper>> getFloat();
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Primitives putFloat" })
         @PUT("complex/primitive/float")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putFloat(@BodyParam("application/json; charset=utf-8") FloatWrapper complexBody);
+        Single<RestResponse<Void, Void>> putFloat(@BodyParam("application/json; charset=utf-8") FloatWrapper complexBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Primitives getDouble" })
         @GET("complex/primitive/double")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<DoubleWrapper> getDouble();
+        Single<RestResponse<Void, DoubleWrapper>> getDouble();
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Primitives putDouble" })
         @PUT("complex/primitive/double")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putDouble(@BodyParam("application/json; charset=utf-8") DoubleWrapper complexBody);
+        Single<RestResponse<Void, Void>> putDouble(@BodyParam("application/json; charset=utf-8") DoubleWrapper complexBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Primitives getBool" })
         @GET("complex/primitive/bool")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<BooleanWrapper> getBool();
+        Single<RestResponse<Void, BooleanWrapper>> getBool();
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Primitives putBool" })
         @PUT("complex/primitive/bool")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putBool(@BodyParam("application/json; charset=utf-8") BooleanWrapper complexBody);
+        Single<RestResponse<Void, Void>> putBool(@BodyParam("application/json; charset=utf-8") BooleanWrapper complexBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Primitives getString" })
         @GET("complex/primitive/string")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<StringWrapper> getString();
+        Single<RestResponse<Void, StringWrapper>> getString();
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Primitives putString" })
         @PUT("complex/primitive/string")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putString(@BodyParam("application/json; charset=utf-8") StringWrapper complexBody);
+        Single<RestResponse<Void, Void>> putString(@BodyParam("application/json; charset=utf-8") StringWrapper complexBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Primitives getDate" })
         @GET("complex/primitive/date")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<DateWrapper> getDate();
+        Single<RestResponse<Void, DateWrapper>> getDate();
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Primitives putDate" })
         @PUT("complex/primitive/date")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putDate(@BodyParam("application/json; charset=utf-8") DateWrapper complexBody);
+        Single<RestResponse<Void, Void>> putDate(@BodyParam("application/json; charset=utf-8") DateWrapper complexBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Primitives getDateTime" })
         @GET("complex/primitive/datetime")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<DatetimeWrapper> getDateTime();
+        Single<RestResponse<Void, DatetimeWrapper>> getDateTime();
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Primitives putDateTime" })
         @PUT("complex/primitive/datetime")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putDateTime(@BodyParam("application/json; charset=utf-8") DatetimeWrapper complexBody);
+        Single<RestResponse<Void, Void>> putDateTime(@BodyParam("application/json; charset=utf-8") DatetimeWrapper complexBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Primitives getDateTimeRfc1123" })
         @GET("complex/primitive/datetimerfc1123")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Datetimerfc1123Wrapper> getDateTimeRfc1123();
+        Single<RestResponse<Void, Datetimerfc1123Wrapper>> getDateTimeRfc1123();
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Primitives putDateTimeRfc1123" })
         @PUT("complex/primitive/datetimerfc1123")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putDateTimeRfc1123(@BodyParam("application/json; charset=utf-8") Datetimerfc1123Wrapper complexBody);
+        Single<RestResponse<Void, Void>> putDateTimeRfc1123(@BodyParam("application/json; charset=utf-8") Datetimerfc1123Wrapper complexBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Primitives getDuration" })
         @GET("complex/primitive/duration")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<DurationWrapper> getDuration();
+        Single<RestResponse<Void, DurationWrapper>> getDuration();
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Primitives putDuration" })
         @PUT("complex/primitive/duration")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putDuration(@BodyParam("application/json; charset=utf-8") DurationWrapper complexBody);
+        Single<RestResponse<Void, Void>> putDuration(@BodyParam("application/json; charset=utf-8") DurationWrapper complexBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Primitives getByte" })
         @GET("complex/primitive/byte")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<ByteWrapper> getByte();
+        Single<RestResponse<Void, ByteWrapper>> getByte();
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Primitives putByte" })
         @PUT("complex/primitive/byte")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putByte(@BodyParam("application/json; charset=utf-8") ByteWrapper complexBody);
+        Single<RestResponse<Void, Void>> putByte(@BodyParam("application/json; charset=utf-8") ByteWrapper complexBody);
 
     }
 
@@ -220,7 +221,7 @@ public class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<IntWrapper> getIntAsync(final ServiceCallback<IntWrapper> serviceCallback) {
+    public ServiceFuture<IntWrapper> getIntAsync(ServiceCallback<IntWrapper> serviceCallback) {
         return ServiceFuture.fromBody(getIntAsync(), serviceCallback);
     }
 
@@ -228,11 +229,22 @@ public class PrimitivesImpl implements Primitives {
      * Get complex types with integer properties.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the IntWrapper object
+     * @return a {@link Single} emitting the RestResponse<Void, IntWrapper> object
      */
-    public Single<IntWrapper> getIntAsync() {
+    public Single<RestResponse<Void, IntWrapper>> getIntWithRestResponseAsync() {
         return service.getInt();
     }
+
+    /**
+     * Get complex types with integer properties.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, IntWrapper> object
+     */
+    public Single<IntWrapper> getIntAsync() {
+        return getIntWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, IntWrapper>, IntWrapper>() { public IntWrapper call(RestResponse<Void, IntWrapper> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -242,6 +254,7 @@ public class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putInt(IntWrapper complexBody) {
         putIntAsync(complexBody).toBlocking().value();
@@ -255,7 +268,7 @@ public class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putIntAsync(IntWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putIntAsync(IntWrapper complexBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putIntAsync(complexBody), serviceCallback);
     }
 
@@ -264,15 +277,27 @@ public class PrimitivesImpl implements Primitives {
      *
      * @param complexBody Please put -1 and 2
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putIntAsync(IntWrapper complexBody) {
+    public Single<RestResponse<Void, Void>> putIntWithRestResponseAsync(IntWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
         Validator.validate(complexBody);
         return service.putInt(complexBody);
     }
+
+    /**
+     * Put complex types with integer properties.
+     *
+     * @param complexBody Please put -1 and 2
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putIntAsync(IntWrapper complexBody) {
+        return putIntWithRestResponseAsync(complexBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -294,7 +319,7 @@ public class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<LongWrapper> getLongAsync(final ServiceCallback<LongWrapper> serviceCallback) {
+    public ServiceFuture<LongWrapper> getLongAsync(ServiceCallback<LongWrapper> serviceCallback) {
         return ServiceFuture.fromBody(getLongAsync(), serviceCallback);
     }
 
@@ -302,11 +327,22 @@ public class PrimitivesImpl implements Primitives {
      * Get complex types with long properties.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the LongWrapper object
+     * @return a {@link Single} emitting the RestResponse<Void, LongWrapper> object
      */
-    public Single<LongWrapper> getLongAsync() {
+    public Single<RestResponse<Void, LongWrapper>> getLongWithRestResponseAsync() {
         return service.getLong();
     }
+
+    /**
+     * Get complex types with long properties.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, LongWrapper> object
+     */
+    public Single<LongWrapper> getLongAsync() {
+        return getLongWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, LongWrapper>, LongWrapper>() { public LongWrapper call(RestResponse<Void, LongWrapper> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -316,6 +352,7 @@ public class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putLong(LongWrapper complexBody) {
         putLongAsync(complexBody).toBlocking().value();
@@ -329,7 +366,7 @@ public class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putLongAsync(LongWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putLongAsync(LongWrapper complexBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putLongAsync(complexBody), serviceCallback);
     }
 
@@ -338,15 +375,27 @@ public class PrimitivesImpl implements Primitives {
      *
      * @param complexBody Please put 1099511627775 and -999511627788
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putLongAsync(LongWrapper complexBody) {
+    public Single<RestResponse<Void, Void>> putLongWithRestResponseAsync(LongWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
         Validator.validate(complexBody);
         return service.putLong(complexBody);
     }
+
+    /**
+     * Put complex types with long properties.
+     *
+     * @param complexBody Please put 1099511627775 and -999511627788
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putLongAsync(LongWrapper complexBody) {
+        return putLongWithRestResponseAsync(complexBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -368,7 +417,7 @@ public class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<FloatWrapper> getFloatAsync(final ServiceCallback<FloatWrapper> serviceCallback) {
+    public ServiceFuture<FloatWrapper> getFloatAsync(ServiceCallback<FloatWrapper> serviceCallback) {
         return ServiceFuture.fromBody(getFloatAsync(), serviceCallback);
     }
 
@@ -376,11 +425,22 @@ public class PrimitivesImpl implements Primitives {
      * Get complex types with float properties.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the FloatWrapper object
+     * @return a {@link Single} emitting the RestResponse<Void, FloatWrapper> object
      */
-    public Single<FloatWrapper> getFloatAsync() {
+    public Single<RestResponse<Void, FloatWrapper>> getFloatWithRestResponseAsync() {
         return service.getFloat();
     }
+
+    /**
+     * Get complex types with float properties.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, FloatWrapper> object
+     */
+    public Single<FloatWrapper> getFloatAsync() {
+        return getFloatWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, FloatWrapper>, FloatWrapper>() { public FloatWrapper call(RestResponse<Void, FloatWrapper> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -390,6 +450,7 @@ public class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putFloat(FloatWrapper complexBody) {
         putFloatAsync(complexBody).toBlocking().value();
@@ -403,7 +464,7 @@ public class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putFloatAsync(FloatWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putFloatAsync(FloatWrapper complexBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putFloatAsync(complexBody), serviceCallback);
     }
 
@@ -412,15 +473,27 @@ public class PrimitivesImpl implements Primitives {
      *
      * @param complexBody Please put 1.05 and -0.003
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putFloatAsync(FloatWrapper complexBody) {
+    public Single<RestResponse<Void, Void>> putFloatWithRestResponseAsync(FloatWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
         Validator.validate(complexBody);
         return service.putFloat(complexBody);
     }
+
+    /**
+     * Put complex types with float properties.
+     *
+     * @param complexBody Please put 1.05 and -0.003
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putFloatAsync(FloatWrapper complexBody) {
+        return putFloatWithRestResponseAsync(complexBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -442,7 +515,7 @@ public class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<DoubleWrapper> getDoubleAsync(final ServiceCallback<DoubleWrapper> serviceCallback) {
+    public ServiceFuture<DoubleWrapper> getDoubleAsync(ServiceCallback<DoubleWrapper> serviceCallback) {
         return ServiceFuture.fromBody(getDoubleAsync(), serviceCallback);
     }
 
@@ -450,11 +523,22 @@ public class PrimitivesImpl implements Primitives {
      * Get complex types with double properties.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the DoubleWrapper object
+     * @return a {@link Single} emitting the RestResponse<Void, DoubleWrapper> object
      */
-    public Single<DoubleWrapper> getDoubleAsync() {
+    public Single<RestResponse<Void, DoubleWrapper>> getDoubleWithRestResponseAsync() {
         return service.getDouble();
     }
+
+    /**
+     * Get complex types with double properties.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, DoubleWrapper> object
+     */
+    public Single<DoubleWrapper> getDoubleAsync() {
+        return getDoubleWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, DoubleWrapper>, DoubleWrapper>() { public DoubleWrapper call(RestResponse<Void, DoubleWrapper> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -464,6 +548,7 @@ public class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putDouble(DoubleWrapper complexBody) {
         putDoubleAsync(complexBody).toBlocking().value();
@@ -477,7 +562,7 @@ public class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putDoubleAsync(DoubleWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putDoubleAsync(DoubleWrapper complexBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putDoubleAsync(complexBody), serviceCallback);
     }
 
@@ -486,15 +571,27 @@ public class PrimitivesImpl implements Primitives {
      *
      * @param complexBody Please put 3e-100 and -0.000000000000000000000000000000000000000000000000000000005
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putDoubleAsync(DoubleWrapper complexBody) {
+    public Single<RestResponse<Void, Void>> putDoubleWithRestResponseAsync(DoubleWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
         Validator.validate(complexBody);
         return service.putDouble(complexBody);
     }
+
+    /**
+     * Put complex types with double properties.
+     *
+     * @param complexBody Please put 3e-100 and -0.000000000000000000000000000000000000000000000000000000005
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putDoubleAsync(DoubleWrapper complexBody) {
+        return putDoubleWithRestResponseAsync(complexBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -516,7 +613,7 @@ public class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<BooleanWrapper> getBoolAsync(final ServiceCallback<BooleanWrapper> serviceCallback) {
+    public ServiceFuture<BooleanWrapper> getBoolAsync(ServiceCallback<BooleanWrapper> serviceCallback) {
         return ServiceFuture.fromBody(getBoolAsync(), serviceCallback);
     }
 
@@ -524,11 +621,22 @@ public class PrimitivesImpl implements Primitives {
      * Get complex types with bool properties.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the BooleanWrapper object
+     * @return a {@link Single} emitting the RestResponse<Void, BooleanWrapper> object
      */
-    public Single<BooleanWrapper> getBoolAsync() {
+    public Single<RestResponse<Void, BooleanWrapper>> getBoolWithRestResponseAsync() {
         return service.getBool();
     }
+
+    /**
+     * Get complex types with bool properties.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, BooleanWrapper> object
+     */
+    public Single<BooleanWrapper> getBoolAsync() {
+        return getBoolWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, BooleanWrapper>, BooleanWrapper>() { public BooleanWrapper call(RestResponse<Void, BooleanWrapper> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -538,6 +646,7 @@ public class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putBool(BooleanWrapper complexBody) {
         putBoolAsync(complexBody).toBlocking().value();
@@ -551,7 +660,7 @@ public class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putBoolAsync(BooleanWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putBoolAsync(BooleanWrapper complexBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putBoolAsync(complexBody), serviceCallback);
     }
 
@@ -560,15 +669,27 @@ public class PrimitivesImpl implements Primitives {
      *
      * @param complexBody Please put true and false
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putBoolAsync(BooleanWrapper complexBody) {
+    public Single<RestResponse<Void, Void>> putBoolWithRestResponseAsync(BooleanWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
         Validator.validate(complexBody);
         return service.putBool(complexBody);
     }
+
+    /**
+     * Put complex types with bool properties.
+     *
+     * @param complexBody Please put true and false
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putBoolAsync(BooleanWrapper complexBody) {
+        return putBoolWithRestResponseAsync(complexBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -590,7 +711,7 @@ public class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<StringWrapper> getStringAsync(final ServiceCallback<StringWrapper> serviceCallback) {
+    public ServiceFuture<StringWrapper> getStringAsync(ServiceCallback<StringWrapper> serviceCallback) {
         return ServiceFuture.fromBody(getStringAsync(), serviceCallback);
     }
 
@@ -598,11 +719,22 @@ public class PrimitivesImpl implements Primitives {
      * Get complex types with string properties.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the StringWrapper object
+     * @return a {@link Single} emitting the RestResponse<Void, StringWrapper> object
      */
-    public Single<StringWrapper> getStringAsync() {
+    public Single<RestResponse<Void, StringWrapper>> getStringWithRestResponseAsync() {
         return service.getString();
     }
+
+    /**
+     * Get complex types with string properties.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, StringWrapper> object
+     */
+    public Single<StringWrapper> getStringAsync() {
+        return getStringWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, StringWrapper>, StringWrapper>() { public StringWrapper call(RestResponse<Void, StringWrapper> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -612,6 +744,7 @@ public class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putString(StringWrapper complexBody) {
         putStringAsync(complexBody).toBlocking().value();
@@ -625,7 +758,7 @@ public class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putStringAsync(StringWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putStringAsync(StringWrapper complexBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putStringAsync(complexBody), serviceCallback);
     }
 
@@ -634,15 +767,27 @@ public class PrimitivesImpl implements Primitives {
      *
      * @param complexBody Please put 'goodrequest', '', and null
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putStringAsync(StringWrapper complexBody) {
+    public Single<RestResponse<Void, Void>> putStringWithRestResponseAsync(StringWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
         Validator.validate(complexBody);
         return service.putString(complexBody);
     }
+
+    /**
+     * Put complex types with string properties.
+     *
+     * @param complexBody Please put 'goodrequest', '', and null
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putStringAsync(StringWrapper complexBody) {
+        return putStringWithRestResponseAsync(complexBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -664,7 +809,7 @@ public class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<DateWrapper> getDateAsync(final ServiceCallback<DateWrapper> serviceCallback) {
+    public ServiceFuture<DateWrapper> getDateAsync(ServiceCallback<DateWrapper> serviceCallback) {
         return ServiceFuture.fromBody(getDateAsync(), serviceCallback);
     }
 
@@ -672,11 +817,22 @@ public class PrimitivesImpl implements Primitives {
      * Get complex types with date properties.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the DateWrapper object
+     * @return a {@link Single} emitting the RestResponse<Void, DateWrapper> object
      */
-    public Single<DateWrapper> getDateAsync() {
+    public Single<RestResponse<Void, DateWrapper>> getDateWithRestResponseAsync() {
         return service.getDate();
     }
+
+    /**
+     * Get complex types with date properties.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, DateWrapper> object
+     */
+    public Single<DateWrapper> getDateAsync() {
+        return getDateWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, DateWrapper>, DateWrapper>() { public DateWrapper call(RestResponse<Void, DateWrapper> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -686,6 +842,7 @@ public class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putDate(DateWrapper complexBody) {
         putDateAsync(complexBody).toBlocking().value();
@@ -699,7 +856,7 @@ public class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putDateAsync(DateWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putDateAsync(DateWrapper complexBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putDateAsync(complexBody), serviceCallback);
     }
 
@@ -708,15 +865,27 @@ public class PrimitivesImpl implements Primitives {
      *
      * @param complexBody Please put '0001-01-01' and '2016-02-29'
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putDateAsync(DateWrapper complexBody) {
+    public Single<RestResponse<Void, Void>> putDateWithRestResponseAsync(DateWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
         Validator.validate(complexBody);
         return service.putDate(complexBody);
     }
+
+    /**
+     * Put complex types with date properties.
+     *
+     * @param complexBody Please put '0001-01-01' and '2016-02-29'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putDateAsync(DateWrapper complexBody) {
+        return putDateWithRestResponseAsync(complexBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -738,7 +907,7 @@ public class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<DatetimeWrapper> getDateTimeAsync(final ServiceCallback<DatetimeWrapper> serviceCallback) {
+    public ServiceFuture<DatetimeWrapper> getDateTimeAsync(ServiceCallback<DatetimeWrapper> serviceCallback) {
         return ServiceFuture.fromBody(getDateTimeAsync(), serviceCallback);
     }
 
@@ -746,11 +915,22 @@ public class PrimitivesImpl implements Primitives {
      * Get complex types with datetime properties.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the DatetimeWrapper object
+     * @return a {@link Single} emitting the RestResponse<Void, DatetimeWrapper> object
      */
-    public Single<DatetimeWrapper> getDateTimeAsync() {
+    public Single<RestResponse<Void, DatetimeWrapper>> getDateTimeWithRestResponseAsync() {
         return service.getDateTime();
     }
+
+    /**
+     * Get complex types with datetime properties.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, DatetimeWrapper> object
+     */
+    public Single<DatetimeWrapper> getDateTimeAsync() {
+        return getDateTimeWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, DatetimeWrapper>, DatetimeWrapper>() { public DatetimeWrapper call(RestResponse<Void, DatetimeWrapper> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -760,6 +940,7 @@ public class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putDateTime(DatetimeWrapper complexBody) {
         putDateTimeAsync(complexBody).toBlocking().value();
@@ -773,7 +954,7 @@ public class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putDateTimeAsync(DatetimeWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putDateTimeAsync(DatetimeWrapper complexBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putDateTimeAsync(complexBody), serviceCallback);
     }
 
@@ -782,15 +963,27 @@ public class PrimitivesImpl implements Primitives {
      *
      * @param complexBody Please put '0001-01-01T12:00:00-04:00' and '2015-05-18T11:38:00-08:00'
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putDateTimeAsync(DatetimeWrapper complexBody) {
+    public Single<RestResponse<Void, Void>> putDateTimeWithRestResponseAsync(DatetimeWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
         Validator.validate(complexBody);
         return service.putDateTime(complexBody);
     }
+
+    /**
+     * Put complex types with datetime properties.
+     *
+     * @param complexBody Please put '0001-01-01T12:00:00-04:00' and '2015-05-18T11:38:00-08:00'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putDateTimeAsync(DatetimeWrapper complexBody) {
+        return putDateTimeWithRestResponseAsync(complexBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -812,7 +1005,7 @@ public class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Datetimerfc1123Wrapper> getDateTimeRfc1123Async(final ServiceCallback<Datetimerfc1123Wrapper> serviceCallback) {
+    public ServiceFuture<Datetimerfc1123Wrapper> getDateTimeRfc1123Async(ServiceCallback<Datetimerfc1123Wrapper> serviceCallback) {
         return ServiceFuture.fromBody(getDateTimeRfc1123Async(), serviceCallback);
     }
 
@@ -820,11 +1013,22 @@ public class PrimitivesImpl implements Primitives {
      * Get complex types with datetimeRfc1123 properties.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Datetimerfc1123Wrapper object
+     * @return a {@link Single} emitting the RestResponse<Void, Datetimerfc1123Wrapper> object
      */
-    public Single<Datetimerfc1123Wrapper> getDateTimeRfc1123Async() {
+    public Single<RestResponse<Void, Datetimerfc1123Wrapper>> getDateTimeRfc1123WithRestResponseAsync() {
         return service.getDateTimeRfc1123();
     }
+
+    /**
+     * Get complex types with datetimeRfc1123 properties.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Datetimerfc1123Wrapper> object
+     */
+    public Single<Datetimerfc1123Wrapper> getDateTimeRfc1123Async() {
+        return getDateTimeRfc1123WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Datetimerfc1123Wrapper>, Datetimerfc1123Wrapper>() { public Datetimerfc1123Wrapper call(RestResponse<Void, Datetimerfc1123Wrapper> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -834,6 +1038,7 @@ public class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putDateTimeRfc1123(Datetimerfc1123Wrapper complexBody) {
         putDateTimeRfc1123Async(complexBody).toBlocking().value();
@@ -847,7 +1052,7 @@ public class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putDateTimeRfc1123Async(Datetimerfc1123Wrapper complexBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putDateTimeRfc1123Async(Datetimerfc1123Wrapper complexBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putDateTimeRfc1123Async(complexBody), serviceCallback);
     }
 
@@ -856,15 +1061,27 @@ public class PrimitivesImpl implements Primitives {
      *
      * @param complexBody Please put 'Mon, 01 Jan 0001 12:00:00 GMT' and 'Mon, 18 May 2015 11:38:00 GMT'
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putDateTimeRfc1123Async(Datetimerfc1123Wrapper complexBody) {
+    public Single<RestResponse<Void, Void>> putDateTimeRfc1123WithRestResponseAsync(Datetimerfc1123Wrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
         Validator.validate(complexBody);
         return service.putDateTimeRfc1123(complexBody);
     }
+
+    /**
+     * Put complex types with datetimeRfc1123 properties.
+     *
+     * @param complexBody Please put 'Mon, 01 Jan 0001 12:00:00 GMT' and 'Mon, 18 May 2015 11:38:00 GMT'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putDateTimeRfc1123Async(Datetimerfc1123Wrapper complexBody) {
+        return putDateTimeRfc1123WithRestResponseAsync(complexBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -886,7 +1103,7 @@ public class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<DurationWrapper> getDurationAsync(final ServiceCallback<DurationWrapper> serviceCallback) {
+    public ServiceFuture<DurationWrapper> getDurationAsync(ServiceCallback<DurationWrapper> serviceCallback) {
         return ServiceFuture.fromBody(getDurationAsync(), serviceCallback);
     }
 
@@ -894,11 +1111,22 @@ public class PrimitivesImpl implements Primitives {
      * Get complex types with duration properties.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the DurationWrapper object
+     * @return a {@link Single} emitting the RestResponse<Void, DurationWrapper> object
      */
-    public Single<DurationWrapper> getDurationAsync() {
+    public Single<RestResponse<Void, DurationWrapper>> getDurationWithRestResponseAsync() {
         return service.getDuration();
     }
+
+    /**
+     * Get complex types with duration properties.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, DurationWrapper> object
+     */
+    public Single<DurationWrapper> getDurationAsync() {
+        return getDurationWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, DurationWrapper>, DurationWrapper>() { public DurationWrapper call(RestResponse<Void, DurationWrapper> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -908,6 +1136,7 @@ public class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putDuration(DurationWrapper complexBody) {
         putDurationAsync(complexBody).toBlocking().value();
@@ -921,7 +1150,7 @@ public class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putDurationAsync(DurationWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putDurationAsync(DurationWrapper complexBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putDurationAsync(complexBody), serviceCallback);
     }
 
@@ -930,15 +1159,27 @@ public class PrimitivesImpl implements Primitives {
      *
      * @param complexBody Please put 'P123DT22H14M12.011S'
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putDurationAsync(DurationWrapper complexBody) {
+    public Single<RestResponse<Void, Void>> putDurationWithRestResponseAsync(DurationWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
         Validator.validate(complexBody);
         return service.putDuration(complexBody);
     }
+
+    /**
+     * Put complex types with duration properties.
+     *
+     * @param complexBody Please put 'P123DT22H14M12.011S'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putDurationAsync(DurationWrapper complexBody) {
+        return putDurationWithRestResponseAsync(complexBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -960,7 +1201,7 @@ public class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ByteWrapper> getByteAsync(final ServiceCallback<ByteWrapper> serviceCallback) {
+    public ServiceFuture<ByteWrapper> getByteAsync(ServiceCallback<ByteWrapper> serviceCallback) {
         return ServiceFuture.fromBody(getByteAsync(), serviceCallback);
     }
 
@@ -968,11 +1209,22 @@ public class PrimitivesImpl implements Primitives {
      * Get complex types with byte properties.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ByteWrapper object
+     * @return a {@link Single} emitting the RestResponse<Void, ByteWrapper> object
      */
-    public Single<ByteWrapper> getByteAsync() {
+    public Single<RestResponse<Void, ByteWrapper>> getByteWithRestResponseAsync() {
         return service.getByte();
     }
+
+    /**
+     * Get complex types with byte properties.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ByteWrapper> object
+     */
+    public Single<ByteWrapper> getByteAsync() {
+        return getByteWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, ByteWrapper>, ByteWrapper>() { public ByteWrapper call(RestResponse<Void, ByteWrapper> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -982,6 +1234,7 @@ public class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putByte(ByteWrapper complexBody) {
         putByteAsync(complexBody).toBlocking().value();
@@ -995,7 +1248,7 @@ public class PrimitivesImpl implements Primitives {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putByteAsync(ByteWrapper complexBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putByteAsync(ByteWrapper complexBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putByteAsync(complexBody), serviceCallback);
     }
 
@@ -1004,15 +1257,27 @@ public class PrimitivesImpl implements Primitives {
      *
      * @param complexBody Please put non-ascii byte string hex(FF FE FD FC 00 FA F9 F8 F7 F6)
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putByteAsync(ByteWrapper complexBody) {
+    public Single<RestResponse<Void, Void>> putByteWithRestResponseAsync(ByteWrapper complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
         Validator.validate(complexBody);
         return service.putByte(complexBody);
     }
+
+    /**
+     * Put complex types with byte properties.
+     *
+     * @param complexBody Please put non-ascii byte string hex(FF FE FD FC 00 FA F9 F8 F7 F6)
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putByteAsync(ByteWrapper complexBody) {
+        return putByteWithRestResponseAsync(complexBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/ReadonlypropertysImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/ReadonlypropertysImpl.java
@@ -11,6 +11,7 @@
 package fixtures.bodycomplex.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.bodycomplex.Readonlypropertys;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.BodyParam;
@@ -61,13 +62,13 @@ public class ReadonlypropertysImpl implements Readonlypropertys {
         @GET("complex/readonlyproperty/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<ReadonlyObj> getValid();
+        Single<RestResponse<Void, ReadonlyObj>> getValid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodycomplex.Readonlypropertys putValid" })
         @PUT("complex/readonlyproperty/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putValid(@BodyParam("application/json; charset=utf-8") ReadonlyObj complexBody);
+        Single<RestResponse<Void, Void>> putValid(@BodyParam("application/json; charset=utf-8") ReadonlyObj complexBody);
 
     }
 
@@ -90,7 +91,7 @@ public class ReadonlypropertysImpl implements Readonlypropertys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ReadonlyObj> getValidAsync(final ServiceCallback<ReadonlyObj> serviceCallback) {
+    public ServiceFuture<ReadonlyObj> getValidAsync(ServiceCallback<ReadonlyObj> serviceCallback) {
         return ServiceFuture.fromBody(getValidAsync(), serviceCallback);
     }
 
@@ -98,11 +99,22 @@ public class ReadonlypropertysImpl implements Readonlypropertys {
      * Get complex types that have readonly properties.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ReadonlyObj object
+     * @return a {@link Single} emitting the RestResponse<Void, ReadonlyObj> object
      */
-    public Single<ReadonlyObj> getValidAsync() {
+    public Single<RestResponse<Void, ReadonlyObj>> getValidWithRestResponseAsync() {
         return service.getValid();
     }
+
+    /**
+     * Get complex types that have readonly properties.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ReadonlyObj> object
+     */
+    public Single<ReadonlyObj> getValidAsync() {
+        return getValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, ReadonlyObj>, ReadonlyObj>() { public ReadonlyObj call(RestResponse<Void, ReadonlyObj> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -112,6 +124,7 @@ public class ReadonlypropertysImpl implements Readonlypropertys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putValid(ReadonlyObj complexBody) {
         putValidAsync(complexBody).toBlocking().value();
@@ -125,7 +138,7 @@ public class ReadonlypropertysImpl implements Readonlypropertys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putValidAsync(ReadonlyObj complexBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putValidAsync(ReadonlyObj complexBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putValidAsync(complexBody), serviceCallback);
     }
 
@@ -134,15 +147,27 @@ public class ReadonlypropertysImpl implements Readonlypropertys {
      *
      * @param complexBody the ReadonlyObj value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putValidAsync(ReadonlyObj complexBody) {
+    public Single<RestResponse<Void, Void>> putValidWithRestResponseAsync(ReadonlyObj complexBody) {
         if (complexBody == null) {
             throw new IllegalArgumentException("Parameter complexBody is required and cannot be null.");
         }
         Validator.validate(complexBody);
         return service.putValid(complexBody);
     }
+
+    /**
+     * Put complex types that have readonly properties.
+     *
+     * @param complexBody the ReadonlyObj value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putValidAsync(ReadonlyObj complexBody) {
+        return putValidWithRestResponseAsync(complexBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodydate/Dates.java
+++ b/test/vanilla/src/main/java/fixtures/bodydate/Dates.java
@@ -10,6 +10,7 @@
 
 package fixtures.bodydate;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.bodydate.models.ErrorException;
@@ -49,6 +50,13 @@ public interface Dates {
      * @return the observable to the LocalDate object
      */
     Single<LocalDate> getNullAsync();
+    /**
+     * Get null date value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the LocalDate object
+     */
+    Single<RestResponse<Void, LocalDate>> getNullWithRestResponseAsync();
 
 
     /**
@@ -77,6 +85,13 @@ public interface Dates {
      * @return the observable to the LocalDate object
      */
     Single<LocalDate> getInvalidDateAsync();
+    /**
+     * Get invalid date value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the LocalDate object
+     */
+    Single<RestResponse<Void, LocalDate>> getInvalidDateWithRestResponseAsync();
 
 
     /**
@@ -105,6 +120,13 @@ public interface Dates {
      * @return the observable to the LocalDate object
      */
     Single<LocalDate> getOverflowDateAsync();
+    /**
+     * Get overflow date value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the LocalDate object
+     */
+    Single<RestResponse<Void, LocalDate>> getOverflowDateWithRestResponseAsync();
 
 
     /**
@@ -133,6 +155,13 @@ public interface Dates {
      * @return the observable to the LocalDate object
      */
     Single<LocalDate> getUnderflowDateAsync();
+    /**
+     * Get underflow date value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the LocalDate object
+     */
+    Single<RestResponse<Void, LocalDate>> getUnderflowDateWithRestResponseAsync();
 
 
     /**
@@ -163,6 +192,14 @@ public interface Dates {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putMaxDateAsync(LocalDate dateBody);
+    /**
+     * Put max date value 9999-12-31.
+     *
+     * @param dateBody the LocalDate value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putMaxDateWithRestResponseAsync(LocalDate dateBody);
 
 
     /**
@@ -191,6 +228,13 @@ public interface Dates {
      * @return the observable to the LocalDate object
      */
     Single<LocalDate> getMaxDateAsync();
+    /**
+     * Get max date value 9999-12-31.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the LocalDate object
+     */
+    Single<RestResponse<Void, LocalDate>> getMaxDateWithRestResponseAsync();
 
 
     /**
@@ -221,6 +265,14 @@ public interface Dates {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putMinDateAsync(LocalDate dateBody);
+    /**
+     * Put min date value 0000-01-01.
+     *
+     * @param dateBody the LocalDate value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putMinDateWithRestResponseAsync(LocalDate dateBody);
 
 
     /**
@@ -249,6 +301,13 @@ public interface Dates {
      * @return the observable to the LocalDate object
      */
     Single<LocalDate> getMinDateAsync();
+    /**
+     * Get min date value 0000-01-01.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the LocalDate object
+     */
+    Single<RestResponse<Void, LocalDate>> getMinDateWithRestResponseAsync();
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodydate/implementation/AutoRestDateTestServiceImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodydate/implementation/AutoRestDateTestServiceImpl.java
@@ -13,6 +13,7 @@ package fixtures.bodydate.implementation;
 import fixtures.bodydate.AutoRestDateTestService;
 import fixtures.bodydate.Dates;
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceClient;
 import com.microsoft.rest.RestClient;
 import rx.Single;

--- a/test/vanilla/src/main/java/fixtures/bodydate/implementation/DatesImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodydate/implementation/DatesImpl.java
@@ -11,6 +11,7 @@
 package fixtures.bodydate.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.bodydate.Dates;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.BodyParam;
@@ -60,49 +61,49 @@ public class DatesImpl implements Dates {
         @GET("date/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<LocalDate> getNull();
+        Single<RestResponse<Void, LocalDate>> getNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydate.Dates getInvalidDate" })
         @GET("date/invaliddate")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<LocalDate> getInvalidDate();
+        Single<RestResponse<Void, LocalDate>> getInvalidDate();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydate.Dates getOverflowDate" })
         @GET("date/overflowdate")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<LocalDate> getOverflowDate();
+        Single<RestResponse<Void, LocalDate>> getOverflowDate();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydate.Dates getUnderflowDate" })
         @GET("date/underflowdate")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<LocalDate> getUnderflowDate();
+        Single<RestResponse<Void, LocalDate>> getUnderflowDate();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydate.Dates putMaxDate" })
         @PUT("date/max")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putMaxDate(@BodyParam("application/json; charset=utf-8") LocalDate dateBody);
+        Single<RestResponse<Void, Void>> putMaxDate(@BodyParam("application/json; charset=utf-8") LocalDate dateBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodydate.Dates getMaxDate" })
         @GET("date/max")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<LocalDate> getMaxDate();
+        Single<RestResponse<Void, LocalDate>> getMaxDate();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydate.Dates putMinDate" })
         @PUT("date/min")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putMinDate(@BodyParam("application/json; charset=utf-8") LocalDate dateBody);
+        Single<RestResponse<Void, Void>> putMinDate(@BodyParam("application/json; charset=utf-8") LocalDate dateBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodydate.Dates getMinDate" })
         @GET("date/min")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<LocalDate> getMinDate();
+        Single<RestResponse<Void, LocalDate>> getMinDate();
 
     }
 
@@ -125,7 +126,7 @@ public class DatesImpl implements Dates {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<LocalDate> getNullAsync(final ServiceCallback<LocalDate> serviceCallback) {
+    public ServiceFuture<LocalDate> getNullAsync(ServiceCallback<LocalDate> serviceCallback) {
         return ServiceFuture.fromBody(getNullAsync(), serviceCallback);
     }
 
@@ -133,11 +134,22 @@ public class DatesImpl implements Dates {
      * Get null date value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the LocalDate object
+     * @return a {@link Single} emitting the RestResponse<Void, LocalDate> object
      */
-    public Single<LocalDate> getNullAsync() {
+    public Single<RestResponse<Void, LocalDate>> getNullWithRestResponseAsync() {
         return service.getNull();
     }
+
+    /**
+     * Get null date value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, LocalDate> object
+     */
+    public Single<LocalDate> getNullAsync() {
+        return getNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, LocalDate>, LocalDate>() { public LocalDate call(RestResponse<Void, LocalDate> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -159,7 +171,7 @@ public class DatesImpl implements Dates {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<LocalDate> getInvalidDateAsync(final ServiceCallback<LocalDate> serviceCallback) {
+    public ServiceFuture<LocalDate> getInvalidDateAsync(ServiceCallback<LocalDate> serviceCallback) {
         return ServiceFuture.fromBody(getInvalidDateAsync(), serviceCallback);
     }
 
@@ -167,11 +179,22 @@ public class DatesImpl implements Dates {
      * Get invalid date value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the LocalDate object
+     * @return a {@link Single} emitting the RestResponse<Void, LocalDate> object
      */
-    public Single<LocalDate> getInvalidDateAsync() {
+    public Single<RestResponse<Void, LocalDate>> getInvalidDateWithRestResponseAsync() {
         return service.getInvalidDate();
     }
+
+    /**
+     * Get invalid date value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, LocalDate> object
+     */
+    public Single<LocalDate> getInvalidDateAsync() {
+        return getInvalidDateWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, LocalDate>, LocalDate>() { public LocalDate call(RestResponse<Void, LocalDate> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -193,7 +216,7 @@ public class DatesImpl implements Dates {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<LocalDate> getOverflowDateAsync(final ServiceCallback<LocalDate> serviceCallback) {
+    public ServiceFuture<LocalDate> getOverflowDateAsync(ServiceCallback<LocalDate> serviceCallback) {
         return ServiceFuture.fromBody(getOverflowDateAsync(), serviceCallback);
     }
 
@@ -201,11 +224,22 @@ public class DatesImpl implements Dates {
      * Get overflow date value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the LocalDate object
+     * @return a {@link Single} emitting the RestResponse<Void, LocalDate> object
      */
-    public Single<LocalDate> getOverflowDateAsync() {
+    public Single<RestResponse<Void, LocalDate>> getOverflowDateWithRestResponseAsync() {
         return service.getOverflowDate();
     }
+
+    /**
+     * Get overflow date value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, LocalDate> object
+     */
+    public Single<LocalDate> getOverflowDateAsync() {
+        return getOverflowDateWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, LocalDate>, LocalDate>() { public LocalDate call(RestResponse<Void, LocalDate> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -227,7 +261,7 @@ public class DatesImpl implements Dates {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<LocalDate> getUnderflowDateAsync(final ServiceCallback<LocalDate> serviceCallback) {
+    public ServiceFuture<LocalDate> getUnderflowDateAsync(ServiceCallback<LocalDate> serviceCallback) {
         return ServiceFuture.fromBody(getUnderflowDateAsync(), serviceCallback);
     }
 
@@ -235,11 +269,22 @@ public class DatesImpl implements Dates {
      * Get underflow date value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the LocalDate object
+     * @return a {@link Single} emitting the RestResponse<Void, LocalDate> object
      */
-    public Single<LocalDate> getUnderflowDateAsync() {
+    public Single<RestResponse<Void, LocalDate>> getUnderflowDateWithRestResponseAsync() {
         return service.getUnderflowDate();
     }
+
+    /**
+     * Get underflow date value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, LocalDate> object
+     */
+    public Single<LocalDate> getUnderflowDateAsync() {
+        return getUnderflowDateWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, LocalDate>, LocalDate>() { public LocalDate call(RestResponse<Void, LocalDate> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -249,6 +294,7 @@ public class DatesImpl implements Dates {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putMaxDate(LocalDate dateBody) {
         putMaxDateAsync(dateBody).toBlocking().value();
@@ -262,7 +308,7 @@ public class DatesImpl implements Dates {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putMaxDateAsync(LocalDate dateBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putMaxDateAsync(LocalDate dateBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putMaxDateAsync(dateBody), serviceCallback);
     }
 
@@ -271,14 +317,26 @@ public class DatesImpl implements Dates {
      *
      * @param dateBody the LocalDate value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putMaxDateAsync(LocalDate dateBody) {
+    public Single<RestResponse<Void, Void>> putMaxDateWithRestResponseAsync(LocalDate dateBody) {
         if (dateBody == null) {
             throw new IllegalArgumentException("Parameter dateBody is required and cannot be null.");
         }
         return service.putMaxDate(dateBody);
     }
+
+    /**
+     * Put max date value 9999-12-31.
+     *
+     * @param dateBody the LocalDate value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putMaxDateAsync(LocalDate dateBody) {
+        return putMaxDateWithRestResponseAsync(dateBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -300,7 +358,7 @@ public class DatesImpl implements Dates {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<LocalDate> getMaxDateAsync(final ServiceCallback<LocalDate> serviceCallback) {
+    public ServiceFuture<LocalDate> getMaxDateAsync(ServiceCallback<LocalDate> serviceCallback) {
         return ServiceFuture.fromBody(getMaxDateAsync(), serviceCallback);
     }
 
@@ -308,11 +366,22 @@ public class DatesImpl implements Dates {
      * Get max date value 9999-12-31.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the LocalDate object
+     * @return a {@link Single} emitting the RestResponse<Void, LocalDate> object
      */
-    public Single<LocalDate> getMaxDateAsync() {
+    public Single<RestResponse<Void, LocalDate>> getMaxDateWithRestResponseAsync() {
         return service.getMaxDate();
     }
+
+    /**
+     * Get max date value 9999-12-31.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, LocalDate> object
+     */
+    public Single<LocalDate> getMaxDateAsync() {
+        return getMaxDateWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, LocalDate>, LocalDate>() { public LocalDate call(RestResponse<Void, LocalDate> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -322,6 +391,7 @@ public class DatesImpl implements Dates {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putMinDate(LocalDate dateBody) {
         putMinDateAsync(dateBody).toBlocking().value();
@@ -335,7 +405,7 @@ public class DatesImpl implements Dates {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putMinDateAsync(LocalDate dateBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putMinDateAsync(LocalDate dateBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putMinDateAsync(dateBody), serviceCallback);
     }
 
@@ -344,14 +414,26 @@ public class DatesImpl implements Dates {
      *
      * @param dateBody the LocalDate value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putMinDateAsync(LocalDate dateBody) {
+    public Single<RestResponse<Void, Void>> putMinDateWithRestResponseAsync(LocalDate dateBody) {
         if (dateBody == null) {
             throw new IllegalArgumentException("Parameter dateBody is required and cannot be null.");
         }
         return service.putMinDate(dateBody);
     }
+
+    /**
+     * Put min date value 0000-01-01.
+     *
+     * @param dateBody the LocalDate value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putMinDateAsync(LocalDate dateBody) {
+        return putMinDateWithRestResponseAsync(dateBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -373,7 +455,7 @@ public class DatesImpl implements Dates {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<LocalDate> getMinDateAsync(final ServiceCallback<LocalDate> serviceCallback) {
+    public ServiceFuture<LocalDate> getMinDateAsync(ServiceCallback<LocalDate> serviceCallback) {
         return ServiceFuture.fromBody(getMinDateAsync(), serviceCallback);
     }
 
@@ -381,11 +463,22 @@ public class DatesImpl implements Dates {
      * Get min date value 0000-01-01.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the LocalDate object
+     * @return a {@link Single} emitting the RestResponse<Void, LocalDate> object
      */
-    public Single<LocalDate> getMinDateAsync() {
+    public Single<RestResponse<Void, LocalDate>> getMinDateWithRestResponseAsync() {
         return service.getMinDate();
     }
+
+    /**
+     * Get min date value 0000-01-01.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, LocalDate> object
+     */
+    public Single<LocalDate> getMinDateAsync() {
+        return getMinDateWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, LocalDate>, LocalDate>() { public LocalDate call(RestResponse<Void, LocalDate> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodydatetime/Datetimes.java
+++ b/test/vanilla/src/main/java/fixtures/bodydatetime/Datetimes.java
@@ -10,6 +10,7 @@
 
 package fixtures.bodydatetime;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.bodydatetime.models.ErrorException;
@@ -49,6 +50,13 @@ public interface Datetimes {
      * @return the observable to the DateTime object
      */
     Single<DateTime> getNullAsync();
+    /**
+     * Get null datetime value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the DateTime object
+     */
+    Single<RestResponse<Void, DateTime>> getNullWithRestResponseAsync();
 
 
     /**
@@ -77,6 +85,13 @@ public interface Datetimes {
      * @return the observable to the DateTime object
      */
     Single<DateTime> getInvalidAsync();
+    /**
+     * Get invalid datetime value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the DateTime object
+     */
+    Single<RestResponse<Void, DateTime>> getInvalidWithRestResponseAsync();
 
 
     /**
@@ -105,6 +120,13 @@ public interface Datetimes {
      * @return the observable to the DateTime object
      */
     Single<DateTime> getOverflowAsync();
+    /**
+     * Get overflow datetime value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the DateTime object
+     */
+    Single<RestResponse<Void, DateTime>> getOverflowWithRestResponseAsync();
 
 
     /**
@@ -133,6 +155,13 @@ public interface Datetimes {
      * @return the observable to the DateTime object
      */
     Single<DateTime> getUnderflowAsync();
+    /**
+     * Get underflow datetime value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the DateTime object
+     */
+    Single<RestResponse<Void, DateTime>> getUnderflowWithRestResponseAsync();
 
 
     /**
@@ -163,6 +192,14 @@ public interface Datetimes {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putUtcMaxDateTimeAsync(DateTime datetimeBody);
+    /**
+     * Put max datetime value 9999-12-31T23:59:59.9999999Z.
+     *
+     * @param datetimeBody the DateTime value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putUtcMaxDateTimeWithRestResponseAsync(DateTime datetimeBody);
 
 
     /**
@@ -191,6 +228,13 @@ public interface Datetimes {
      * @return the observable to the DateTime object
      */
     Single<DateTime> getUtcLowercaseMaxDateTimeAsync();
+    /**
+     * Get max datetime value 9999-12-31t23:59:59.9999999z.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the DateTime object
+     */
+    Single<RestResponse<Void, DateTime>> getUtcLowercaseMaxDateTimeWithRestResponseAsync();
 
 
     /**
@@ -219,6 +263,13 @@ public interface Datetimes {
      * @return the observable to the DateTime object
      */
     Single<DateTime> getUtcUppercaseMaxDateTimeAsync();
+    /**
+     * Get max datetime value 9999-12-31T23:59:59.9999999Z.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the DateTime object
+     */
+    Single<RestResponse<Void, DateTime>> getUtcUppercaseMaxDateTimeWithRestResponseAsync();
 
 
     /**
@@ -249,6 +300,14 @@ public interface Datetimes {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putLocalPositiveOffsetMaxDateTimeAsync(DateTime datetimeBody);
+    /**
+     * Put max datetime value with positive numoffset 9999-12-31t23:59:59.9999999+14:00.
+     *
+     * @param datetimeBody the DateTime value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putLocalPositiveOffsetMaxDateTimeWithRestResponseAsync(DateTime datetimeBody);
 
 
     /**
@@ -277,6 +336,13 @@ public interface Datetimes {
      * @return the observable to the DateTime object
      */
     Single<DateTime> getLocalPositiveOffsetLowercaseMaxDateTimeAsync();
+    /**
+     * Get max datetime value with positive num offset 9999-12-31t23:59:59.9999999+14:00.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the DateTime object
+     */
+    Single<RestResponse<Void, DateTime>> getLocalPositiveOffsetLowercaseMaxDateTimeWithRestResponseAsync();
 
 
     /**
@@ -305,6 +371,13 @@ public interface Datetimes {
      * @return the observable to the DateTime object
      */
     Single<DateTime> getLocalPositiveOffsetUppercaseMaxDateTimeAsync();
+    /**
+     * Get max datetime value with positive num offset 9999-12-31T23:59:59.9999999+14:00.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the DateTime object
+     */
+    Single<RestResponse<Void, DateTime>> getLocalPositiveOffsetUppercaseMaxDateTimeWithRestResponseAsync();
 
 
     /**
@@ -335,6 +408,14 @@ public interface Datetimes {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putLocalNegativeOffsetMaxDateTimeAsync(DateTime datetimeBody);
+    /**
+     * Put max datetime value with positive numoffset 9999-12-31t23:59:59.9999999-14:00.
+     *
+     * @param datetimeBody the DateTime value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putLocalNegativeOffsetMaxDateTimeWithRestResponseAsync(DateTime datetimeBody);
 
 
     /**
@@ -363,6 +444,13 @@ public interface Datetimes {
      * @return the observable to the DateTime object
      */
     Single<DateTime> getLocalNegativeOffsetUppercaseMaxDateTimeAsync();
+    /**
+     * Get max datetime value with positive num offset 9999-12-31T23:59:59.9999999-14:00.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the DateTime object
+     */
+    Single<RestResponse<Void, DateTime>> getLocalNegativeOffsetUppercaseMaxDateTimeWithRestResponseAsync();
 
 
     /**
@@ -391,6 +479,13 @@ public interface Datetimes {
      * @return the observable to the DateTime object
      */
     Single<DateTime> getLocalNegativeOffsetLowercaseMaxDateTimeAsync();
+    /**
+     * Get max datetime value with positive num offset 9999-12-31t23:59:59.9999999-14:00.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the DateTime object
+     */
+    Single<RestResponse<Void, DateTime>> getLocalNegativeOffsetLowercaseMaxDateTimeWithRestResponseAsync();
 
 
     /**
@@ -421,6 +516,14 @@ public interface Datetimes {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putUtcMinDateTimeAsync(DateTime datetimeBody);
+    /**
+     * Put min datetime value 0001-01-01T00:00:00Z.
+     *
+     * @param datetimeBody the DateTime value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putUtcMinDateTimeWithRestResponseAsync(DateTime datetimeBody);
 
 
     /**
@@ -449,6 +552,13 @@ public interface Datetimes {
      * @return the observable to the DateTime object
      */
     Single<DateTime> getUtcMinDateTimeAsync();
+    /**
+     * Get min datetime value 0001-01-01T00:00:00Z.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the DateTime object
+     */
+    Single<RestResponse<Void, DateTime>> getUtcMinDateTimeWithRestResponseAsync();
 
 
     /**
@@ -479,6 +589,14 @@ public interface Datetimes {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putLocalPositiveOffsetMinDateTimeAsync(DateTime datetimeBody);
+    /**
+     * Put min datetime value 0001-01-01T00:00:00+14:00.
+     *
+     * @param datetimeBody the DateTime value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putLocalPositiveOffsetMinDateTimeWithRestResponseAsync(DateTime datetimeBody);
 
 
     /**
@@ -507,6 +625,13 @@ public interface Datetimes {
      * @return the observable to the DateTime object
      */
     Single<DateTime> getLocalPositiveOffsetMinDateTimeAsync();
+    /**
+     * Get min datetime value 0001-01-01T00:00:00+14:00.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the DateTime object
+     */
+    Single<RestResponse<Void, DateTime>> getLocalPositiveOffsetMinDateTimeWithRestResponseAsync();
 
 
     /**
@@ -537,6 +662,14 @@ public interface Datetimes {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putLocalNegativeOffsetMinDateTimeAsync(DateTime datetimeBody);
+    /**
+     * Put min datetime value 0001-01-01T00:00:00-14:00.
+     *
+     * @param datetimeBody the DateTime value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putLocalNegativeOffsetMinDateTimeWithRestResponseAsync(DateTime datetimeBody);
 
 
     /**
@@ -565,6 +698,13 @@ public interface Datetimes {
      * @return the observable to the DateTime object
      */
     Single<DateTime> getLocalNegativeOffsetMinDateTimeAsync();
+    /**
+     * Get min datetime value 0001-01-01T00:00:00-14:00.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the DateTime object
+     */
+    Single<RestResponse<Void, DateTime>> getLocalNegativeOffsetMinDateTimeWithRestResponseAsync();
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodydatetime/implementation/AutoRestDateTimeTestServiceImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodydatetime/implementation/AutoRestDateTimeTestServiceImpl.java
@@ -13,6 +13,7 @@ package fixtures.bodydatetime.implementation;
 import fixtures.bodydatetime.AutoRestDateTimeTestService;
 import fixtures.bodydatetime.Datetimes;
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceClient;
 import com.microsoft.rest.RestClient;
 import rx.Single;

--- a/test/vanilla/src/main/java/fixtures/bodydatetime/implementation/DatetimesImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodydatetime/implementation/DatetimesImpl.java
@@ -11,6 +11,7 @@
 package fixtures.bodydatetime.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.bodydatetime.Datetimes;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.BodyParam;
@@ -60,115 +61,115 @@ public class DatetimesImpl implements Datetimes {
         @GET("datetime/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<DateTime> getNull();
+        Single<RestResponse<Void, DateTime>> getNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydatetime.Datetimes getInvalid" })
         @GET("datetime/invalid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<DateTime> getInvalid();
+        Single<RestResponse<Void, DateTime>> getInvalid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydatetime.Datetimes getOverflow" })
         @GET("datetime/overflow")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<DateTime> getOverflow();
+        Single<RestResponse<Void, DateTime>> getOverflow();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydatetime.Datetimes getUnderflow" })
         @GET("datetime/underflow")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<DateTime> getUnderflow();
+        Single<RestResponse<Void, DateTime>> getUnderflow();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydatetime.Datetimes putUtcMaxDateTime" })
         @PUT("datetime/max/utc")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putUtcMaxDateTime(@BodyParam("application/json; charset=utf-8") DateTime datetimeBody);
+        Single<RestResponse<Void, Void>> putUtcMaxDateTime(@BodyParam("application/json; charset=utf-8") DateTime datetimeBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodydatetime.Datetimes getUtcLowercaseMaxDateTime" })
         @GET("datetime/max/utc/lowercase")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<DateTime> getUtcLowercaseMaxDateTime();
+        Single<RestResponse<Void, DateTime>> getUtcLowercaseMaxDateTime();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydatetime.Datetimes getUtcUppercaseMaxDateTime" })
         @GET("datetime/max/utc/uppercase")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<DateTime> getUtcUppercaseMaxDateTime();
+        Single<RestResponse<Void, DateTime>> getUtcUppercaseMaxDateTime();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydatetime.Datetimes putLocalPositiveOffsetMaxDateTime" })
         @PUT("datetime/max/localpositiveoffset")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putLocalPositiveOffsetMaxDateTime(@BodyParam("application/json; charset=utf-8") DateTime datetimeBody);
+        Single<RestResponse<Void, Void>> putLocalPositiveOffsetMaxDateTime(@BodyParam("application/json; charset=utf-8") DateTime datetimeBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodydatetime.Datetimes getLocalPositiveOffsetLowercaseMaxDateTime" })
         @GET("datetime/max/localpositiveoffset/lowercase")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<DateTime> getLocalPositiveOffsetLowercaseMaxDateTime();
+        Single<RestResponse<Void, DateTime>> getLocalPositiveOffsetLowercaseMaxDateTime();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydatetime.Datetimes getLocalPositiveOffsetUppercaseMaxDateTime" })
         @GET("datetime/max/localpositiveoffset/uppercase")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<DateTime> getLocalPositiveOffsetUppercaseMaxDateTime();
+        Single<RestResponse<Void, DateTime>> getLocalPositiveOffsetUppercaseMaxDateTime();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydatetime.Datetimes putLocalNegativeOffsetMaxDateTime" })
         @PUT("datetime/max/localnegativeoffset")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putLocalNegativeOffsetMaxDateTime(@BodyParam("application/json; charset=utf-8") DateTime datetimeBody);
+        Single<RestResponse<Void, Void>> putLocalNegativeOffsetMaxDateTime(@BodyParam("application/json; charset=utf-8") DateTime datetimeBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodydatetime.Datetimes getLocalNegativeOffsetUppercaseMaxDateTime" })
         @GET("datetime/max/localnegativeoffset/uppercase")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<DateTime> getLocalNegativeOffsetUppercaseMaxDateTime();
+        Single<RestResponse<Void, DateTime>> getLocalNegativeOffsetUppercaseMaxDateTime();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydatetime.Datetimes getLocalNegativeOffsetLowercaseMaxDateTime" })
         @GET("datetime/max/localnegativeoffset/lowercase")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<DateTime> getLocalNegativeOffsetLowercaseMaxDateTime();
+        Single<RestResponse<Void, DateTime>> getLocalNegativeOffsetLowercaseMaxDateTime();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydatetime.Datetimes putUtcMinDateTime" })
         @PUT("datetime/min/utc")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putUtcMinDateTime(@BodyParam("application/json; charset=utf-8") DateTime datetimeBody);
+        Single<RestResponse<Void, Void>> putUtcMinDateTime(@BodyParam("application/json; charset=utf-8") DateTime datetimeBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodydatetime.Datetimes getUtcMinDateTime" })
         @GET("datetime/min/utc")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<DateTime> getUtcMinDateTime();
+        Single<RestResponse<Void, DateTime>> getUtcMinDateTime();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydatetime.Datetimes putLocalPositiveOffsetMinDateTime" })
         @PUT("datetime/min/localpositiveoffset")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putLocalPositiveOffsetMinDateTime(@BodyParam("application/json; charset=utf-8") DateTime datetimeBody);
+        Single<RestResponse<Void, Void>> putLocalPositiveOffsetMinDateTime(@BodyParam("application/json; charset=utf-8") DateTime datetimeBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodydatetime.Datetimes getLocalPositiveOffsetMinDateTime" })
         @GET("datetime/min/localpositiveoffset")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<DateTime> getLocalPositiveOffsetMinDateTime();
+        Single<RestResponse<Void, DateTime>> getLocalPositiveOffsetMinDateTime();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydatetime.Datetimes putLocalNegativeOffsetMinDateTime" })
         @PUT("datetime/min/localnegativeoffset")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putLocalNegativeOffsetMinDateTime(@BodyParam("application/json; charset=utf-8") DateTime datetimeBody);
+        Single<RestResponse<Void, Void>> putLocalNegativeOffsetMinDateTime(@BodyParam("application/json; charset=utf-8") DateTime datetimeBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodydatetime.Datetimes getLocalNegativeOffsetMinDateTime" })
         @GET("datetime/min/localnegativeoffset")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<DateTime> getLocalNegativeOffsetMinDateTime();
+        Single<RestResponse<Void, DateTime>> getLocalNegativeOffsetMinDateTime();
 
     }
 
@@ -191,7 +192,7 @@ public class DatetimesImpl implements Datetimes {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<DateTime> getNullAsync(final ServiceCallback<DateTime> serviceCallback) {
+    public ServiceFuture<DateTime> getNullAsync(ServiceCallback<DateTime> serviceCallback) {
         return ServiceFuture.fromBody(getNullAsync(), serviceCallback);
     }
 
@@ -199,11 +200,22 @@ public class DatetimesImpl implements Datetimes {
      * Get null datetime value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the DateTime object
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
      */
-    public Single<DateTime> getNullAsync() {
+    public Single<RestResponse<Void, DateTime>> getNullWithRestResponseAsync() {
         return service.getNull();
     }
+
+    /**
+     * Get null datetime value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
+     */
+    public Single<DateTime> getNullAsync() {
+        return getNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, DateTime>, DateTime>() { public DateTime call(RestResponse<Void, DateTime> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -225,7 +237,7 @@ public class DatetimesImpl implements Datetimes {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<DateTime> getInvalidAsync(final ServiceCallback<DateTime> serviceCallback) {
+    public ServiceFuture<DateTime> getInvalidAsync(ServiceCallback<DateTime> serviceCallback) {
         return ServiceFuture.fromBody(getInvalidAsync(), serviceCallback);
     }
 
@@ -233,11 +245,22 @@ public class DatetimesImpl implements Datetimes {
      * Get invalid datetime value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the DateTime object
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
      */
-    public Single<DateTime> getInvalidAsync() {
+    public Single<RestResponse<Void, DateTime>> getInvalidWithRestResponseAsync() {
         return service.getInvalid();
     }
+
+    /**
+     * Get invalid datetime value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
+     */
+    public Single<DateTime> getInvalidAsync() {
+        return getInvalidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, DateTime>, DateTime>() { public DateTime call(RestResponse<Void, DateTime> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -259,7 +282,7 @@ public class DatetimesImpl implements Datetimes {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<DateTime> getOverflowAsync(final ServiceCallback<DateTime> serviceCallback) {
+    public ServiceFuture<DateTime> getOverflowAsync(ServiceCallback<DateTime> serviceCallback) {
         return ServiceFuture.fromBody(getOverflowAsync(), serviceCallback);
     }
 
@@ -267,11 +290,22 @@ public class DatetimesImpl implements Datetimes {
      * Get overflow datetime value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the DateTime object
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
      */
-    public Single<DateTime> getOverflowAsync() {
+    public Single<RestResponse<Void, DateTime>> getOverflowWithRestResponseAsync() {
         return service.getOverflow();
     }
+
+    /**
+     * Get overflow datetime value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
+     */
+    public Single<DateTime> getOverflowAsync() {
+        return getOverflowWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, DateTime>, DateTime>() { public DateTime call(RestResponse<Void, DateTime> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -293,7 +327,7 @@ public class DatetimesImpl implements Datetimes {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<DateTime> getUnderflowAsync(final ServiceCallback<DateTime> serviceCallback) {
+    public ServiceFuture<DateTime> getUnderflowAsync(ServiceCallback<DateTime> serviceCallback) {
         return ServiceFuture.fromBody(getUnderflowAsync(), serviceCallback);
     }
 
@@ -301,11 +335,22 @@ public class DatetimesImpl implements Datetimes {
      * Get underflow datetime value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the DateTime object
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
      */
-    public Single<DateTime> getUnderflowAsync() {
+    public Single<RestResponse<Void, DateTime>> getUnderflowWithRestResponseAsync() {
         return service.getUnderflow();
     }
+
+    /**
+     * Get underflow datetime value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
+     */
+    public Single<DateTime> getUnderflowAsync() {
+        return getUnderflowWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, DateTime>, DateTime>() { public DateTime call(RestResponse<Void, DateTime> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -315,6 +360,7 @@ public class DatetimesImpl implements Datetimes {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putUtcMaxDateTime(DateTime datetimeBody) {
         putUtcMaxDateTimeAsync(datetimeBody).toBlocking().value();
@@ -328,7 +374,7 @@ public class DatetimesImpl implements Datetimes {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putUtcMaxDateTimeAsync(DateTime datetimeBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putUtcMaxDateTimeAsync(DateTime datetimeBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putUtcMaxDateTimeAsync(datetimeBody), serviceCallback);
     }
 
@@ -337,14 +383,26 @@ public class DatetimesImpl implements Datetimes {
      *
      * @param datetimeBody the DateTime value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putUtcMaxDateTimeAsync(DateTime datetimeBody) {
+    public Single<RestResponse<Void, Void>> putUtcMaxDateTimeWithRestResponseAsync(DateTime datetimeBody) {
         if (datetimeBody == null) {
             throw new IllegalArgumentException("Parameter datetimeBody is required and cannot be null.");
         }
         return service.putUtcMaxDateTime(datetimeBody);
     }
+
+    /**
+     * Put max datetime value 9999-12-31T23:59:59.9999999Z.
+     *
+     * @param datetimeBody the DateTime value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putUtcMaxDateTimeAsync(DateTime datetimeBody) {
+        return putUtcMaxDateTimeWithRestResponseAsync(datetimeBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -366,7 +424,7 @@ public class DatetimesImpl implements Datetimes {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<DateTime> getUtcLowercaseMaxDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
+    public ServiceFuture<DateTime> getUtcLowercaseMaxDateTimeAsync(ServiceCallback<DateTime> serviceCallback) {
         return ServiceFuture.fromBody(getUtcLowercaseMaxDateTimeAsync(), serviceCallback);
     }
 
@@ -374,11 +432,22 @@ public class DatetimesImpl implements Datetimes {
      * Get max datetime value 9999-12-31t23:59:59.9999999z.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the DateTime object
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
      */
-    public Single<DateTime> getUtcLowercaseMaxDateTimeAsync() {
+    public Single<RestResponse<Void, DateTime>> getUtcLowercaseMaxDateTimeWithRestResponseAsync() {
         return service.getUtcLowercaseMaxDateTime();
     }
+
+    /**
+     * Get max datetime value 9999-12-31t23:59:59.9999999z.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
+     */
+    public Single<DateTime> getUtcLowercaseMaxDateTimeAsync() {
+        return getUtcLowercaseMaxDateTimeWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, DateTime>, DateTime>() { public DateTime call(RestResponse<Void, DateTime> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -400,7 +469,7 @@ public class DatetimesImpl implements Datetimes {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<DateTime> getUtcUppercaseMaxDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
+    public ServiceFuture<DateTime> getUtcUppercaseMaxDateTimeAsync(ServiceCallback<DateTime> serviceCallback) {
         return ServiceFuture.fromBody(getUtcUppercaseMaxDateTimeAsync(), serviceCallback);
     }
 
@@ -408,11 +477,22 @@ public class DatetimesImpl implements Datetimes {
      * Get max datetime value 9999-12-31T23:59:59.9999999Z.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the DateTime object
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
      */
-    public Single<DateTime> getUtcUppercaseMaxDateTimeAsync() {
+    public Single<RestResponse<Void, DateTime>> getUtcUppercaseMaxDateTimeWithRestResponseAsync() {
         return service.getUtcUppercaseMaxDateTime();
     }
+
+    /**
+     * Get max datetime value 9999-12-31T23:59:59.9999999Z.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
+     */
+    public Single<DateTime> getUtcUppercaseMaxDateTimeAsync() {
+        return getUtcUppercaseMaxDateTimeWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, DateTime>, DateTime>() { public DateTime call(RestResponse<Void, DateTime> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -422,6 +502,7 @@ public class DatetimesImpl implements Datetimes {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putLocalPositiveOffsetMaxDateTime(DateTime datetimeBody) {
         putLocalPositiveOffsetMaxDateTimeAsync(datetimeBody).toBlocking().value();
@@ -435,7 +516,7 @@ public class DatetimesImpl implements Datetimes {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putLocalPositiveOffsetMaxDateTimeAsync(DateTime datetimeBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putLocalPositiveOffsetMaxDateTimeAsync(DateTime datetimeBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putLocalPositiveOffsetMaxDateTimeAsync(datetimeBody), serviceCallback);
     }
 
@@ -444,14 +525,26 @@ public class DatetimesImpl implements Datetimes {
      *
      * @param datetimeBody the DateTime value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putLocalPositiveOffsetMaxDateTimeAsync(DateTime datetimeBody) {
+    public Single<RestResponse<Void, Void>> putLocalPositiveOffsetMaxDateTimeWithRestResponseAsync(DateTime datetimeBody) {
         if (datetimeBody == null) {
             throw new IllegalArgumentException("Parameter datetimeBody is required and cannot be null.");
         }
         return service.putLocalPositiveOffsetMaxDateTime(datetimeBody);
     }
+
+    /**
+     * Put max datetime value with positive numoffset 9999-12-31t23:59:59.9999999+14:00.
+     *
+     * @param datetimeBody the DateTime value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putLocalPositiveOffsetMaxDateTimeAsync(DateTime datetimeBody) {
+        return putLocalPositiveOffsetMaxDateTimeWithRestResponseAsync(datetimeBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -473,7 +566,7 @@ public class DatetimesImpl implements Datetimes {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<DateTime> getLocalPositiveOffsetLowercaseMaxDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
+    public ServiceFuture<DateTime> getLocalPositiveOffsetLowercaseMaxDateTimeAsync(ServiceCallback<DateTime> serviceCallback) {
         return ServiceFuture.fromBody(getLocalPositiveOffsetLowercaseMaxDateTimeAsync(), serviceCallback);
     }
 
@@ -481,11 +574,22 @@ public class DatetimesImpl implements Datetimes {
      * Get max datetime value with positive num offset 9999-12-31t23:59:59.9999999+14:00.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the DateTime object
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
      */
-    public Single<DateTime> getLocalPositiveOffsetLowercaseMaxDateTimeAsync() {
+    public Single<RestResponse<Void, DateTime>> getLocalPositiveOffsetLowercaseMaxDateTimeWithRestResponseAsync() {
         return service.getLocalPositiveOffsetLowercaseMaxDateTime();
     }
+
+    /**
+     * Get max datetime value with positive num offset 9999-12-31t23:59:59.9999999+14:00.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
+     */
+    public Single<DateTime> getLocalPositiveOffsetLowercaseMaxDateTimeAsync() {
+        return getLocalPositiveOffsetLowercaseMaxDateTimeWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, DateTime>, DateTime>() { public DateTime call(RestResponse<Void, DateTime> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -507,7 +611,7 @@ public class DatetimesImpl implements Datetimes {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<DateTime> getLocalPositiveOffsetUppercaseMaxDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
+    public ServiceFuture<DateTime> getLocalPositiveOffsetUppercaseMaxDateTimeAsync(ServiceCallback<DateTime> serviceCallback) {
         return ServiceFuture.fromBody(getLocalPositiveOffsetUppercaseMaxDateTimeAsync(), serviceCallback);
     }
 
@@ -515,11 +619,22 @@ public class DatetimesImpl implements Datetimes {
      * Get max datetime value with positive num offset 9999-12-31T23:59:59.9999999+14:00.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the DateTime object
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
      */
-    public Single<DateTime> getLocalPositiveOffsetUppercaseMaxDateTimeAsync() {
+    public Single<RestResponse<Void, DateTime>> getLocalPositiveOffsetUppercaseMaxDateTimeWithRestResponseAsync() {
         return service.getLocalPositiveOffsetUppercaseMaxDateTime();
     }
+
+    /**
+     * Get max datetime value with positive num offset 9999-12-31T23:59:59.9999999+14:00.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
+     */
+    public Single<DateTime> getLocalPositiveOffsetUppercaseMaxDateTimeAsync() {
+        return getLocalPositiveOffsetUppercaseMaxDateTimeWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, DateTime>, DateTime>() { public DateTime call(RestResponse<Void, DateTime> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -529,6 +644,7 @@ public class DatetimesImpl implements Datetimes {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putLocalNegativeOffsetMaxDateTime(DateTime datetimeBody) {
         putLocalNegativeOffsetMaxDateTimeAsync(datetimeBody).toBlocking().value();
@@ -542,7 +658,7 @@ public class DatetimesImpl implements Datetimes {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putLocalNegativeOffsetMaxDateTimeAsync(DateTime datetimeBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putLocalNegativeOffsetMaxDateTimeAsync(DateTime datetimeBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putLocalNegativeOffsetMaxDateTimeAsync(datetimeBody), serviceCallback);
     }
 
@@ -551,14 +667,26 @@ public class DatetimesImpl implements Datetimes {
      *
      * @param datetimeBody the DateTime value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putLocalNegativeOffsetMaxDateTimeAsync(DateTime datetimeBody) {
+    public Single<RestResponse<Void, Void>> putLocalNegativeOffsetMaxDateTimeWithRestResponseAsync(DateTime datetimeBody) {
         if (datetimeBody == null) {
             throw new IllegalArgumentException("Parameter datetimeBody is required and cannot be null.");
         }
         return service.putLocalNegativeOffsetMaxDateTime(datetimeBody);
     }
+
+    /**
+     * Put max datetime value with positive numoffset 9999-12-31t23:59:59.9999999-14:00.
+     *
+     * @param datetimeBody the DateTime value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putLocalNegativeOffsetMaxDateTimeAsync(DateTime datetimeBody) {
+        return putLocalNegativeOffsetMaxDateTimeWithRestResponseAsync(datetimeBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -580,7 +708,7 @@ public class DatetimesImpl implements Datetimes {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<DateTime> getLocalNegativeOffsetUppercaseMaxDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
+    public ServiceFuture<DateTime> getLocalNegativeOffsetUppercaseMaxDateTimeAsync(ServiceCallback<DateTime> serviceCallback) {
         return ServiceFuture.fromBody(getLocalNegativeOffsetUppercaseMaxDateTimeAsync(), serviceCallback);
     }
 
@@ -588,11 +716,22 @@ public class DatetimesImpl implements Datetimes {
      * Get max datetime value with positive num offset 9999-12-31T23:59:59.9999999-14:00.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the DateTime object
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
      */
-    public Single<DateTime> getLocalNegativeOffsetUppercaseMaxDateTimeAsync() {
+    public Single<RestResponse<Void, DateTime>> getLocalNegativeOffsetUppercaseMaxDateTimeWithRestResponseAsync() {
         return service.getLocalNegativeOffsetUppercaseMaxDateTime();
     }
+
+    /**
+     * Get max datetime value with positive num offset 9999-12-31T23:59:59.9999999-14:00.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
+     */
+    public Single<DateTime> getLocalNegativeOffsetUppercaseMaxDateTimeAsync() {
+        return getLocalNegativeOffsetUppercaseMaxDateTimeWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, DateTime>, DateTime>() { public DateTime call(RestResponse<Void, DateTime> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -614,7 +753,7 @@ public class DatetimesImpl implements Datetimes {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<DateTime> getLocalNegativeOffsetLowercaseMaxDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
+    public ServiceFuture<DateTime> getLocalNegativeOffsetLowercaseMaxDateTimeAsync(ServiceCallback<DateTime> serviceCallback) {
         return ServiceFuture.fromBody(getLocalNegativeOffsetLowercaseMaxDateTimeAsync(), serviceCallback);
     }
 
@@ -622,11 +761,22 @@ public class DatetimesImpl implements Datetimes {
      * Get max datetime value with positive num offset 9999-12-31t23:59:59.9999999-14:00.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the DateTime object
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
      */
-    public Single<DateTime> getLocalNegativeOffsetLowercaseMaxDateTimeAsync() {
+    public Single<RestResponse<Void, DateTime>> getLocalNegativeOffsetLowercaseMaxDateTimeWithRestResponseAsync() {
         return service.getLocalNegativeOffsetLowercaseMaxDateTime();
     }
+
+    /**
+     * Get max datetime value with positive num offset 9999-12-31t23:59:59.9999999-14:00.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
+     */
+    public Single<DateTime> getLocalNegativeOffsetLowercaseMaxDateTimeAsync() {
+        return getLocalNegativeOffsetLowercaseMaxDateTimeWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, DateTime>, DateTime>() { public DateTime call(RestResponse<Void, DateTime> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -636,6 +786,7 @@ public class DatetimesImpl implements Datetimes {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putUtcMinDateTime(DateTime datetimeBody) {
         putUtcMinDateTimeAsync(datetimeBody).toBlocking().value();
@@ -649,7 +800,7 @@ public class DatetimesImpl implements Datetimes {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putUtcMinDateTimeAsync(DateTime datetimeBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putUtcMinDateTimeAsync(DateTime datetimeBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putUtcMinDateTimeAsync(datetimeBody), serviceCallback);
     }
 
@@ -658,14 +809,26 @@ public class DatetimesImpl implements Datetimes {
      *
      * @param datetimeBody the DateTime value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putUtcMinDateTimeAsync(DateTime datetimeBody) {
+    public Single<RestResponse<Void, Void>> putUtcMinDateTimeWithRestResponseAsync(DateTime datetimeBody) {
         if (datetimeBody == null) {
             throw new IllegalArgumentException("Parameter datetimeBody is required and cannot be null.");
         }
         return service.putUtcMinDateTime(datetimeBody);
     }
+
+    /**
+     * Put min datetime value 0001-01-01T00:00:00Z.
+     *
+     * @param datetimeBody the DateTime value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putUtcMinDateTimeAsync(DateTime datetimeBody) {
+        return putUtcMinDateTimeWithRestResponseAsync(datetimeBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -687,7 +850,7 @@ public class DatetimesImpl implements Datetimes {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<DateTime> getUtcMinDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
+    public ServiceFuture<DateTime> getUtcMinDateTimeAsync(ServiceCallback<DateTime> serviceCallback) {
         return ServiceFuture.fromBody(getUtcMinDateTimeAsync(), serviceCallback);
     }
 
@@ -695,11 +858,22 @@ public class DatetimesImpl implements Datetimes {
      * Get min datetime value 0001-01-01T00:00:00Z.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the DateTime object
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
      */
-    public Single<DateTime> getUtcMinDateTimeAsync() {
+    public Single<RestResponse<Void, DateTime>> getUtcMinDateTimeWithRestResponseAsync() {
         return service.getUtcMinDateTime();
     }
+
+    /**
+     * Get min datetime value 0001-01-01T00:00:00Z.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
+     */
+    public Single<DateTime> getUtcMinDateTimeAsync() {
+        return getUtcMinDateTimeWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, DateTime>, DateTime>() { public DateTime call(RestResponse<Void, DateTime> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -709,6 +883,7 @@ public class DatetimesImpl implements Datetimes {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putLocalPositiveOffsetMinDateTime(DateTime datetimeBody) {
         putLocalPositiveOffsetMinDateTimeAsync(datetimeBody).toBlocking().value();
@@ -722,7 +897,7 @@ public class DatetimesImpl implements Datetimes {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putLocalPositiveOffsetMinDateTimeAsync(DateTime datetimeBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putLocalPositiveOffsetMinDateTimeAsync(DateTime datetimeBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putLocalPositiveOffsetMinDateTimeAsync(datetimeBody), serviceCallback);
     }
 
@@ -731,14 +906,26 @@ public class DatetimesImpl implements Datetimes {
      *
      * @param datetimeBody the DateTime value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putLocalPositiveOffsetMinDateTimeAsync(DateTime datetimeBody) {
+    public Single<RestResponse<Void, Void>> putLocalPositiveOffsetMinDateTimeWithRestResponseAsync(DateTime datetimeBody) {
         if (datetimeBody == null) {
             throw new IllegalArgumentException("Parameter datetimeBody is required and cannot be null.");
         }
         return service.putLocalPositiveOffsetMinDateTime(datetimeBody);
     }
+
+    /**
+     * Put min datetime value 0001-01-01T00:00:00+14:00.
+     *
+     * @param datetimeBody the DateTime value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putLocalPositiveOffsetMinDateTimeAsync(DateTime datetimeBody) {
+        return putLocalPositiveOffsetMinDateTimeWithRestResponseAsync(datetimeBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -760,7 +947,7 @@ public class DatetimesImpl implements Datetimes {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<DateTime> getLocalPositiveOffsetMinDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
+    public ServiceFuture<DateTime> getLocalPositiveOffsetMinDateTimeAsync(ServiceCallback<DateTime> serviceCallback) {
         return ServiceFuture.fromBody(getLocalPositiveOffsetMinDateTimeAsync(), serviceCallback);
     }
 
@@ -768,11 +955,22 @@ public class DatetimesImpl implements Datetimes {
      * Get min datetime value 0001-01-01T00:00:00+14:00.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the DateTime object
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
      */
-    public Single<DateTime> getLocalPositiveOffsetMinDateTimeAsync() {
+    public Single<RestResponse<Void, DateTime>> getLocalPositiveOffsetMinDateTimeWithRestResponseAsync() {
         return service.getLocalPositiveOffsetMinDateTime();
     }
+
+    /**
+     * Get min datetime value 0001-01-01T00:00:00+14:00.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
+     */
+    public Single<DateTime> getLocalPositiveOffsetMinDateTimeAsync() {
+        return getLocalPositiveOffsetMinDateTimeWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, DateTime>, DateTime>() { public DateTime call(RestResponse<Void, DateTime> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -782,6 +980,7 @@ public class DatetimesImpl implements Datetimes {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putLocalNegativeOffsetMinDateTime(DateTime datetimeBody) {
         putLocalNegativeOffsetMinDateTimeAsync(datetimeBody).toBlocking().value();
@@ -795,7 +994,7 @@ public class DatetimesImpl implements Datetimes {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putLocalNegativeOffsetMinDateTimeAsync(DateTime datetimeBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putLocalNegativeOffsetMinDateTimeAsync(DateTime datetimeBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putLocalNegativeOffsetMinDateTimeAsync(datetimeBody), serviceCallback);
     }
 
@@ -804,14 +1003,26 @@ public class DatetimesImpl implements Datetimes {
      *
      * @param datetimeBody the DateTime value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putLocalNegativeOffsetMinDateTimeAsync(DateTime datetimeBody) {
+    public Single<RestResponse<Void, Void>> putLocalNegativeOffsetMinDateTimeWithRestResponseAsync(DateTime datetimeBody) {
         if (datetimeBody == null) {
             throw new IllegalArgumentException("Parameter datetimeBody is required and cannot be null.");
         }
         return service.putLocalNegativeOffsetMinDateTime(datetimeBody);
     }
+
+    /**
+     * Put min datetime value 0001-01-01T00:00:00-14:00.
+     *
+     * @param datetimeBody the DateTime value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putLocalNegativeOffsetMinDateTimeAsync(DateTime datetimeBody) {
+        return putLocalNegativeOffsetMinDateTimeWithRestResponseAsync(datetimeBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -833,7 +1044,7 @@ public class DatetimesImpl implements Datetimes {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<DateTime> getLocalNegativeOffsetMinDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
+    public ServiceFuture<DateTime> getLocalNegativeOffsetMinDateTimeAsync(ServiceCallback<DateTime> serviceCallback) {
         return ServiceFuture.fromBody(getLocalNegativeOffsetMinDateTimeAsync(), serviceCallback);
     }
 
@@ -841,11 +1052,22 @@ public class DatetimesImpl implements Datetimes {
      * Get min datetime value 0001-01-01T00:00:00-14:00.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the DateTime object
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
      */
-    public Single<DateTime> getLocalNegativeOffsetMinDateTimeAsync() {
+    public Single<RestResponse<Void, DateTime>> getLocalNegativeOffsetMinDateTimeWithRestResponseAsync() {
         return service.getLocalNegativeOffsetMinDateTime();
     }
+
+    /**
+     * Get min datetime value 0001-01-01T00:00:00-14:00.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
+     */
+    public Single<DateTime> getLocalNegativeOffsetMinDateTimeAsync() {
+        return getLocalNegativeOffsetMinDateTimeWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, DateTime>, DateTime>() { public DateTime call(RestResponse<Void, DateTime> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodydatetimerfc1123/Datetimerfc1123s.java
+++ b/test/vanilla/src/main/java/fixtures/bodydatetimerfc1123/Datetimerfc1123s.java
@@ -10,6 +10,7 @@
 
 package fixtures.bodydatetimerfc1123;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.bodydatetimerfc1123.models.ErrorException;
@@ -49,6 +50,13 @@ public interface Datetimerfc1123s {
      * @return the observable to the DateTime object
      */
     Single<DateTime> getNullAsync();
+    /**
+     * Get null datetime value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the DateTime object
+     */
+    Single<RestResponse<Void, DateTime>> getNullWithRestResponseAsync();
 
 
     /**
@@ -77,6 +85,13 @@ public interface Datetimerfc1123s {
      * @return the observable to the DateTime object
      */
     Single<DateTime> getInvalidAsync();
+    /**
+     * Get invalid datetime value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the DateTime object
+     */
+    Single<RestResponse<Void, DateTime>> getInvalidWithRestResponseAsync();
 
 
     /**
@@ -105,6 +120,13 @@ public interface Datetimerfc1123s {
      * @return the observable to the DateTime object
      */
     Single<DateTime> getOverflowAsync();
+    /**
+     * Get overflow datetime value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the DateTime object
+     */
+    Single<RestResponse<Void, DateTime>> getOverflowWithRestResponseAsync();
 
 
     /**
@@ -133,6 +155,13 @@ public interface Datetimerfc1123s {
      * @return the observable to the DateTime object
      */
     Single<DateTime> getUnderflowAsync();
+    /**
+     * Get underflow datetime value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the DateTime object
+     */
+    Single<RestResponse<Void, DateTime>> getUnderflowWithRestResponseAsync();
 
 
     /**
@@ -163,6 +192,14 @@ public interface Datetimerfc1123s {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putUtcMaxDateTimeAsync(DateTime datetimeBody);
+    /**
+     * Put max datetime value Fri, 31 Dec 9999 23:59:59 GMT.
+     *
+     * @param datetimeBody the DateTimeRfc1123 value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putUtcMaxDateTimeWithRestResponseAsync(DateTime datetimeBody);
 
 
     /**
@@ -191,6 +228,13 @@ public interface Datetimerfc1123s {
      * @return the observable to the DateTime object
      */
     Single<DateTime> getUtcLowercaseMaxDateTimeAsync();
+    /**
+     * Get max datetime value fri, 31 dec 9999 23:59:59 gmt.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the DateTime object
+     */
+    Single<RestResponse<Void, DateTime>> getUtcLowercaseMaxDateTimeWithRestResponseAsync();
 
 
     /**
@@ -219,6 +263,13 @@ public interface Datetimerfc1123s {
      * @return the observable to the DateTime object
      */
     Single<DateTime> getUtcUppercaseMaxDateTimeAsync();
+    /**
+     * Get max datetime value FRI, 31 DEC 9999 23:59:59 GMT.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the DateTime object
+     */
+    Single<RestResponse<Void, DateTime>> getUtcUppercaseMaxDateTimeWithRestResponseAsync();
 
 
     /**
@@ -249,6 +300,14 @@ public interface Datetimerfc1123s {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putUtcMinDateTimeAsync(DateTime datetimeBody);
+    /**
+     * Put min datetime value Mon, 1 Jan 0001 00:00:00 GMT.
+     *
+     * @param datetimeBody the DateTimeRfc1123 value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putUtcMinDateTimeWithRestResponseAsync(DateTime datetimeBody);
 
 
     /**
@@ -277,6 +336,13 @@ public interface Datetimerfc1123s {
      * @return the observable to the DateTime object
      */
     Single<DateTime> getUtcMinDateTimeAsync();
+    /**
+     * Get min datetime value Mon, 1 Jan 0001 00:00:00 GMT.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the DateTime object
+     */
+    Single<RestResponse<Void, DateTime>> getUtcMinDateTimeWithRestResponseAsync();
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodydatetimerfc1123/implementation/AutoRestRFC1123DateTimeTestServiceImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodydatetimerfc1123/implementation/AutoRestRFC1123DateTimeTestServiceImpl.java
@@ -13,6 +13,7 @@ package fixtures.bodydatetimerfc1123.implementation;
 import fixtures.bodydatetimerfc1123.AutoRestRFC1123DateTimeTestService;
 import fixtures.bodydatetimerfc1123.Datetimerfc1123s;
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceClient;
 import com.microsoft.rest.RestClient;
 import rx.Single;

--- a/test/vanilla/src/main/java/fixtures/bodydatetimerfc1123/implementation/Datetimerfc1123sImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodydatetimerfc1123/implementation/Datetimerfc1123sImpl.java
@@ -11,6 +11,7 @@
 package fixtures.bodydatetimerfc1123.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.bodydatetimerfc1123.Datetimerfc1123s;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.BodyParam;
@@ -63,61 +64,61 @@ public class Datetimerfc1123sImpl implements Datetimerfc1123s {
         @ExpectedResponses({200})
         @ReturnValueWireType(DateTimeRfc1123.class)
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<DateTime> getNull();
+        Single<RestResponse<Void, DateTime>> getNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydatetimerfc1123.Datetimerfc1123s getInvalid" })
         @GET("datetimerfc1123/invalid")
         @ExpectedResponses({200})
         @ReturnValueWireType(DateTimeRfc1123.class)
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<DateTime> getInvalid();
+        Single<RestResponse<Void, DateTime>> getInvalid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydatetimerfc1123.Datetimerfc1123s getOverflow" })
         @GET("datetimerfc1123/overflow")
         @ExpectedResponses({200})
         @ReturnValueWireType(DateTimeRfc1123.class)
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<DateTime> getOverflow();
+        Single<RestResponse<Void, DateTime>> getOverflow();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydatetimerfc1123.Datetimerfc1123s getUnderflow" })
         @GET("datetimerfc1123/underflow")
         @ExpectedResponses({200})
         @ReturnValueWireType(DateTimeRfc1123.class)
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<DateTime> getUnderflow();
+        Single<RestResponse<Void, DateTime>> getUnderflow();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydatetimerfc1123.Datetimerfc1123s putUtcMaxDateTime" })
         @PUT("datetimerfc1123/max")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putUtcMaxDateTime(@BodyParam("application/json; charset=utf-8") DateTimeRfc1123 datetimeBody);
+        Single<RestResponse<Void, Void>> putUtcMaxDateTime(@BodyParam("application/json; charset=utf-8") DateTimeRfc1123 datetimeBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodydatetimerfc1123.Datetimerfc1123s getUtcLowercaseMaxDateTime" })
         @GET("datetimerfc1123/max/lowercase")
         @ExpectedResponses({200})
         @ReturnValueWireType(DateTimeRfc1123.class)
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<DateTime> getUtcLowercaseMaxDateTime();
+        Single<RestResponse<Void, DateTime>> getUtcLowercaseMaxDateTime();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydatetimerfc1123.Datetimerfc1123s getUtcUppercaseMaxDateTime" })
         @GET("datetimerfc1123/max/uppercase")
         @ExpectedResponses({200})
         @ReturnValueWireType(DateTimeRfc1123.class)
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<DateTime> getUtcUppercaseMaxDateTime();
+        Single<RestResponse<Void, DateTime>> getUtcUppercaseMaxDateTime();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydatetimerfc1123.Datetimerfc1123s putUtcMinDateTime" })
         @PUT("datetimerfc1123/min")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putUtcMinDateTime(@BodyParam("application/json; charset=utf-8") DateTimeRfc1123 datetimeBody);
+        Single<RestResponse<Void, Void>> putUtcMinDateTime(@BodyParam("application/json; charset=utf-8") DateTimeRfc1123 datetimeBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodydatetimerfc1123.Datetimerfc1123s getUtcMinDateTime" })
         @GET("datetimerfc1123/min")
         @ExpectedResponses({200})
         @ReturnValueWireType(DateTimeRfc1123.class)
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<DateTime> getUtcMinDateTime();
+        Single<RestResponse<Void, DateTime>> getUtcMinDateTime();
 
     }
 
@@ -140,7 +141,7 @@ public class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<DateTime> getNullAsync(final ServiceCallback<DateTime> serviceCallback) {
+    public ServiceFuture<DateTime> getNullAsync(ServiceCallback<DateTime> serviceCallback) {
         return ServiceFuture.fromBody(getNullAsync(), serviceCallback);
     }
 
@@ -148,11 +149,22 @@ public class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * Get null datetime value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the DateTime object
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
      */
-    public Single<DateTime> getNullAsync() {
+    public Single<RestResponse<Void, DateTime>> getNullWithRestResponseAsync() {
         return service.getNull();
     }
+
+    /**
+     * Get null datetime value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
+     */
+    public Single<DateTime> getNullAsync() {
+        return getNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, DateTime>, DateTime>() { public DateTime call(RestResponse<Void, DateTime> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -174,7 +186,7 @@ public class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<DateTime> getInvalidAsync(final ServiceCallback<DateTime> serviceCallback) {
+    public ServiceFuture<DateTime> getInvalidAsync(ServiceCallback<DateTime> serviceCallback) {
         return ServiceFuture.fromBody(getInvalidAsync(), serviceCallback);
     }
 
@@ -182,11 +194,22 @@ public class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * Get invalid datetime value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the DateTime object
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
      */
-    public Single<DateTime> getInvalidAsync() {
+    public Single<RestResponse<Void, DateTime>> getInvalidWithRestResponseAsync() {
         return service.getInvalid();
     }
+
+    /**
+     * Get invalid datetime value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
+     */
+    public Single<DateTime> getInvalidAsync() {
+        return getInvalidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, DateTime>, DateTime>() { public DateTime call(RestResponse<Void, DateTime> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -208,7 +231,7 @@ public class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<DateTime> getOverflowAsync(final ServiceCallback<DateTime> serviceCallback) {
+    public ServiceFuture<DateTime> getOverflowAsync(ServiceCallback<DateTime> serviceCallback) {
         return ServiceFuture.fromBody(getOverflowAsync(), serviceCallback);
     }
 
@@ -216,11 +239,22 @@ public class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * Get overflow datetime value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the DateTime object
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
      */
-    public Single<DateTime> getOverflowAsync() {
+    public Single<RestResponse<Void, DateTime>> getOverflowWithRestResponseAsync() {
         return service.getOverflow();
     }
+
+    /**
+     * Get overflow datetime value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
+     */
+    public Single<DateTime> getOverflowAsync() {
+        return getOverflowWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, DateTime>, DateTime>() { public DateTime call(RestResponse<Void, DateTime> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -242,7 +276,7 @@ public class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<DateTime> getUnderflowAsync(final ServiceCallback<DateTime> serviceCallback) {
+    public ServiceFuture<DateTime> getUnderflowAsync(ServiceCallback<DateTime> serviceCallback) {
         return ServiceFuture.fromBody(getUnderflowAsync(), serviceCallback);
     }
 
@@ -250,11 +284,22 @@ public class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * Get underflow datetime value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the DateTime object
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
      */
-    public Single<DateTime> getUnderflowAsync() {
+    public Single<RestResponse<Void, DateTime>> getUnderflowWithRestResponseAsync() {
         return service.getUnderflow();
     }
+
+    /**
+     * Get underflow datetime value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
+     */
+    public Single<DateTime> getUnderflowAsync() {
+        return getUnderflowWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, DateTime>, DateTime>() { public DateTime call(RestResponse<Void, DateTime> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -264,6 +309,7 @@ public class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putUtcMaxDateTime(DateTime datetimeBody) {
         putUtcMaxDateTimeAsync(datetimeBody).toBlocking().value();
@@ -277,7 +323,7 @@ public class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putUtcMaxDateTimeAsync(DateTime datetimeBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putUtcMaxDateTimeAsync(DateTime datetimeBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putUtcMaxDateTimeAsync(datetimeBody), serviceCallback);
     }
 
@@ -286,15 +332,27 @@ public class Datetimerfc1123sImpl implements Datetimerfc1123s {
      *
      * @param datetimeBody the DateTimeRfc1123 value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putUtcMaxDateTimeAsync(DateTime datetimeBody) {
+    public Single<RestResponse<Void, Void>> putUtcMaxDateTimeWithRestResponseAsync(DateTime datetimeBody) {
         if (datetimeBody == null) {
             throw new IllegalArgumentException("Parameter datetimeBody is required and cannot be null.");
         }
-        DateTimeRfc1123 datetimeBodyConverted = new DateTimeRfc1123(datetimeBody);
+    DateTimeRfc1123 datetimeBodyConverted = new DateTimeRfc1123(datetimeBody);
         return service.putUtcMaxDateTime(datetimeBodyConverted);
     }
+
+    /**
+     * Put max datetime value Fri, 31 Dec 9999 23:59:59 GMT.
+     *
+     * @param datetimeBody the DateTimeRfc1123 value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putUtcMaxDateTimeAsync(DateTime datetimeBody) {
+        return putUtcMaxDateTimeWithRestResponseAsync(datetimeBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -316,7 +374,7 @@ public class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<DateTime> getUtcLowercaseMaxDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
+    public ServiceFuture<DateTime> getUtcLowercaseMaxDateTimeAsync(ServiceCallback<DateTime> serviceCallback) {
         return ServiceFuture.fromBody(getUtcLowercaseMaxDateTimeAsync(), serviceCallback);
     }
 
@@ -324,11 +382,22 @@ public class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * Get max datetime value fri, 31 dec 9999 23:59:59 gmt.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the DateTime object
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
      */
-    public Single<DateTime> getUtcLowercaseMaxDateTimeAsync() {
+    public Single<RestResponse<Void, DateTime>> getUtcLowercaseMaxDateTimeWithRestResponseAsync() {
         return service.getUtcLowercaseMaxDateTime();
     }
+
+    /**
+     * Get max datetime value fri, 31 dec 9999 23:59:59 gmt.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
+     */
+    public Single<DateTime> getUtcLowercaseMaxDateTimeAsync() {
+        return getUtcLowercaseMaxDateTimeWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, DateTime>, DateTime>() { public DateTime call(RestResponse<Void, DateTime> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -350,7 +419,7 @@ public class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<DateTime> getUtcUppercaseMaxDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
+    public ServiceFuture<DateTime> getUtcUppercaseMaxDateTimeAsync(ServiceCallback<DateTime> serviceCallback) {
         return ServiceFuture.fromBody(getUtcUppercaseMaxDateTimeAsync(), serviceCallback);
     }
 
@@ -358,11 +427,22 @@ public class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * Get max datetime value FRI, 31 DEC 9999 23:59:59 GMT.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the DateTime object
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
      */
-    public Single<DateTime> getUtcUppercaseMaxDateTimeAsync() {
+    public Single<RestResponse<Void, DateTime>> getUtcUppercaseMaxDateTimeWithRestResponseAsync() {
         return service.getUtcUppercaseMaxDateTime();
     }
+
+    /**
+     * Get max datetime value FRI, 31 DEC 9999 23:59:59 GMT.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
+     */
+    public Single<DateTime> getUtcUppercaseMaxDateTimeAsync() {
+        return getUtcUppercaseMaxDateTimeWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, DateTime>, DateTime>() { public DateTime call(RestResponse<Void, DateTime> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -372,6 +452,7 @@ public class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putUtcMinDateTime(DateTime datetimeBody) {
         putUtcMinDateTimeAsync(datetimeBody).toBlocking().value();
@@ -385,7 +466,7 @@ public class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putUtcMinDateTimeAsync(DateTime datetimeBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putUtcMinDateTimeAsync(DateTime datetimeBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putUtcMinDateTimeAsync(datetimeBody), serviceCallback);
     }
 
@@ -394,15 +475,27 @@ public class Datetimerfc1123sImpl implements Datetimerfc1123s {
      *
      * @param datetimeBody the DateTimeRfc1123 value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putUtcMinDateTimeAsync(DateTime datetimeBody) {
+    public Single<RestResponse<Void, Void>> putUtcMinDateTimeWithRestResponseAsync(DateTime datetimeBody) {
         if (datetimeBody == null) {
             throw new IllegalArgumentException("Parameter datetimeBody is required and cannot be null.");
         }
-        DateTimeRfc1123 datetimeBodyConverted = new DateTimeRfc1123(datetimeBody);
+    DateTimeRfc1123 datetimeBodyConverted = new DateTimeRfc1123(datetimeBody);
         return service.putUtcMinDateTime(datetimeBodyConverted);
     }
+
+    /**
+     * Put min datetime value Mon, 1 Jan 0001 00:00:00 GMT.
+     *
+     * @param datetimeBody the DateTimeRfc1123 value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putUtcMinDateTimeAsync(DateTime datetimeBody) {
+        return putUtcMinDateTimeWithRestResponseAsync(datetimeBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -424,7 +517,7 @@ public class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<DateTime> getUtcMinDateTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
+    public ServiceFuture<DateTime> getUtcMinDateTimeAsync(ServiceCallback<DateTime> serviceCallback) {
         return ServiceFuture.fromBody(getUtcMinDateTimeAsync(), serviceCallback);
     }
 
@@ -432,11 +525,22 @@ public class Datetimerfc1123sImpl implements Datetimerfc1123s {
      * Get min datetime value Mon, 1 Jan 0001 00:00:00 GMT.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the DateTime object
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
      */
-    public Single<DateTime> getUtcMinDateTimeAsync() {
+    public Single<RestResponse<Void, DateTime>> getUtcMinDateTimeWithRestResponseAsync() {
         return service.getUtcMinDateTime();
     }
+
+    /**
+     * Get min datetime value Mon, 1 Jan 0001 00:00:00 GMT.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
+     */
+    public Single<DateTime> getUtcMinDateTimeAsync() {
+        return getUtcMinDateTimeWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, DateTime>, DateTime>() { public DateTime call(RestResponse<Void, DateTime> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodydictionary/Dictionarys.java
+++ b/test/vanilla/src/main/java/fixtures/bodydictionary/Dictionarys.java
@@ -10,6 +10,7 @@
 
 package fixtures.bodydictionary;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.bodydictionary.models.ErrorException;
@@ -54,6 +55,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
     Single<Map<String, Integer>> getNullAsync();
+    /**
+     * Get null dictionary value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, Integer&gt; object
+     */
+    Single<RestResponse<Void, Map<String, Integer>>> getNullWithRestResponseAsync();
 
 
     /**
@@ -82,6 +90,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
     Single<Map<String, Integer>> getEmptyAsync();
+    /**
+     * Get empty dictionary value {}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, Integer&gt; object
+     */
+    Single<RestResponse<Void, Map<String, Integer>>> getEmptyWithRestResponseAsync();
 
 
     /**
@@ -112,6 +127,14 @@ public interface Dictionarys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putEmptyAsync(Map<String, String> arrayBody);
+    /**
+     * Set dictionary value empty {}.
+     *
+     * @param arrayBody the Map&lt;String, String&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putEmptyWithRestResponseAsync(Map<String, String> arrayBody);
 
 
     /**
@@ -140,6 +163,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, String&gt; object
      */
     Single<Map<String, String>> getNullValueAsync();
+    /**
+     * Get Dictionary with null value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, String&gt; object
+     */
+    Single<RestResponse<Void, Map<String, String>>> getNullValueWithRestResponseAsync();
 
 
     /**
@@ -168,6 +198,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, String&gt; object
      */
     Single<Map<String, String>> getNullKeyAsync();
+    /**
+     * Get Dictionary with null key.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, String&gt; object
+     */
+    Single<RestResponse<Void, Map<String, String>>> getNullKeyWithRestResponseAsync();
 
 
     /**
@@ -196,6 +233,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, String&gt; object
      */
     Single<Map<String, String>> getEmptyStringKeyAsync();
+    /**
+     * Get Dictionary with key as empty string.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, String&gt; object
+     */
+    Single<RestResponse<Void, Map<String, String>>> getEmptyStringKeyWithRestResponseAsync();
 
 
     /**
@@ -224,6 +268,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, String&gt; object
      */
     Single<Map<String, String>> getInvalidAsync();
+    /**
+     * Get invalid Dictionary value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, String&gt; object
+     */
+    Single<RestResponse<Void, Map<String, String>>> getInvalidWithRestResponseAsync();
 
 
     /**
@@ -252,6 +303,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, Boolean&gt; object
      */
     Single<Map<String, Boolean>> getBooleanTfftAsync();
+    /**
+     * Get boolean dictionary value {"0": true, "1": false, "2": false, "3": true }.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, Boolean&gt; object
+     */
+    Single<RestResponse<Void, Map<String, Boolean>>> getBooleanTfftWithRestResponseAsync();
 
 
     /**
@@ -282,6 +340,14 @@ public interface Dictionarys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putBooleanTfftAsync(Map<String, Boolean> arrayBody);
+    /**
+     * Set dictionary value empty {"0": true, "1": false, "2": false, "3": true }.
+     *
+     * @param arrayBody the Map&lt;String, Boolean&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putBooleanTfftWithRestResponseAsync(Map<String, Boolean> arrayBody);
 
 
     /**
@@ -310,6 +376,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, Boolean&gt; object
      */
     Single<Map<String, Boolean>> getBooleanInvalidNullAsync();
+    /**
+     * Get boolean dictionary value {"0": true, "1": null, "2": false }.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, Boolean&gt; object
+     */
+    Single<RestResponse<Void, Map<String, Boolean>>> getBooleanInvalidNullWithRestResponseAsync();
 
 
     /**
@@ -338,6 +411,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, Boolean&gt; object
      */
     Single<Map<String, Boolean>> getBooleanInvalidStringAsync();
+    /**
+     * Get boolean dictionary value '{"0": true, "1": "boolean", "2": false}'.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, Boolean&gt; object
+     */
+    Single<RestResponse<Void, Map<String, Boolean>>> getBooleanInvalidStringWithRestResponseAsync();
 
 
     /**
@@ -366,6 +446,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
     Single<Map<String, Integer>> getIntegerValidAsync();
+    /**
+     * Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, Integer&gt; object
+     */
+    Single<RestResponse<Void, Map<String, Integer>>> getIntegerValidWithRestResponseAsync();
 
 
     /**
@@ -396,6 +483,14 @@ public interface Dictionarys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putIntegerValidAsync(Map<String, Integer> arrayBody);
+    /**
+     * Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}.
+     *
+     * @param arrayBody the Map&lt;String, Integer&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putIntegerValidWithRestResponseAsync(Map<String, Integer> arrayBody);
 
 
     /**
@@ -424,6 +519,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
     Single<Map<String, Integer>> getIntInvalidNullAsync();
+    /**
+     * Get integer dictionary value {"0": 1, "1": null, "2": 0}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, Integer&gt; object
+     */
+    Single<RestResponse<Void, Map<String, Integer>>> getIntInvalidNullWithRestResponseAsync();
 
 
     /**
@@ -452,6 +554,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
     Single<Map<String, Integer>> getIntInvalidStringAsync();
+    /**
+     * Get integer dictionary value {"0": 1, "1": "integer", "2": 0}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, Integer&gt; object
+     */
+    Single<RestResponse<Void, Map<String, Integer>>> getIntInvalidStringWithRestResponseAsync();
 
 
     /**
@@ -480,6 +589,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, Long&gt; object
      */
     Single<Map<String, Long>> getLongValidAsync();
+    /**
+     * Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, Long&gt; object
+     */
+    Single<RestResponse<Void, Map<String, Long>>> getLongValidWithRestResponseAsync();
 
 
     /**
@@ -510,6 +626,14 @@ public interface Dictionarys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putLongValidAsync(Map<String, Long> arrayBody);
+    /**
+     * Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}.
+     *
+     * @param arrayBody the Map&lt;String, Long&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putLongValidWithRestResponseAsync(Map<String, Long> arrayBody);
 
 
     /**
@@ -538,6 +662,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, Long&gt; object
      */
     Single<Map<String, Long>> getLongInvalidNullAsync();
+    /**
+     * Get long dictionary value {"0": 1, "1": null, "2": 0}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, Long&gt; object
+     */
+    Single<RestResponse<Void, Map<String, Long>>> getLongInvalidNullWithRestResponseAsync();
 
 
     /**
@@ -566,6 +697,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, Long&gt; object
      */
     Single<Map<String, Long>> getLongInvalidStringAsync();
+    /**
+     * Get long dictionary value {"0": 1, "1": "integer", "2": 0}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, Long&gt; object
+     */
+    Single<RestResponse<Void, Map<String, Long>>> getLongInvalidStringWithRestResponseAsync();
 
 
     /**
@@ -594,6 +732,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, Double&gt; object
      */
     Single<Map<String, Double>> getFloatValidAsync();
+    /**
+     * Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, Double&gt; object
+     */
+    Single<RestResponse<Void, Map<String, Double>>> getFloatValidWithRestResponseAsync();
 
 
     /**
@@ -624,6 +769,14 @@ public interface Dictionarys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putFloatValidAsync(Map<String, Double> arrayBody);
+    /**
+     * Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     *
+     * @param arrayBody the Map&lt;String, Double&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putFloatValidWithRestResponseAsync(Map<String, Double> arrayBody);
 
 
     /**
@@ -652,6 +805,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, Double&gt; object
      */
     Single<Map<String, Double>> getFloatInvalidNullAsync();
+    /**
+     * Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, Double&gt; object
+     */
+    Single<RestResponse<Void, Map<String, Double>>> getFloatInvalidNullWithRestResponseAsync();
 
 
     /**
@@ -680,6 +840,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, Double&gt; object
      */
     Single<Map<String, Double>> getFloatInvalidStringAsync();
+    /**
+     * Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, Double&gt; object
+     */
+    Single<RestResponse<Void, Map<String, Double>>> getFloatInvalidStringWithRestResponseAsync();
 
 
     /**
@@ -708,6 +875,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, Double&gt; object
      */
     Single<Map<String, Double>> getDoubleValidAsync();
+    /**
+     * Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, Double&gt; object
+     */
+    Single<RestResponse<Void, Map<String, Double>>> getDoubleValidWithRestResponseAsync();
 
 
     /**
@@ -738,6 +912,14 @@ public interface Dictionarys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putDoubleValidAsync(Map<String, Double> arrayBody);
+    /**
+     * Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     *
+     * @param arrayBody the Map&lt;String, Double&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putDoubleValidWithRestResponseAsync(Map<String, Double> arrayBody);
 
 
     /**
@@ -766,6 +948,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, Double&gt; object
      */
     Single<Map<String, Double>> getDoubleInvalidNullAsync();
+    /**
+     * Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, Double&gt; object
+     */
+    Single<RestResponse<Void, Map<String, Double>>> getDoubleInvalidNullWithRestResponseAsync();
 
 
     /**
@@ -794,6 +983,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, Double&gt; object
      */
     Single<Map<String, Double>> getDoubleInvalidStringAsync();
+    /**
+     * Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, Double&gt; object
+     */
+    Single<RestResponse<Void, Map<String, Double>>> getDoubleInvalidStringWithRestResponseAsync();
 
 
     /**
@@ -822,6 +1018,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, String&gt; object
      */
     Single<Map<String, String>> getStringValidAsync();
+    /**
+     * Get string dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, String&gt; object
+     */
+    Single<RestResponse<Void, Map<String, String>>> getStringValidWithRestResponseAsync();
 
 
     /**
@@ -852,6 +1055,14 @@ public interface Dictionarys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putStringValidAsync(Map<String, String> arrayBody);
+    /**
+     * Set dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
+     *
+     * @param arrayBody the Map&lt;String, String&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putStringValidWithRestResponseAsync(Map<String, String> arrayBody);
 
 
     /**
@@ -880,6 +1091,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, String&gt; object
      */
     Single<Map<String, String>> getStringWithNullAsync();
+    /**
+     * Get string dictionary value {"0": "foo", "1": null, "2": "foo2"}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, String&gt; object
+     */
+    Single<RestResponse<Void, Map<String, String>>> getStringWithNullWithRestResponseAsync();
 
 
     /**
@@ -908,6 +1126,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, String&gt; object
      */
     Single<Map<String, String>> getStringWithInvalidAsync();
+    /**
+     * Get string dictionary value {"0": "foo", "1": 123, "2": "foo2"}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, String&gt; object
+     */
+    Single<RestResponse<Void, Map<String, String>>> getStringWithInvalidWithRestResponseAsync();
 
 
     /**
@@ -936,6 +1161,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, LocalDate&gt; object
      */
     Single<Map<String, LocalDate>> getDateValidAsync();
+    /**
+     * Get integer dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, LocalDate&gt; object
+     */
+    Single<RestResponse<Void, Map<String, LocalDate>>> getDateValidWithRestResponseAsync();
 
 
     /**
@@ -966,6 +1198,14 @@ public interface Dictionarys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putDateValidAsync(Map<String, LocalDate> arrayBody);
+    /**
+     * Set dictionary value  {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
+     *
+     * @param arrayBody the Map&lt;String, LocalDate&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putDateValidWithRestResponseAsync(Map<String, LocalDate> arrayBody);
 
 
     /**
@@ -994,6 +1234,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, LocalDate&gt; object
      */
     Single<Map<String, LocalDate>> getDateInvalidNullAsync();
+    /**
+     * Get date dictionary value {"0": "2012-01-01", "1": null, "2": "1776-07-04"}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, LocalDate&gt; object
+     */
+    Single<RestResponse<Void, Map<String, LocalDate>>> getDateInvalidNullWithRestResponseAsync();
 
 
     /**
@@ -1022,6 +1269,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, LocalDate&gt; object
      */
     Single<Map<String, LocalDate>> getDateInvalidCharsAsync();
+    /**
+     * Get date dictionary value {"0": "2011-03-22", "1": "date"}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, LocalDate&gt; object
+     */
+    Single<RestResponse<Void, Map<String, LocalDate>>> getDateInvalidCharsWithRestResponseAsync();
 
 
     /**
@@ -1050,6 +1304,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, DateTime&gt; object
      */
     Single<Map<String, DateTime>> getDateTimeValidAsync();
+    /**
+     * Get date-time dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, DateTime&gt; object
+     */
+    Single<RestResponse<Void, Map<String, DateTime>>> getDateTimeValidWithRestResponseAsync();
 
 
     /**
@@ -1080,6 +1341,14 @@ public interface Dictionarys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putDateTimeValidAsync(Map<String, DateTime> arrayBody);
+    /**
+     * Set dictionary value  {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}.
+     *
+     * @param arrayBody the Map&lt;String, DateTime&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putDateTimeValidWithRestResponseAsync(Map<String, DateTime> arrayBody);
 
 
     /**
@@ -1108,6 +1377,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, DateTime&gt; object
      */
     Single<Map<String, DateTime>> getDateTimeInvalidNullAsync();
+    /**
+     * Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": null}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, DateTime&gt; object
+     */
+    Single<RestResponse<Void, Map<String, DateTime>>> getDateTimeInvalidNullWithRestResponseAsync();
 
 
     /**
@@ -1136,6 +1412,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, DateTime&gt; object
      */
     Single<Map<String, DateTime>> getDateTimeInvalidCharsAsync();
+    /**
+     * Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": "date-time"}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, DateTime&gt; object
+     */
+    Single<RestResponse<Void, Map<String, DateTime>>> getDateTimeInvalidCharsWithRestResponseAsync();
 
 
     /**
@@ -1164,6 +1447,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, DateTime&gt; object
      */
     Single<Map<String, DateTime>> getDateTimeRfc1123ValidAsync();
+    /**
+     * Get date-time-rfc1123 dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, DateTime&gt; object
+     */
+    Single<RestResponse<Void, Map<String, DateTime>>> getDateTimeRfc1123ValidWithRestResponseAsync();
 
 
     /**
@@ -1194,6 +1484,14 @@ public interface Dictionarys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putDateTimeRfc1123ValidAsync(Map<String, DateTime> arrayBody);
+    /**
+     * Set dictionary value empty {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}.
+     *
+     * @param arrayBody the Map&lt;String, DateTimeRfc1123&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putDateTimeRfc1123ValidWithRestResponseAsync(Map<String, DateTime> arrayBody);
 
 
     /**
@@ -1222,6 +1520,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, Period&gt; object
      */
     Single<Map<String, Period>> getDurationValidAsync();
+    /**
+     * Get duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, Period&gt; object
+     */
+    Single<RestResponse<Void, Map<String, Period>>> getDurationValidWithRestResponseAsync();
 
 
     /**
@@ -1252,6 +1557,14 @@ public interface Dictionarys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putDurationValidAsync(Map<String, Period> arrayBody);
+    /**
+     * Set dictionary value  {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
+     *
+     * @param arrayBody the Map&lt;String, Period&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putDurationValidWithRestResponseAsync(Map<String, Period> arrayBody);
 
 
     /**
@@ -1280,6 +1593,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, byte[]&gt; object
      */
     Single<Map<String, byte[]>> getByteValidAsync();
+    /**
+     * Get byte dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each item encoded in base64.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, byte[]&gt; object
+     */
+    Single<RestResponse<Void, Map<String, byte[]>>> getByteValidWithRestResponseAsync();
 
 
     /**
@@ -1310,6 +1630,14 @@ public interface Dictionarys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putByteValidAsync(Map<String, byte[]> arrayBody);
+    /**
+     * Put the dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each elementencoded in base 64.
+     *
+     * @param arrayBody the Map&lt;String, byte[]&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putByteValidWithRestResponseAsync(Map<String, byte[]> arrayBody);
 
 
     /**
@@ -1338,6 +1666,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, byte[]&gt; object
      */
     Single<Map<String, byte[]>> getByteInvalidNullAsync();
+    /**
+     * Get byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first item base64 encoded.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, byte[]&gt; object
+     */
+    Single<RestResponse<Void, Map<String, byte[]>>> getByteInvalidNullWithRestResponseAsync();
 
 
     /**
@@ -1366,6 +1701,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, byte[]&gt; object
      */
     Single<Map<String, byte[]>> getBase64UrlAsync();
+    /**
+     * Get base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2": "Lorem ipsum"}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, byte[]&gt; object
+     */
+    Single<RestResponse<Void, Map<String, byte[]>>> getBase64UrlWithRestResponseAsync();
 
 
     /**
@@ -1394,6 +1736,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, Widget&gt; object
      */
     Single<Map<String, Widget>> getComplexNullAsync();
+    /**
+     * Get dictionary of complex type null value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, Widget&gt; object
+     */
+    Single<RestResponse<Void, Map<String, Widget>>> getComplexNullWithRestResponseAsync();
 
 
     /**
@@ -1422,6 +1771,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, Widget&gt; object
      */
     Single<Map<String, Widget>> getComplexEmptyAsync();
+    /**
+     * Get empty dictionary of complex type {}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, Widget&gt; object
+     */
+    Single<RestResponse<Void, Map<String, Widget>>> getComplexEmptyWithRestResponseAsync();
 
 
     /**
@@ -1450,6 +1806,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, Widget&gt; object
      */
     Single<Map<String, Widget>> getComplexItemNullAsync();
+    /**
+     * Get dictionary of complex type with null item {"0": {"integer": 1, "string": "2"}, "1": null, "2": {"integer": 5, "string": "6"}}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, Widget&gt; object
+     */
+    Single<RestResponse<Void, Map<String, Widget>>> getComplexItemNullWithRestResponseAsync();
 
 
     /**
@@ -1478,6 +1841,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, Widget&gt; object
      */
     Single<Map<String, Widget>> getComplexItemEmptyAsync();
+    /**
+     * Get dictionary of complex type with empty item {"0": {"integer": 1, "string": "2"}, "1:" {}, "2": {"integer": 5, "string": "6"}}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, Widget&gt; object
+     */
+    Single<RestResponse<Void, Map<String, Widget>>> getComplexItemEmptyWithRestResponseAsync();
 
 
     /**
@@ -1506,6 +1876,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, Widget&gt; object
      */
     Single<Map<String, Widget>> getComplexValidAsync();
+    /**
+     * Get dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, Widget&gt; object
+     */
+    Single<RestResponse<Void, Map<String, Widget>>> getComplexValidWithRestResponseAsync();
 
 
     /**
@@ -1536,6 +1913,14 @@ public interface Dictionarys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putComplexValidAsync(Map<String, Widget> arrayBody);
+    /**
+     * Put an dictionary of complex type with values {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}.
+     *
+     * @param arrayBody the Map&lt;String, Widget&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putComplexValidWithRestResponseAsync(Map<String, Widget> arrayBody);
 
 
     /**
@@ -1564,6 +1949,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
      */
     Single<Map<String, List<String>>> getArrayNullAsync();
+    /**
+     * Get a null array.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
+     */
+    Single<RestResponse<Void, Map<String, List<String>>>> getArrayNullWithRestResponseAsync();
 
 
     /**
@@ -1592,6 +1984,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
      */
     Single<Map<String, List<String>>> getArrayEmptyAsync();
+    /**
+     * Get an empty dictionary {}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
+     */
+    Single<RestResponse<Void, Map<String, List<String>>>> getArrayEmptyWithRestResponseAsync();
 
 
     /**
@@ -1620,6 +2019,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
      */
     Single<Map<String, List<String>>> getArrayItemNullAsync();
+    /**
+     * Get an dictionary of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
+     */
+    Single<RestResponse<Void, Map<String, List<String>>>> getArrayItemNullWithRestResponseAsync();
 
 
     /**
@@ -1648,6 +2054,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
      */
     Single<Map<String, List<String>>> getArrayItemEmptyAsync();
+    /**
+     * Get an array of array of strings [{"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
+     */
+    Single<RestResponse<Void, Map<String, List<String>>>> getArrayItemEmptyWithRestResponseAsync();
 
 
     /**
@@ -1676,6 +2089,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
      */
     Single<Map<String, List<String>>> getArrayValidAsync();
+    /**
+     * Get an array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
+     */
+    Single<RestResponse<Void, Map<String, List<String>>>> getArrayValidWithRestResponseAsync();
 
 
     /**
@@ -1706,6 +2126,14 @@ public interface Dictionarys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putArrayValidAsync(Map<String, List<String>> arrayBody);
+    /**
+     * Put An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
+     *
+     * @param arrayBody the Map&lt;String, List&lt;String&gt;&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putArrayValidWithRestResponseAsync(Map<String, List<String>> arrayBody);
 
 
     /**
@@ -1734,6 +2162,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
      */
     Single<Map<String, Map<String, String>>> getDictionaryNullAsync();
+    /**
+     * Get an dictionaries of dictionaries with value null.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
+     */
+    Single<RestResponse<Void, Map<String, Map<String, String>>>> getDictionaryNullWithRestResponseAsync();
 
 
     /**
@@ -1762,6 +2197,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
      */
     Single<Map<String, Map<String, String>>> getDictionaryEmptyAsync();
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
+     */
+    Single<RestResponse<Void, Map<String, Map<String, String>>>> getDictionaryEmptyWithRestResponseAsync();
 
 
     /**
@@ -1790,6 +2232,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
      */
     Single<Map<String, Map<String, String>>> getDictionaryItemNullAsync();
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": null, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
+     */
+    Single<RestResponse<Void, Map<String, Map<String, String>>>> getDictionaryItemNullWithRestResponseAsync();
 
 
     /**
@@ -1818,6 +2267,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
      */
     Single<Map<String, Map<String, String>>> getDictionaryItemEmptyAsync();
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
+     */
+    Single<RestResponse<Void, Map<String, Map<String, String>>>> getDictionaryItemEmptyWithRestResponseAsync();
 
 
     /**
@@ -1846,6 +2302,13 @@ public interface Dictionarys {
      * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
      */
     Single<Map<String, Map<String, String>>> getDictionaryValidAsync();
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
+     */
+    Single<RestResponse<Void, Map<String, Map<String, String>>>> getDictionaryValidWithRestResponseAsync();
 
 
     /**
@@ -1876,6 +2339,14 @@ public interface Dictionarys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putDictionaryValidAsync(Map<String, Map<String, String>> arrayBody);
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     *
+     * @param arrayBody the Map&lt;String, Map&lt;String, String&gt;&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putDictionaryValidWithRestResponseAsync(Map<String, Map<String, String>> arrayBody);
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodydictionary/implementation/AutoRestSwaggerBATdictionaryServiceImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodydictionary/implementation/AutoRestSwaggerBATdictionaryServiceImpl.java
@@ -13,6 +13,7 @@ package fixtures.bodydictionary.implementation;
 import fixtures.bodydictionary.AutoRestSwaggerBATdictionaryService;
 import fixtures.bodydictionary.Dictionarys;
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceClient;
 import com.microsoft.rest.RestClient;
 import rx.Single;

--- a/test/vanilla/src/main/java/fixtures/bodydictionary/implementation/DictionarysImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodydictionary/implementation/DictionarysImpl.java
@@ -11,6 +11,7 @@
 package fixtures.bodydictionary.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.bodydictionary.Dictionarys;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.BodyParam;
@@ -70,393 +71,393 @@ public class DictionarysImpl implements Dictionarys {
         @GET("dictionary/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, Integer>> getNull();
+        Single<RestResponse<Void, Map<String, Integer>>> getNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getEmpty" })
         @GET("dictionary/empty")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, Integer>> getEmpty();
+        Single<RestResponse<Void, Map<String, Integer>>> getEmpty();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys putEmpty" })
         @PUT("dictionary/empty")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putEmpty(@BodyParam("application/json; charset=utf-8") Map<String, String> arrayBody);
+        Single<RestResponse<Void, Void>> putEmpty(@BodyParam("application/json; charset=utf-8") Map<String, String> arrayBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getNullValue" })
         @GET("dictionary/nullvalue")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, String>> getNullValue();
+        Single<RestResponse<Void, Map<String, String>>> getNullValue();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getNullKey" })
         @GET("dictionary/nullkey")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, String>> getNullKey();
+        Single<RestResponse<Void, Map<String, String>>> getNullKey();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getEmptyStringKey" })
         @GET("dictionary/keyemptystring")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, String>> getEmptyStringKey();
+        Single<RestResponse<Void, Map<String, String>>> getEmptyStringKey();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getInvalid" })
         @GET("dictionary/invalid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, String>> getInvalid();
+        Single<RestResponse<Void, Map<String, String>>> getInvalid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getBooleanTfft" })
         @GET("dictionary/prim/boolean/tfft")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, Boolean>> getBooleanTfft();
+        Single<RestResponse<Void, Map<String, Boolean>>> getBooleanTfft();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys putBooleanTfft" })
         @PUT("dictionary/prim/boolean/tfft")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putBooleanTfft(@BodyParam("application/json; charset=utf-8") Map<String, Boolean> arrayBody);
+        Single<RestResponse<Void, Void>> putBooleanTfft(@BodyParam("application/json; charset=utf-8") Map<String, Boolean> arrayBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getBooleanInvalidNull" })
         @GET("dictionary/prim/boolean/true.null.false")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, Boolean>> getBooleanInvalidNull();
+        Single<RestResponse<Void, Map<String, Boolean>>> getBooleanInvalidNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getBooleanInvalidString" })
         @GET("dictionary/prim/boolean/true.boolean.false")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, Boolean>> getBooleanInvalidString();
+        Single<RestResponse<Void, Map<String, Boolean>>> getBooleanInvalidString();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getIntegerValid" })
         @GET("dictionary/prim/integer/1.-1.3.300")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, Integer>> getIntegerValid();
+        Single<RestResponse<Void, Map<String, Integer>>> getIntegerValid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys putIntegerValid" })
         @PUT("dictionary/prim/integer/1.-1.3.300")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putIntegerValid(@BodyParam("application/json; charset=utf-8") Map<String, Integer> arrayBody);
+        Single<RestResponse<Void, Void>> putIntegerValid(@BodyParam("application/json; charset=utf-8") Map<String, Integer> arrayBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getIntInvalidNull" })
         @GET("dictionary/prim/integer/1.null.zero")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, Integer>> getIntInvalidNull();
+        Single<RestResponse<Void, Map<String, Integer>>> getIntInvalidNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getIntInvalidString" })
         @GET("dictionary/prim/integer/1.integer.0")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, Integer>> getIntInvalidString();
+        Single<RestResponse<Void, Map<String, Integer>>> getIntInvalidString();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getLongValid" })
         @GET("dictionary/prim/long/1.-1.3.300")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, Long>> getLongValid();
+        Single<RestResponse<Void, Map<String, Long>>> getLongValid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys putLongValid" })
         @PUT("dictionary/prim/long/1.-1.3.300")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putLongValid(@BodyParam("application/json; charset=utf-8") Map<String, Long> arrayBody);
+        Single<RestResponse<Void, Void>> putLongValid(@BodyParam("application/json; charset=utf-8") Map<String, Long> arrayBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getLongInvalidNull" })
         @GET("dictionary/prim/long/1.null.zero")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, Long>> getLongInvalidNull();
+        Single<RestResponse<Void, Map<String, Long>>> getLongInvalidNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getLongInvalidString" })
         @GET("dictionary/prim/long/1.integer.0")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, Long>> getLongInvalidString();
+        Single<RestResponse<Void, Map<String, Long>>> getLongInvalidString();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getFloatValid" })
         @GET("dictionary/prim/float/0--0.01-1.2e20")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, Double>> getFloatValid();
+        Single<RestResponse<Void, Map<String, Double>>> getFloatValid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys putFloatValid" })
         @PUT("dictionary/prim/float/0--0.01-1.2e20")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putFloatValid(@BodyParam("application/json; charset=utf-8") Map<String, Double> arrayBody);
+        Single<RestResponse<Void, Void>> putFloatValid(@BodyParam("application/json; charset=utf-8") Map<String, Double> arrayBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getFloatInvalidNull" })
         @GET("dictionary/prim/float/0.0-null-1.2e20")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, Double>> getFloatInvalidNull();
+        Single<RestResponse<Void, Map<String, Double>>> getFloatInvalidNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getFloatInvalidString" })
         @GET("dictionary/prim/float/1.number.0")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, Double>> getFloatInvalidString();
+        Single<RestResponse<Void, Map<String, Double>>> getFloatInvalidString();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getDoubleValid" })
         @GET("dictionary/prim/double/0--0.01-1.2e20")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, Double>> getDoubleValid();
+        Single<RestResponse<Void, Map<String, Double>>> getDoubleValid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys putDoubleValid" })
         @PUT("dictionary/prim/double/0--0.01-1.2e20")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putDoubleValid(@BodyParam("application/json; charset=utf-8") Map<String, Double> arrayBody);
+        Single<RestResponse<Void, Void>> putDoubleValid(@BodyParam("application/json; charset=utf-8") Map<String, Double> arrayBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getDoubleInvalidNull" })
         @GET("dictionary/prim/double/0.0-null-1.2e20")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, Double>> getDoubleInvalidNull();
+        Single<RestResponse<Void, Map<String, Double>>> getDoubleInvalidNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getDoubleInvalidString" })
         @GET("dictionary/prim/double/1.number.0")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, Double>> getDoubleInvalidString();
+        Single<RestResponse<Void, Map<String, Double>>> getDoubleInvalidString();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getStringValid" })
         @GET("dictionary/prim/string/foo1.foo2.foo3")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, String>> getStringValid();
+        Single<RestResponse<Void, Map<String, String>>> getStringValid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys putStringValid" })
         @PUT("dictionary/prim/string/foo1.foo2.foo3")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putStringValid(@BodyParam("application/json; charset=utf-8") Map<String, String> arrayBody);
+        Single<RestResponse<Void, Void>> putStringValid(@BodyParam("application/json; charset=utf-8") Map<String, String> arrayBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getStringWithNull" })
         @GET("dictionary/prim/string/foo.null.foo2")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, String>> getStringWithNull();
+        Single<RestResponse<Void, Map<String, String>>> getStringWithNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getStringWithInvalid" })
         @GET("dictionary/prim/string/foo.123.foo2")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, String>> getStringWithInvalid();
+        Single<RestResponse<Void, Map<String, String>>> getStringWithInvalid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getDateValid" })
         @GET("dictionary/prim/date/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, LocalDate>> getDateValid();
+        Single<RestResponse<Void, Map<String, LocalDate>>> getDateValid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys putDateValid" })
         @PUT("dictionary/prim/date/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putDateValid(@BodyParam("application/json; charset=utf-8") Map<String, LocalDate> arrayBody);
+        Single<RestResponse<Void, Void>> putDateValid(@BodyParam("application/json; charset=utf-8") Map<String, LocalDate> arrayBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getDateInvalidNull" })
         @GET("dictionary/prim/date/invalidnull")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, LocalDate>> getDateInvalidNull();
+        Single<RestResponse<Void, Map<String, LocalDate>>> getDateInvalidNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getDateInvalidChars" })
         @GET("dictionary/prim/date/invalidchars")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, LocalDate>> getDateInvalidChars();
+        Single<RestResponse<Void, Map<String, LocalDate>>> getDateInvalidChars();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getDateTimeValid" })
         @GET("dictionary/prim/date-time/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, DateTime>> getDateTimeValid();
+        Single<RestResponse<Void, Map<String, DateTime>>> getDateTimeValid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys putDateTimeValid" })
         @PUT("dictionary/prim/date-time/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putDateTimeValid(@BodyParam("application/json; charset=utf-8") Map<String, DateTime> arrayBody);
+        Single<RestResponse<Void, Void>> putDateTimeValid(@BodyParam("application/json; charset=utf-8") Map<String, DateTime> arrayBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getDateTimeInvalidNull" })
         @GET("dictionary/prim/date-time/invalidnull")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, DateTime>> getDateTimeInvalidNull();
+        Single<RestResponse<Void, Map<String, DateTime>>> getDateTimeInvalidNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getDateTimeInvalidChars" })
         @GET("dictionary/prim/date-time/invalidchars")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, DateTime>> getDateTimeInvalidChars();
+        Single<RestResponse<Void, Map<String, DateTime>>> getDateTimeInvalidChars();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getDateTimeRfc1123Valid" })
         @GET("dictionary/prim/date-time-rfc1123/valid")
         @ExpectedResponses({200})
         @ReturnValueWireType(DateTimeRfc1123.class)
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, DateTime>> getDateTimeRfc1123Valid();
+        Single<RestResponse<Void, Map<String, DateTime>>> getDateTimeRfc1123Valid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys putDateTimeRfc1123Valid" })
         @PUT("dictionary/prim/date-time-rfc1123/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putDateTimeRfc1123Valid(@BodyParam("application/json; charset=utf-8") Map<String, DateTimeRfc1123> arrayBody);
+        Single<RestResponse<Void, Void>> putDateTimeRfc1123Valid(@BodyParam("application/json; charset=utf-8") Map<String, DateTimeRfc1123> arrayBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getDurationValid" })
         @GET("dictionary/prim/duration/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, Period>> getDurationValid();
+        Single<RestResponse<Void, Map<String, Period>>> getDurationValid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys putDurationValid" })
         @PUT("dictionary/prim/duration/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putDurationValid(@BodyParam("application/json; charset=utf-8") Map<String, Period> arrayBody);
+        Single<RestResponse<Void, Void>> putDurationValid(@BodyParam("application/json; charset=utf-8") Map<String, Period> arrayBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getByteValid" })
         @GET("dictionary/prim/byte/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, byte[]>> getByteValid();
+        Single<RestResponse<Void, Map<String, byte[]>>> getByteValid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys putByteValid" })
         @PUT("dictionary/prim/byte/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putByteValid(@BodyParam("application/json; charset=utf-8") Map<String, byte[]> arrayBody);
+        Single<RestResponse<Void, Void>> putByteValid(@BodyParam("application/json; charset=utf-8") Map<String, byte[]> arrayBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getByteInvalidNull" })
         @GET("dictionary/prim/byte/invalidnull")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, byte[]>> getByteInvalidNull();
+        Single<RestResponse<Void, Map<String, byte[]>>> getByteInvalidNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getBase64Url" })
         @GET("dictionary/prim/base64url/valid")
         @ExpectedResponses({200})
         @ReturnValueWireType(Base64Url.class)
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, byte[]>> getBase64Url();
+        Single<RestResponse<Void, Map<String, byte[]>>> getBase64Url();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getComplexNull" })
         @GET("dictionary/complex/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, Widget>> getComplexNull();
+        Single<RestResponse<Void, Map<String, Widget>>> getComplexNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getComplexEmpty" })
         @GET("dictionary/complex/empty")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, Widget>> getComplexEmpty();
+        Single<RestResponse<Void, Map<String, Widget>>> getComplexEmpty();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getComplexItemNull" })
         @GET("dictionary/complex/itemnull")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, Widget>> getComplexItemNull();
+        Single<RestResponse<Void, Map<String, Widget>>> getComplexItemNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getComplexItemEmpty" })
         @GET("dictionary/complex/itemempty")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, Widget>> getComplexItemEmpty();
+        Single<RestResponse<Void, Map<String, Widget>>> getComplexItemEmpty();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getComplexValid" })
         @GET("dictionary/complex/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, Widget>> getComplexValid();
+        Single<RestResponse<Void, Map<String, Widget>>> getComplexValid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys putComplexValid" })
         @PUT("dictionary/complex/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putComplexValid(@BodyParam("application/json; charset=utf-8") Map<String, Widget> arrayBody);
+        Single<RestResponse<Void, Void>> putComplexValid(@BodyParam("application/json; charset=utf-8") Map<String, Widget> arrayBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getArrayNull" })
         @GET("dictionary/array/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, List<String>>> getArrayNull();
+        Single<RestResponse<Void, Map<String, List<String>>>> getArrayNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getArrayEmpty" })
         @GET("dictionary/array/empty")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, List<String>>> getArrayEmpty();
+        Single<RestResponse<Void, Map<String, List<String>>>> getArrayEmpty();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getArrayItemNull" })
         @GET("dictionary/array/itemnull")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, List<String>>> getArrayItemNull();
+        Single<RestResponse<Void, Map<String, List<String>>>> getArrayItemNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getArrayItemEmpty" })
         @GET("dictionary/array/itemempty")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, List<String>>> getArrayItemEmpty();
+        Single<RestResponse<Void, Map<String, List<String>>>> getArrayItemEmpty();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getArrayValid" })
         @GET("dictionary/array/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, List<String>>> getArrayValid();
+        Single<RestResponse<Void, Map<String, List<String>>>> getArrayValid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys putArrayValid" })
         @PUT("dictionary/array/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putArrayValid(@BodyParam("application/json; charset=utf-8") Map<String, List<String>> arrayBody);
+        Single<RestResponse<Void, Void>> putArrayValid(@BodyParam("application/json; charset=utf-8") Map<String, List<String>> arrayBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getDictionaryNull" })
         @GET("dictionary/dictionary/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, Map<String, String>>> getDictionaryNull();
+        Single<RestResponse<Void, Map<String, Map<String, String>>>> getDictionaryNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getDictionaryEmpty" })
         @GET("dictionary/dictionary/empty")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, Map<String, String>>> getDictionaryEmpty();
+        Single<RestResponse<Void, Map<String, Map<String, String>>>> getDictionaryEmpty();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getDictionaryItemNull" })
         @GET("dictionary/dictionary/itemnull")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, Map<String, String>>> getDictionaryItemNull();
+        Single<RestResponse<Void, Map<String, Map<String, String>>>> getDictionaryItemNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getDictionaryItemEmpty" })
         @GET("dictionary/dictionary/itemempty")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, Map<String, String>>> getDictionaryItemEmpty();
+        Single<RestResponse<Void, Map<String, Map<String, String>>>> getDictionaryItemEmpty();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys getDictionaryValid" })
         @GET("dictionary/dictionary/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, Map<String, String>>> getDictionaryValid();
+        Single<RestResponse<Void, Map<String, Map<String, String>>>> getDictionaryValid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodydictionary.Dictionarys putDictionaryValid" })
         @PUT("dictionary/dictionary/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putDictionaryValid(@BodyParam("application/json; charset=utf-8") Map<String, Map<String, String>> arrayBody);
+        Single<RestResponse<Void, Void>> putDictionaryValid(@BodyParam("application/json; charset=utf-8") Map<String, Map<String, String>> arrayBody);
 
     }
 
@@ -479,7 +480,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, Integer>> getNullAsync(final ServiceCallback<Map<String, Integer>> serviceCallback) {
+    public ServiceFuture<Map<String, Integer>> getNullAsync(ServiceCallback<Map<String, Integer>> serviceCallback) {
         return ServiceFuture.fromBody(getNullAsync(), serviceCallback);
     }
 
@@ -487,11 +488,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get null dictionary value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, Integer&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Integer>> object
      */
-    public Single<Map<String, Integer>> getNullAsync() {
+    public Single<RestResponse<Void, Map<String, Integer>>> getNullWithRestResponseAsync() {
         return service.getNull();
     }
+
+    /**
+     * Get null dictionary value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Integer>> object
+     */
+    public Single<Map<String, Integer>> getNullAsync() {
+        return getNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, Integer>>, Map<String, Integer>>() { public Map<String, Integer> call(RestResponse<Void, Map<String, Integer>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -513,7 +525,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, Integer>> getEmptyAsync(final ServiceCallback<Map<String, Integer>> serviceCallback) {
+    public ServiceFuture<Map<String, Integer>> getEmptyAsync(ServiceCallback<Map<String, Integer>> serviceCallback) {
         return ServiceFuture.fromBody(getEmptyAsync(), serviceCallback);
     }
 
@@ -521,11 +533,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get empty dictionary value {}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, Integer&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Integer>> object
      */
-    public Single<Map<String, Integer>> getEmptyAsync() {
+    public Single<RestResponse<Void, Map<String, Integer>>> getEmptyWithRestResponseAsync() {
         return service.getEmpty();
     }
+
+    /**
+     * Get empty dictionary value {}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Integer>> object
+     */
+    public Single<Map<String, Integer>> getEmptyAsync() {
+        return getEmptyWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, Integer>>, Map<String, Integer>>() { public Map<String, Integer> call(RestResponse<Void, Map<String, Integer>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -535,6 +558,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putEmpty(Map<String, String> arrayBody) {
         putEmptyAsync(arrayBody).toBlocking().value();
@@ -548,7 +572,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putEmptyAsync(Map<String, String> arrayBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putEmptyAsync(Map<String, String> arrayBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putEmptyAsync(arrayBody), serviceCallback);
     }
 
@@ -557,15 +581,27 @@ public class DictionarysImpl implements Dictionarys {
      *
      * @param arrayBody the Map&lt;String, String&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putEmptyAsync(Map<String, String> arrayBody) {
+    public Single<RestResponse<Void, Void>> putEmptyWithRestResponseAsync(Map<String, String> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
         Validator.validate(arrayBody);
         return service.putEmpty(arrayBody);
     }
+
+    /**
+     * Set dictionary value empty {}.
+     *
+     * @param arrayBody the Map&lt;String, String&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putEmptyAsync(Map<String, String> arrayBody) {
+        return putEmptyWithRestResponseAsync(arrayBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -587,7 +623,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, String>> getNullValueAsync(final ServiceCallback<Map<String, String>> serviceCallback) {
+    public ServiceFuture<Map<String, String>> getNullValueAsync(ServiceCallback<Map<String, String>> serviceCallback) {
         return ServiceFuture.fromBody(getNullValueAsync(), serviceCallback);
     }
 
@@ -595,11 +631,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get Dictionary with null value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, String&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, String>> object
      */
-    public Single<Map<String, String>> getNullValueAsync() {
+    public Single<RestResponse<Void, Map<String, String>>> getNullValueWithRestResponseAsync() {
         return service.getNullValue();
     }
+
+    /**
+     * Get Dictionary with null value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, String>> object
+     */
+    public Single<Map<String, String>> getNullValueAsync() {
+        return getNullValueWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, String>>, Map<String, String>>() { public Map<String, String> call(RestResponse<Void, Map<String, String>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -621,7 +668,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, String>> getNullKeyAsync(final ServiceCallback<Map<String, String>> serviceCallback) {
+    public ServiceFuture<Map<String, String>> getNullKeyAsync(ServiceCallback<Map<String, String>> serviceCallback) {
         return ServiceFuture.fromBody(getNullKeyAsync(), serviceCallback);
     }
 
@@ -629,11 +676,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get Dictionary with null key.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, String&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, String>> object
      */
-    public Single<Map<String, String>> getNullKeyAsync() {
+    public Single<RestResponse<Void, Map<String, String>>> getNullKeyWithRestResponseAsync() {
         return service.getNullKey();
     }
+
+    /**
+     * Get Dictionary with null key.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, String>> object
+     */
+    public Single<Map<String, String>> getNullKeyAsync() {
+        return getNullKeyWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, String>>, Map<String, String>>() { public Map<String, String> call(RestResponse<Void, Map<String, String>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -655,7 +713,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, String>> getEmptyStringKeyAsync(final ServiceCallback<Map<String, String>> serviceCallback) {
+    public ServiceFuture<Map<String, String>> getEmptyStringKeyAsync(ServiceCallback<Map<String, String>> serviceCallback) {
         return ServiceFuture.fromBody(getEmptyStringKeyAsync(), serviceCallback);
     }
 
@@ -663,11 +721,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get Dictionary with key as empty string.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, String&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, String>> object
      */
-    public Single<Map<String, String>> getEmptyStringKeyAsync() {
+    public Single<RestResponse<Void, Map<String, String>>> getEmptyStringKeyWithRestResponseAsync() {
         return service.getEmptyStringKey();
     }
+
+    /**
+     * Get Dictionary with key as empty string.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, String>> object
+     */
+    public Single<Map<String, String>> getEmptyStringKeyAsync() {
+        return getEmptyStringKeyWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, String>>, Map<String, String>>() { public Map<String, String> call(RestResponse<Void, Map<String, String>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -689,7 +758,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, String>> getInvalidAsync(final ServiceCallback<Map<String, String>> serviceCallback) {
+    public ServiceFuture<Map<String, String>> getInvalidAsync(ServiceCallback<Map<String, String>> serviceCallback) {
         return ServiceFuture.fromBody(getInvalidAsync(), serviceCallback);
     }
 
@@ -697,11 +766,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get invalid Dictionary value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, String&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, String>> object
      */
-    public Single<Map<String, String>> getInvalidAsync() {
+    public Single<RestResponse<Void, Map<String, String>>> getInvalidWithRestResponseAsync() {
         return service.getInvalid();
     }
+
+    /**
+     * Get invalid Dictionary value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, String>> object
+     */
+    public Single<Map<String, String>> getInvalidAsync() {
+        return getInvalidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, String>>, Map<String, String>>() { public Map<String, String> call(RestResponse<Void, Map<String, String>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -723,7 +803,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, Boolean>> getBooleanTfftAsync(final ServiceCallback<Map<String, Boolean>> serviceCallback) {
+    public ServiceFuture<Map<String, Boolean>> getBooleanTfftAsync(ServiceCallback<Map<String, Boolean>> serviceCallback) {
         return ServiceFuture.fromBody(getBooleanTfftAsync(), serviceCallback);
     }
 
@@ -731,11 +811,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get boolean dictionary value {"0": true, "1": false, "2": false, "3": true }.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, Boolean&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Boolean>> object
      */
-    public Single<Map<String, Boolean>> getBooleanTfftAsync() {
+    public Single<RestResponse<Void, Map<String, Boolean>>> getBooleanTfftWithRestResponseAsync() {
         return service.getBooleanTfft();
     }
+
+    /**
+     * Get boolean dictionary value {"0": true, "1": false, "2": false, "3": true }.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Boolean>> object
+     */
+    public Single<Map<String, Boolean>> getBooleanTfftAsync() {
+        return getBooleanTfftWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, Boolean>>, Map<String, Boolean>>() { public Map<String, Boolean> call(RestResponse<Void, Map<String, Boolean>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -745,6 +836,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putBooleanTfft(Map<String, Boolean> arrayBody) {
         putBooleanTfftAsync(arrayBody).toBlocking().value();
@@ -758,7 +850,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putBooleanTfftAsync(Map<String, Boolean> arrayBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putBooleanTfftAsync(Map<String, Boolean> arrayBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putBooleanTfftAsync(arrayBody), serviceCallback);
     }
 
@@ -767,15 +859,27 @@ public class DictionarysImpl implements Dictionarys {
      *
      * @param arrayBody the Map&lt;String, Boolean&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putBooleanTfftAsync(Map<String, Boolean> arrayBody) {
+    public Single<RestResponse<Void, Void>> putBooleanTfftWithRestResponseAsync(Map<String, Boolean> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
         Validator.validate(arrayBody);
         return service.putBooleanTfft(arrayBody);
     }
+
+    /**
+     * Set dictionary value empty {"0": true, "1": false, "2": false, "3": true }.
+     *
+     * @param arrayBody the Map&lt;String, Boolean&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putBooleanTfftAsync(Map<String, Boolean> arrayBody) {
+        return putBooleanTfftWithRestResponseAsync(arrayBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -797,7 +901,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, Boolean>> getBooleanInvalidNullAsync(final ServiceCallback<Map<String, Boolean>> serviceCallback) {
+    public ServiceFuture<Map<String, Boolean>> getBooleanInvalidNullAsync(ServiceCallback<Map<String, Boolean>> serviceCallback) {
         return ServiceFuture.fromBody(getBooleanInvalidNullAsync(), serviceCallback);
     }
 
@@ -805,11 +909,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get boolean dictionary value {"0": true, "1": null, "2": false }.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, Boolean&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Boolean>> object
      */
-    public Single<Map<String, Boolean>> getBooleanInvalidNullAsync() {
+    public Single<RestResponse<Void, Map<String, Boolean>>> getBooleanInvalidNullWithRestResponseAsync() {
         return service.getBooleanInvalidNull();
     }
+
+    /**
+     * Get boolean dictionary value {"0": true, "1": null, "2": false }.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Boolean>> object
+     */
+    public Single<Map<String, Boolean>> getBooleanInvalidNullAsync() {
+        return getBooleanInvalidNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, Boolean>>, Map<String, Boolean>>() { public Map<String, Boolean> call(RestResponse<Void, Map<String, Boolean>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -831,7 +946,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, Boolean>> getBooleanInvalidStringAsync(final ServiceCallback<Map<String, Boolean>> serviceCallback) {
+    public ServiceFuture<Map<String, Boolean>> getBooleanInvalidStringAsync(ServiceCallback<Map<String, Boolean>> serviceCallback) {
         return ServiceFuture.fromBody(getBooleanInvalidStringAsync(), serviceCallback);
     }
 
@@ -839,11 +954,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get boolean dictionary value '{"0": true, "1": "boolean", "2": false}'.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, Boolean&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Boolean>> object
      */
-    public Single<Map<String, Boolean>> getBooleanInvalidStringAsync() {
+    public Single<RestResponse<Void, Map<String, Boolean>>> getBooleanInvalidStringWithRestResponseAsync() {
         return service.getBooleanInvalidString();
     }
+
+    /**
+     * Get boolean dictionary value '{"0": true, "1": "boolean", "2": false}'.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Boolean>> object
+     */
+    public Single<Map<String, Boolean>> getBooleanInvalidStringAsync() {
+        return getBooleanInvalidStringWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, Boolean>>, Map<String, Boolean>>() { public Map<String, Boolean> call(RestResponse<Void, Map<String, Boolean>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -865,7 +991,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, Integer>> getIntegerValidAsync(final ServiceCallback<Map<String, Integer>> serviceCallback) {
+    public ServiceFuture<Map<String, Integer>> getIntegerValidAsync(ServiceCallback<Map<String, Integer>> serviceCallback) {
         return ServiceFuture.fromBody(getIntegerValidAsync(), serviceCallback);
     }
 
@@ -873,11 +999,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, Integer&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Integer>> object
      */
-    public Single<Map<String, Integer>> getIntegerValidAsync() {
+    public Single<RestResponse<Void, Map<String, Integer>>> getIntegerValidWithRestResponseAsync() {
         return service.getIntegerValid();
     }
+
+    /**
+     * Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Integer>> object
+     */
+    public Single<Map<String, Integer>> getIntegerValidAsync() {
+        return getIntegerValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, Integer>>, Map<String, Integer>>() { public Map<String, Integer> call(RestResponse<Void, Map<String, Integer>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -887,6 +1024,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putIntegerValid(Map<String, Integer> arrayBody) {
         putIntegerValidAsync(arrayBody).toBlocking().value();
@@ -900,7 +1038,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putIntegerValidAsync(Map<String, Integer> arrayBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putIntegerValidAsync(Map<String, Integer> arrayBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putIntegerValidAsync(arrayBody), serviceCallback);
     }
 
@@ -909,15 +1047,27 @@ public class DictionarysImpl implements Dictionarys {
      *
      * @param arrayBody the Map&lt;String, Integer&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putIntegerValidAsync(Map<String, Integer> arrayBody) {
+    public Single<RestResponse<Void, Void>> putIntegerValidWithRestResponseAsync(Map<String, Integer> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
         Validator.validate(arrayBody);
         return service.putIntegerValid(arrayBody);
     }
+
+    /**
+     * Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}.
+     *
+     * @param arrayBody the Map&lt;String, Integer&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putIntegerValidAsync(Map<String, Integer> arrayBody) {
+        return putIntegerValidWithRestResponseAsync(arrayBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -939,7 +1089,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, Integer>> getIntInvalidNullAsync(final ServiceCallback<Map<String, Integer>> serviceCallback) {
+    public ServiceFuture<Map<String, Integer>> getIntInvalidNullAsync(ServiceCallback<Map<String, Integer>> serviceCallback) {
         return ServiceFuture.fromBody(getIntInvalidNullAsync(), serviceCallback);
     }
 
@@ -947,11 +1097,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get integer dictionary value {"0": 1, "1": null, "2": 0}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, Integer&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Integer>> object
      */
-    public Single<Map<String, Integer>> getIntInvalidNullAsync() {
+    public Single<RestResponse<Void, Map<String, Integer>>> getIntInvalidNullWithRestResponseAsync() {
         return service.getIntInvalidNull();
     }
+
+    /**
+     * Get integer dictionary value {"0": 1, "1": null, "2": 0}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Integer>> object
+     */
+    public Single<Map<String, Integer>> getIntInvalidNullAsync() {
+        return getIntInvalidNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, Integer>>, Map<String, Integer>>() { public Map<String, Integer> call(RestResponse<Void, Map<String, Integer>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -973,7 +1134,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, Integer>> getIntInvalidStringAsync(final ServiceCallback<Map<String, Integer>> serviceCallback) {
+    public ServiceFuture<Map<String, Integer>> getIntInvalidStringAsync(ServiceCallback<Map<String, Integer>> serviceCallback) {
         return ServiceFuture.fromBody(getIntInvalidStringAsync(), serviceCallback);
     }
 
@@ -981,11 +1142,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get integer dictionary value {"0": 1, "1": "integer", "2": 0}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, Integer&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Integer>> object
      */
-    public Single<Map<String, Integer>> getIntInvalidStringAsync() {
+    public Single<RestResponse<Void, Map<String, Integer>>> getIntInvalidStringWithRestResponseAsync() {
         return service.getIntInvalidString();
     }
+
+    /**
+     * Get integer dictionary value {"0": 1, "1": "integer", "2": 0}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Integer>> object
+     */
+    public Single<Map<String, Integer>> getIntInvalidStringAsync() {
+        return getIntInvalidStringWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, Integer>>, Map<String, Integer>>() { public Map<String, Integer> call(RestResponse<Void, Map<String, Integer>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1007,7 +1179,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, Long>> getLongValidAsync(final ServiceCallback<Map<String, Long>> serviceCallback) {
+    public ServiceFuture<Map<String, Long>> getLongValidAsync(ServiceCallback<Map<String, Long>> serviceCallback) {
         return ServiceFuture.fromBody(getLongValidAsync(), serviceCallback);
     }
 
@@ -1015,11 +1187,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, Long&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Long>> object
      */
-    public Single<Map<String, Long>> getLongValidAsync() {
+    public Single<RestResponse<Void, Map<String, Long>>> getLongValidWithRestResponseAsync() {
         return service.getLongValid();
     }
+
+    /**
+     * Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Long>> object
+     */
+    public Single<Map<String, Long>> getLongValidAsync() {
+        return getLongValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, Long>>, Map<String, Long>>() { public Map<String, Long> call(RestResponse<Void, Map<String, Long>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1029,6 +1212,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putLongValid(Map<String, Long> arrayBody) {
         putLongValidAsync(arrayBody).toBlocking().value();
@@ -1042,7 +1226,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putLongValidAsync(Map<String, Long> arrayBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putLongValidAsync(Map<String, Long> arrayBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putLongValidAsync(arrayBody), serviceCallback);
     }
 
@@ -1051,15 +1235,27 @@ public class DictionarysImpl implements Dictionarys {
      *
      * @param arrayBody the Map&lt;String, Long&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putLongValidAsync(Map<String, Long> arrayBody) {
+    public Single<RestResponse<Void, Void>> putLongValidWithRestResponseAsync(Map<String, Long> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
         Validator.validate(arrayBody);
         return service.putLongValid(arrayBody);
     }
+
+    /**
+     * Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}.
+     *
+     * @param arrayBody the Map&lt;String, Long&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putLongValidAsync(Map<String, Long> arrayBody) {
+        return putLongValidWithRestResponseAsync(arrayBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1081,7 +1277,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, Long>> getLongInvalidNullAsync(final ServiceCallback<Map<String, Long>> serviceCallback) {
+    public ServiceFuture<Map<String, Long>> getLongInvalidNullAsync(ServiceCallback<Map<String, Long>> serviceCallback) {
         return ServiceFuture.fromBody(getLongInvalidNullAsync(), serviceCallback);
     }
 
@@ -1089,11 +1285,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get long dictionary value {"0": 1, "1": null, "2": 0}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, Long&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Long>> object
      */
-    public Single<Map<String, Long>> getLongInvalidNullAsync() {
+    public Single<RestResponse<Void, Map<String, Long>>> getLongInvalidNullWithRestResponseAsync() {
         return service.getLongInvalidNull();
     }
+
+    /**
+     * Get long dictionary value {"0": 1, "1": null, "2": 0}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Long>> object
+     */
+    public Single<Map<String, Long>> getLongInvalidNullAsync() {
+        return getLongInvalidNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, Long>>, Map<String, Long>>() { public Map<String, Long> call(RestResponse<Void, Map<String, Long>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1115,7 +1322,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, Long>> getLongInvalidStringAsync(final ServiceCallback<Map<String, Long>> serviceCallback) {
+    public ServiceFuture<Map<String, Long>> getLongInvalidStringAsync(ServiceCallback<Map<String, Long>> serviceCallback) {
         return ServiceFuture.fromBody(getLongInvalidStringAsync(), serviceCallback);
     }
 
@@ -1123,11 +1330,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get long dictionary value {"0": 1, "1": "integer", "2": 0}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, Long&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Long>> object
      */
-    public Single<Map<String, Long>> getLongInvalidStringAsync() {
+    public Single<RestResponse<Void, Map<String, Long>>> getLongInvalidStringWithRestResponseAsync() {
         return service.getLongInvalidString();
     }
+
+    /**
+     * Get long dictionary value {"0": 1, "1": "integer", "2": 0}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Long>> object
+     */
+    public Single<Map<String, Long>> getLongInvalidStringAsync() {
+        return getLongInvalidStringWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, Long>>, Map<String, Long>>() { public Map<String, Long> call(RestResponse<Void, Map<String, Long>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1149,7 +1367,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, Double>> getFloatValidAsync(final ServiceCallback<Map<String, Double>> serviceCallback) {
+    public ServiceFuture<Map<String, Double>> getFloatValidAsync(ServiceCallback<Map<String, Double>> serviceCallback) {
         return ServiceFuture.fromBody(getFloatValidAsync(), serviceCallback);
     }
 
@@ -1157,11 +1375,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, Double&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Double>> object
      */
-    public Single<Map<String, Double>> getFloatValidAsync() {
+    public Single<RestResponse<Void, Map<String, Double>>> getFloatValidWithRestResponseAsync() {
         return service.getFloatValid();
     }
+
+    /**
+     * Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Double>> object
+     */
+    public Single<Map<String, Double>> getFloatValidAsync() {
+        return getFloatValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, Double>>, Map<String, Double>>() { public Map<String, Double> call(RestResponse<Void, Map<String, Double>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1171,6 +1400,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putFloatValid(Map<String, Double> arrayBody) {
         putFloatValidAsync(arrayBody).toBlocking().value();
@@ -1184,7 +1414,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putFloatValidAsync(Map<String, Double> arrayBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putFloatValidAsync(Map<String, Double> arrayBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putFloatValidAsync(arrayBody), serviceCallback);
     }
 
@@ -1193,15 +1423,27 @@ public class DictionarysImpl implements Dictionarys {
      *
      * @param arrayBody the Map&lt;String, Double&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putFloatValidAsync(Map<String, Double> arrayBody) {
+    public Single<RestResponse<Void, Void>> putFloatValidWithRestResponseAsync(Map<String, Double> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
         Validator.validate(arrayBody);
         return service.putFloatValid(arrayBody);
     }
+
+    /**
+     * Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     *
+     * @param arrayBody the Map&lt;String, Double&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putFloatValidAsync(Map<String, Double> arrayBody) {
+        return putFloatValidWithRestResponseAsync(arrayBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1223,7 +1465,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, Double>> getFloatInvalidNullAsync(final ServiceCallback<Map<String, Double>> serviceCallback) {
+    public ServiceFuture<Map<String, Double>> getFloatInvalidNullAsync(ServiceCallback<Map<String, Double>> serviceCallback) {
         return ServiceFuture.fromBody(getFloatInvalidNullAsync(), serviceCallback);
     }
 
@@ -1231,11 +1473,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, Double&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Double>> object
      */
-    public Single<Map<String, Double>> getFloatInvalidNullAsync() {
+    public Single<RestResponse<Void, Map<String, Double>>> getFloatInvalidNullWithRestResponseAsync() {
         return service.getFloatInvalidNull();
     }
+
+    /**
+     * Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Double>> object
+     */
+    public Single<Map<String, Double>> getFloatInvalidNullAsync() {
+        return getFloatInvalidNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, Double>>, Map<String, Double>>() { public Map<String, Double> call(RestResponse<Void, Map<String, Double>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1257,7 +1510,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, Double>> getFloatInvalidStringAsync(final ServiceCallback<Map<String, Double>> serviceCallback) {
+    public ServiceFuture<Map<String, Double>> getFloatInvalidStringAsync(ServiceCallback<Map<String, Double>> serviceCallback) {
         return ServiceFuture.fromBody(getFloatInvalidStringAsync(), serviceCallback);
     }
 
@@ -1265,11 +1518,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, Double&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Double>> object
      */
-    public Single<Map<String, Double>> getFloatInvalidStringAsync() {
+    public Single<RestResponse<Void, Map<String, Double>>> getFloatInvalidStringWithRestResponseAsync() {
         return service.getFloatInvalidString();
     }
+
+    /**
+     * Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Double>> object
+     */
+    public Single<Map<String, Double>> getFloatInvalidStringAsync() {
+        return getFloatInvalidStringWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, Double>>, Map<String, Double>>() { public Map<String, Double> call(RestResponse<Void, Map<String, Double>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1291,7 +1555,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, Double>> getDoubleValidAsync(final ServiceCallback<Map<String, Double>> serviceCallback) {
+    public ServiceFuture<Map<String, Double>> getDoubleValidAsync(ServiceCallback<Map<String, Double>> serviceCallback) {
         return ServiceFuture.fromBody(getDoubleValidAsync(), serviceCallback);
     }
 
@@ -1299,11 +1563,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, Double&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Double>> object
      */
-    public Single<Map<String, Double>> getDoubleValidAsync() {
+    public Single<RestResponse<Void, Map<String, Double>>> getDoubleValidWithRestResponseAsync() {
         return service.getDoubleValid();
     }
+
+    /**
+     * Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Double>> object
+     */
+    public Single<Map<String, Double>> getDoubleValidAsync() {
+        return getDoubleValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, Double>>, Map<String, Double>>() { public Map<String, Double> call(RestResponse<Void, Map<String, Double>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1313,6 +1588,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putDoubleValid(Map<String, Double> arrayBody) {
         putDoubleValidAsync(arrayBody).toBlocking().value();
@@ -1326,7 +1602,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putDoubleValidAsync(Map<String, Double> arrayBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putDoubleValidAsync(Map<String, Double> arrayBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putDoubleValidAsync(arrayBody), serviceCallback);
     }
 
@@ -1335,15 +1611,27 @@ public class DictionarysImpl implements Dictionarys {
      *
      * @param arrayBody the Map&lt;String, Double&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putDoubleValidAsync(Map<String, Double> arrayBody) {
+    public Single<RestResponse<Void, Void>> putDoubleValidWithRestResponseAsync(Map<String, Double> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
         Validator.validate(arrayBody);
         return service.putDoubleValid(arrayBody);
     }
+
+    /**
+     * Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     *
+     * @param arrayBody the Map&lt;String, Double&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putDoubleValidAsync(Map<String, Double> arrayBody) {
+        return putDoubleValidWithRestResponseAsync(arrayBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1365,7 +1653,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, Double>> getDoubleInvalidNullAsync(final ServiceCallback<Map<String, Double>> serviceCallback) {
+    public ServiceFuture<Map<String, Double>> getDoubleInvalidNullAsync(ServiceCallback<Map<String, Double>> serviceCallback) {
         return ServiceFuture.fromBody(getDoubleInvalidNullAsync(), serviceCallback);
     }
 
@@ -1373,11 +1661,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, Double&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Double>> object
      */
-    public Single<Map<String, Double>> getDoubleInvalidNullAsync() {
+    public Single<RestResponse<Void, Map<String, Double>>> getDoubleInvalidNullWithRestResponseAsync() {
         return service.getDoubleInvalidNull();
     }
+
+    /**
+     * Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Double>> object
+     */
+    public Single<Map<String, Double>> getDoubleInvalidNullAsync() {
+        return getDoubleInvalidNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, Double>>, Map<String, Double>>() { public Map<String, Double> call(RestResponse<Void, Map<String, Double>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1399,7 +1698,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, Double>> getDoubleInvalidStringAsync(final ServiceCallback<Map<String, Double>> serviceCallback) {
+    public ServiceFuture<Map<String, Double>> getDoubleInvalidStringAsync(ServiceCallback<Map<String, Double>> serviceCallback) {
         return ServiceFuture.fromBody(getDoubleInvalidStringAsync(), serviceCallback);
     }
 
@@ -1407,11 +1706,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, Double&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Double>> object
      */
-    public Single<Map<String, Double>> getDoubleInvalidStringAsync() {
+    public Single<RestResponse<Void, Map<String, Double>>> getDoubleInvalidStringWithRestResponseAsync() {
         return service.getDoubleInvalidString();
     }
+
+    /**
+     * Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Double>> object
+     */
+    public Single<Map<String, Double>> getDoubleInvalidStringAsync() {
+        return getDoubleInvalidStringWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, Double>>, Map<String, Double>>() { public Map<String, Double> call(RestResponse<Void, Map<String, Double>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1433,7 +1743,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, String>> getStringValidAsync(final ServiceCallback<Map<String, String>> serviceCallback) {
+    public ServiceFuture<Map<String, String>> getStringValidAsync(ServiceCallback<Map<String, String>> serviceCallback) {
         return ServiceFuture.fromBody(getStringValidAsync(), serviceCallback);
     }
 
@@ -1441,11 +1751,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get string dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, String&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, String>> object
      */
-    public Single<Map<String, String>> getStringValidAsync() {
+    public Single<RestResponse<Void, Map<String, String>>> getStringValidWithRestResponseAsync() {
         return service.getStringValid();
     }
+
+    /**
+     * Get string dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, String>> object
+     */
+    public Single<Map<String, String>> getStringValidAsync() {
+        return getStringValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, String>>, Map<String, String>>() { public Map<String, String> call(RestResponse<Void, Map<String, String>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1455,6 +1776,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putStringValid(Map<String, String> arrayBody) {
         putStringValidAsync(arrayBody).toBlocking().value();
@@ -1468,7 +1790,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putStringValidAsync(Map<String, String> arrayBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putStringValidAsync(Map<String, String> arrayBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putStringValidAsync(arrayBody), serviceCallback);
     }
 
@@ -1477,15 +1799,27 @@ public class DictionarysImpl implements Dictionarys {
      *
      * @param arrayBody the Map&lt;String, String&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putStringValidAsync(Map<String, String> arrayBody) {
+    public Single<RestResponse<Void, Void>> putStringValidWithRestResponseAsync(Map<String, String> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
         Validator.validate(arrayBody);
         return service.putStringValid(arrayBody);
     }
+
+    /**
+     * Set dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
+     *
+     * @param arrayBody the Map&lt;String, String&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putStringValidAsync(Map<String, String> arrayBody) {
+        return putStringValidWithRestResponseAsync(arrayBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1507,7 +1841,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, String>> getStringWithNullAsync(final ServiceCallback<Map<String, String>> serviceCallback) {
+    public ServiceFuture<Map<String, String>> getStringWithNullAsync(ServiceCallback<Map<String, String>> serviceCallback) {
         return ServiceFuture.fromBody(getStringWithNullAsync(), serviceCallback);
     }
 
@@ -1515,11 +1849,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get string dictionary value {"0": "foo", "1": null, "2": "foo2"}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, String&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, String>> object
      */
-    public Single<Map<String, String>> getStringWithNullAsync() {
+    public Single<RestResponse<Void, Map<String, String>>> getStringWithNullWithRestResponseAsync() {
         return service.getStringWithNull();
     }
+
+    /**
+     * Get string dictionary value {"0": "foo", "1": null, "2": "foo2"}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, String>> object
+     */
+    public Single<Map<String, String>> getStringWithNullAsync() {
+        return getStringWithNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, String>>, Map<String, String>>() { public Map<String, String> call(RestResponse<Void, Map<String, String>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1541,7 +1886,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, String>> getStringWithInvalidAsync(final ServiceCallback<Map<String, String>> serviceCallback) {
+    public ServiceFuture<Map<String, String>> getStringWithInvalidAsync(ServiceCallback<Map<String, String>> serviceCallback) {
         return ServiceFuture.fromBody(getStringWithInvalidAsync(), serviceCallback);
     }
 
@@ -1549,11 +1894,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get string dictionary value {"0": "foo", "1": 123, "2": "foo2"}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, String&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, String>> object
      */
-    public Single<Map<String, String>> getStringWithInvalidAsync() {
+    public Single<RestResponse<Void, Map<String, String>>> getStringWithInvalidWithRestResponseAsync() {
         return service.getStringWithInvalid();
     }
+
+    /**
+     * Get string dictionary value {"0": "foo", "1": 123, "2": "foo2"}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, String>> object
+     */
+    public Single<Map<String, String>> getStringWithInvalidAsync() {
+        return getStringWithInvalidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, String>>, Map<String, String>>() { public Map<String, String> call(RestResponse<Void, Map<String, String>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1575,7 +1931,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, LocalDate>> getDateValidAsync(final ServiceCallback<Map<String, LocalDate>> serviceCallback) {
+    public ServiceFuture<Map<String, LocalDate>> getDateValidAsync(ServiceCallback<Map<String, LocalDate>> serviceCallback) {
         return ServiceFuture.fromBody(getDateValidAsync(), serviceCallback);
     }
 
@@ -1583,11 +1939,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get integer dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, LocalDate&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, LocalDate>> object
      */
-    public Single<Map<String, LocalDate>> getDateValidAsync() {
+    public Single<RestResponse<Void, Map<String, LocalDate>>> getDateValidWithRestResponseAsync() {
         return service.getDateValid();
     }
+
+    /**
+     * Get integer dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, LocalDate>> object
+     */
+    public Single<Map<String, LocalDate>> getDateValidAsync() {
+        return getDateValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, LocalDate>>, Map<String, LocalDate>>() { public Map<String, LocalDate> call(RestResponse<Void, Map<String, LocalDate>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1597,6 +1964,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putDateValid(Map<String, LocalDate> arrayBody) {
         putDateValidAsync(arrayBody).toBlocking().value();
@@ -1610,7 +1978,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putDateValidAsync(Map<String, LocalDate> arrayBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putDateValidAsync(Map<String, LocalDate> arrayBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putDateValidAsync(arrayBody), serviceCallback);
     }
 
@@ -1619,15 +1987,27 @@ public class DictionarysImpl implements Dictionarys {
      *
      * @param arrayBody the Map&lt;String, LocalDate&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putDateValidAsync(Map<String, LocalDate> arrayBody) {
+    public Single<RestResponse<Void, Void>> putDateValidWithRestResponseAsync(Map<String, LocalDate> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
         Validator.validate(arrayBody);
         return service.putDateValid(arrayBody);
     }
+
+    /**
+     * Set dictionary value  {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
+     *
+     * @param arrayBody the Map&lt;String, LocalDate&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putDateValidAsync(Map<String, LocalDate> arrayBody) {
+        return putDateValidWithRestResponseAsync(arrayBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1649,7 +2029,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, LocalDate>> getDateInvalidNullAsync(final ServiceCallback<Map<String, LocalDate>> serviceCallback) {
+    public ServiceFuture<Map<String, LocalDate>> getDateInvalidNullAsync(ServiceCallback<Map<String, LocalDate>> serviceCallback) {
         return ServiceFuture.fromBody(getDateInvalidNullAsync(), serviceCallback);
     }
 
@@ -1657,11 +2037,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get date dictionary value {"0": "2012-01-01", "1": null, "2": "1776-07-04"}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, LocalDate&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, LocalDate>> object
      */
-    public Single<Map<String, LocalDate>> getDateInvalidNullAsync() {
+    public Single<RestResponse<Void, Map<String, LocalDate>>> getDateInvalidNullWithRestResponseAsync() {
         return service.getDateInvalidNull();
     }
+
+    /**
+     * Get date dictionary value {"0": "2012-01-01", "1": null, "2": "1776-07-04"}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, LocalDate>> object
+     */
+    public Single<Map<String, LocalDate>> getDateInvalidNullAsync() {
+        return getDateInvalidNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, LocalDate>>, Map<String, LocalDate>>() { public Map<String, LocalDate> call(RestResponse<Void, Map<String, LocalDate>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1683,7 +2074,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, LocalDate>> getDateInvalidCharsAsync(final ServiceCallback<Map<String, LocalDate>> serviceCallback) {
+    public ServiceFuture<Map<String, LocalDate>> getDateInvalidCharsAsync(ServiceCallback<Map<String, LocalDate>> serviceCallback) {
         return ServiceFuture.fromBody(getDateInvalidCharsAsync(), serviceCallback);
     }
 
@@ -1691,11 +2082,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get date dictionary value {"0": "2011-03-22", "1": "date"}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, LocalDate&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, LocalDate>> object
      */
-    public Single<Map<String, LocalDate>> getDateInvalidCharsAsync() {
+    public Single<RestResponse<Void, Map<String, LocalDate>>> getDateInvalidCharsWithRestResponseAsync() {
         return service.getDateInvalidChars();
     }
+
+    /**
+     * Get date dictionary value {"0": "2011-03-22", "1": "date"}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, LocalDate>> object
+     */
+    public Single<Map<String, LocalDate>> getDateInvalidCharsAsync() {
+        return getDateInvalidCharsWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, LocalDate>>, Map<String, LocalDate>>() { public Map<String, LocalDate> call(RestResponse<Void, Map<String, LocalDate>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1717,7 +2119,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, DateTime>> getDateTimeValidAsync(final ServiceCallback<Map<String, DateTime>> serviceCallback) {
+    public ServiceFuture<Map<String, DateTime>> getDateTimeValidAsync(ServiceCallback<Map<String, DateTime>> serviceCallback) {
         return ServiceFuture.fromBody(getDateTimeValidAsync(), serviceCallback);
     }
 
@@ -1725,11 +2127,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get date-time dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, DateTime&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, DateTime>> object
      */
-    public Single<Map<String, DateTime>> getDateTimeValidAsync() {
+    public Single<RestResponse<Void, Map<String, DateTime>>> getDateTimeValidWithRestResponseAsync() {
         return service.getDateTimeValid();
     }
+
+    /**
+     * Get date-time dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, DateTime>> object
+     */
+    public Single<Map<String, DateTime>> getDateTimeValidAsync() {
+        return getDateTimeValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, DateTime>>, Map<String, DateTime>>() { public Map<String, DateTime> call(RestResponse<Void, Map<String, DateTime>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1739,6 +2152,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putDateTimeValid(Map<String, DateTime> arrayBody) {
         putDateTimeValidAsync(arrayBody).toBlocking().value();
@@ -1752,7 +2166,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putDateTimeValidAsync(Map<String, DateTime> arrayBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putDateTimeValidAsync(Map<String, DateTime> arrayBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putDateTimeValidAsync(arrayBody), serviceCallback);
     }
 
@@ -1761,15 +2175,27 @@ public class DictionarysImpl implements Dictionarys {
      *
      * @param arrayBody the Map&lt;String, DateTime&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putDateTimeValidAsync(Map<String, DateTime> arrayBody) {
+    public Single<RestResponse<Void, Void>> putDateTimeValidWithRestResponseAsync(Map<String, DateTime> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
         Validator.validate(arrayBody);
         return service.putDateTimeValid(arrayBody);
     }
+
+    /**
+     * Set dictionary value  {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}.
+     *
+     * @param arrayBody the Map&lt;String, DateTime&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putDateTimeValidAsync(Map<String, DateTime> arrayBody) {
+        return putDateTimeValidWithRestResponseAsync(arrayBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1791,7 +2217,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, DateTime>> getDateTimeInvalidNullAsync(final ServiceCallback<Map<String, DateTime>> serviceCallback) {
+    public ServiceFuture<Map<String, DateTime>> getDateTimeInvalidNullAsync(ServiceCallback<Map<String, DateTime>> serviceCallback) {
         return ServiceFuture.fromBody(getDateTimeInvalidNullAsync(), serviceCallback);
     }
 
@@ -1799,11 +2225,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": null}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, DateTime&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, DateTime>> object
      */
-    public Single<Map<String, DateTime>> getDateTimeInvalidNullAsync() {
+    public Single<RestResponse<Void, Map<String, DateTime>>> getDateTimeInvalidNullWithRestResponseAsync() {
         return service.getDateTimeInvalidNull();
     }
+
+    /**
+     * Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": null}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, DateTime>> object
+     */
+    public Single<Map<String, DateTime>> getDateTimeInvalidNullAsync() {
+        return getDateTimeInvalidNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, DateTime>>, Map<String, DateTime>>() { public Map<String, DateTime> call(RestResponse<Void, Map<String, DateTime>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1825,7 +2262,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, DateTime>> getDateTimeInvalidCharsAsync(final ServiceCallback<Map<String, DateTime>> serviceCallback) {
+    public ServiceFuture<Map<String, DateTime>> getDateTimeInvalidCharsAsync(ServiceCallback<Map<String, DateTime>> serviceCallback) {
         return ServiceFuture.fromBody(getDateTimeInvalidCharsAsync(), serviceCallback);
     }
 
@@ -1833,11 +2270,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": "date-time"}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, DateTime&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, DateTime>> object
      */
-    public Single<Map<String, DateTime>> getDateTimeInvalidCharsAsync() {
+    public Single<RestResponse<Void, Map<String, DateTime>>> getDateTimeInvalidCharsWithRestResponseAsync() {
         return service.getDateTimeInvalidChars();
     }
+
+    /**
+     * Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": "date-time"}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, DateTime>> object
+     */
+    public Single<Map<String, DateTime>> getDateTimeInvalidCharsAsync() {
+        return getDateTimeInvalidCharsWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, DateTime>>, Map<String, DateTime>>() { public Map<String, DateTime> call(RestResponse<Void, Map<String, DateTime>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1859,7 +2307,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, DateTime>> getDateTimeRfc1123ValidAsync(final ServiceCallback<Map<String, DateTime>> serviceCallback) {
+    public ServiceFuture<Map<String, DateTime>> getDateTimeRfc1123ValidAsync(ServiceCallback<Map<String, DateTime>> serviceCallback) {
         return ServiceFuture.fromBody(getDateTimeRfc1123ValidAsync(), serviceCallback);
     }
 
@@ -1867,11 +2315,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get date-time-rfc1123 dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, DateTime&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, DateTime>> object
      */
-    public Single<Map<String, DateTime>> getDateTimeRfc1123ValidAsync() {
+    public Single<RestResponse<Void, Map<String, DateTime>>> getDateTimeRfc1123ValidWithRestResponseAsync() {
         return service.getDateTimeRfc1123Valid();
     }
+
+    /**
+     * Get date-time-rfc1123 dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, DateTime>> object
+     */
+    public Single<Map<String, DateTime>> getDateTimeRfc1123ValidAsync() {
+        return getDateTimeRfc1123ValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, DateTime>>, Map<String, DateTime>>() { public Map<String, DateTime> call(RestResponse<Void, Map<String, DateTime>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1881,6 +2340,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putDateTimeRfc1123Valid(Map<String, DateTime> arrayBody) {
         putDateTimeRfc1123ValidAsync(arrayBody).toBlocking().value();
@@ -1894,7 +2354,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putDateTimeRfc1123ValidAsync(Map<String, DateTime> arrayBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putDateTimeRfc1123ValidAsync(Map<String, DateTime> arrayBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putDateTimeRfc1123ValidAsync(arrayBody), serviceCallback);
     }
 
@@ -1903,20 +2363,32 @@ public class DictionarysImpl implements Dictionarys {
      *
      * @param arrayBody the Map&lt;String, DateTimeRfc1123&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putDateTimeRfc1123ValidAsync(Map<String, DateTime> arrayBody) {
+    public Single<RestResponse<Void, Void>> putDateTimeRfc1123ValidWithRestResponseAsync(Map<String, DateTime> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
         Validator.validate(arrayBody);
-        Map<String, DateTimeRfc1123> arrayBodyConverted = new HashMap<String, DateTimeRfc1123>();
-        for (Map.Entry<String, DateTime> entry : arrayBody.entrySet()) {
-            DateTimeRfc1123 value = new DateTimeRfc1123(entry.getValue());
-            arrayBodyConverted.put(entry.getKey(), value);
-        }
+    Map<String, DateTimeRfc1123> arrayBodyConverted = new HashMap<String, DateTimeRfc1123>();
+    for (Map.Entry<String, DateTime> entry : arrayBody.entrySet()) {
+        DateTimeRfc1123 value = new DateTimeRfc1123(entry.getValue());
+        arrayBodyConverted.put(entry.getKey(), value);
+    }
         return service.putDateTimeRfc1123Valid(arrayBodyConverted);
     }
+
+    /**
+     * Set dictionary value empty {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}.
+     *
+     * @param arrayBody the Map&lt;String, DateTimeRfc1123&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putDateTimeRfc1123ValidAsync(Map<String, DateTime> arrayBody) {
+        return putDateTimeRfc1123ValidWithRestResponseAsync(arrayBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1938,7 +2410,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, Period>> getDurationValidAsync(final ServiceCallback<Map<String, Period>> serviceCallback) {
+    public ServiceFuture<Map<String, Period>> getDurationValidAsync(ServiceCallback<Map<String, Period>> serviceCallback) {
         return ServiceFuture.fromBody(getDurationValidAsync(), serviceCallback);
     }
 
@@ -1946,11 +2418,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, Period&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Period>> object
      */
-    public Single<Map<String, Period>> getDurationValidAsync() {
+    public Single<RestResponse<Void, Map<String, Period>>> getDurationValidWithRestResponseAsync() {
         return service.getDurationValid();
     }
+
+    /**
+     * Get duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Period>> object
+     */
+    public Single<Map<String, Period>> getDurationValidAsync() {
+        return getDurationValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, Period>>, Map<String, Period>>() { public Map<String, Period> call(RestResponse<Void, Map<String, Period>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1960,6 +2443,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putDurationValid(Map<String, Period> arrayBody) {
         putDurationValidAsync(arrayBody).toBlocking().value();
@@ -1973,7 +2457,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putDurationValidAsync(Map<String, Period> arrayBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putDurationValidAsync(Map<String, Period> arrayBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putDurationValidAsync(arrayBody), serviceCallback);
     }
 
@@ -1982,15 +2466,27 @@ public class DictionarysImpl implements Dictionarys {
      *
      * @param arrayBody the Map&lt;String, Period&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putDurationValidAsync(Map<String, Period> arrayBody) {
+    public Single<RestResponse<Void, Void>> putDurationValidWithRestResponseAsync(Map<String, Period> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
         Validator.validate(arrayBody);
         return service.putDurationValid(arrayBody);
     }
+
+    /**
+     * Set dictionary value  {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
+     *
+     * @param arrayBody the Map&lt;String, Period&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putDurationValidAsync(Map<String, Period> arrayBody) {
+        return putDurationValidWithRestResponseAsync(arrayBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2012,7 +2508,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, byte[]>> getByteValidAsync(final ServiceCallback<Map<String, byte[]>> serviceCallback) {
+    public ServiceFuture<Map<String, byte[]>> getByteValidAsync(ServiceCallback<Map<String, byte[]>> serviceCallback) {
         return ServiceFuture.fromBody(getByteValidAsync(), serviceCallback);
     }
 
@@ -2020,11 +2516,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get byte dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each item encoded in base64.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, byte[]&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, byte[]>> object
      */
-    public Single<Map<String, byte[]>> getByteValidAsync() {
+    public Single<RestResponse<Void, Map<String, byte[]>>> getByteValidWithRestResponseAsync() {
         return service.getByteValid();
     }
+
+    /**
+     * Get byte dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each item encoded in base64.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, byte[]>> object
+     */
+    public Single<Map<String, byte[]>> getByteValidAsync() {
+        return getByteValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, byte[]>>, Map<String, byte[]>>() { public Map<String, byte[]> call(RestResponse<Void, Map<String, byte[]>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2034,6 +2541,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putByteValid(Map<String, byte[]> arrayBody) {
         putByteValidAsync(arrayBody).toBlocking().value();
@@ -2047,7 +2555,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putByteValidAsync(Map<String, byte[]> arrayBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putByteValidAsync(Map<String, byte[]> arrayBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putByteValidAsync(arrayBody), serviceCallback);
     }
 
@@ -2056,15 +2564,27 @@ public class DictionarysImpl implements Dictionarys {
      *
      * @param arrayBody the Map&lt;String, byte[]&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putByteValidAsync(Map<String, byte[]> arrayBody) {
+    public Single<RestResponse<Void, Void>> putByteValidWithRestResponseAsync(Map<String, byte[]> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
         Validator.validate(arrayBody);
         return service.putByteValid(arrayBody);
     }
+
+    /**
+     * Put the dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each elementencoded in base 64.
+     *
+     * @param arrayBody the Map&lt;String, byte[]&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putByteValidAsync(Map<String, byte[]> arrayBody) {
+        return putByteValidWithRestResponseAsync(arrayBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2086,7 +2606,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, byte[]>> getByteInvalidNullAsync(final ServiceCallback<Map<String, byte[]>> serviceCallback) {
+    public ServiceFuture<Map<String, byte[]>> getByteInvalidNullAsync(ServiceCallback<Map<String, byte[]>> serviceCallback) {
         return ServiceFuture.fromBody(getByteInvalidNullAsync(), serviceCallback);
     }
 
@@ -2094,11 +2614,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first item base64 encoded.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, byte[]&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, byte[]>> object
      */
-    public Single<Map<String, byte[]>> getByteInvalidNullAsync() {
+    public Single<RestResponse<Void, Map<String, byte[]>>> getByteInvalidNullWithRestResponseAsync() {
         return service.getByteInvalidNull();
     }
+
+    /**
+     * Get byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first item base64 encoded.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, byte[]>> object
+     */
+    public Single<Map<String, byte[]>> getByteInvalidNullAsync() {
+        return getByteInvalidNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, byte[]>>, Map<String, byte[]>>() { public Map<String, byte[]> call(RestResponse<Void, Map<String, byte[]>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2120,7 +2651,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, byte[]>> getBase64UrlAsync(final ServiceCallback<Map<String, byte[]>> serviceCallback) {
+    public ServiceFuture<Map<String, byte[]>> getBase64UrlAsync(ServiceCallback<Map<String, byte[]>> serviceCallback) {
         return ServiceFuture.fromBody(getBase64UrlAsync(), serviceCallback);
     }
 
@@ -2128,11 +2659,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2": "Lorem ipsum"}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, byte[]&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, byte[]>> object
      */
-    public Single<Map<String, byte[]>> getBase64UrlAsync() {
+    public Single<RestResponse<Void, Map<String, byte[]>>> getBase64UrlWithRestResponseAsync() {
         return service.getBase64Url();
     }
+
+    /**
+     * Get base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2": "Lorem ipsum"}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, byte[]>> object
+     */
+    public Single<Map<String, byte[]>> getBase64UrlAsync() {
+        return getBase64UrlWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, byte[]>>, Map<String, byte[]>>() { public Map<String, byte[]> call(RestResponse<Void, Map<String, byte[]>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2154,7 +2696,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, Widget>> getComplexNullAsync(final ServiceCallback<Map<String, Widget>> serviceCallback) {
+    public ServiceFuture<Map<String, Widget>> getComplexNullAsync(ServiceCallback<Map<String, Widget>> serviceCallback) {
         return ServiceFuture.fromBody(getComplexNullAsync(), serviceCallback);
     }
 
@@ -2162,11 +2704,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get dictionary of complex type null value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, Widget&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Widget>> object
      */
-    public Single<Map<String, Widget>> getComplexNullAsync() {
+    public Single<RestResponse<Void, Map<String, Widget>>> getComplexNullWithRestResponseAsync() {
         return service.getComplexNull();
     }
+
+    /**
+     * Get dictionary of complex type null value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Widget>> object
+     */
+    public Single<Map<String, Widget>> getComplexNullAsync() {
+        return getComplexNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, Widget>>, Map<String, Widget>>() { public Map<String, Widget> call(RestResponse<Void, Map<String, Widget>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2188,7 +2741,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, Widget>> getComplexEmptyAsync(final ServiceCallback<Map<String, Widget>> serviceCallback) {
+    public ServiceFuture<Map<String, Widget>> getComplexEmptyAsync(ServiceCallback<Map<String, Widget>> serviceCallback) {
         return ServiceFuture.fromBody(getComplexEmptyAsync(), serviceCallback);
     }
 
@@ -2196,11 +2749,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get empty dictionary of complex type {}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, Widget&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Widget>> object
      */
-    public Single<Map<String, Widget>> getComplexEmptyAsync() {
+    public Single<RestResponse<Void, Map<String, Widget>>> getComplexEmptyWithRestResponseAsync() {
         return service.getComplexEmpty();
     }
+
+    /**
+     * Get empty dictionary of complex type {}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Widget>> object
+     */
+    public Single<Map<String, Widget>> getComplexEmptyAsync() {
+        return getComplexEmptyWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, Widget>>, Map<String, Widget>>() { public Map<String, Widget> call(RestResponse<Void, Map<String, Widget>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2222,7 +2786,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, Widget>> getComplexItemNullAsync(final ServiceCallback<Map<String, Widget>> serviceCallback) {
+    public ServiceFuture<Map<String, Widget>> getComplexItemNullAsync(ServiceCallback<Map<String, Widget>> serviceCallback) {
         return ServiceFuture.fromBody(getComplexItemNullAsync(), serviceCallback);
     }
 
@@ -2230,11 +2794,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get dictionary of complex type with null item {"0": {"integer": 1, "string": "2"}, "1": null, "2": {"integer": 5, "string": "6"}}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, Widget&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Widget>> object
      */
-    public Single<Map<String, Widget>> getComplexItemNullAsync() {
+    public Single<RestResponse<Void, Map<String, Widget>>> getComplexItemNullWithRestResponseAsync() {
         return service.getComplexItemNull();
     }
+
+    /**
+     * Get dictionary of complex type with null item {"0": {"integer": 1, "string": "2"}, "1": null, "2": {"integer": 5, "string": "6"}}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Widget>> object
+     */
+    public Single<Map<String, Widget>> getComplexItemNullAsync() {
+        return getComplexItemNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, Widget>>, Map<String, Widget>>() { public Map<String, Widget> call(RestResponse<Void, Map<String, Widget>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2256,7 +2831,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, Widget>> getComplexItemEmptyAsync(final ServiceCallback<Map<String, Widget>> serviceCallback) {
+    public ServiceFuture<Map<String, Widget>> getComplexItemEmptyAsync(ServiceCallback<Map<String, Widget>> serviceCallback) {
         return ServiceFuture.fromBody(getComplexItemEmptyAsync(), serviceCallback);
     }
 
@@ -2264,11 +2839,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get dictionary of complex type with empty item {"0": {"integer": 1, "string": "2"}, "1:" {}, "2": {"integer": 5, "string": "6"}}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, Widget&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Widget>> object
      */
-    public Single<Map<String, Widget>> getComplexItemEmptyAsync() {
+    public Single<RestResponse<Void, Map<String, Widget>>> getComplexItemEmptyWithRestResponseAsync() {
         return service.getComplexItemEmpty();
     }
+
+    /**
+     * Get dictionary of complex type with empty item {"0": {"integer": 1, "string": "2"}, "1:" {}, "2": {"integer": 5, "string": "6"}}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Widget>> object
+     */
+    public Single<Map<String, Widget>> getComplexItemEmptyAsync() {
+        return getComplexItemEmptyWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, Widget>>, Map<String, Widget>>() { public Map<String, Widget> call(RestResponse<Void, Map<String, Widget>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2290,7 +2876,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, Widget>> getComplexValidAsync(final ServiceCallback<Map<String, Widget>> serviceCallback) {
+    public ServiceFuture<Map<String, Widget>> getComplexValidAsync(ServiceCallback<Map<String, Widget>> serviceCallback) {
         return ServiceFuture.fromBody(getComplexValidAsync(), serviceCallback);
     }
 
@@ -2298,11 +2884,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, Widget&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Widget>> object
      */
-    public Single<Map<String, Widget>> getComplexValidAsync() {
+    public Single<RestResponse<Void, Map<String, Widget>>> getComplexValidWithRestResponseAsync() {
         return service.getComplexValid();
     }
+
+    /**
+     * Get dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Widget>> object
+     */
+    public Single<Map<String, Widget>> getComplexValidAsync() {
+        return getComplexValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, Widget>>, Map<String, Widget>>() { public Map<String, Widget> call(RestResponse<Void, Map<String, Widget>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2312,6 +2909,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putComplexValid(Map<String, Widget> arrayBody) {
         putComplexValidAsync(arrayBody).toBlocking().value();
@@ -2325,7 +2923,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putComplexValidAsync(Map<String, Widget> arrayBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putComplexValidAsync(Map<String, Widget> arrayBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putComplexValidAsync(arrayBody), serviceCallback);
     }
 
@@ -2334,15 +2932,27 @@ public class DictionarysImpl implements Dictionarys {
      *
      * @param arrayBody the Map&lt;String, Widget&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putComplexValidAsync(Map<String, Widget> arrayBody) {
+    public Single<RestResponse<Void, Void>> putComplexValidWithRestResponseAsync(Map<String, Widget> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
         Validator.validate(arrayBody);
         return service.putComplexValid(arrayBody);
     }
+
+    /**
+     * Put an dictionary of complex type with values {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}.
+     *
+     * @param arrayBody the Map&lt;String, Widget&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putComplexValidAsync(Map<String, Widget> arrayBody) {
+        return putComplexValidWithRestResponseAsync(arrayBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2364,7 +2974,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, List<String>>> getArrayNullAsync(final ServiceCallback<Map<String, List<String>>> serviceCallback) {
+    public ServiceFuture<Map<String, List<String>>> getArrayNullAsync(ServiceCallback<Map<String, List<String>>> serviceCallback) {
         return ServiceFuture.fromBody(getArrayNullAsync(), serviceCallback);
     }
 
@@ -2372,11 +2982,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get a null array.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, List<String>>> object
      */
-    public Single<Map<String, List<String>>> getArrayNullAsync() {
+    public Single<RestResponse<Void, Map<String, List<String>>>> getArrayNullWithRestResponseAsync() {
         return service.getArrayNull();
     }
+
+    /**
+     * Get a null array.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, List<String>>> object
+     */
+    public Single<Map<String, List<String>>> getArrayNullAsync() {
+        return getArrayNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, List<String>>>, Map<String, List<String>>>() { public Map<String, List<String>> call(RestResponse<Void, Map<String, List<String>>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2398,7 +3019,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, List<String>>> getArrayEmptyAsync(final ServiceCallback<Map<String, List<String>>> serviceCallback) {
+    public ServiceFuture<Map<String, List<String>>> getArrayEmptyAsync(ServiceCallback<Map<String, List<String>>> serviceCallback) {
         return ServiceFuture.fromBody(getArrayEmptyAsync(), serviceCallback);
     }
 
@@ -2406,11 +3027,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get an empty dictionary {}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, List<String>>> object
      */
-    public Single<Map<String, List<String>>> getArrayEmptyAsync() {
+    public Single<RestResponse<Void, Map<String, List<String>>>> getArrayEmptyWithRestResponseAsync() {
         return service.getArrayEmpty();
     }
+
+    /**
+     * Get an empty dictionary {}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, List<String>>> object
+     */
+    public Single<Map<String, List<String>>> getArrayEmptyAsync() {
+        return getArrayEmptyWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, List<String>>>, Map<String, List<String>>>() { public Map<String, List<String>> call(RestResponse<Void, Map<String, List<String>>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2432,7 +3064,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, List<String>>> getArrayItemNullAsync(final ServiceCallback<Map<String, List<String>>> serviceCallback) {
+    public ServiceFuture<Map<String, List<String>>> getArrayItemNullAsync(ServiceCallback<Map<String, List<String>>> serviceCallback) {
         return ServiceFuture.fromBody(getArrayItemNullAsync(), serviceCallback);
     }
 
@@ -2440,11 +3072,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get an dictionary of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, List<String>>> object
      */
-    public Single<Map<String, List<String>>> getArrayItemNullAsync() {
+    public Single<RestResponse<Void, Map<String, List<String>>>> getArrayItemNullWithRestResponseAsync() {
         return service.getArrayItemNull();
     }
+
+    /**
+     * Get an dictionary of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, List<String>>> object
+     */
+    public Single<Map<String, List<String>>> getArrayItemNullAsync() {
+        return getArrayItemNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, List<String>>>, Map<String, List<String>>>() { public Map<String, List<String>> call(RestResponse<Void, Map<String, List<String>>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2466,7 +3109,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, List<String>>> getArrayItemEmptyAsync(final ServiceCallback<Map<String, List<String>>> serviceCallback) {
+    public ServiceFuture<Map<String, List<String>>> getArrayItemEmptyAsync(ServiceCallback<Map<String, List<String>>> serviceCallback) {
         return ServiceFuture.fromBody(getArrayItemEmptyAsync(), serviceCallback);
     }
 
@@ -2474,11 +3117,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get an array of array of strings [{"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, List<String>>> object
      */
-    public Single<Map<String, List<String>>> getArrayItemEmptyAsync() {
+    public Single<RestResponse<Void, Map<String, List<String>>>> getArrayItemEmptyWithRestResponseAsync() {
         return service.getArrayItemEmpty();
     }
+
+    /**
+     * Get an array of array of strings [{"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, List<String>>> object
+     */
+    public Single<Map<String, List<String>>> getArrayItemEmptyAsync() {
+        return getArrayItemEmptyWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, List<String>>>, Map<String, List<String>>>() { public Map<String, List<String>> call(RestResponse<Void, Map<String, List<String>>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2500,7 +3154,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, List<String>>> getArrayValidAsync(final ServiceCallback<Map<String, List<String>>> serviceCallback) {
+    public ServiceFuture<Map<String, List<String>>> getArrayValidAsync(ServiceCallback<Map<String, List<String>>> serviceCallback) {
         return ServiceFuture.fromBody(getArrayValidAsync(), serviceCallback);
     }
 
@@ -2508,11 +3162,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get an array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, List&lt;String&gt;&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, List<String>>> object
      */
-    public Single<Map<String, List<String>>> getArrayValidAsync() {
+    public Single<RestResponse<Void, Map<String, List<String>>>> getArrayValidWithRestResponseAsync() {
         return service.getArrayValid();
     }
+
+    /**
+     * Get an array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, List<String>>> object
+     */
+    public Single<Map<String, List<String>>> getArrayValidAsync() {
+        return getArrayValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, List<String>>>, Map<String, List<String>>>() { public Map<String, List<String>> call(RestResponse<Void, Map<String, List<String>>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2522,6 +3187,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putArrayValid(Map<String, List<String>> arrayBody) {
         putArrayValidAsync(arrayBody).toBlocking().value();
@@ -2535,7 +3201,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putArrayValidAsync(Map<String, List<String>> arrayBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putArrayValidAsync(Map<String, List<String>> arrayBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putArrayValidAsync(arrayBody), serviceCallback);
     }
 
@@ -2544,15 +3210,27 @@ public class DictionarysImpl implements Dictionarys {
      *
      * @param arrayBody the Map&lt;String, List&lt;String&gt;&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putArrayValidAsync(Map<String, List<String>> arrayBody) {
+    public Single<RestResponse<Void, Void>> putArrayValidWithRestResponseAsync(Map<String, List<String>> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
         Validator.validate(arrayBody);
         return service.putArrayValid(arrayBody);
     }
+
+    /**
+     * Put An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
+     *
+     * @param arrayBody the Map&lt;String, List&lt;String&gt;&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putArrayValidAsync(Map<String, List<String>> arrayBody) {
+        return putArrayValidWithRestResponseAsync(arrayBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2574,7 +3252,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, Map<String, String>>> getDictionaryNullAsync(final ServiceCallback<Map<String, Map<String, String>>> serviceCallback) {
+    public ServiceFuture<Map<String, Map<String, String>>> getDictionaryNullAsync(ServiceCallback<Map<String, Map<String, String>>> serviceCallback) {
         return ServiceFuture.fromBody(getDictionaryNullAsync(), serviceCallback);
     }
 
@@ -2582,11 +3260,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get an dictionaries of dictionaries with value null.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Map<String, String>>> object
      */
-    public Single<Map<String, Map<String, String>>> getDictionaryNullAsync() {
+    public Single<RestResponse<Void, Map<String, Map<String, String>>>> getDictionaryNullWithRestResponseAsync() {
         return service.getDictionaryNull();
     }
+
+    /**
+     * Get an dictionaries of dictionaries with value null.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Map<String, String>>> object
+     */
+    public Single<Map<String, Map<String, String>>> getDictionaryNullAsync() {
+        return getDictionaryNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, Map<String, String>>>, Map<String, Map<String, String>>>() { public Map<String, Map<String, String>> call(RestResponse<Void, Map<String, Map<String, String>>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2608,7 +3297,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, Map<String, String>>> getDictionaryEmptyAsync(final ServiceCallback<Map<String, Map<String, String>>> serviceCallback) {
+    public ServiceFuture<Map<String, Map<String, String>>> getDictionaryEmptyAsync(ServiceCallback<Map<String, Map<String, String>>> serviceCallback) {
         return ServiceFuture.fromBody(getDictionaryEmptyAsync(), serviceCallback);
     }
 
@@ -2616,11 +3305,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Map<String, String>>> object
      */
-    public Single<Map<String, Map<String, String>>> getDictionaryEmptyAsync() {
+    public Single<RestResponse<Void, Map<String, Map<String, String>>>> getDictionaryEmptyWithRestResponseAsync() {
         return service.getDictionaryEmpty();
     }
+
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Map<String, String>>> object
+     */
+    public Single<Map<String, Map<String, String>>> getDictionaryEmptyAsync() {
+        return getDictionaryEmptyWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, Map<String, String>>>, Map<String, Map<String, String>>>() { public Map<String, Map<String, String>> call(RestResponse<Void, Map<String, Map<String, String>>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2642,7 +3342,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, Map<String, String>>> getDictionaryItemNullAsync(final ServiceCallback<Map<String, Map<String, String>>> serviceCallback) {
+    public ServiceFuture<Map<String, Map<String, String>>> getDictionaryItemNullAsync(ServiceCallback<Map<String, Map<String, String>>> serviceCallback) {
         return ServiceFuture.fromBody(getDictionaryItemNullAsync(), serviceCallback);
     }
 
@@ -2650,11 +3350,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": null, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Map<String, String>>> object
      */
-    public Single<Map<String, Map<String, String>>> getDictionaryItemNullAsync() {
+    public Single<RestResponse<Void, Map<String, Map<String, String>>>> getDictionaryItemNullWithRestResponseAsync() {
         return service.getDictionaryItemNull();
     }
+
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": null, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Map<String, String>>> object
+     */
+    public Single<Map<String, Map<String, String>>> getDictionaryItemNullAsync() {
+        return getDictionaryItemNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, Map<String, String>>>, Map<String, Map<String, String>>>() { public Map<String, Map<String, String>> call(RestResponse<Void, Map<String, Map<String, String>>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2676,7 +3387,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, Map<String, String>>> getDictionaryItemEmptyAsync(final ServiceCallback<Map<String, Map<String, String>>> serviceCallback) {
+    public ServiceFuture<Map<String, Map<String, String>>> getDictionaryItemEmptyAsync(ServiceCallback<Map<String, Map<String, String>>> serviceCallback) {
         return ServiceFuture.fromBody(getDictionaryItemEmptyAsync(), serviceCallback);
     }
 
@@ -2684,11 +3395,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Map<String, String>>> object
      */
-    public Single<Map<String, Map<String, String>>> getDictionaryItemEmptyAsync() {
+    public Single<RestResponse<Void, Map<String, Map<String, String>>>> getDictionaryItemEmptyWithRestResponseAsync() {
         return service.getDictionaryItemEmpty();
     }
+
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Map<String, String>>> object
+     */
+    public Single<Map<String, Map<String, String>>> getDictionaryItemEmptyAsync() {
+        return getDictionaryItemEmptyWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, Map<String, String>>>, Map<String, Map<String, String>>>() { public Map<String, Map<String, String>> call(RestResponse<Void, Map<String, Map<String, String>>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2710,7 +3432,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, Map<String, String>>> getDictionaryValidAsync(final ServiceCallback<Map<String, Map<String, String>>> serviceCallback) {
+    public ServiceFuture<Map<String, Map<String, String>>> getDictionaryValidAsync(ServiceCallback<Map<String, Map<String, String>>> serviceCallback) {
         return ServiceFuture.fromBody(getDictionaryValidAsync(), serviceCallback);
     }
 
@@ -2718,11 +3440,22 @@ public class DictionarysImpl implements Dictionarys {
      * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, Map&lt;String, String&gt;&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Map<String, String>>> object
      */
-    public Single<Map<String, Map<String, String>>> getDictionaryValidAsync() {
+    public Single<RestResponse<Void, Map<String, Map<String, String>>>> getDictionaryValidWithRestResponseAsync() {
         return service.getDictionaryValid();
     }
+
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Map<String, String>>> object
+     */
+    public Single<Map<String, Map<String, String>>> getDictionaryValidAsync() {
+        return getDictionaryValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, Map<String, String>>>, Map<String, Map<String, String>>>() { public Map<String, Map<String, String>> call(RestResponse<Void, Map<String, Map<String, String>>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2732,6 +3465,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putDictionaryValid(Map<String, Map<String, String>> arrayBody) {
         putDictionaryValidAsync(arrayBody).toBlocking().value();
@@ -2745,7 +3479,7 @@ public class DictionarysImpl implements Dictionarys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putDictionaryValidAsync(Map<String, Map<String, String>> arrayBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putDictionaryValidAsync(Map<String, Map<String, String>> arrayBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putDictionaryValidAsync(arrayBody), serviceCallback);
     }
 
@@ -2754,15 +3488,27 @@ public class DictionarysImpl implements Dictionarys {
      *
      * @param arrayBody the Map&lt;String, Map&lt;String, String&gt;&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putDictionaryValidAsync(Map<String, Map<String, String>> arrayBody) {
+    public Single<RestResponse<Void, Void>> putDictionaryValidWithRestResponseAsync(Map<String, Map<String, String>> arrayBody) {
         if (arrayBody == null) {
             throw new IllegalArgumentException("Parameter arrayBody is required and cannot be null.");
         }
         Validator.validate(arrayBody);
         return service.putDictionaryValid(arrayBody);
     }
+
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     *
+     * @param arrayBody the Map&lt;String, Map&lt;String, String&gt;&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putDictionaryValidAsync(Map<String, Map<String, String>> arrayBody) {
+        return putDictionaryValidWithRestResponseAsync(arrayBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodyduration/Durations.java
+++ b/test/vanilla/src/main/java/fixtures/bodyduration/Durations.java
@@ -10,6 +10,7 @@
 
 package fixtures.bodyduration;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.bodyduration.models.ErrorException;
@@ -49,6 +50,13 @@ public interface Durations {
      * @return the observable to the Period object
      */
     Single<Period> getNullAsync();
+    /**
+     * Get null duration value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Period object
+     */
+    Single<RestResponse<Void, Period>> getNullWithRestResponseAsync();
 
 
     /**
@@ -79,6 +87,14 @@ public interface Durations {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putPositiveDurationAsync(Period durationBody);
+    /**
+     * Put a positive duration value.
+     *
+     * @param durationBody the Period value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putPositiveDurationWithRestResponseAsync(Period durationBody);
 
 
     /**
@@ -107,6 +123,13 @@ public interface Durations {
      * @return the observable to the Period object
      */
     Single<Period> getPositiveDurationAsync();
+    /**
+     * Get a positive duration value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Period object
+     */
+    Single<RestResponse<Void, Period>> getPositiveDurationWithRestResponseAsync();
 
 
     /**
@@ -135,6 +158,13 @@ public interface Durations {
      * @return the observable to the Period object
      */
     Single<Period> getInvalidAsync();
+    /**
+     * Get an invalid duration value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Period object
+     */
+    Single<RestResponse<Void, Period>> getInvalidWithRestResponseAsync();
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodyduration/implementation/AutoRestDurationTestServiceImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodyduration/implementation/AutoRestDurationTestServiceImpl.java
@@ -13,6 +13,7 @@ package fixtures.bodyduration.implementation;
 import fixtures.bodyduration.AutoRestDurationTestService;
 import fixtures.bodyduration.Durations;
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceClient;
 import com.microsoft.rest.RestClient;
 import rx.Single;

--- a/test/vanilla/src/main/java/fixtures/bodyduration/implementation/DurationsImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodyduration/implementation/DurationsImpl.java
@@ -11,6 +11,7 @@
 package fixtures.bodyduration.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.bodyduration.Durations;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.BodyParam;
@@ -60,25 +61,25 @@ public class DurationsImpl implements Durations {
         @GET("duration/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Period> getNull();
+        Single<RestResponse<Void, Period>> getNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyduration.Durations putPositiveDuration" })
         @PUT("duration/positiveduration")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putPositiveDuration(@BodyParam("application/json; charset=utf-8") Period durationBody);
+        Single<RestResponse<Void, Void>> putPositiveDuration(@BodyParam("application/json; charset=utf-8") Period durationBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodyduration.Durations getPositiveDuration" })
         @GET("duration/positiveduration")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Period> getPositiveDuration();
+        Single<RestResponse<Void, Period>> getPositiveDuration();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyduration.Durations getInvalid" })
         @GET("duration/invalid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Period> getInvalid();
+        Single<RestResponse<Void, Period>> getInvalid();
 
     }
 
@@ -101,7 +102,7 @@ public class DurationsImpl implements Durations {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Period> getNullAsync(final ServiceCallback<Period> serviceCallback) {
+    public ServiceFuture<Period> getNullAsync(ServiceCallback<Period> serviceCallback) {
         return ServiceFuture.fromBody(getNullAsync(), serviceCallback);
     }
 
@@ -109,11 +110,22 @@ public class DurationsImpl implements Durations {
      * Get null duration value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Period object
+     * @return a {@link Single} emitting the RestResponse<Void, Period> object
      */
-    public Single<Period> getNullAsync() {
+    public Single<RestResponse<Void, Period>> getNullWithRestResponseAsync() {
         return service.getNull();
     }
+
+    /**
+     * Get null duration value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Period> object
+     */
+    public Single<Period> getNullAsync() {
+        return getNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Period>, Period>() { public Period call(RestResponse<Void, Period> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -123,6 +135,7 @@ public class DurationsImpl implements Durations {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putPositiveDuration(Period durationBody) {
         putPositiveDurationAsync(durationBody).toBlocking().value();
@@ -136,7 +149,7 @@ public class DurationsImpl implements Durations {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putPositiveDurationAsync(Period durationBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putPositiveDurationAsync(Period durationBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putPositiveDurationAsync(durationBody), serviceCallback);
     }
 
@@ -145,14 +158,26 @@ public class DurationsImpl implements Durations {
      *
      * @param durationBody the Period value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putPositiveDurationAsync(Period durationBody) {
+    public Single<RestResponse<Void, Void>> putPositiveDurationWithRestResponseAsync(Period durationBody) {
         if (durationBody == null) {
             throw new IllegalArgumentException("Parameter durationBody is required and cannot be null.");
         }
         return service.putPositiveDuration(durationBody);
     }
+
+    /**
+     * Put a positive duration value.
+     *
+     * @param durationBody the Period value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putPositiveDurationAsync(Period durationBody) {
+        return putPositiveDurationWithRestResponseAsync(durationBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -174,7 +199,7 @@ public class DurationsImpl implements Durations {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Period> getPositiveDurationAsync(final ServiceCallback<Period> serviceCallback) {
+    public ServiceFuture<Period> getPositiveDurationAsync(ServiceCallback<Period> serviceCallback) {
         return ServiceFuture.fromBody(getPositiveDurationAsync(), serviceCallback);
     }
 
@@ -182,11 +207,22 @@ public class DurationsImpl implements Durations {
      * Get a positive duration value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Period object
+     * @return a {@link Single} emitting the RestResponse<Void, Period> object
      */
-    public Single<Period> getPositiveDurationAsync() {
+    public Single<RestResponse<Void, Period>> getPositiveDurationWithRestResponseAsync() {
         return service.getPositiveDuration();
     }
+
+    /**
+     * Get a positive duration value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Period> object
+     */
+    public Single<Period> getPositiveDurationAsync() {
+        return getPositiveDurationWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Period>, Period>() { public Period call(RestResponse<Void, Period> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -208,7 +244,7 @@ public class DurationsImpl implements Durations {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Period> getInvalidAsync(final ServiceCallback<Period> serviceCallback) {
+    public ServiceFuture<Period> getInvalidAsync(ServiceCallback<Period> serviceCallback) {
         return ServiceFuture.fromBody(getInvalidAsync(), serviceCallback);
     }
 
@@ -216,11 +252,22 @@ public class DurationsImpl implements Durations {
      * Get an invalid duration value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Period object
+     * @return a {@link Single} emitting the RestResponse<Void, Period> object
      */
-    public Single<Period> getInvalidAsync() {
+    public Single<RestResponse<Void, Period>> getInvalidWithRestResponseAsync() {
         return service.getInvalid();
     }
+
+    /**
+     * Get an invalid duration value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Period> object
+     */
+    public Single<Period> getInvalidAsync() {
+        return getInvalidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Period>, Period>() { public Period call(RestResponse<Void, Period> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodyfile/Files.java
+++ b/test/vanilla/src/main/java/fixtures/bodyfile/Files.java
@@ -10,6 +10,7 @@
 
 package fixtures.bodyfile;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.bodyfile.models.ErrorException;
@@ -49,6 +50,13 @@ public interface Files {
      * @return the observable to the InputStream object
      */
     Single<InputStream> getFileAsync();
+    /**
+     * Get file.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the InputStream object
+     */
+    Single<RestResponse<Void, InputStream>> getFileWithRestResponseAsync();
 
 
     /**
@@ -77,6 +85,13 @@ public interface Files {
      * @return the observable to the InputStream object
      */
     Single<InputStream> getFileLargeAsync();
+    /**
+     * Get a large file.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the InputStream object
+     */
+    Single<RestResponse<Void, InputStream>> getFileLargeWithRestResponseAsync();
 
 
     /**
@@ -105,6 +120,13 @@ public interface Files {
      * @return the observable to the InputStream object
      */
     Single<InputStream> getEmptyFileAsync();
+    /**
+     * Get empty file.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the InputStream object
+     */
+    Single<RestResponse<Void, InputStream>> getEmptyFileWithRestResponseAsync();
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodyfile/implementation/AutoRestSwaggerBATFileServiceImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodyfile/implementation/AutoRestSwaggerBATFileServiceImpl.java
@@ -13,6 +13,7 @@ package fixtures.bodyfile.implementation;
 import fixtures.bodyfile.AutoRestSwaggerBATFileService;
 import fixtures.bodyfile.Files;
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceClient;
 import com.microsoft.rest.RestClient;
 import rx.Single;

--- a/test/vanilla/src/main/java/fixtures/bodyfile/implementation/FilesImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodyfile/implementation/FilesImpl.java
@@ -11,6 +11,7 @@
 package fixtures.bodyfile.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.bodyfile.Files;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.ExpectedResponses;
@@ -59,21 +60,21 @@ public class FilesImpl implements Files {
         // @Streaming not supported by RestProxy
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<InputStream> getFile();
+        Single<RestResponse<Void, InputStream>> getFile();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyfile.Files getFileLarge" })
         @GET("files/stream/verylarge")
         // @Streaming not supported by RestProxy
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<InputStream> getFileLarge();
+        Single<RestResponse<Void, InputStream>> getFileLarge();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyfile.Files getEmptyFile" })
         @GET("files/stream/empty")
         // @Streaming not supported by RestProxy
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<InputStream> getEmptyFile();
+        Single<RestResponse<Void, InputStream>> getEmptyFile();
 
     }
 
@@ -96,7 +97,7 @@ public class FilesImpl implements Files {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<InputStream> getFileAsync(final ServiceCallback<InputStream> serviceCallback) {
+    public ServiceFuture<InputStream> getFileAsync(ServiceCallback<InputStream> serviceCallback) {
         return ServiceFuture.fromBody(getFileAsync(), serviceCallback);
     }
 
@@ -104,11 +105,22 @@ public class FilesImpl implements Files {
      * Get file.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the InputStream object
+     * @return a {@link Single} emitting the RestResponse<Void, InputStream> object
      */
-    public Single<InputStream> getFileAsync() {
+    public Single<RestResponse<Void, InputStream>> getFileWithRestResponseAsync() {
         return service.getFile();
     }
+
+    /**
+     * Get file.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, InputStream> object
+     */
+    public Single<InputStream> getFileAsync() {
+        return getFileWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, InputStream>, InputStream>() { public InputStream call(RestResponse<Void, InputStream> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -130,7 +142,7 @@ public class FilesImpl implements Files {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<InputStream> getFileLargeAsync(final ServiceCallback<InputStream> serviceCallback) {
+    public ServiceFuture<InputStream> getFileLargeAsync(ServiceCallback<InputStream> serviceCallback) {
         return ServiceFuture.fromBody(getFileLargeAsync(), serviceCallback);
     }
 
@@ -138,11 +150,22 @@ public class FilesImpl implements Files {
      * Get a large file.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the InputStream object
+     * @return a {@link Single} emitting the RestResponse<Void, InputStream> object
      */
-    public Single<InputStream> getFileLargeAsync() {
+    public Single<RestResponse<Void, InputStream>> getFileLargeWithRestResponseAsync() {
         return service.getFileLarge();
     }
+
+    /**
+     * Get a large file.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, InputStream> object
+     */
+    public Single<InputStream> getFileLargeAsync() {
+        return getFileLargeWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, InputStream>, InputStream>() { public InputStream call(RestResponse<Void, InputStream> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -164,7 +187,7 @@ public class FilesImpl implements Files {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<InputStream> getEmptyFileAsync(final ServiceCallback<InputStream> serviceCallback) {
+    public ServiceFuture<InputStream> getEmptyFileAsync(ServiceCallback<InputStream> serviceCallback) {
         return ServiceFuture.fromBody(getEmptyFileAsync(), serviceCallback);
     }
 
@@ -172,11 +195,22 @@ public class FilesImpl implements Files {
      * Get empty file.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the InputStream object
+     * @return a {@link Single} emitting the RestResponse<Void, InputStream> object
      */
-    public Single<InputStream> getEmptyFileAsync() {
+    public Single<RestResponse<Void, InputStream>> getEmptyFileWithRestResponseAsync() {
         return service.getEmptyFile();
     }
+
+    /**
+     * Get empty file.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, InputStream> object
+     */
+    public Single<InputStream> getEmptyFileAsync() {
+        return getEmptyFileWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, InputStream>, InputStream>() { public InputStream call(RestResponse<Void, InputStream> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodyformdata/Formdatas.java
+++ b/test/vanilla/src/main/java/fixtures/bodyformdata/Formdatas.java
@@ -10,6 +10,7 @@
 
 package fixtures.bodyformdata;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.bodyformdata.models.ErrorException;
@@ -55,6 +56,15 @@ public interface Formdatas {
      * @return the observable to the InputStream object
      */
     Single<InputStream> uploadFileAsync(byte[] fileContent, String fileName);
+    /**
+     * Upload file.
+     *
+     * @param fileContent File to upload.
+     * @param fileName File name to upload. Name has to be spelled exactly as written here.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the InputStream object
+     */
+    Single<RestResponse<Void, InputStream>> uploadFileWithRestResponseAsync(byte[] fileContent, String fileName);
 
 
     /**
@@ -86,6 +96,14 @@ public interface Formdatas {
      * @return the observable to the InputStream object
      */
     Single<InputStream> uploadFileViaBodyAsync(byte[] fileContent);
+    /**
+     * Upload file.
+     *
+     * @param fileContent File to upload.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the InputStream object
+     */
+    Single<RestResponse<Void, InputStream>> uploadFileViaBodyWithRestResponseAsync(byte[] fileContent);
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodyformdata/implementation/AutoRestSwaggerBATFormDataServiceImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodyformdata/implementation/AutoRestSwaggerBATFormDataServiceImpl.java
@@ -13,6 +13,7 @@ package fixtures.bodyformdata.implementation;
 import fixtures.bodyformdata.AutoRestSwaggerBATFormDataService;
 import fixtures.bodyformdata.Formdatas;
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceClient;
 import com.microsoft.rest.RestClient;
 import rx.Single;

--- a/test/vanilla/src/main/java/fixtures/bodyformdata/implementation/FormdatasImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodyformdata/implementation/FormdatasImpl.java
@@ -11,6 +11,7 @@
 package fixtures.bodyformdata.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.bodyformdata.Formdatas;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.BodyParam;
@@ -61,14 +62,14 @@ public class FormdatasImpl implements Formdatas {
         // @Streaming not supported by RestProxy
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<InputStream> uploadFile(/* @Part("fileContent") not supported by RestProxy */byte[] fileContent, /* @Part("fileName") not supported by RestProxy */String fileName);
+        Single<RestResponse<Void, InputStream>> uploadFile(/* @Part("fileContent") not supported by RestProxy */byte[] fileContent, /* @Part("fileName") not supported by RestProxy */String fileName);
 
         @Headers({ "x-ms-logging-context: fixtures.bodyformdata.Formdatas uploadFileViaBody" })
         @PUT("formdata/stream/uploadfile")
         // @Streaming not supported by RestProxy
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<InputStream> uploadFileViaBody(@BodyParam("application/octet-stream") byte[] fileContent);
+        Single<RestResponse<Void, InputStream>> uploadFileViaBody(@BodyParam("application/octet-stream") byte[] fileContent);
 
     }
 
@@ -95,7 +96,7 @@ public class FormdatasImpl implements Formdatas {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<InputStream> uploadFileAsync(byte[] fileContent, String fileName, final ServiceCallback<InputStream> serviceCallback) {
+    public ServiceFuture<InputStream> uploadFileAsync(byte[] fileContent, String fileName, ServiceCallback<InputStream> serviceCallback) {
         return ServiceFuture.fromBody(uploadFileAsync(fileContent, fileName), serviceCallback);
     }
 
@@ -105,9 +106,9 @@ public class FormdatasImpl implements Formdatas {
      * @param fileContent File to upload.
      * @param fileName File name to upload. Name has to be spelled exactly as written here.
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the InputStream object
+     * @return a {@link Single} emitting the RestResponse<Void, InputStream> object
      */
-    public Single<InputStream> uploadFileAsync(byte[] fileContent, String fileName) {
+    public Single<RestResponse<Void, InputStream>> uploadFileWithRestResponseAsync(byte[] fileContent, String fileName) {
         if (fileContent == null) {
             throw new IllegalArgumentException("Parameter fileContent is required and cannot be null.");
         }
@@ -116,6 +117,19 @@ public class FormdatasImpl implements Formdatas {
         }
         return service.uploadFile(fileContent, fileName);
     }
+
+    /**
+     * Upload file.
+     *
+     * @param fileContent File to upload.
+     * @param fileName File name to upload. Name has to be spelled exactly as written here.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, InputStream> object
+     */
+    public Single<InputStream> uploadFileAsync(byte[] fileContent, String fileName) {
+        return uploadFileWithRestResponseAsync(fileContent, fileName)
+            .map(new Func1<RestResponse<Void, InputStream>, InputStream>() { public InputStream call(RestResponse<Void, InputStream> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -139,7 +153,7 @@ public class FormdatasImpl implements Formdatas {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<InputStream> uploadFileViaBodyAsync(byte[] fileContent, final ServiceCallback<InputStream> serviceCallback) {
+    public ServiceFuture<InputStream> uploadFileViaBodyAsync(byte[] fileContent, ServiceCallback<InputStream> serviceCallback) {
         return ServiceFuture.fromBody(uploadFileViaBodyAsync(fileContent), serviceCallback);
     }
 
@@ -148,14 +162,26 @@ public class FormdatasImpl implements Formdatas {
      *
      * @param fileContent File to upload.
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the InputStream object
+     * @return a {@link Single} emitting the RestResponse<Void, InputStream> object
      */
-    public Single<InputStream> uploadFileViaBodyAsync(byte[] fileContent) {
+    public Single<RestResponse<Void, InputStream>> uploadFileViaBodyWithRestResponseAsync(byte[] fileContent) {
         if (fileContent == null) {
             throw new IllegalArgumentException("Parameter fileContent is required and cannot be null.");
         }
         return service.uploadFileViaBody(fileContent);
     }
+
+    /**
+     * Upload file.
+     *
+     * @param fileContent File to upload.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, InputStream> object
+     */
+    public Single<InputStream> uploadFileViaBodyAsync(byte[] fileContent) {
+        return uploadFileViaBodyWithRestResponseAsync(fileContent)
+            .map(new Func1<RestResponse<Void, InputStream>, InputStream>() { public InputStream call(RestResponse<Void, InputStream> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodyinteger/Ints.java
+++ b/test/vanilla/src/main/java/fixtures/bodyinteger/Ints.java
@@ -10,6 +10,7 @@
 
 package fixtures.bodyinteger;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.bodyinteger.models.ErrorException;
@@ -49,6 +50,13 @@ public interface Ints {
      * @return the observable to the int object
      */
     Single<Integer> getNullAsync();
+    /**
+     * Get null Int value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the int object
+     */
+    Single<RestResponse<Void, Integer>> getNullWithRestResponseAsync();
 
 
     /**
@@ -77,6 +85,13 @@ public interface Ints {
      * @return the observable to the int object
      */
     Single<Integer> getInvalidAsync();
+    /**
+     * Get invalid Int value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the int object
+     */
+    Single<RestResponse<Void, Integer>> getInvalidWithRestResponseAsync();
 
 
     /**
@@ -105,6 +120,13 @@ public interface Ints {
      * @return the observable to the int object
      */
     Single<Integer> getOverflowInt32Async();
+    /**
+     * Get overflow Int32 value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the int object
+     */
+    Single<RestResponse<Void, Integer>> getOverflowInt32WithRestResponseAsync();
 
 
     /**
@@ -133,6 +155,13 @@ public interface Ints {
      * @return the observable to the int object
      */
     Single<Integer> getUnderflowInt32Async();
+    /**
+     * Get underflow Int32 value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the int object
+     */
+    Single<RestResponse<Void, Integer>> getUnderflowInt32WithRestResponseAsync();
 
 
     /**
@@ -161,6 +190,13 @@ public interface Ints {
      * @return the observable to the long object
      */
     Single<Long> getOverflowInt64Async();
+    /**
+     * Get overflow Int64 value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the long object
+     */
+    Single<RestResponse<Void, Long>> getOverflowInt64WithRestResponseAsync();
 
 
     /**
@@ -189,6 +225,13 @@ public interface Ints {
      * @return the observable to the long object
      */
     Single<Long> getUnderflowInt64Async();
+    /**
+     * Get underflow Int64 value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the long object
+     */
+    Single<RestResponse<Void, Long>> getUnderflowInt64WithRestResponseAsync();
 
 
     /**
@@ -219,6 +262,14 @@ public interface Ints {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putMax32Async(int intBody);
+    /**
+     * Put max int32 value.
+     *
+     * @param intBody the int value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putMax32WithRestResponseAsync(int intBody);
 
 
     /**
@@ -249,6 +300,14 @@ public interface Ints {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putMax64Async(long intBody);
+    /**
+     * Put max int64 value.
+     *
+     * @param intBody the long value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putMax64WithRestResponseAsync(long intBody);
 
 
     /**
@@ -279,6 +338,14 @@ public interface Ints {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putMin32Async(int intBody);
+    /**
+     * Put min int32 value.
+     *
+     * @param intBody the int value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putMin32WithRestResponseAsync(int intBody);
 
 
     /**
@@ -309,6 +376,14 @@ public interface Ints {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putMin64Async(long intBody);
+    /**
+     * Put min int64 value.
+     *
+     * @param intBody the long value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putMin64WithRestResponseAsync(long intBody);
 
 
     /**
@@ -337,6 +412,13 @@ public interface Ints {
      * @return the observable to the DateTime object
      */
     Single<DateTime> getUnixTimeAsync();
+    /**
+     * Get datetime encoded as Unix time value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the DateTime object
+     */
+    Single<RestResponse<Void, DateTime>> getUnixTimeWithRestResponseAsync();
 
 
     /**
@@ -367,6 +449,14 @@ public interface Ints {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putUnixTimeDateAsync(DateTime intBody);
+    /**
+     * Put datetime encoded as Unix time.
+     *
+     * @param intBody the long value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putUnixTimeDateWithRestResponseAsync(DateTime intBody);
 
 
     /**
@@ -395,6 +485,13 @@ public interface Ints {
      * @return the observable to the DateTime object
      */
     Single<DateTime> getInvalidUnixTimeAsync();
+    /**
+     * Get invalid Unix time value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the DateTime object
+     */
+    Single<RestResponse<Void, DateTime>> getInvalidUnixTimeWithRestResponseAsync();
 
 
     /**
@@ -423,6 +520,13 @@ public interface Ints {
      * @return the observable to the DateTime object
      */
     Single<DateTime> getNullUnixTimeAsync();
+    /**
+     * Get null Unix time value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the DateTime object
+     */
+    Single<RestResponse<Void, DateTime>> getNullUnixTimeWithRestResponseAsync();
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodyinteger/implementation/AutoRestIntegerTestServiceImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodyinteger/implementation/AutoRestIntegerTestServiceImpl.java
@@ -13,6 +13,7 @@ package fixtures.bodyinteger.implementation;
 import fixtures.bodyinteger.AutoRestIntegerTestService;
 import fixtures.bodyinteger.Ints;
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceClient;
 import com.microsoft.rest.RestClient;
 import rx.Single;

--- a/test/vanilla/src/main/java/fixtures/bodyinteger/implementation/IntsImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodyinteger/implementation/IntsImpl.java
@@ -11,6 +11,7 @@
 package fixtures.bodyinteger.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.bodyinteger.Ints;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.BodyParam;
@@ -63,88 +64,88 @@ public class IntsImpl implements Ints {
         @GET("int/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Integer> getNull();
+        Single<RestResponse<Void, Integer>> getNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyinteger.Ints getInvalid" })
         @GET("int/invalid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Integer> getInvalid();
+        Single<RestResponse<Void, Integer>> getInvalid();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyinteger.Ints getOverflowInt32" })
         @GET("int/overflowint32")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Integer> getOverflowInt32();
+        Single<RestResponse<Void, Integer>> getOverflowInt32();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyinteger.Ints getUnderflowInt32" })
         @GET("int/underflowint32")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Integer> getUnderflowInt32();
+        Single<RestResponse<Void, Integer>> getUnderflowInt32();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyinteger.Ints getOverflowInt64" })
         @GET("int/overflowint64")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Long> getOverflowInt64();
+        Single<RestResponse<Void, Long>> getOverflowInt64();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyinteger.Ints getUnderflowInt64" })
         @GET("int/underflowint64")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Long> getUnderflowInt64();
+        Single<RestResponse<Void, Long>> getUnderflowInt64();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyinteger.Ints putMax32" })
         @PUT("int/max/32")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putMax32(@BodyParam("application/json; charset=utf-8") int intBody);
+        Single<RestResponse<Void, Void>> putMax32(@BodyParam("application/json; charset=utf-8") int intBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodyinteger.Ints putMax64" })
         @PUT("int/max/64")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putMax64(@BodyParam("application/json; charset=utf-8") long intBody);
+        Single<RestResponse<Void, Void>> putMax64(@BodyParam("application/json; charset=utf-8") long intBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodyinteger.Ints putMin32" })
         @PUT("int/min/32")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putMin32(@BodyParam("application/json; charset=utf-8") int intBody);
+        Single<RestResponse<Void, Void>> putMin32(@BodyParam("application/json; charset=utf-8") int intBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodyinteger.Ints putMin64" })
         @PUT("int/min/64")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putMin64(@BodyParam("application/json; charset=utf-8") long intBody);
+        Single<RestResponse<Void, Void>> putMin64(@BodyParam("application/json; charset=utf-8") long intBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodyinteger.Ints getUnixTime" })
         @GET("int/unixtime")
         @ExpectedResponses({200})
         @ReturnValueWireType(UnixTime.class)
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<DateTime> getUnixTime();
+        Single<RestResponse<Void, DateTime>> getUnixTime();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyinteger.Ints putUnixTimeDate" })
         @PUT("int/unixtime")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putUnixTimeDate(@BodyParam("application/json; charset=utf-8") long intBody);
+        Single<RestResponse<Void, Void>> putUnixTimeDate(@BodyParam("application/json; charset=utf-8") long intBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodyinteger.Ints getInvalidUnixTime" })
         @GET("int/invalidunixtime")
         @ExpectedResponses({200})
         @ReturnValueWireType(UnixTime.class)
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<DateTime> getInvalidUnixTime();
+        Single<RestResponse<Void, DateTime>> getInvalidUnixTime();
 
         @Headers({ "x-ms-logging-context: fixtures.bodyinteger.Ints getNullUnixTime" })
         @GET("int/nullunixtime")
         @ExpectedResponses({200})
         @ReturnValueWireType(UnixTime.class)
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<DateTime> getNullUnixTime();
+        Single<RestResponse<Void, DateTime>> getNullUnixTime();
 
     }
 
@@ -167,7 +168,7 @@ public class IntsImpl implements Ints {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Integer> getNullAsync(final ServiceCallback<Integer> serviceCallback) {
+    public ServiceFuture<Integer> getNullAsync(ServiceCallback<Integer> serviceCallback) {
         return ServiceFuture.fromBody(getNullAsync(), serviceCallback);
     }
 
@@ -175,11 +176,22 @@ public class IntsImpl implements Ints {
      * Get null Int value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Integer object
+     * @return a {@link Single} emitting the RestResponse<Void, Integer> object
      */
-    public Single<Integer> getNullAsync() {
+    public Single<RestResponse<Void, Integer>> getNullWithRestResponseAsync() {
         return service.getNull();
     }
+
+    /**
+     * Get null Int value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Integer> object
+     */
+    public Single<Integer> getNullAsync() {
+        return getNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Integer>, Integer>() { public Integer call(RestResponse<Void, Integer> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -201,7 +213,7 @@ public class IntsImpl implements Ints {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Integer> getInvalidAsync(final ServiceCallback<Integer> serviceCallback) {
+    public ServiceFuture<Integer> getInvalidAsync(ServiceCallback<Integer> serviceCallback) {
         return ServiceFuture.fromBody(getInvalidAsync(), serviceCallback);
     }
 
@@ -209,11 +221,22 @@ public class IntsImpl implements Ints {
      * Get invalid Int value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Integer object
+     * @return a {@link Single} emitting the RestResponse<Void, Integer> object
      */
-    public Single<Integer> getInvalidAsync() {
+    public Single<RestResponse<Void, Integer>> getInvalidWithRestResponseAsync() {
         return service.getInvalid();
     }
+
+    /**
+     * Get invalid Int value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Integer> object
+     */
+    public Single<Integer> getInvalidAsync() {
+        return getInvalidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Integer>, Integer>() { public Integer call(RestResponse<Void, Integer> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -235,7 +258,7 @@ public class IntsImpl implements Ints {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Integer> getOverflowInt32Async(final ServiceCallback<Integer> serviceCallback) {
+    public ServiceFuture<Integer> getOverflowInt32Async(ServiceCallback<Integer> serviceCallback) {
         return ServiceFuture.fromBody(getOverflowInt32Async(), serviceCallback);
     }
 
@@ -243,11 +266,22 @@ public class IntsImpl implements Ints {
      * Get overflow Int32 value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Integer object
+     * @return a {@link Single} emitting the RestResponse<Void, Integer> object
      */
-    public Single<Integer> getOverflowInt32Async() {
+    public Single<RestResponse<Void, Integer>> getOverflowInt32WithRestResponseAsync() {
         return service.getOverflowInt32();
     }
+
+    /**
+     * Get overflow Int32 value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Integer> object
+     */
+    public Single<Integer> getOverflowInt32Async() {
+        return getOverflowInt32WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Integer>, Integer>() { public Integer call(RestResponse<Void, Integer> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -269,7 +303,7 @@ public class IntsImpl implements Ints {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Integer> getUnderflowInt32Async(final ServiceCallback<Integer> serviceCallback) {
+    public ServiceFuture<Integer> getUnderflowInt32Async(ServiceCallback<Integer> serviceCallback) {
         return ServiceFuture.fromBody(getUnderflowInt32Async(), serviceCallback);
     }
 
@@ -277,11 +311,22 @@ public class IntsImpl implements Ints {
      * Get underflow Int32 value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Integer object
+     * @return a {@link Single} emitting the RestResponse<Void, Integer> object
      */
-    public Single<Integer> getUnderflowInt32Async() {
+    public Single<RestResponse<Void, Integer>> getUnderflowInt32WithRestResponseAsync() {
         return service.getUnderflowInt32();
     }
+
+    /**
+     * Get underflow Int32 value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Integer> object
+     */
+    public Single<Integer> getUnderflowInt32Async() {
+        return getUnderflowInt32WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Integer>, Integer>() { public Integer call(RestResponse<Void, Integer> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -303,7 +348,7 @@ public class IntsImpl implements Ints {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Long> getOverflowInt64Async(final ServiceCallback<Long> serviceCallback) {
+    public ServiceFuture<Long> getOverflowInt64Async(ServiceCallback<Long> serviceCallback) {
         return ServiceFuture.fromBody(getOverflowInt64Async(), serviceCallback);
     }
 
@@ -311,11 +356,22 @@ public class IntsImpl implements Ints {
      * Get overflow Int64 value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Long object
+     * @return a {@link Single} emitting the RestResponse<Void, Long> object
      */
-    public Single<Long> getOverflowInt64Async() {
+    public Single<RestResponse<Void, Long>> getOverflowInt64WithRestResponseAsync() {
         return service.getOverflowInt64();
     }
+
+    /**
+     * Get overflow Int64 value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Long> object
+     */
+    public Single<Long> getOverflowInt64Async() {
+        return getOverflowInt64WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Long>, Long>() { public Long call(RestResponse<Void, Long> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -337,7 +393,7 @@ public class IntsImpl implements Ints {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Long> getUnderflowInt64Async(final ServiceCallback<Long> serviceCallback) {
+    public ServiceFuture<Long> getUnderflowInt64Async(ServiceCallback<Long> serviceCallback) {
         return ServiceFuture.fromBody(getUnderflowInt64Async(), serviceCallback);
     }
 
@@ -345,11 +401,22 @@ public class IntsImpl implements Ints {
      * Get underflow Int64 value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Long object
+     * @return a {@link Single} emitting the RestResponse<Void, Long> object
      */
-    public Single<Long> getUnderflowInt64Async() {
+    public Single<RestResponse<Void, Long>> getUnderflowInt64WithRestResponseAsync() {
         return service.getUnderflowInt64();
     }
+
+    /**
+     * Get underflow Int64 value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Long> object
+     */
+    public Single<Long> getUnderflowInt64Async() {
+        return getUnderflowInt64WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Long>, Long>() { public Long call(RestResponse<Void, Long> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -359,6 +426,7 @@ public class IntsImpl implements Ints {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putMax32(int intBody) {
         putMax32Async(intBody).toBlocking().value();
@@ -372,7 +440,7 @@ public class IntsImpl implements Ints {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putMax32Async(int intBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putMax32Async(int intBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putMax32Async(intBody), serviceCallback);
     }
 
@@ -381,11 +449,23 @@ public class IntsImpl implements Ints {
      *
      * @param intBody the int value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putMax32Async(int intBody) {
+    public Single<RestResponse<Void, Void>> putMax32WithRestResponseAsync(int intBody) {
         return service.putMax32(intBody);
     }
+
+    /**
+     * Put max int32 value.
+     *
+     * @param intBody the int value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putMax32Async(int intBody) {
+        return putMax32WithRestResponseAsync(intBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -395,6 +475,7 @@ public class IntsImpl implements Ints {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putMax64(long intBody) {
         putMax64Async(intBody).toBlocking().value();
@@ -408,7 +489,7 @@ public class IntsImpl implements Ints {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putMax64Async(long intBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putMax64Async(long intBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putMax64Async(intBody), serviceCallback);
     }
 
@@ -417,11 +498,23 @@ public class IntsImpl implements Ints {
      *
      * @param intBody the long value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putMax64Async(long intBody) {
+    public Single<RestResponse<Void, Void>> putMax64WithRestResponseAsync(long intBody) {
         return service.putMax64(intBody);
     }
+
+    /**
+     * Put max int64 value.
+     *
+     * @param intBody the long value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putMax64Async(long intBody) {
+        return putMax64WithRestResponseAsync(intBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -431,6 +524,7 @@ public class IntsImpl implements Ints {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putMin32(int intBody) {
         putMin32Async(intBody).toBlocking().value();
@@ -444,7 +538,7 @@ public class IntsImpl implements Ints {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putMin32Async(int intBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putMin32Async(int intBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putMin32Async(intBody), serviceCallback);
     }
 
@@ -453,11 +547,23 @@ public class IntsImpl implements Ints {
      *
      * @param intBody the int value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putMin32Async(int intBody) {
+    public Single<RestResponse<Void, Void>> putMin32WithRestResponseAsync(int intBody) {
         return service.putMin32(intBody);
     }
+
+    /**
+     * Put min int32 value.
+     *
+     * @param intBody the int value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putMin32Async(int intBody) {
+        return putMin32WithRestResponseAsync(intBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -467,6 +573,7 @@ public class IntsImpl implements Ints {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putMin64(long intBody) {
         putMin64Async(intBody).toBlocking().value();
@@ -480,7 +587,7 @@ public class IntsImpl implements Ints {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putMin64Async(long intBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putMin64Async(long intBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putMin64Async(intBody), serviceCallback);
     }
 
@@ -489,11 +596,23 @@ public class IntsImpl implements Ints {
      *
      * @param intBody the long value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putMin64Async(long intBody) {
+    public Single<RestResponse<Void, Void>> putMin64WithRestResponseAsync(long intBody) {
         return service.putMin64(intBody);
     }
+
+    /**
+     * Put min int64 value.
+     *
+     * @param intBody the long value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putMin64Async(long intBody) {
+        return putMin64WithRestResponseAsync(intBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -515,7 +634,7 @@ public class IntsImpl implements Ints {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<DateTime> getUnixTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
+    public ServiceFuture<DateTime> getUnixTimeAsync(ServiceCallback<DateTime> serviceCallback) {
         return ServiceFuture.fromBody(getUnixTimeAsync(), serviceCallback);
     }
 
@@ -523,11 +642,22 @@ public class IntsImpl implements Ints {
      * Get datetime encoded as Unix time value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the DateTime object
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
      */
-    public Single<DateTime> getUnixTimeAsync() {
+    public Single<RestResponse<Void, DateTime>> getUnixTimeWithRestResponseAsync() {
         return service.getUnixTime();
     }
+
+    /**
+     * Get datetime encoded as Unix time value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
+     */
+    public Single<DateTime> getUnixTimeAsync() {
+        return getUnixTimeWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, DateTime>, DateTime>() { public DateTime call(RestResponse<Void, DateTime> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -537,6 +667,7 @@ public class IntsImpl implements Ints {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putUnixTimeDate(DateTime intBody) {
         putUnixTimeDateAsync(intBody).toBlocking().value();
@@ -550,7 +681,7 @@ public class IntsImpl implements Ints {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putUnixTimeDateAsync(DateTime intBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putUnixTimeDateAsync(DateTime intBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putUnixTimeDateAsync(intBody), serviceCallback);
     }
 
@@ -559,12 +690,24 @@ public class IntsImpl implements Ints {
      *
      * @param intBody the long value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putUnixTimeDateAsync(DateTime intBody) {
-        Long intBodyConverted = intBody.toDateTime(DateTimeZone.UTC).getMillis() / 1000;
+    public Single<RestResponse<Void, Void>> putUnixTimeDateWithRestResponseAsync(DateTime intBody) {
+    Long intBodyConverted = intBody.toDateTime(DateTimeZone.UTC).getMillis() / 1000;
         return service.putUnixTimeDate(intBodyConverted);
     }
+
+    /**
+     * Put datetime encoded as Unix time.
+     *
+     * @param intBody the long value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putUnixTimeDateAsync(DateTime intBody) {
+        return putUnixTimeDateWithRestResponseAsync(intBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -586,7 +729,7 @@ public class IntsImpl implements Ints {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<DateTime> getInvalidUnixTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
+    public ServiceFuture<DateTime> getInvalidUnixTimeAsync(ServiceCallback<DateTime> serviceCallback) {
         return ServiceFuture.fromBody(getInvalidUnixTimeAsync(), serviceCallback);
     }
 
@@ -594,11 +737,22 @@ public class IntsImpl implements Ints {
      * Get invalid Unix time value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the DateTime object
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
      */
-    public Single<DateTime> getInvalidUnixTimeAsync() {
+    public Single<RestResponse<Void, DateTime>> getInvalidUnixTimeWithRestResponseAsync() {
         return service.getInvalidUnixTime();
     }
+
+    /**
+     * Get invalid Unix time value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
+     */
+    public Single<DateTime> getInvalidUnixTimeAsync() {
+        return getInvalidUnixTimeWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, DateTime>, DateTime>() { public DateTime call(RestResponse<Void, DateTime> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -620,7 +774,7 @@ public class IntsImpl implements Ints {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<DateTime> getNullUnixTimeAsync(final ServiceCallback<DateTime> serviceCallback) {
+    public ServiceFuture<DateTime> getNullUnixTimeAsync(ServiceCallback<DateTime> serviceCallback) {
         return ServiceFuture.fromBody(getNullUnixTimeAsync(), serviceCallback);
     }
 
@@ -628,11 +782,22 @@ public class IntsImpl implements Ints {
      * Get null Unix time value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the DateTime object
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
      */
-    public Single<DateTime> getNullUnixTimeAsync() {
+    public Single<RestResponse<Void, DateTime>> getNullUnixTimeWithRestResponseAsync() {
         return service.getNullUnixTime();
     }
+
+    /**
+     * Get null Unix time value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, DateTime> object
+     */
+    public Single<DateTime> getNullUnixTimeAsync() {
+        return getNullUnixTimeWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, DateTime>, DateTime>() { public DateTime call(RestResponse<Void, DateTime> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodynumber/Numbers.java
+++ b/test/vanilla/src/main/java/fixtures/bodynumber/Numbers.java
@@ -10,6 +10,7 @@
 
 package fixtures.bodynumber;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.bodynumber.models.ErrorException;
@@ -49,6 +50,13 @@ public interface Numbers {
      * @return the observable to the double object
      */
     Single<Double> getNullAsync();
+    /**
+     * Get null Number value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the double object
+     */
+    Single<RestResponse<Void, Double>> getNullWithRestResponseAsync();
 
 
     /**
@@ -77,6 +85,13 @@ public interface Numbers {
      * @return the observable to the double object
      */
     Single<Double> getInvalidFloatAsync();
+    /**
+     * Get invalid float Number value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the double object
+     */
+    Single<RestResponse<Void, Double>> getInvalidFloatWithRestResponseAsync();
 
 
     /**
@@ -105,6 +120,13 @@ public interface Numbers {
      * @return the observable to the double object
      */
     Single<Double> getInvalidDoubleAsync();
+    /**
+     * Get invalid double Number value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the double object
+     */
+    Single<RestResponse<Void, Double>> getInvalidDoubleWithRestResponseAsync();
 
 
     /**
@@ -133,6 +155,13 @@ public interface Numbers {
      * @return the observable to the BigDecimal object
      */
     Single<BigDecimal> getInvalidDecimalAsync();
+    /**
+     * Get invalid decimal Number value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the BigDecimal object
+     */
+    Single<RestResponse<Void, BigDecimal>> getInvalidDecimalWithRestResponseAsync();
 
 
     /**
@@ -163,6 +192,14 @@ public interface Numbers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putBigFloatAsync(double numberBody);
+    /**
+     * Put big float value 3.402823e+20.
+     *
+     * @param numberBody the double value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putBigFloatWithRestResponseAsync(double numberBody);
 
 
     /**
@@ -191,6 +228,13 @@ public interface Numbers {
      * @return the observable to the double object
      */
     Single<Double> getBigFloatAsync();
+    /**
+     * Get big float value 3.402823e+20.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the double object
+     */
+    Single<RestResponse<Void, Double>> getBigFloatWithRestResponseAsync();
 
 
     /**
@@ -221,6 +265,14 @@ public interface Numbers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putBigDoubleAsync(double numberBody);
+    /**
+     * Put big double value 2.5976931e+101.
+     *
+     * @param numberBody the double value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putBigDoubleWithRestResponseAsync(double numberBody);
 
 
     /**
@@ -249,6 +301,13 @@ public interface Numbers {
      * @return the observable to the double object
      */
     Single<Double> getBigDoubleAsync();
+    /**
+     * Get big double value 2.5976931e+101.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the double object
+     */
+    Single<RestResponse<Void, Double>> getBigDoubleWithRestResponseAsync();
 
 
     /**
@@ -279,6 +338,14 @@ public interface Numbers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putBigDoublePositiveDecimalAsync(double numberBody);
+    /**
+     * Put big double value 99999999.99.
+     *
+     * @param numberBody the double value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putBigDoublePositiveDecimalWithRestResponseAsync(double numberBody);
 
 
     /**
@@ -307,6 +374,13 @@ public interface Numbers {
      * @return the observable to the double object
      */
     Single<Double> getBigDoublePositiveDecimalAsync();
+    /**
+     * Get big double value 99999999.99.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the double object
+     */
+    Single<RestResponse<Void, Double>> getBigDoublePositiveDecimalWithRestResponseAsync();
 
 
     /**
@@ -337,6 +411,14 @@ public interface Numbers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putBigDoubleNegativeDecimalAsync(double numberBody);
+    /**
+     * Put big double value -99999999.99.
+     *
+     * @param numberBody the double value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putBigDoubleNegativeDecimalWithRestResponseAsync(double numberBody);
 
 
     /**
@@ -365,6 +447,13 @@ public interface Numbers {
      * @return the observable to the double object
      */
     Single<Double> getBigDoubleNegativeDecimalAsync();
+    /**
+     * Get big double value -99999999.99.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the double object
+     */
+    Single<RestResponse<Void, Double>> getBigDoubleNegativeDecimalWithRestResponseAsync();
 
 
     /**
@@ -395,6 +484,14 @@ public interface Numbers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putBigDecimalAsync(BigDecimal numberBody);
+    /**
+     * Put big decimal value 2.5976931e+101.
+     *
+     * @param numberBody the BigDecimal value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putBigDecimalWithRestResponseAsync(BigDecimal numberBody);
 
 
     /**
@@ -423,6 +520,13 @@ public interface Numbers {
      * @return the observable to the BigDecimal object
      */
     Single<BigDecimal> getBigDecimalAsync();
+    /**
+     * Get big decimal value 2.5976931e+101.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the BigDecimal object
+     */
+    Single<RestResponse<Void, BigDecimal>> getBigDecimalWithRestResponseAsync();
 
 
     /**
@@ -453,6 +557,14 @@ public interface Numbers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putBigDecimalPositiveDecimalAsync(BigDecimal numberBody);
+    /**
+     * Put big decimal value 99999999.99.
+     *
+     * @param numberBody the BigDecimal value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putBigDecimalPositiveDecimalWithRestResponseAsync(BigDecimal numberBody);
 
 
     /**
@@ -481,6 +593,13 @@ public interface Numbers {
      * @return the observable to the BigDecimal object
      */
     Single<BigDecimal> getBigDecimalPositiveDecimalAsync();
+    /**
+     * Get big decimal value 99999999.99.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the BigDecimal object
+     */
+    Single<RestResponse<Void, BigDecimal>> getBigDecimalPositiveDecimalWithRestResponseAsync();
 
 
     /**
@@ -511,6 +630,14 @@ public interface Numbers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putBigDecimalNegativeDecimalAsync(BigDecimal numberBody);
+    /**
+     * Put big decimal value -99999999.99.
+     *
+     * @param numberBody the BigDecimal value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putBigDecimalNegativeDecimalWithRestResponseAsync(BigDecimal numberBody);
 
 
     /**
@@ -539,6 +666,13 @@ public interface Numbers {
      * @return the observable to the BigDecimal object
      */
     Single<BigDecimal> getBigDecimalNegativeDecimalAsync();
+    /**
+     * Get big decimal value -99999999.99.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the BigDecimal object
+     */
+    Single<RestResponse<Void, BigDecimal>> getBigDecimalNegativeDecimalWithRestResponseAsync();
 
 
     /**
@@ -569,6 +703,14 @@ public interface Numbers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putSmallFloatAsync(double numberBody);
+    /**
+     * Put small float value 3.402823e-20.
+     *
+     * @param numberBody the double value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putSmallFloatWithRestResponseAsync(double numberBody);
 
 
     /**
@@ -597,6 +739,13 @@ public interface Numbers {
      * @return the observable to the double object
      */
     Single<Double> getSmallFloatAsync();
+    /**
+     * Get big double value 3.402823e-20.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the double object
+     */
+    Single<RestResponse<Void, Double>> getSmallFloatWithRestResponseAsync();
 
 
     /**
@@ -627,6 +776,14 @@ public interface Numbers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putSmallDoubleAsync(double numberBody);
+    /**
+     * Put small double value 2.5976931e-101.
+     *
+     * @param numberBody the double value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putSmallDoubleWithRestResponseAsync(double numberBody);
 
 
     /**
@@ -655,6 +812,13 @@ public interface Numbers {
      * @return the observable to the double object
      */
     Single<Double> getSmallDoubleAsync();
+    /**
+     * Get big double value 2.5976931e-101.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the double object
+     */
+    Single<RestResponse<Void, Double>> getSmallDoubleWithRestResponseAsync();
 
 
     /**
@@ -685,6 +849,14 @@ public interface Numbers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putSmallDecimalAsync(BigDecimal numberBody);
+    /**
+     * Put small decimal value 2.5976931e-101.
+     *
+     * @param numberBody the BigDecimal value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putSmallDecimalWithRestResponseAsync(BigDecimal numberBody);
 
 
     /**
@@ -713,6 +885,13 @@ public interface Numbers {
      * @return the observable to the BigDecimal object
      */
     Single<BigDecimal> getSmallDecimalAsync();
+    /**
+     * Get small decimal value 2.5976931e-101.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the BigDecimal object
+     */
+    Single<RestResponse<Void, BigDecimal>> getSmallDecimalWithRestResponseAsync();
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodynumber/implementation/AutoRestNumberTestServiceImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodynumber/implementation/AutoRestNumberTestServiceImpl.java
@@ -13,6 +13,7 @@ package fixtures.bodynumber.implementation;
 import fixtures.bodynumber.AutoRestNumberTestService;
 import fixtures.bodynumber.Numbers;
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceClient;
 import com.microsoft.rest.RestClient;
 import rx.Single;

--- a/test/vanilla/src/main/java/fixtures/bodynumber/implementation/NumbersImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodynumber/implementation/NumbersImpl.java
@@ -11,6 +11,7 @@
 package fixtures.bodynumber.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.bodynumber.Numbers;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.BodyParam;
@@ -60,145 +61,145 @@ public class NumbersImpl implements Numbers {
         @GET("number/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Double> getNull();
+        Single<RestResponse<Void, Double>> getNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodynumber.Numbers getInvalidFloat" })
         @GET("number/invalidfloat")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Double> getInvalidFloat();
+        Single<RestResponse<Void, Double>> getInvalidFloat();
 
         @Headers({ "x-ms-logging-context: fixtures.bodynumber.Numbers getInvalidDouble" })
         @GET("number/invaliddouble")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Double> getInvalidDouble();
+        Single<RestResponse<Void, Double>> getInvalidDouble();
 
         @Headers({ "x-ms-logging-context: fixtures.bodynumber.Numbers getInvalidDecimal" })
         @GET("number/invaliddecimal")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<BigDecimal> getInvalidDecimal();
+        Single<RestResponse<Void, BigDecimal>> getInvalidDecimal();
 
         @Headers({ "x-ms-logging-context: fixtures.bodynumber.Numbers putBigFloat" })
         @PUT("number/big/float/3.402823e+20")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putBigFloat(@BodyParam("application/json; charset=utf-8") double numberBody);
+        Single<RestResponse<Void, Void>> putBigFloat(@BodyParam("application/json; charset=utf-8") double numberBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodynumber.Numbers getBigFloat" })
         @GET("number/big/float/3.402823e+20")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Double> getBigFloat();
+        Single<RestResponse<Void, Double>> getBigFloat();
 
         @Headers({ "x-ms-logging-context: fixtures.bodynumber.Numbers putBigDouble" })
         @PUT("number/big/double/2.5976931e+101")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putBigDouble(@BodyParam("application/json; charset=utf-8") double numberBody);
+        Single<RestResponse<Void, Void>> putBigDouble(@BodyParam("application/json; charset=utf-8") double numberBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodynumber.Numbers getBigDouble" })
         @GET("number/big/double/2.5976931e+101")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Double> getBigDouble();
+        Single<RestResponse<Void, Double>> getBigDouble();
 
         @Headers({ "x-ms-logging-context: fixtures.bodynumber.Numbers putBigDoublePositiveDecimal" })
         @PUT("number/big/double/99999999.99")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putBigDoublePositiveDecimal(@BodyParam("application/json; charset=utf-8") double numberBody);
+        Single<RestResponse<Void, Void>> putBigDoublePositiveDecimal(@BodyParam("application/json; charset=utf-8") double numberBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodynumber.Numbers getBigDoublePositiveDecimal" })
         @GET("number/big/double/99999999.99")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Double> getBigDoublePositiveDecimal();
+        Single<RestResponse<Void, Double>> getBigDoublePositiveDecimal();
 
         @Headers({ "x-ms-logging-context: fixtures.bodynumber.Numbers putBigDoubleNegativeDecimal" })
         @PUT("number/big/double/-99999999.99")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putBigDoubleNegativeDecimal(@BodyParam("application/json; charset=utf-8") double numberBody);
+        Single<RestResponse<Void, Void>> putBigDoubleNegativeDecimal(@BodyParam("application/json; charset=utf-8") double numberBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodynumber.Numbers getBigDoubleNegativeDecimal" })
         @GET("number/big/double/-99999999.99")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Double> getBigDoubleNegativeDecimal();
+        Single<RestResponse<Void, Double>> getBigDoubleNegativeDecimal();
 
         @Headers({ "x-ms-logging-context: fixtures.bodynumber.Numbers putBigDecimal" })
         @PUT("number/big/decimal/2.5976931e+101")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putBigDecimal(@BodyParam("application/json; charset=utf-8") BigDecimal numberBody);
+        Single<RestResponse<Void, Void>> putBigDecimal(@BodyParam("application/json; charset=utf-8") BigDecimal numberBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodynumber.Numbers getBigDecimal" })
         @GET("number/big/decimal/2.5976931e+101")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<BigDecimal> getBigDecimal();
+        Single<RestResponse<Void, BigDecimal>> getBigDecimal();
 
         @Headers({ "x-ms-logging-context: fixtures.bodynumber.Numbers putBigDecimalPositiveDecimal" })
         @PUT("number/big/decimal/99999999.99")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putBigDecimalPositiveDecimal(@BodyParam("application/json; charset=utf-8") BigDecimal numberBody);
+        Single<RestResponse<Void, Void>> putBigDecimalPositiveDecimal(@BodyParam("application/json; charset=utf-8") BigDecimal numberBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodynumber.Numbers getBigDecimalPositiveDecimal" })
         @GET("number/big/decimal/99999999.99")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<BigDecimal> getBigDecimalPositiveDecimal();
+        Single<RestResponse<Void, BigDecimal>> getBigDecimalPositiveDecimal();
 
         @Headers({ "x-ms-logging-context: fixtures.bodynumber.Numbers putBigDecimalNegativeDecimal" })
         @PUT("number/big/decimal/-99999999.99")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putBigDecimalNegativeDecimal(@BodyParam("application/json; charset=utf-8") BigDecimal numberBody);
+        Single<RestResponse<Void, Void>> putBigDecimalNegativeDecimal(@BodyParam("application/json; charset=utf-8") BigDecimal numberBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodynumber.Numbers getBigDecimalNegativeDecimal" })
         @GET("number/big/decimal/-99999999.99")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<BigDecimal> getBigDecimalNegativeDecimal();
+        Single<RestResponse<Void, BigDecimal>> getBigDecimalNegativeDecimal();
 
         @Headers({ "x-ms-logging-context: fixtures.bodynumber.Numbers putSmallFloat" })
         @PUT("number/small/float/3.402823e-20")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putSmallFloat(@BodyParam("application/json; charset=utf-8") double numberBody);
+        Single<RestResponse<Void, Void>> putSmallFloat(@BodyParam("application/json; charset=utf-8") double numberBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodynumber.Numbers getSmallFloat" })
         @GET("number/small/float/3.402823e-20")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Double> getSmallFloat();
+        Single<RestResponse<Void, Double>> getSmallFloat();
 
         @Headers({ "x-ms-logging-context: fixtures.bodynumber.Numbers putSmallDouble" })
         @PUT("number/small/double/2.5976931e-101")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putSmallDouble(@BodyParam("application/json; charset=utf-8") double numberBody);
+        Single<RestResponse<Void, Void>> putSmallDouble(@BodyParam("application/json; charset=utf-8") double numberBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodynumber.Numbers getSmallDouble" })
         @GET("number/small/double/2.5976931e-101")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Double> getSmallDouble();
+        Single<RestResponse<Void, Double>> getSmallDouble();
 
         @Headers({ "x-ms-logging-context: fixtures.bodynumber.Numbers putSmallDecimal" })
         @PUT("number/small/decimal/2.5976931e-101")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putSmallDecimal(@BodyParam("application/json; charset=utf-8") BigDecimal numberBody);
+        Single<RestResponse<Void, Void>> putSmallDecimal(@BodyParam("application/json; charset=utf-8") BigDecimal numberBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodynumber.Numbers getSmallDecimal" })
         @GET("number/small/decimal/2.5976931e-101")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<BigDecimal> getSmallDecimal();
+        Single<RestResponse<Void, BigDecimal>> getSmallDecimal();
 
     }
 
@@ -221,7 +222,7 @@ public class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Double> getNullAsync(final ServiceCallback<Double> serviceCallback) {
+    public ServiceFuture<Double> getNullAsync(ServiceCallback<Double> serviceCallback) {
         return ServiceFuture.fromBody(getNullAsync(), serviceCallback);
     }
 
@@ -229,11 +230,22 @@ public class NumbersImpl implements Numbers {
      * Get null Number value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Double object
+     * @return a {@link Single} emitting the RestResponse<Void, Double> object
      */
-    public Single<Double> getNullAsync() {
+    public Single<RestResponse<Void, Double>> getNullWithRestResponseAsync() {
         return service.getNull();
     }
+
+    /**
+     * Get null Number value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Double> object
+     */
+    public Single<Double> getNullAsync() {
+        return getNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Double>, Double>() { public Double call(RestResponse<Void, Double> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -255,7 +267,7 @@ public class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Double> getInvalidFloatAsync(final ServiceCallback<Double> serviceCallback) {
+    public ServiceFuture<Double> getInvalidFloatAsync(ServiceCallback<Double> serviceCallback) {
         return ServiceFuture.fromBody(getInvalidFloatAsync(), serviceCallback);
     }
 
@@ -263,11 +275,22 @@ public class NumbersImpl implements Numbers {
      * Get invalid float Number value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Double object
+     * @return a {@link Single} emitting the RestResponse<Void, Double> object
      */
-    public Single<Double> getInvalidFloatAsync() {
+    public Single<RestResponse<Void, Double>> getInvalidFloatWithRestResponseAsync() {
         return service.getInvalidFloat();
     }
+
+    /**
+     * Get invalid float Number value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Double> object
+     */
+    public Single<Double> getInvalidFloatAsync() {
+        return getInvalidFloatWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Double>, Double>() { public Double call(RestResponse<Void, Double> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -289,7 +312,7 @@ public class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Double> getInvalidDoubleAsync(final ServiceCallback<Double> serviceCallback) {
+    public ServiceFuture<Double> getInvalidDoubleAsync(ServiceCallback<Double> serviceCallback) {
         return ServiceFuture.fromBody(getInvalidDoubleAsync(), serviceCallback);
     }
 
@@ -297,11 +320,22 @@ public class NumbersImpl implements Numbers {
      * Get invalid double Number value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Double object
+     * @return a {@link Single} emitting the RestResponse<Void, Double> object
      */
-    public Single<Double> getInvalidDoubleAsync() {
+    public Single<RestResponse<Void, Double>> getInvalidDoubleWithRestResponseAsync() {
         return service.getInvalidDouble();
     }
+
+    /**
+     * Get invalid double Number value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Double> object
+     */
+    public Single<Double> getInvalidDoubleAsync() {
+        return getInvalidDoubleWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Double>, Double>() { public Double call(RestResponse<Void, Double> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -323,7 +357,7 @@ public class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<BigDecimal> getInvalidDecimalAsync(final ServiceCallback<BigDecimal> serviceCallback) {
+    public ServiceFuture<BigDecimal> getInvalidDecimalAsync(ServiceCallback<BigDecimal> serviceCallback) {
         return ServiceFuture.fromBody(getInvalidDecimalAsync(), serviceCallback);
     }
 
@@ -331,11 +365,22 @@ public class NumbersImpl implements Numbers {
      * Get invalid decimal Number value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the BigDecimal object
+     * @return a {@link Single} emitting the RestResponse<Void, BigDecimal> object
      */
-    public Single<BigDecimal> getInvalidDecimalAsync() {
+    public Single<RestResponse<Void, BigDecimal>> getInvalidDecimalWithRestResponseAsync() {
         return service.getInvalidDecimal();
     }
+
+    /**
+     * Get invalid decimal Number value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, BigDecimal> object
+     */
+    public Single<BigDecimal> getInvalidDecimalAsync() {
+        return getInvalidDecimalWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, BigDecimal>, BigDecimal>() { public BigDecimal call(RestResponse<Void, BigDecimal> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -345,6 +390,7 @@ public class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putBigFloat(double numberBody) {
         putBigFloatAsync(numberBody).toBlocking().value();
@@ -358,7 +404,7 @@ public class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putBigFloatAsync(double numberBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putBigFloatAsync(double numberBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putBigFloatAsync(numberBody), serviceCallback);
     }
 
@@ -367,11 +413,23 @@ public class NumbersImpl implements Numbers {
      *
      * @param numberBody the double value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putBigFloatAsync(double numberBody) {
+    public Single<RestResponse<Void, Void>> putBigFloatWithRestResponseAsync(double numberBody) {
         return service.putBigFloat(numberBody);
     }
+
+    /**
+     * Put big float value 3.402823e+20.
+     *
+     * @param numberBody the double value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putBigFloatAsync(double numberBody) {
+        return putBigFloatWithRestResponseAsync(numberBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -393,7 +451,7 @@ public class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Double> getBigFloatAsync(final ServiceCallback<Double> serviceCallback) {
+    public ServiceFuture<Double> getBigFloatAsync(ServiceCallback<Double> serviceCallback) {
         return ServiceFuture.fromBody(getBigFloatAsync(), serviceCallback);
     }
 
@@ -401,11 +459,22 @@ public class NumbersImpl implements Numbers {
      * Get big float value 3.402823e+20.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Double object
+     * @return a {@link Single} emitting the RestResponse<Void, Double> object
      */
-    public Single<Double> getBigFloatAsync() {
+    public Single<RestResponse<Void, Double>> getBigFloatWithRestResponseAsync() {
         return service.getBigFloat();
     }
+
+    /**
+     * Get big float value 3.402823e+20.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Double> object
+     */
+    public Single<Double> getBigFloatAsync() {
+        return getBigFloatWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Double>, Double>() { public Double call(RestResponse<Void, Double> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -415,6 +484,7 @@ public class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putBigDouble(double numberBody) {
         putBigDoubleAsync(numberBody).toBlocking().value();
@@ -428,7 +498,7 @@ public class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putBigDoubleAsync(double numberBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putBigDoubleAsync(double numberBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putBigDoubleAsync(numberBody), serviceCallback);
     }
 
@@ -437,11 +507,23 @@ public class NumbersImpl implements Numbers {
      *
      * @param numberBody the double value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putBigDoubleAsync(double numberBody) {
+    public Single<RestResponse<Void, Void>> putBigDoubleWithRestResponseAsync(double numberBody) {
         return service.putBigDouble(numberBody);
     }
+
+    /**
+     * Put big double value 2.5976931e+101.
+     *
+     * @param numberBody the double value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putBigDoubleAsync(double numberBody) {
+        return putBigDoubleWithRestResponseAsync(numberBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -463,7 +545,7 @@ public class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Double> getBigDoubleAsync(final ServiceCallback<Double> serviceCallback) {
+    public ServiceFuture<Double> getBigDoubleAsync(ServiceCallback<Double> serviceCallback) {
         return ServiceFuture.fromBody(getBigDoubleAsync(), serviceCallback);
     }
 
@@ -471,11 +553,22 @@ public class NumbersImpl implements Numbers {
      * Get big double value 2.5976931e+101.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Double object
+     * @return a {@link Single} emitting the RestResponse<Void, Double> object
      */
-    public Single<Double> getBigDoubleAsync() {
+    public Single<RestResponse<Void, Double>> getBigDoubleWithRestResponseAsync() {
         return service.getBigDouble();
     }
+
+    /**
+     * Get big double value 2.5976931e+101.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Double> object
+     */
+    public Single<Double> getBigDoubleAsync() {
+        return getBigDoubleWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Double>, Double>() { public Double call(RestResponse<Void, Double> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -485,6 +578,7 @@ public class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putBigDoublePositiveDecimal(double numberBody) {
         putBigDoublePositiveDecimalAsync(numberBody).toBlocking().value();
@@ -498,7 +592,7 @@ public class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putBigDoublePositiveDecimalAsync(double numberBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putBigDoublePositiveDecimalAsync(double numberBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putBigDoublePositiveDecimalAsync(numberBody), serviceCallback);
     }
 
@@ -507,11 +601,23 @@ public class NumbersImpl implements Numbers {
      *
      * @param numberBody the double value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putBigDoublePositiveDecimalAsync(double numberBody) {
+    public Single<RestResponse<Void, Void>> putBigDoublePositiveDecimalWithRestResponseAsync(double numberBody) {
         return service.putBigDoublePositiveDecimal(numberBody);
     }
+
+    /**
+     * Put big double value 99999999.99.
+     *
+     * @param numberBody the double value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putBigDoublePositiveDecimalAsync(double numberBody) {
+        return putBigDoublePositiveDecimalWithRestResponseAsync(numberBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -533,7 +639,7 @@ public class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Double> getBigDoublePositiveDecimalAsync(final ServiceCallback<Double> serviceCallback) {
+    public ServiceFuture<Double> getBigDoublePositiveDecimalAsync(ServiceCallback<Double> serviceCallback) {
         return ServiceFuture.fromBody(getBigDoublePositiveDecimalAsync(), serviceCallback);
     }
 
@@ -541,11 +647,22 @@ public class NumbersImpl implements Numbers {
      * Get big double value 99999999.99.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Double object
+     * @return a {@link Single} emitting the RestResponse<Void, Double> object
      */
-    public Single<Double> getBigDoublePositiveDecimalAsync() {
+    public Single<RestResponse<Void, Double>> getBigDoublePositiveDecimalWithRestResponseAsync() {
         return service.getBigDoublePositiveDecimal();
     }
+
+    /**
+     * Get big double value 99999999.99.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Double> object
+     */
+    public Single<Double> getBigDoublePositiveDecimalAsync() {
+        return getBigDoublePositiveDecimalWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Double>, Double>() { public Double call(RestResponse<Void, Double> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -555,6 +672,7 @@ public class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putBigDoubleNegativeDecimal(double numberBody) {
         putBigDoubleNegativeDecimalAsync(numberBody).toBlocking().value();
@@ -568,7 +686,7 @@ public class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putBigDoubleNegativeDecimalAsync(double numberBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putBigDoubleNegativeDecimalAsync(double numberBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putBigDoubleNegativeDecimalAsync(numberBody), serviceCallback);
     }
 
@@ -577,11 +695,23 @@ public class NumbersImpl implements Numbers {
      *
      * @param numberBody the double value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putBigDoubleNegativeDecimalAsync(double numberBody) {
+    public Single<RestResponse<Void, Void>> putBigDoubleNegativeDecimalWithRestResponseAsync(double numberBody) {
         return service.putBigDoubleNegativeDecimal(numberBody);
     }
+
+    /**
+     * Put big double value -99999999.99.
+     *
+     * @param numberBody the double value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putBigDoubleNegativeDecimalAsync(double numberBody) {
+        return putBigDoubleNegativeDecimalWithRestResponseAsync(numberBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -603,7 +733,7 @@ public class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Double> getBigDoubleNegativeDecimalAsync(final ServiceCallback<Double> serviceCallback) {
+    public ServiceFuture<Double> getBigDoubleNegativeDecimalAsync(ServiceCallback<Double> serviceCallback) {
         return ServiceFuture.fromBody(getBigDoubleNegativeDecimalAsync(), serviceCallback);
     }
 
@@ -611,11 +741,22 @@ public class NumbersImpl implements Numbers {
      * Get big double value -99999999.99.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Double object
+     * @return a {@link Single} emitting the RestResponse<Void, Double> object
      */
-    public Single<Double> getBigDoubleNegativeDecimalAsync() {
+    public Single<RestResponse<Void, Double>> getBigDoubleNegativeDecimalWithRestResponseAsync() {
         return service.getBigDoubleNegativeDecimal();
     }
+
+    /**
+     * Get big double value -99999999.99.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Double> object
+     */
+    public Single<Double> getBigDoubleNegativeDecimalAsync() {
+        return getBigDoubleNegativeDecimalWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Double>, Double>() { public Double call(RestResponse<Void, Double> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -625,6 +766,7 @@ public class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putBigDecimal(BigDecimal numberBody) {
         putBigDecimalAsync(numberBody).toBlocking().value();
@@ -638,7 +780,7 @@ public class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putBigDecimalAsync(BigDecimal numberBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putBigDecimalAsync(BigDecimal numberBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putBigDecimalAsync(numberBody), serviceCallback);
     }
 
@@ -647,14 +789,26 @@ public class NumbersImpl implements Numbers {
      *
      * @param numberBody the BigDecimal value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putBigDecimalAsync(BigDecimal numberBody) {
+    public Single<RestResponse<Void, Void>> putBigDecimalWithRestResponseAsync(BigDecimal numberBody) {
         if (numberBody == null) {
             throw new IllegalArgumentException("Parameter numberBody is required and cannot be null.");
         }
         return service.putBigDecimal(numberBody);
     }
+
+    /**
+     * Put big decimal value 2.5976931e+101.
+     *
+     * @param numberBody the BigDecimal value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putBigDecimalAsync(BigDecimal numberBody) {
+        return putBigDecimalWithRestResponseAsync(numberBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -676,7 +830,7 @@ public class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<BigDecimal> getBigDecimalAsync(final ServiceCallback<BigDecimal> serviceCallback) {
+    public ServiceFuture<BigDecimal> getBigDecimalAsync(ServiceCallback<BigDecimal> serviceCallback) {
         return ServiceFuture.fromBody(getBigDecimalAsync(), serviceCallback);
     }
 
@@ -684,11 +838,22 @@ public class NumbersImpl implements Numbers {
      * Get big decimal value 2.5976931e+101.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the BigDecimal object
+     * @return a {@link Single} emitting the RestResponse<Void, BigDecimal> object
      */
-    public Single<BigDecimal> getBigDecimalAsync() {
+    public Single<RestResponse<Void, BigDecimal>> getBigDecimalWithRestResponseAsync() {
         return service.getBigDecimal();
     }
+
+    /**
+     * Get big decimal value 2.5976931e+101.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, BigDecimal> object
+     */
+    public Single<BigDecimal> getBigDecimalAsync() {
+        return getBigDecimalWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, BigDecimal>, BigDecimal>() { public BigDecimal call(RestResponse<Void, BigDecimal> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -698,6 +863,7 @@ public class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putBigDecimalPositiveDecimal(BigDecimal numberBody) {
         putBigDecimalPositiveDecimalAsync(numberBody).toBlocking().value();
@@ -711,7 +877,7 @@ public class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putBigDecimalPositiveDecimalAsync(BigDecimal numberBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putBigDecimalPositiveDecimalAsync(BigDecimal numberBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putBigDecimalPositiveDecimalAsync(numberBody), serviceCallback);
     }
 
@@ -720,14 +886,26 @@ public class NumbersImpl implements Numbers {
      *
      * @param numberBody the BigDecimal value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putBigDecimalPositiveDecimalAsync(BigDecimal numberBody) {
+    public Single<RestResponse<Void, Void>> putBigDecimalPositiveDecimalWithRestResponseAsync(BigDecimal numberBody) {
         if (numberBody == null) {
             throw new IllegalArgumentException("Parameter numberBody is required and cannot be null.");
         }
         return service.putBigDecimalPositiveDecimal(numberBody);
     }
+
+    /**
+     * Put big decimal value 99999999.99.
+     *
+     * @param numberBody the BigDecimal value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putBigDecimalPositiveDecimalAsync(BigDecimal numberBody) {
+        return putBigDecimalPositiveDecimalWithRestResponseAsync(numberBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -749,7 +927,7 @@ public class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<BigDecimal> getBigDecimalPositiveDecimalAsync(final ServiceCallback<BigDecimal> serviceCallback) {
+    public ServiceFuture<BigDecimal> getBigDecimalPositiveDecimalAsync(ServiceCallback<BigDecimal> serviceCallback) {
         return ServiceFuture.fromBody(getBigDecimalPositiveDecimalAsync(), serviceCallback);
     }
 
@@ -757,11 +935,22 @@ public class NumbersImpl implements Numbers {
      * Get big decimal value 99999999.99.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the BigDecimal object
+     * @return a {@link Single} emitting the RestResponse<Void, BigDecimal> object
      */
-    public Single<BigDecimal> getBigDecimalPositiveDecimalAsync() {
+    public Single<RestResponse<Void, BigDecimal>> getBigDecimalPositiveDecimalWithRestResponseAsync() {
         return service.getBigDecimalPositiveDecimal();
     }
+
+    /**
+     * Get big decimal value 99999999.99.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, BigDecimal> object
+     */
+    public Single<BigDecimal> getBigDecimalPositiveDecimalAsync() {
+        return getBigDecimalPositiveDecimalWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, BigDecimal>, BigDecimal>() { public BigDecimal call(RestResponse<Void, BigDecimal> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -771,6 +960,7 @@ public class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putBigDecimalNegativeDecimal(BigDecimal numberBody) {
         putBigDecimalNegativeDecimalAsync(numberBody).toBlocking().value();
@@ -784,7 +974,7 @@ public class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putBigDecimalNegativeDecimalAsync(BigDecimal numberBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putBigDecimalNegativeDecimalAsync(BigDecimal numberBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putBigDecimalNegativeDecimalAsync(numberBody), serviceCallback);
     }
 
@@ -793,14 +983,26 @@ public class NumbersImpl implements Numbers {
      *
      * @param numberBody the BigDecimal value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putBigDecimalNegativeDecimalAsync(BigDecimal numberBody) {
+    public Single<RestResponse<Void, Void>> putBigDecimalNegativeDecimalWithRestResponseAsync(BigDecimal numberBody) {
         if (numberBody == null) {
             throw new IllegalArgumentException("Parameter numberBody is required and cannot be null.");
         }
         return service.putBigDecimalNegativeDecimal(numberBody);
     }
+
+    /**
+     * Put big decimal value -99999999.99.
+     *
+     * @param numberBody the BigDecimal value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putBigDecimalNegativeDecimalAsync(BigDecimal numberBody) {
+        return putBigDecimalNegativeDecimalWithRestResponseAsync(numberBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -822,7 +1024,7 @@ public class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<BigDecimal> getBigDecimalNegativeDecimalAsync(final ServiceCallback<BigDecimal> serviceCallback) {
+    public ServiceFuture<BigDecimal> getBigDecimalNegativeDecimalAsync(ServiceCallback<BigDecimal> serviceCallback) {
         return ServiceFuture.fromBody(getBigDecimalNegativeDecimalAsync(), serviceCallback);
     }
 
@@ -830,11 +1032,22 @@ public class NumbersImpl implements Numbers {
      * Get big decimal value -99999999.99.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the BigDecimal object
+     * @return a {@link Single} emitting the RestResponse<Void, BigDecimal> object
      */
-    public Single<BigDecimal> getBigDecimalNegativeDecimalAsync() {
+    public Single<RestResponse<Void, BigDecimal>> getBigDecimalNegativeDecimalWithRestResponseAsync() {
         return service.getBigDecimalNegativeDecimal();
     }
+
+    /**
+     * Get big decimal value -99999999.99.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, BigDecimal> object
+     */
+    public Single<BigDecimal> getBigDecimalNegativeDecimalAsync() {
+        return getBigDecimalNegativeDecimalWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, BigDecimal>, BigDecimal>() { public BigDecimal call(RestResponse<Void, BigDecimal> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -844,6 +1057,7 @@ public class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putSmallFloat(double numberBody) {
         putSmallFloatAsync(numberBody).toBlocking().value();
@@ -857,7 +1071,7 @@ public class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putSmallFloatAsync(double numberBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putSmallFloatAsync(double numberBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putSmallFloatAsync(numberBody), serviceCallback);
     }
 
@@ -866,11 +1080,23 @@ public class NumbersImpl implements Numbers {
      *
      * @param numberBody the double value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putSmallFloatAsync(double numberBody) {
+    public Single<RestResponse<Void, Void>> putSmallFloatWithRestResponseAsync(double numberBody) {
         return service.putSmallFloat(numberBody);
     }
+
+    /**
+     * Put small float value 3.402823e-20.
+     *
+     * @param numberBody the double value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putSmallFloatAsync(double numberBody) {
+        return putSmallFloatWithRestResponseAsync(numberBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -892,7 +1118,7 @@ public class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Double> getSmallFloatAsync(final ServiceCallback<Double> serviceCallback) {
+    public ServiceFuture<Double> getSmallFloatAsync(ServiceCallback<Double> serviceCallback) {
         return ServiceFuture.fromBody(getSmallFloatAsync(), serviceCallback);
     }
 
@@ -900,11 +1126,22 @@ public class NumbersImpl implements Numbers {
      * Get big double value 3.402823e-20.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Double object
+     * @return a {@link Single} emitting the RestResponse<Void, Double> object
      */
-    public Single<Double> getSmallFloatAsync() {
+    public Single<RestResponse<Void, Double>> getSmallFloatWithRestResponseAsync() {
         return service.getSmallFloat();
     }
+
+    /**
+     * Get big double value 3.402823e-20.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Double> object
+     */
+    public Single<Double> getSmallFloatAsync() {
+        return getSmallFloatWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Double>, Double>() { public Double call(RestResponse<Void, Double> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -914,6 +1151,7 @@ public class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putSmallDouble(double numberBody) {
         putSmallDoubleAsync(numberBody).toBlocking().value();
@@ -927,7 +1165,7 @@ public class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putSmallDoubleAsync(double numberBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putSmallDoubleAsync(double numberBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putSmallDoubleAsync(numberBody), serviceCallback);
     }
 
@@ -936,11 +1174,23 @@ public class NumbersImpl implements Numbers {
      *
      * @param numberBody the double value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putSmallDoubleAsync(double numberBody) {
+    public Single<RestResponse<Void, Void>> putSmallDoubleWithRestResponseAsync(double numberBody) {
         return service.putSmallDouble(numberBody);
     }
+
+    /**
+     * Put small double value 2.5976931e-101.
+     *
+     * @param numberBody the double value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putSmallDoubleAsync(double numberBody) {
+        return putSmallDoubleWithRestResponseAsync(numberBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -962,7 +1212,7 @@ public class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Double> getSmallDoubleAsync(final ServiceCallback<Double> serviceCallback) {
+    public ServiceFuture<Double> getSmallDoubleAsync(ServiceCallback<Double> serviceCallback) {
         return ServiceFuture.fromBody(getSmallDoubleAsync(), serviceCallback);
     }
 
@@ -970,11 +1220,22 @@ public class NumbersImpl implements Numbers {
      * Get big double value 2.5976931e-101.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Double object
+     * @return a {@link Single} emitting the RestResponse<Void, Double> object
      */
-    public Single<Double> getSmallDoubleAsync() {
+    public Single<RestResponse<Void, Double>> getSmallDoubleWithRestResponseAsync() {
         return service.getSmallDouble();
     }
+
+    /**
+     * Get big double value 2.5976931e-101.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Double> object
+     */
+    public Single<Double> getSmallDoubleAsync() {
+        return getSmallDoubleWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Double>, Double>() { public Double call(RestResponse<Void, Double> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -984,6 +1245,7 @@ public class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putSmallDecimal(BigDecimal numberBody) {
         putSmallDecimalAsync(numberBody).toBlocking().value();
@@ -997,7 +1259,7 @@ public class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putSmallDecimalAsync(BigDecimal numberBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putSmallDecimalAsync(BigDecimal numberBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putSmallDecimalAsync(numberBody), serviceCallback);
     }
 
@@ -1006,14 +1268,26 @@ public class NumbersImpl implements Numbers {
      *
      * @param numberBody the BigDecimal value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putSmallDecimalAsync(BigDecimal numberBody) {
+    public Single<RestResponse<Void, Void>> putSmallDecimalWithRestResponseAsync(BigDecimal numberBody) {
         if (numberBody == null) {
             throw new IllegalArgumentException("Parameter numberBody is required and cannot be null.");
         }
         return service.putSmallDecimal(numberBody);
     }
+
+    /**
+     * Put small decimal value 2.5976931e-101.
+     *
+     * @param numberBody the BigDecimal value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putSmallDecimalAsync(BigDecimal numberBody) {
+        return putSmallDecimalWithRestResponseAsync(numberBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1035,7 +1309,7 @@ public class NumbersImpl implements Numbers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<BigDecimal> getSmallDecimalAsync(final ServiceCallback<BigDecimal> serviceCallback) {
+    public ServiceFuture<BigDecimal> getSmallDecimalAsync(ServiceCallback<BigDecimal> serviceCallback) {
         return ServiceFuture.fromBody(getSmallDecimalAsync(), serviceCallback);
     }
 
@@ -1043,11 +1317,22 @@ public class NumbersImpl implements Numbers {
      * Get small decimal value 2.5976931e-101.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the BigDecimal object
+     * @return a {@link Single} emitting the RestResponse<Void, BigDecimal> object
      */
-    public Single<BigDecimal> getSmallDecimalAsync() {
+    public Single<RestResponse<Void, BigDecimal>> getSmallDecimalWithRestResponseAsync() {
         return service.getSmallDecimal();
     }
+
+    /**
+     * Get small decimal value 2.5976931e-101.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, BigDecimal> object
+     */
+    public Single<BigDecimal> getSmallDecimalAsync() {
+        return getSmallDecimalWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, BigDecimal>, BigDecimal>() { public BigDecimal call(RestResponse<Void, BigDecimal> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodystring/Enums.java
+++ b/test/vanilla/src/main/java/fixtures/bodystring/Enums.java
@@ -10,6 +10,7 @@
 
 package fixtures.bodystring;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.bodystring.models.Colors;
@@ -50,6 +51,13 @@ public interface Enums {
      * @return the observable to the Colors object
      */
     Single<Colors> getNotExpandableAsync();
+    /**
+     * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Colors object
+     */
+    Single<RestResponse<Void, Colors>> getNotExpandableWithRestResponseAsync();
 
 
     /**
@@ -80,6 +88,14 @@ public interface Enums {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putNotExpandableAsync(Colors stringBody);
+    /**
+     * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @param stringBody Possible values include: 'red color', 'green-color', 'blue_color'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putNotExpandableWithRestResponseAsync(Colors stringBody);
 
 
     /**
@@ -108,6 +124,13 @@ public interface Enums {
      * @return the observable to the Colors object
      */
     Single<Colors> getReferencedAsync();
+    /**
+     * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Colors object
+     */
+    Single<RestResponse<Void, Colors>> getReferencedWithRestResponseAsync();
 
 
     /**
@@ -138,6 +161,14 @@ public interface Enums {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putReferencedAsync(Colors enumStringBody);
+    /**
+     * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @param enumStringBody Possible values include: 'red color', 'green-color', 'blue_color'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putReferencedWithRestResponseAsync(Colors enumStringBody);
 
 
     /**
@@ -166,6 +197,13 @@ public interface Enums {
      * @return the observable to the RefColorConstant object
      */
     Single<RefColorConstant> getReferencedConstantAsync();
+    /**
+     * Get value 'green-color' from the constant.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the RefColorConstant object
+     */
+    Single<RestResponse<Void, RefColorConstant>> getReferencedConstantWithRestResponseAsync();
 
 
     /**
@@ -196,6 +234,14 @@ public interface Enums {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putReferencedConstantAsync(RefColorConstant enumStringBody);
+    /**
+     * Sends value 'green-color' from a constant.
+     *
+     * @param enumStringBody the RefColorConstant value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putReferencedConstantWithRestResponseAsync(RefColorConstant enumStringBody);
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodystring/Strings.java
+++ b/test/vanilla/src/main/java/fixtures/bodystring/Strings.java
@@ -10,6 +10,7 @@
 
 package fixtures.bodystring;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.bodystring.models.ErrorException;
@@ -48,6 +49,13 @@ public interface Strings {
      * @return the observable to the String object
      */
     Single<String> getNullAsync();
+    /**
+     * Get null string value value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the String object
+     */
+    Single<RestResponse<Void, String>> getNullWithRestResponseAsync();
 
 
     /**
@@ -75,6 +83,14 @@ public interface Strings {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putNullAsync();
+
+    /**
+     * Set string value null.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putNullWithRestResponseAsync();
     /**
      * Set string value null.
      *
@@ -103,6 +119,14 @@ public interface Strings {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putNullAsync(String stringBody);
+    /**
+     * Set string value null.
+     *
+     * @param stringBody Possible values include: ''
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putNullWithRestResponseAsync(String stringBody);
 
 
     /**
@@ -131,6 +155,13 @@ public interface Strings {
      * @return the observable to the String object
      */
     Single<String> getEmptyAsync();
+    /**
+     * Get empty string value value ''.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the String object
+     */
+    Single<RestResponse<Void, String>> getEmptyWithRestResponseAsync();
 
 
     /**
@@ -161,6 +192,14 @@ public interface Strings {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putEmptyAsync(String stringBody);
+    /**
+     * Set string value empty ''.
+     *
+     * @param stringBody Possible values include: ''
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putEmptyWithRestResponseAsync(String stringBody);
 
 
     /**
@@ -189,6 +228,13 @@ public interface Strings {
      * @return the observable to the String object
      */
     Single<String> getMbcsAsync();
+    /**
+     * Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ▇█〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€ '.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the String object
+     */
+    Single<RestResponse<Void, String>> getMbcsWithRestResponseAsync();
 
 
     /**
@@ -219,6 +265,14 @@ public interface Strings {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putMbcsAsync(String stringBody);
+    /**
+     * Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ▇█〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€ '.
+     *
+     * @param stringBody Possible values include: '啊齄丂狛狜隣郎隣兀﨩ˊ▇█〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€ '
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putMbcsWithRestResponseAsync(String stringBody);
 
 
     /**
@@ -247,6 +301,13 @@ public interface Strings {
      * @return the observable to the String object
      */
     Single<String> getWhitespaceAsync();
+    /**
+     * Get string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the String object
+     */
+    Single<RestResponse<Void, String>> getWhitespaceWithRestResponseAsync();
 
 
     /**
@@ -277,6 +338,14 @@ public interface Strings {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putWhitespaceAsync(String stringBody);
+    /**
+     * Set String value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
+     *
+     * @param stringBody Possible values include: '    Now is the time for all good men to come to the aid of their country    '
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putWhitespaceWithRestResponseAsync(String stringBody);
 
 
     /**
@@ -305,6 +374,13 @@ public interface Strings {
      * @return the observable to the String object
      */
     Single<String> getNotProvidedAsync();
+    /**
+     * Get String value when no string value is sent in response payload.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the String object
+     */
+    Single<RestResponse<Void, String>> getNotProvidedWithRestResponseAsync();
 
 
     /**
@@ -333,6 +409,13 @@ public interface Strings {
      * @return the observable to the byte[] object
      */
     Single<byte[]> getBase64EncodedAsync();
+    /**
+     * Get value that is base64 encoded.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the byte[] object
+     */
+    Single<RestResponse<Void, byte[]>> getBase64EncodedWithRestResponseAsync();
 
 
     /**
@@ -361,6 +444,13 @@ public interface Strings {
      * @return the observable to the byte[] object
      */
     Single<byte[]> getBase64UrlEncodedAsync();
+    /**
+     * Get value that is base64url encoded.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the byte[] object
+     */
+    Single<RestResponse<Void, byte[]>> getBase64UrlEncodedWithRestResponseAsync();
 
 
     /**
@@ -391,6 +481,14 @@ public interface Strings {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putBase64UrlEncodedAsync(byte[] stringBody);
+    /**
+     * Put value that is base64url encoded.
+     *
+     * @param stringBody the Base64Url value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putBase64UrlEncodedWithRestResponseAsync(byte[] stringBody);
 
 
     /**
@@ -419,6 +517,13 @@ public interface Strings {
      * @return the observable to the byte[] object
      */
     Single<byte[]> getNullBase64UrlEncodedAsync();
+    /**
+     * Get null value that is expected to be base64url encoded.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the byte[] object
+     */
+    Single<RestResponse<Void, byte[]>> getNullBase64UrlEncodedWithRestResponseAsync();
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodystring/implementation/AutoRestSwaggerBATServiceImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodystring/implementation/AutoRestSwaggerBATServiceImpl.java
@@ -14,6 +14,7 @@ import fixtures.bodystring.AutoRestSwaggerBATService;
 import fixtures.bodystring.Strings;
 import fixtures.bodystring.Enums;
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceClient;
 import com.microsoft.rest.RestClient;
 import rx.Single;

--- a/test/vanilla/src/main/java/fixtures/bodystring/implementation/EnumsImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodystring/implementation/EnumsImpl.java
@@ -11,6 +11,7 @@
 package fixtures.bodystring.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.bodystring.Enums;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.BodyParam;
@@ -62,37 +63,37 @@ public class EnumsImpl implements Enums {
         @GET("string/enum/notExpandable")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Colors> getNotExpandable();
+        Single<RestResponse<Void, Colors>> getNotExpandable();
 
         @Headers({ "x-ms-logging-context: fixtures.bodystring.Enums putNotExpandable" })
         @PUT("string/enum/notExpandable")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putNotExpandable(@BodyParam("application/json; charset=utf-8") Colors stringBody);
+        Single<RestResponse<Void, Void>> putNotExpandable(@BodyParam("application/json; charset=utf-8") Colors stringBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodystring.Enums getReferenced" })
         @GET("string/enum/Referenced")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Colors> getReferenced();
+        Single<RestResponse<Void, Colors>> getReferenced();
 
         @Headers({ "x-ms-logging-context: fixtures.bodystring.Enums putReferenced" })
         @PUT("string/enum/Referenced")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putReferenced(@BodyParam("application/json; charset=utf-8") Colors enumStringBody);
+        Single<RestResponse<Void, Void>> putReferenced(@BodyParam("application/json; charset=utf-8") Colors enumStringBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodystring.Enums getReferencedConstant" })
         @GET("string/enum/ReferencedConstant")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<RefColorConstant> getReferencedConstant();
+        Single<RestResponse<Void, RefColorConstant>> getReferencedConstant();
 
         @Headers({ "x-ms-logging-context: fixtures.bodystring.Enums putReferencedConstant" })
         @PUT("string/enum/ReferencedConstant")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putReferencedConstant(@BodyParam("application/json; charset=utf-8") RefColorConstant enumStringBody);
+        Single<RestResponse<Void, Void>> putReferencedConstant(@BodyParam("application/json; charset=utf-8") RefColorConstant enumStringBody);
 
     }
 
@@ -115,7 +116,7 @@ public class EnumsImpl implements Enums {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Colors> getNotExpandableAsync(final ServiceCallback<Colors> serviceCallback) {
+    public ServiceFuture<Colors> getNotExpandableAsync(ServiceCallback<Colors> serviceCallback) {
         return ServiceFuture.fromBody(getNotExpandableAsync(), serviceCallback);
     }
 
@@ -123,11 +124,22 @@ public class EnumsImpl implements Enums {
      * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Colors object
+     * @return a {@link Single} emitting the RestResponse<Void, Colors> object
      */
-    public Single<Colors> getNotExpandableAsync() {
+    public Single<RestResponse<Void, Colors>> getNotExpandableWithRestResponseAsync() {
         return service.getNotExpandable();
     }
+
+    /**
+     * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Colors> object
+     */
+    public Single<Colors> getNotExpandableAsync() {
+        return getNotExpandableWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Colors>, Colors>() { public Colors call(RestResponse<Void, Colors> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -137,6 +149,7 @@ public class EnumsImpl implements Enums {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putNotExpandable(Colors stringBody) {
         putNotExpandableAsync(stringBody).toBlocking().value();
@@ -150,7 +163,7 @@ public class EnumsImpl implements Enums {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putNotExpandableAsync(Colors stringBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putNotExpandableAsync(Colors stringBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putNotExpandableAsync(stringBody), serviceCallback);
     }
 
@@ -159,14 +172,26 @@ public class EnumsImpl implements Enums {
      *
      * @param stringBody Possible values include: 'red color', 'green-color', 'blue_color'
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putNotExpandableAsync(Colors stringBody) {
+    public Single<RestResponse<Void, Void>> putNotExpandableWithRestResponseAsync(Colors stringBody) {
         if (stringBody == null) {
             throw new IllegalArgumentException("Parameter stringBody is required and cannot be null.");
         }
         return service.putNotExpandable(stringBody);
     }
+
+    /**
+     * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @param stringBody Possible values include: 'red color', 'green-color', 'blue_color'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putNotExpandableAsync(Colors stringBody) {
+        return putNotExpandableWithRestResponseAsync(stringBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -188,7 +213,7 @@ public class EnumsImpl implements Enums {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Colors> getReferencedAsync(final ServiceCallback<Colors> serviceCallback) {
+    public ServiceFuture<Colors> getReferencedAsync(ServiceCallback<Colors> serviceCallback) {
         return ServiceFuture.fromBody(getReferencedAsync(), serviceCallback);
     }
 
@@ -196,11 +221,22 @@ public class EnumsImpl implements Enums {
      * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Colors object
+     * @return a {@link Single} emitting the RestResponse<Void, Colors> object
      */
-    public Single<Colors> getReferencedAsync() {
+    public Single<RestResponse<Void, Colors>> getReferencedWithRestResponseAsync() {
         return service.getReferenced();
     }
+
+    /**
+     * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Colors> object
+     */
+    public Single<Colors> getReferencedAsync() {
+        return getReferencedWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Colors>, Colors>() { public Colors call(RestResponse<Void, Colors> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -210,6 +246,7 @@ public class EnumsImpl implements Enums {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putReferenced(Colors enumStringBody) {
         putReferencedAsync(enumStringBody).toBlocking().value();
@@ -223,7 +260,7 @@ public class EnumsImpl implements Enums {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putReferencedAsync(Colors enumStringBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putReferencedAsync(Colors enumStringBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putReferencedAsync(enumStringBody), serviceCallback);
     }
 
@@ -232,14 +269,26 @@ public class EnumsImpl implements Enums {
      *
      * @param enumStringBody Possible values include: 'red color', 'green-color', 'blue_color'
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putReferencedAsync(Colors enumStringBody) {
+    public Single<RestResponse<Void, Void>> putReferencedWithRestResponseAsync(Colors enumStringBody) {
         if (enumStringBody == null) {
             throw new IllegalArgumentException("Parameter enumStringBody is required and cannot be null.");
         }
         return service.putReferenced(enumStringBody);
     }
+
+    /**
+     * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @param enumStringBody Possible values include: 'red color', 'green-color', 'blue_color'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putReferencedAsync(Colors enumStringBody) {
+        return putReferencedWithRestResponseAsync(enumStringBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -261,7 +310,7 @@ public class EnumsImpl implements Enums {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<RefColorConstant> getReferencedConstantAsync(final ServiceCallback<RefColorConstant> serviceCallback) {
+    public ServiceFuture<RefColorConstant> getReferencedConstantAsync(ServiceCallback<RefColorConstant> serviceCallback) {
         return ServiceFuture.fromBody(getReferencedConstantAsync(), serviceCallback);
     }
 
@@ -269,11 +318,22 @@ public class EnumsImpl implements Enums {
      * Get value 'green-color' from the constant.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the RefColorConstant object
+     * @return a {@link Single} emitting the RestResponse<Void, RefColorConstant> object
      */
-    public Single<RefColorConstant> getReferencedConstantAsync() {
+    public Single<RestResponse<Void, RefColorConstant>> getReferencedConstantWithRestResponseAsync() {
         return service.getReferencedConstant();
     }
+
+    /**
+     * Get value 'green-color' from the constant.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, RefColorConstant> object
+     */
+    public Single<RefColorConstant> getReferencedConstantAsync() {
+        return getReferencedConstantWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, RefColorConstant>, RefColorConstant>() { public RefColorConstant call(RestResponse<Void, RefColorConstant> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -283,6 +343,7 @@ public class EnumsImpl implements Enums {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putReferencedConstant(RefColorConstant enumStringBody) {
         putReferencedConstantAsync(enumStringBody).toBlocking().value();
@@ -296,7 +357,7 @@ public class EnumsImpl implements Enums {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putReferencedConstantAsync(RefColorConstant enumStringBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putReferencedConstantAsync(RefColorConstant enumStringBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putReferencedConstantAsync(enumStringBody), serviceCallback);
     }
 
@@ -305,15 +366,27 @@ public class EnumsImpl implements Enums {
      *
      * @param enumStringBody the RefColorConstant value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putReferencedConstantAsync(RefColorConstant enumStringBody) {
+    public Single<RestResponse<Void, Void>> putReferencedConstantWithRestResponseAsync(RefColorConstant enumStringBody) {
         if (enumStringBody == null) {
             throw new IllegalArgumentException("Parameter enumStringBody is required and cannot be null.");
         }
         Validator.validate(enumStringBody);
         return service.putReferencedConstant(enumStringBody);
     }
+
+    /**
+     * Sends value 'green-color' from a constant.
+     *
+     * @param enumStringBody the RefColorConstant value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putReferencedConstantAsync(RefColorConstant enumStringBody) {
+        return putReferencedConstantWithRestResponseAsync(enumStringBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/bodystring/implementation/StringsImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodystring/implementation/StringsImpl.java
@@ -11,6 +11,7 @@
 package fixtures.bodystring.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.bodystring.Strings;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.BodyParam;
@@ -61,82 +62,82 @@ public class StringsImpl implements Strings {
         @GET("string/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<String> getNull();
+        Single<RestResponse<Void, String>> getNull();
 
         @Headers({ "x-ms-logging-context: fixtures.bodystring.Strings putNull" })
         @PUT("string/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putNull(@BodyParam("application/json; charset=utf-8") String stringBody);
+        Single<RestResponse<Void, Void>> putNull(@BodyParam("application/json; charset=utf-8") String stringBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodystring.Strings getEmpty" })
         @GET("string/empty")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<String> getEmpty();
+        Single<RestResponse<Void, String>> getEmpty();
 
         @Headers({ "x-ms-logging-context: fixtures.bodystring.Strings putEmpty" })
         @PUT("string/empty")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putEmpty(@BodyParam("application/json; charset=utf-8") String stringBody);
+        Single<RestResponse<Void, Void>> putEmpty(@BodyParam("application/json; charset=utf-8") String stringBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodystring.Strings getMbcs" })
         @GET("string/mbcs")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<String> getMbcs();
+        Single<RestResponse<Void, String>> getMbcs();
 
         @Headers({ "x-ms-logging-context: fixtures.bodystring.Strings putMbcs" })
         @PUT("string/mbcs")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putMbcs(@BodyParam("application/json; charset=utf-8") String stringBody);
+        Single<RestResponse<Void, Void>> putMbcs(@BodyParam("application/json; charset=utf-8") String stringBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodystring.Strings getWhitespace" })
         @GET("string/whitespace")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<String> getWhitespace();
+        Single<RestResponse<Void, String>> getWhitespace();
 
         @Headers({ "x-ms-logging-context: fixtures.bodystring.Strings putWhitespace" })
         @PUT("string/whitespace")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putWhitespace(@BodyParam("application/json; charset=utf-8") String stringBody);
+        Single<RestResponse<Void, Void>> putWhitespace(@BodyParam("application/json; charset=utf-8") String stringBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodystring.Strings getNotProvided" })
         @GET("string/notProvided")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<String> getNotProvided();
+        Single<RestResponse<Void, String>> getNotProvided();
 
         @Headers({ "x-ms-logging-context: fixtures.bodystring.Strings getBase64Encoded" })
         @GET("string/base64Encoding")
         @ExpectedResponses({200})
         @ReturnValueWireType(Base64Url.class)
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<byte[]> getBase64Encoded();
+        Single<RestResponse<Void, byte[]>> getBase64Encoded();
 
         @Headers({ "x-ms-logging-context: fixtures.bodystring.Strings getBase64UrlEncoded" })
         @GET("string/base64UrlEncoding")
         @ExpectedResponses({200})
         @ReturnValueWireType(Base64Url.class)
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<byte[]> getBase64UrlEncoded();
+        Single<RestResponse<Void, byte[]>> getBase64UrlEncoded();
 
         @Headers({ "x-ms-logging-context: fixtures.bodystring.Strings putBase64UrlEncoded" })
         @PUT("string/base64UrlEncoding")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putBase64UrlEncoded(@BodyParam("application/json; charset=utf-8") Base64Url stringBody);
+        Single<RestResponse<Void, Void>> putBase64UrlEncoded(@BodyParam("application/json; charset=utf-8") Base64Url stringBody);
 
         @Headers({ "x-ms-logging-context: fixtures.bodystring.Strings getNullBase64UrlEncoded" })
         @GET("string/nullBase64UrlEncoding")
         @ExpectedResponses({200})
         @ReturnValueWireType(Base64Url.class)
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<byte[]> getNullBase64UrlEncoded();
+        Single<RestResponse<Void, byte[]>> getNullBase64UrlEncoded();
 
     }
 
@@ -159,7 +160,7 @@ public class StringsImpl implements Strings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<String> getNullAsync(final ServiceCallback<String> serviceCallback) {
+    public ServiceFuture<String> getNullAsync(ServiceCallback<String> serviceCallback) {
         return ServiceFuture.fromBody(getNullAsync(), serviceCallback);
     }
 
@@ -167,11 +168,22 @@ public class StringsImpl implements Strings {
      * Get null string value value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the String object
+     * @return a {@link Single} emitting the RestResponse<Void, String> object
      */
-    public Single<String> getNullAsync() {
+    public Single<RestResponse<Void, String>> getNullWithRestResponseAsync() {
         return service.getNull();
     }
+
+    /**
+     * Get null string value value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, String> object
+     */
+    public Single<String> getNullAsync() {
+        return getNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, String>, String>() { public String call(RestResponse<Void, String> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -180,6 +192,7 @@ public class StringsImpl implements Strings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putNull() {
         putNullAsync().toBlocking().value();
@@ -192,7 +205,7 @@ public class StringsImpl implements Strings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putNullAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putNullAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putNullAsync(), serviceCallback);
     }
 
@@ -200,12 +213,23 @@ public class StringsImpl implements Strings {
      * Set string value null.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putNullAsync() {
+    public Single<RestResponse<Void, Void>> putNullWithRestResponseAsync() {
         final String stringBody = null;
         return service.putNull(stringBody);
     }
+
+    /**
+     * Set string value null.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putNullAsync() {
+        return putNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Set string value null.
@@ -214,6 +238,7 @@ public class StringsImpl implements Strings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putNull(String stringBody) {
         putNullAsync(stringBody).toBlocking().value();
@@ -227,7 +252,7 @@ public class StringsImpl implements Strings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putNullAsync(String stringBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putNullAsync(String stringBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putNullAsync(stringBody), serviceCallback);
     }
 
@@ -236,11 +261,23 @@ public class StringsImpl implements Strings {
      *
      * @param stringBody Possible values include: ''
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putNullAsync(String stringBody) {
+    public Single<RestResponse<Void, Void>> putNullWithRestResponseAsync(String stringBody) {
         return service.putNull(stringBody);
     }
+
+    /**
+     * Set string value null.
+     *
+     * @param stringBody Possible values include: ''
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putNullAsync(String stringBody) {
+        return putNullWithRestResponseAsync(stringBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -262,7 +299,7 @@ public class StringsImpl implements Strings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<String> getEmptyAsync(final ServiceCallback<String> serviceCallback) {
+    public ServiceFuture<String> getEmptyAsync(ServiceCallback<String> serviceCallback) {
         return ServiceFuture.fromBody(getEmptyAsync(), serviceCallback);
     }
 
@@ -270,11 +307,22 @@ public class StringsImpl implements Strings {
      * Get empty string value value ''.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the String object
+     * @return a {@link Single} emitting the RestResponse<Void, String> object
      */
-    public Single<String> getEmptyAsync() {
+    public Single<RestResponse<Void, String>> getEmptyWithRestResponseAsync() {
         return service.getEmpty();
     }
+
+    /**
+     * Get empty string value value ''.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, String> object
+     */
+    public Single<String> getEmptyAsync() {
+        return getEmptyWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, String>, String>() { public String call(RestResponse<Void, String> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -284,6 +332,7 @@ public class StringsImpl implements Strings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putEmpty(String stringBody) {
         putEmptyAsync(stringBody).toBlocking().value();
@@ -297,7 +346,7 @@ public class StringsImpl implements Strings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putEmptyAsync(String stringBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putEmptyAsync(String stringBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putEmptyAsync(stringBody), serviceCallback);
     }
 
@@ -306,14 +355,26 @@ public class StringsImpl implements Strings {
      *
      * @param stringBody Possible values include: ''
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putEmptyAsync(String stringBody) {
+    public Single<RestResponse<Void, Void>> putEmptyWithRestResponseAsync(String stringBody) {
         if (stringBody == null) {
             throw new IllegalArgumentException("Parameter stringBody is required and cannot be null.");
         }
         return service.putEmpty(stringBody);
     }
+
+    /**
+     * Set string value empty ''.
+     *
+     * @param stringBody Possible values include: ''
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putEmptyAsync(String stringBody) {
+        return putEmptyWithRestResponseAsync(stringBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -335,7 +396,7 @@ public class StringsImpl implements Strings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<String> getMbcsAsync(final ServiceCallback<String> serviceCallback) {
+    public ServiceFuture<String> getMbcsAsync(ServiceCallback<String> serviceCallback) {
         return ServiceFuture.fromBody(getMbcsAsync(), serviceCallback);
     }
 
@@ -343,11 +404,22 @@ public class StringsImpl implements Strings {
      * Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ▇█〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€ '.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the String object
+     * @return a {@link Single} emitting the RestResponse<Void, String> object
      */
-    public Single<String> getMbcsAsync() {
+    public Single<RestResponse<Void, String>> getMbcsWithRestResponseAsync() {
         return service.getMbcs();
     }
+
+    /**
+     * Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ▇█〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€ '.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, String> object
+     */
+    public Single<String> getMbcsAsync() {
+        return getMbcsWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, String>, String>() { public String call(RestResponse<Void, String> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -357,6 +429,7 @@ public class StringsImpl implements Strings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putMbcs(String stringBody) {
         putMbcsAsync(stringBody).toBlocking().value();
@@ -370,7 +443,7 @@ public class StringsImpl implements Strings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putMbcsAsync(String stringBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putMbcsAsync(String stringBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putMbcsAsync(stringBody), serviceCallback);
     }
 
@@ -379,14 +452,26 @@ public class StringsImpl implements Strings {
      *
      * @param stringBody Possible values include: '啊齄丂狛狜隣郎隣兀﨩ˊ▇█〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€ '
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putMbcsAsync(String stringBody) {
+    public Single<RestResponse<Void, Void>> putMbcsWithRestResponseAsync(String stringBody) {
         if (stringBody == null) {
             throw new IllegalArgumentException("Parameter stringBody is required and cannot be null.");
         }
         return service.putMbcs(stringBody);
     }
+
+    /**
+     * Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ▇█〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€ '.
+     *
+     * @param stringBody Possible values include: '啊齄丂狛狜隣郎隣兀﨩ˊ▇█〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€ '
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putMbcsAsync(String stringBody) {
+        return putMbcsWithRestResponseAsync(stringBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -408,7 +493,7 @@ public class StringsImpl implements Strings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<String> getWhitespaceAsync(final ServiceCallback<String> serviceCallback) {
+    public ServiceFuture<String> getWhitespaceAsync(ServiceCallback<String> serviceCallback) {
         return ServiceFuture.fromBody(getWhitespaceAsync(), serviceCallback);
     }
 
@@ -416,11 +501,22 @@ public class StringsImpl implements Strings {
      * Get string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the String object
+     * @return a {@link Single} emitting the RestResponse<Void, String> object
      */
-    public Single<String> getWhitespaceAsync() {
+    public Single<RestResponse<Void, String>> getWhitespaceWithRestResponseAsync() {
         return service.getWhitespace();
     }
+
+    /**
+     * Get string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, String> object
+     */
+    public Single<String> getWhitespaceAsync() {
+        return getWhitespaceWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, String>, String>() { public String call(RestResponse<Void, String> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -430,6 +526,7 @@ public class StringsImpl implements Strings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putWhitespace(String stringBody) {
         putWhitespaceAsync(stringBody).toBlocking().value();
@@ -443,7 +540,7 @@ public class StringsImpl implements Strings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putWhitespaceAsync(String stringBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putWhitespaceAsync(String stringBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putWhitespaceAsync(stringBody), serviceCallback);
     }
 
@@ -452,14 +549,26 @@ public class StringsImpl implements Strings {
      *
      * @param stringBody Possible values include: '    Now is the time for all good men to come to the aid of their country    '
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putWhitespaceAsync(String stringBody) {
+    public Single<RestResponse<Void, Void>> putWhitespaceWithRestResponseAsync(String stringBody) {
         if (stringBody == null) {
             throw new IllegalArgumentException("Parameter stringBody is required and cannot be null.");
         }
         return service.putWhitespace(stringBody);
     }
+
+    /**
+     * Set String value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
+     *
+     * @param stringBody Possible values include: '    Now is the time for all good men to come to the aid of their country    '
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putWhitespaceAsync(String stringBody) {
+        return putWhitespaceWithRestResponseAsync(stringBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -481,7 +590,7 @@ public class StringsImpl implements Strings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<String> getNotProvidedAsync(final ServiceCallback<String> serviceCallback) {
+    public ServiceFuture<String> getNotProvidedAsync(ServiceCallback<String> serviceCallback) {
         return ServiceFuture.fromBody(getNotProvidedAsync(), serviceCallback);
     }
 
@@ -489,11 +598,22 @@ public class StringsImpl implements Strings {
      * Get String value when no string value is sent in response payload.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the String object
+     * @return a {@link Single} emitting the RestResponse<Void, String> object
      */
-    public Single<String> getNotProvidedAsync() {
+    public Single<RestResponse<Void, String>> getNotProvidedWithRestResponseAsync() {
         return service.getNotProvided();
     }
+
+    /**
+     * Get String value when no string value is sent in response payload.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, String> object
+     */
+    public Single<String> getNotProvidedAsync() {
+        return getNotProvidedWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, String>, String>() { public String call(RestResponse<Void, String> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -515,7 +635,7 @@ public class StringsImpl implements Strings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<byte[]> getBase64EncodedAsync(final ServiceCallback<byte[]> serviceCallback) {
+    public ServiceFuture<byte[]> getBase64EncodedAsync(ServiceCallback<byte[]> serviceCallback) {
         return ServiceFuture.fromBody(getBase64EncodedAsync(), serviceCallback);
     }
 
@@ -523,11 +643,22 @@ public class StringsImpl implements Strings {
      * Get value that is base64 encoded.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the byte[] object
+     * @return a {@link Single} emitting the RestResponse<Void, byte[]> object
      */
-    public Single<byte[]> getBase64EncodedAsync() {
+    public Single<RestResponse<Void, byte[]>> getBase64EncodedWithRestResponseAsync() {
         return service.getBase64Encoded();
     }
+
+    /**
+     * Get value that is base64 encoded.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, byte[]> object
+     */
+    public Single<byte[]> getBase64EncodedAsync() {
+        return getBase64EncodedWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, byte[]>, byte[]>() { public byte[] call(RestResponse<Void, byte[]> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -549,7 +680,7 @@ public class StringsImpl implements Strings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<byte[]> getBase64UrlEncodedAsync(final ServiceCallback<byte[]> serviceCallback) {
+    public ServiceFuture<byte[]> getBase64UrlEncodedAsync(ServiceCallback<byte[]> serviceCallback) {
         return ServiceFuture.fromBody(getBase64UrlEncodedAsync(), serviceCallback);
     }
 
@@ -557,11 +688,22 @@ public class StringsImpl implements Strings {
      * Get value that is base64url encoded.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the byte[] object
+     * @return a {@link Single} emitting the RestResponse<Void, byte[]> object
      */
-    public Single<byte[]> getBase64UrlEncodedAsync() {
+    public Single<RestResponse<Void, byte[]>> getBase64UrlEncodedWithRestResponseAsync() {
         return service.getBase64UrlEncoded();
     }
+
+    /**
+     * Get value that is base64url encoded.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, byte[]> object
+     */
+    public Single<byte[]> getBase64UrlEncodedAsync() {
+        return getBase64UrlEncodedWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, byte[]>, byte[]>() { public byte[] call(RestResponse<Void, byte[]> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -571,6 +713,7 @@ public class StringsImpl implements Strings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putBase64UrlEncoded(byte[] stringBody) {
         putBase64UrlEncodedAsync(stringBody).toBlocking().value();
@@ -584,7 +727,7 @@ public class StringsImpl implements Strings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putBase64UrlEncodedAsync(byte[] stringBody, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putBase64UrlEncodedAsync(byte[] stringBody, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putBase64UrlEncodedAsync(stringBody), serviceCallback);
     }
 
@@ -593,15 +736,27 @@ public class StringsImpl implements Strings {
      *
      * @param stringBody the Base64Url value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putBase64UrlEncodedAsync(byte[] stringBody) {
+    public Single<RestResponse<Void, Void>> putBase64UrlEncodedWithRestResponseAsync(byte[] stringBody) {
         if (stringBody == null) {
             throw new IllegalArgumentException("Parameter stringBody is required and cannot be null.");
         }
-        Base64Url stringBodyConverted = Base64Url.encode(stringBody);
+    Base64Url stringBodyConverted = Base64Url.encode(stringBody);
         return service.putBase64UrlEncoded(stringBodyConverted);
     }
+
+    /**
+     * Put value that is base64url encoded.
+     *
+     * @param stringBody the Base64Url value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putBase64UrlEncodedAsync(byte[] stringBody) {
+        return putBase64UrlEncodedWithRestResponseAsync(stringBody)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -623,7 +778,7 @@ public class StringsImpl implements Strings {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<byte[]> getNullBase64UrlEncodedAsync(final ServiceCallback<byte[]> serviceCallback) {
+    public ServiceFuture<byte[]> getNullBase64UrlEncodedAsync(ServiceCallback<byte[]> serviceCallback) {
         return ServiceFuture.fromBody(getNullBase64UrlEncodedAsync(), serviceCallback);
     }
 
@@ -631,11 +786,22 @@ public class StringsImpl implements Strings {
      * Get null value that is expected to be base64url encoded.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the byte[] object
+     * @return a {@link Single} emitting the RestResponse<Void, byte[]> object
      */
-    public Single<byte[]> getNullBase64UrlEncodedAsync() {
+    public Single<RestResponse<Void, byte[]>> getNullBase64UrlEncodedWithRestResponseAsync() {
         return service.getNullBase64UrlEncoded();
     }
+
+    /**
+     * Get null value that is expected to be base64url encoded.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, byte[]> object
+     */
+    public Single<byte[]> getNullBase64UrlEncodedAsync() {
+        return getNullBase64UrlEncodedWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, byte[]>, byte[]>() { public byte[] call(RestResponse<Void, byte[]> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/custombaseuri/Paths.java
+++ b/test/vanilla/src/main/java/fixtures/custombaseuri/Paths.java
@@ -10,6 +10,7 @@
 
 package fixtures.custombaseuri;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.custombaseuri.models.ErrorException;
@@ -50,6 +51,14 @@ public interface Paths {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getEmptyAsync(String accountName);
+    /**
+     * Get a 200 to test a valid base uri.
+     *
+     * @param accountName Account Name
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> getEmptyWithRestResponseAsync(String accountName);
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/custombaseuri/implementation/AutoRestParameterizedHostTestClientImpl.java
+++ b/test/vanilla/src/main/java/fixtures/custombaseuri/implementation/AutoRestParameterizedHostTestClientImpl.java
@@ -13,6 +13,7 @@ package fixtures.custombaseuri.implementation;
 import fixtures.custombaseuri.AutoRestParameterizedHostTestClient;
 import fixtures.custombaseuri.Paths;
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceClient;
 import com.microsoft.rest.RestClient;
 import rx.Single;

--- a/test/vanilla/src/main/java/fixtures/custombaseuri/implementation/PathsImpl.java
+++ b/test/vanilla/src/main/java/fixtures/custombaseuri/implementation/PathsImpl.java
@@ -11,6 +11,7 @@
 package fixtures.custombaseuri.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.custombaseuri.Paths;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.ExpectedResponses;
@@ -59,7 +60,7 @@ public class PathsImpl implements Paths {
         @GET("customuri")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getEmpty(@HostParam("accountName") String accountName, @HostParam("host") String host);
+        Single<RestResponse<Void, Void>> getEmpty(@HostParam("accountName") String accountName, @HostParam("host") String host);
 
     }
 
@@ -70,6 +71,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getEmpty(String accountName) {
         getEmptyAsync(accountName).toBlocking().value();
@@ -83,7 +85,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getEmptyAsync(String accountName, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getEmptyAsync(String accountName, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getEmptyAsync(accountName), serviceCallback);
     }
 
@@ -92,9 +94,9 @@ public class PathsImpl implements Paths {
      *
      * @param accountName Account Name
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getEmptyAsync(String accountName) {
+    public Single<RestResponse<Void, Void>> getEmptyWithRestResponseAsync(String accountName) {
         if (accountName == null) {
             throw new IllegalArgumentException("Parameter accountName is required and cannot be null.");
         }
@@ -103,6 +105,18 @@ public class PathsImpl implements Paths {
         }
         return service.getEmpty(accountName, this.client.host());
     }
+
+    /**
+     * Get a 200 to test a valid base uri.
+     *
+     * @param accountName Account Name
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getEmptyAsync(String accountName) {
+        return getEmptyWithRestResponseAsync(accountName)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/custombaseurimoreoptions/Paths.java
+++ b/test/vanilla/src/main/java/fixtures/custombaseurimoreoptions/Paths.java
@@ -10,6 +10,7 @@
 
 package fixtures.custombaseurimoreoptions;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.custombaseurimoreoptions.models.ErrorException;
@@ -56,6 +57,17 @@ public interface Paths {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getEmptyAsync(String vault, String secret, String keyName);
+
+    /**
+     * Get a 200 to test a valid base uri.
+     *
+     * @param vault The vault name, e.g. https://myvault
+     * @param secret Secret value.
+     * @param keyName The key name with value 'key1'.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> getEmptyWithRestResponseAsync(String vault, String secret, String keyName);
     /**
      * Get a 200 to test a valid base uri.
      *
@@ -93,6 +105,17 @@ public interface Paths {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getEmptyAsync(String vault, String secret, String keyName, String keyVersion);
+    /**
+     * Get a 200 to test a valid base uri.
+     *
+     * @param vault The vault name, e.g. https://myvault
+     * @param secret Secret value.
+     * @param keyName The key name with value 'key1'.
+     * @param keyVersion The key version. Default value 'v1'.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> getEmptyWithRestResponseAsync(String vault, String secret, String keyName, String keyVersion);
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/custombaseurimoreoptions/implementation/AutoRestParameterizedCustomHostTestClientImpl.java
+++ b/test/vanilla/src/main/java/fixtures/custombaseurimoreoptions/implementation/AutoRestParameterizedCustomHostTestClientImpl.java
@@ -13,6 +13,7 @@ package fixtures.custombaseurimoreoptions.implementation;
 import fixtures.custombaseurimoreoptions.AutoRestParameterizedCustomHostTestClient;
 import fixtures.custombaseurimoreoptions.Paths;
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceClient;
 import com.microsoft.rest.RestClient;
 import rx.Single;

--- a/test/vanilla/src/main/java/fixtures/custombaseurimoreoptions/implementation/PathsImpl.java
+++ b/test/vanilla/src/main/java/fixtures/custombaseurimoreoptions/implementation/PathsImpl.java
@@ -11,6 +11,7 @@
 package fixtures.custombaseurimoreoptions.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.custombaseurimoreoptions.Paths;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.ExpectedResponses;
@@ -60,7 +61,7 @@ public class PathsImpl implements Paths {
         @GET("customuri/{subscriptionId}/{keyName}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getEmpty(@HostParam("vault") String vault, @HostParam("secret") String secret, @HostParam("dnsSuffix") String dnsSuffix, @PathParam("keyName") String keyName, @PathParam("subscriptionId") String subscriptionId, @QueryParam("keyVersion") String keyVersion);
+        Single<RestResponse<Void, Void>> getEmpty(@HostParam("vault") String vault, @HostParam("secret") String secret, @HostParam("dnsSuffix") String dnsSuffix, @PathParam("keyName") String keyName, @PathParam("subscriptionId") String subscriptionId, @QueryParam("keyVersion") String keyVersion);
 
     }
 
@@ -73,6 +74,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getEmpty(String vault, String secret, String keyName) {
         getEmptyAsync(vault, secret, keyName).toBlocking().value();
@@ -88,7 +90,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getEmptyAsync(String vault, String secret, String keyName, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getEmptyAsync(String vault, String secret, String keyName, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getEmptyAsync(vault, secret, keyName), serviceCallback);
     }
 
@@ -99,9 +101,9 @@ public class PathsImpl implements Paths {
      * @param secret Secret value.
      * @param keyName The key name with value 'key1'.
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getEmptyAsync(String vault, String secret, String keyName) {
+    public Single<RestResponse<Void, Void>> getEmptyWithRestResponseAsync(String vault, String secret, String keyName) {
         if (vault == null) {
             throw new IllegalArgumentException("Parameter vault is required and cannot be null.");
         }
@@ -127,10 +129,25 @@ public class PathsImpl implements Paths {
      * @param vault The vault name, e.g. https://myvault
      * @param secret Secret value.
      * @param keyName The key name with value 'key1'.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getEmptyAsync(String vault, String secret, String keyName) {
+        return getEmptyWithRestResponseAsync(vault, secret, keyName)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
+
+    /**
+     * Get a 200 to test a valid base uri.
+     *
+     * @param vault The vault name, e.g. https://myvault
+     * @param secret Secret value.
+     * @param keyName The key name with value 'key1'.
      * @param keyVersion The key version. Default value 'v1'.
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getEmpty(String vault, String secret, String keyName, String keyVersion) {
         getEmptyAsync(vault, secret, keyName, keyVersion).toBlocking().value();
@@ -147,7 +164,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getEmptyAsync(String vault, String secret, String keyName, String keyVersion, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getEmptyAsync(String vault, String secret, String keyName, String keyVersion, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getEmptyAsync(vault, secret, keyName, keyVersion), serviceCallback);
     }
 
@@ -159,9 +176,9 @@ public class PathsImpl implements Paths {
      * @param keyName The key name with value 'key1'.
      * @param keyVersion The key version. Default value 'v1'.
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getEmptyAsync(String vault, String secret, String keyName, String keyVersion) {
+    public Single<RestResponse<Void, Void>> getEmptyWithRestResponseAsync(String vault, String secret, String keyName, String keyVersion) {
         if (vault == null) {
             throw new IllegalArgumentException("Parameter vault is required and cannot be null.");
         }
@@ -179,6 +196,21 @@ public class PathsImpl implements Paths {
         }
         return service.getEmpty(vault, secret, this.client.dnsSuffix(), keyName, this.client.subscriptionId(), keyVersion);
     }
+
+    /**
+     * Get a 200 to test a valid base uri.
+     *
+     * @param vault The vault name, e.g. https://myvault
+     * @param secret Secret value.
+     * @param keyName The key name with value 'key1'.
+     * @param keyVersion The key version. Default value 'v1'.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getEmptyAsync(String vault, String secret, String keyName, String keyVersion) {
+        return getEmptyWithRestResponseAsync(vault, secret, keyName, keyVersion)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/header/Headers.java
+++ b/test/vanilla/src/main/java/fixtures/header/Headers.java
@@ -10,6 +10,7 @@
 
 package fixtures.header;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.header.models.ErrorException;
@@ -68,6 +69,14 @@ public interface Headers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> paramExistingKeyAsync(String userAgent);
+    /**
+     * Send a post request with header value "User-Agent": "overwrite".
+     *
+     * @param userAgent Send a post request with header value "User-Agent": "overwrite"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> paramExistingKeyWithRestResponseAsync(String userAgent);
 
 
     /**
@@ -95,6 +104,13 @@ public interface Headers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> responseExistingKeyAsync();
+    /**
+     * Get a response with header value "User-Agent": "overwrite".
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HeaderResponseExistingKeyHeaders, Void>> responseExistingKeyWithRestResponseAsync();
 
 
     /**
@@ -125,6 +141,14 @@ public interface Headers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> paramProtectedKeyAsync(String contentType);
+    /**
+     * Send a post request with header value "Content-Type": "text/html".
+     *
+     * @param contentType Send a post request with header value "Content-Type": "text/html"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> paramProtectedKeyWithRestResponseAsync(String contentType);
 
 
     /**
@@ -152,6 +176,13 @@ public interface Headers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> responseProtectedKeyAsync();
+    /**
+     * Get a response with header value "Content-Type": "text/html".
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HeaderResponseProtectedKeyHeaders, Void>> responseProtectedKeyWithRestResponseAsync();
 
 
     /**
@@ -185,6 +216,15 @@ public interface Headers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> paramIntegerAsync(String scenario, int value);
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 1 or "scenario": "negative", "value": -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+     * @param value Send a post request with header values 1 or -2
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> paramIntegerWithRestResponseAsync(String scenario, int value);
 
 
     /**
@@ -215,6 +255,14 @@ public interface Headers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> responseIntegerAsync(String scenario);
+    /**
+     * Get a response with header value "value": 1 or -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HeaderResponseIntegerHeaders, Void>> responseIntegerWithRestResponseAsync(String scenario);
 
 
     /**
@@ -248,6 +296,15 @@ public interface Headers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> paramLongAsync(String scenario, long value);
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 105 or "scenario": "negative", "value": -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+     * @param value Send a post request with header values 105 or -2
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> paramLongWithRestResponseAsync(String scenario, long value);
 
 
     /**
@@ -278,6 +335,14 @@ public interface Headers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> responseLongAsync(String scenario);
+    /**
+     * Get a response with header value "value": 105 or -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HeaderResponseLongHeaders, Void>> responseLongWithRestResponseAsync(String scenario);
 
 
     /**
@@ -311,6 +376,15 @@ public interface Headers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> paramFloatAsync(String scenario, double value);
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 0.07 or "scenario": "negative", "value": -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+     * @param value Send a post request with header values 0.07 or -3.0
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> paramFloatWithRestResponseAsync(String scenario, double value);
 
 
     /**
@@ -341,6 +415,14 @@ public interface Headers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> responseFloatAsync(String scenario);
+    /**
+     * Get a response with header value "value": 0.07 or -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HeaderResponseFloatHeaders, Void>> responseFloatWithRestResponseAsync(String scenario);
 
 
     /**
@@ -374,6 +456,15 @@ public interface Headers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> paramDoubleAsync(String scenario, double value);
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 7e120 or "scenario": "negative", "value": -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+     * @param value Send a post request with header values 7e120 or -3.0
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> paramDoubleWithRestResponseAsync(String scenario, double value);
 
 
     /**
@@ -404,6 +495,14 @@ public interface Headers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> responseDoubleAsync(String scenario);
+    /**
+     * Get a response with header value "value": 7e120 or -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HeaderResponseDoubleHeaders, Void>> responseDoubleWithRestResponseAsync(String scenario);
 
 
     /**
@@ -437,6 +536,15 @@ public interface Headers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> paramBoolAsync(String scenario, boolean value);
+    /**
+     * Send a post request with header values "scenario": "true", "value": true or "scenario": "false", "value": false.
+     *
+     * @param scenario Send a post request with header values "scenario": "true" or "false"
+     * @param value Send a post request with header values true or false
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> paramBoolWithRestResponseAsync(String scenario, boolean value);
 
 
     /**
@@ -467,6 +575,14 @@ public interface Headers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> responseBoolAsync(String scenario);
+    /**
+     * Get a response with header value "value": true or false.
+     *
+     * @param scenario Send a post request with header values "scenario": "true" or "false"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HeaderResponseBoolHeaders, Void>> responseBoolWithRestResponseAsync(String scenario);
 
 
     /**
@@ -497,6 +613,15 @@ public interface Headers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> paramStringAsync(String scenario);
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": "".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> paramStringWithRestResponseAsync(String scenario);
     /**
      * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": "".
      *
@@ -528,6 +653,15 @@ public interface Headers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> paramStringAsync(String scenario, String value);
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": "".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
+     * @param value Send a post request with header values "The quick brown fox jumps over the lazy dog" or null or ""
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> paramStringWithRestResponseAsync(String scenario, String value);
 
 
     /**
@@ -558,6 +692,14 @@ public interface Headers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> responseStringAsync(String scenario);
+    /**
+     * Get a response with header values "The quick brown fox jumps over the lazy dog" or null or "".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HeaderResponseStringHeaders, Void>> responseStringWithRestResponseAsync(String scenario);
 
 
     /**
@@ -591,6 +733,15 @@ public interface Headers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> paramDateAsync(String scenario, LocalDate value);
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "2010-01-01" or "scenario": "min", "value": "0001-01-01".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min"
+     * @param value Send a post request with header values "2010-01-01" or "0001-01-01"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> paramDateWithRestResponseAsync(String scenario, LocalDate value);
 
 
     /**
@@ -621,6 +772,14 @@ public interface Headers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> responseDateAsync(String scenario);
+    /**
+     * Get a response with header values "2010-01-01" or "0001-01-01".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HeaderResponseDateHeaders, Void>> responseDateWithRestResponseAsync(String scenario);
 
 
     /**
@@ -654,6 +813,15 @@ public interface Headers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> paramDatetimeAsync(String scenario, DateTime value);
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "2010-01-01T12:34:56Z" or "scenario": "min", "value": "0001-01-01T00:00:00Z".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min"
+     * @param value Send a post request with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> paramDatetimeWithRestResponseAsync(String scenario, DateTime value);
 
 
     /**
@@ -684,6 +852,14 @@ public interface Headers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> responseDatetimeAsync(String scenario);
+    /**
+     * Get a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HeaderResponseDatetimeHeaders, Void>> responseDatetimeWithRestResponseAsync(String scenario);
 
 
     /**
@@ -714,6 +890,15 @@ public interface Headers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> paramDatetimeRfc1123Async(String scenario);
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> paramDatetimeRfc1123WithRestResponseAsync(String scenario);
     /**
      * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT".
      *
@@ -745,6 +930,15 @@ public interface Headers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> paramDatetimeRfc1123Async(String scenario, DateTime value);
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min"
+     * @param value Send a post request with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> paramDatetimeRfc1123WithRestResponseAsync(String scenario, DateTime value);
 
 
     /**
@@ -775,6 +969,14 @@ public interface Headers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> responseDatetimeRfc1123Async(String scenario);
+    /**
+     * Get a response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HeaderResponseDatetimeRfc1123Headers, Void>> responseDatetimeRfc1123WithRestResponseAsync(String scenario);
 
 
     /**
@@ -808,6 +1010,15 @@ public interface Headers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> paramDurationAsync(String scenario, Period value);
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "P123DT22H14M12.011S".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid"
+     * @param value Send a post request with header values "P123DT22H14M12.011S"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> paramDurationWithRestResponseAsync(String scenario, Period value);
 
 
     /**
@@ -838,6 +1049,14 @@ public interface Headers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> responseDurationAsync(String scenario);
+    /**
+     * Get a response with header values "P123DT22H14M12.011S".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HeaderResponseDurationHeaders, Void>> responseDurationWithRestResponseAsync(String scenario);
 
 
     /**
@@ -871,6 +1090,15 @@ public interface Headers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> paramByteAsync(String scenario, byte[] value);
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "啊齄丂狛狜隣郎隣兀﨩".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid"
+     * @param value Send a post request with header values "啊齄丂狛狜隣郎隣兀﨩"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> paramByteWithRestResponseAsync(String scenario, byte[] value);
 
 
     /**
@@ -901,6 +1129,14 @@ public interface Headers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> responseByteAsync(String scenario);
+    /**
+     * Get a response with header values "啊齄丂狛狜隣郎隣兀﨩".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HeaderResponseByteHeaders, Void>> responseByteWithRestResponseAsync(String scenario);
 
 
     /**
@@ -931,6 +1167,15 @@ public interface Headers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> paramEnumAsync(String scenario);
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null.
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> paramEnumWithRestResponseAsync(String scenario);
     /**
      * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null.
      *
@@ -962,6 +1207,15 @@ public interface Headers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> paramEnumAsync(String scenario, GreyscaleColors value);
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null.
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
+     * @param value Send a post request with header values 'GREY'. Possible values include: 'White', 'black', 'GREY'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> paramEnumWithRestResponseAsync(String scenario, GreyscaleColors value);
 
 
     /**
@@ -992,6 +1246,14 @@ public interface Headers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> responseEnumAsync(String scenario);
+    /**
+     * Get a response with header values "GREY" or null.
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HeaderResponseEnumHeaders, Void>> responseEnumWithRestResponseAsync(String scenario);
 
 
     /**
@@ -1019,6 +1281,13 @@ public interface Headers {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> customRequestIdAsync();
+    /**
+     * Send x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> customRequestIdWithRestResponseAsync();
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/header/implementation/AutoRestSwaggerBATHeaderServiceImpl.java
+++ b/test/vanilla/src/main/java/fixtures/header/implementation/AutoRestSwaggerBATHeaderServiceImpl.java
@@ -13,6 +13,7 @@ package fixtures.header.implementation;
 import fixtures.header.AutoRestSwaggerBATHeaderService;
 import fixtures.header.Headers;
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceClient;
 import com.microsoft.rest.RestClient;
 import rx.Single;

--- a/test/vanilla/src/main/java/fixtures/header/implementation/HeadersImpl.java
+++ b/test/vanilla/src/main/java/fixtures/header/implementation/HeadersImpl.java
@@ -11,6 +11,7 @@
 package fixtures.header.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.ExpectedResponses;
 import com.microsoft.rest.annotations.HeaderParam;
@@ -77,175 +78,175 @@ public class HeadersImpl implements fixtures.header.Headers {
         @POST("header/param/existingkey")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> paramExistingKey(@HeaderParam("User-Agent") String userAgent);
+        Single<RestResponse<Void, Void>> paramExistingKey(@HeaderParam("User-Agent") String userAgent);
 
         @Headers({ "x-ms-logging-context: fixtures.header.Headers responseExistingKey" })
         @POST("header/response/existingkey")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> responseExistingKey();
+        Single<RestResponse<HeaderResponseExistingKeyHeaders, Void>> responseExistingKey();
 
         @Headers({ "x-ms-logging-context: fixtures.header.Headers paramProtectedKey" })
         @POST("header/param/protectedkey")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> paramProtectedKey(@HeaderParam("Content-Type") String contentType);
+        Single<RestResponse<Void, Void>> paramProtectedKey(@HeaderParam("Content-Type") String contentType);
 
         @Headers({ "x-ms-logging-context: fixtures.header.Headers responseProtectedKey" })
         @POST("header/response/protectedkey")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> responseProtectedKey();
+        Single<RestResponse<HeaderResponseProtectedKeyHeaders, Void>> responseProtectedKey();
 
         @Headers({ "x-ms-logging-context: fixtures.header.Headers paramInteger" })
         @POST("header/param/prim/integer")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> paramInteger(@HeaderParam("scenario") String scenario, @HeaderParam("value") int value);
+        Single<RestResponse<Void, Void>> paramInteger(@HeaderParam("scenario") String scenario, @HeaderParam("value") int value);
 
         @Headers({ "x-ms-logging-context: fixtures.header.Headers responseInteger" })
         @POST("header/response/prim/integer")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> responseInteger(@HeaderParam("scenario") String scenario);
+        Single<RestResponse<HeaderResponseIntegerHeaders, Void>> responseInteger(@HeaderParam("scenario") String scenario);
 
         @Headers({ "x-ms-logging-context: fixtures.header.Headers paramLong" })
         @POST("header/param/prim/long")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> paramLong(@HeaderParam("scenario") String scenario, @HeaderParam("value") long value);
+        Single<RestResponse<Void, Void>> paramLong(@HeaderParam("scenario") String scenario, @HeaderParam("value") long value);
 
         @Headers({ "x-ms-logging-context: fixtures.header.Headers responseLong" })
         @POST("header/response/prim/long")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> responseLong(@HeaderParam("scenario") String scenario);
+        Single<RestResponse<HeaderResponseLongHeaders, Void>> responseLong(@HeaderParam("scenario") String scenario);
 
         @Headers({ "x-ms-logging-context: fixtures.header.Headers paramFloat" })
         @POST("header/param/prim/float")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> paramFloat(@HeaderParam("scenario") String scenario, @HeaderParam("value") double value);
+        Single<RestResponse<Void, Void>> paramFloat(@HeaderParam("scenario") String scenario, @HeaderParam("value") double value);
 
         @Headers({ "x-ms-logging-context: fixtures.header.Headers responseFloat" })
         @POST("header/response/prim/float")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> responseFloat(@HeaderParam("scenario") String scenario);
+        Single<RestResponse<HeaderResponseFloatHeaders, Void>> responseFloat(@HeaderParam("scenario") String scenario);
 
         @Headers({ "x-ms-logging-context: fixtures.header.Headers paramDouble" })
         @POST("header/param/prim/double")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> paramDouble(@HeaderParam("scenario") String scenario, @HeaderParam("value") double value);
+        Single<RestResponse<Void, Void>> paramDouble(@HeaderParam("scenario") String scenario, @HeaderParam("value") double value);
 
         @Headers({ "x-ms-logging-context: fixtures.header.Headers responseDouble" })
         @POST("header/response/prim/double")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> responseDouble(@HeaderParam("scenario") String scenario);
+        Single<RestResponse<HeaderResponseDoubleHeaders, Void>> responseDouble(@HeaderParam("scenario") String scenario);
 
         @Headers({ "x-ms-logging-context: fixtures.header.Headers paramBool" })
         @POST("header/param/prim/bool")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> paramBool(@HeaderParam("scenario") String scenario, @HeaderParam("value") boolean value);
+        Single<RestResponse<Void, Void>> paramBool(@HeaderParam("scenario") String scenario, @HeaderParam("value") boolean value);
 
         @Headers({ "x-ms-logging-context: fixtures.header.Headers responseBool" })
         @POST("header/response/prim/bool")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> responseBool(@HeaderParam("scenario") String scenario);
+        Single<RestResponse<HeaderResponseBoolHeaders, Void>> responseBool(@HeaderParam("scenario") String scenario);
 
         @Headers({ "x-ms-logging-context: fixtures.header.Headers paramString" })
         @POST("header/param/prim/string")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> paramString(@HeaderParam("scenario") String scenario, @HeaderParam("value") String value);
+        Single<RestResponse<Void, Void>> paramString(@HeaderParam("scenario") String scenario, @HeaderParam("value") String value);
 
         @Headers({ "x-ms-logging-context: fixtures.header.Headers responseString" })
         @POST("header/response/prim/string")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> responseString(@HeaderParam("scenario") String scenario);
+        Single<RestResponse<HeaderResponseStringHeaders, Void>> responseString(@HeaderParam("scenario") String scenario);
 
         @Headers({ "x-ms-logging-context: fixtures.header.Headers paramDate" })
         @POST("header/param/prim/date")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> paramDate(@HeaderParam("scenario") String scenario, @HeaderParam("value") LocalDate value);
+        Single<RestResponse<Void, Void>> paramDate(@HeaderParam("scenario") String scenario, @HeaderParam("value") LocalDate value);
 
         @Headers({ "x-ms-logging-context: fixtures.header.Headers responseDate" })
         @POST("header/response/prim/date")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> responseDate(@HeaderParam("scenario") String scenario);
+        Single<RestResponse<HeaderResponseDateHeaders, Void>> responseDate(@HeaderParam("scenario") String scenario);
 
         @Headers({ "x-ms-logging-context: fixtures.header.Headers paramDatetime" })
         @POST("header/param/prim/datetime")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> paramDatetime(@HeaderParam("scenario") String scenario, @HeaderParam("value") DateTime value);
+        Single<RestResponse<Void, Void>> paramDatetime(@HeaderParam("scenario") String scenario, @HeaderParam("value") DateTime value);
 
         @Headers({ "x-ms-logging-context: fixtures.header.Headers responseDatetime" })
         @POST("header/response/prim/datetime")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> responseDatetime(@HeaderParam("scenario") String scenario);
+        Single<RestResponse<HeaderResponseDatetimeHeaders, Void>> responseDatetime(@HeaderParam("scenario") String scenario);
 
         @Headers({ "x-ms-logging-context: fixtures.header.Headers paramDatetimeRfc1123" })
         @POST("header/param/prim/datetimerfc1123")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> paramDatetimeRfc1123(@HeaderParam("scenario") String scenario, @HeaderParam("value") DateTimeRfc1123 value);
+        Single<RestResponse<Void, Void>> paramDatetimeRfc1123(@HeaderParam("scenario") String scenario, @HeaderParam("value") DateTimeRfc1123 value);
 
         @Headers({ "x-ms-logging-context: fixtures.header.Headers responseDatetimeRfc1123" })
         @POST("header/response/prim/datetimerfc1123")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> responseDatetimeRfc1123(@HeaderParam("scenario") String scenario);
+        Single<RestResponse<HeaderResponseDatetimeRfc1123Headers, Void>> responseDatetimeRfc1123(@HeaderParam("scenario") String scenario);
 
         @Headers({ "x-ms-logging-context: fixtures.header.Headers paramDuration" })
         @POST("header/param/prim/duration")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> paramDuration(@HeaderParam("scenario") String scenario, @HeaderParam("value") Period value);
+        Single<RestResponse<Void, Void>> paramDuration(@HeaderParam("scenario") String scenario, @HeaderParam("value") Period value);
 
         @Headers({ "x-ms-logging-context: fixtures.header.Headers responseDuration" })
         @POST("header/response/prim/duration")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> responseDuration(@HeaderParam("scenario") String scenario);
+        Single<RestResponse<HeaderResponseDurationHeaders, Void>> responseDuration(@HeaderParam("scenario") String scenario);
 
         @Headers({ "x-ms-logging-context: fixtures.header.Headers paramByte" })
         @POST("header/param/prim/byte")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> paramByte(@HeaderParam("scenario") String scenario, @HeaderParam("value") String value);
+        Single<RestResponse<Void, Void>> paramByte(@HeaderParam("scenario") String scenario, @HeaderParam("value") String value);
 
         @Headers({ "x-ms-logging-context: fixtures.header.Headers responseByte" })
         @POST("header/response/prim/byte")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> responseByte(@HeaderParam("scenario") String scenario);
+        Single<RestResponse<HeaderResponseByteHeaders, Void>> responseByte(@HeaderParam("scenario") String scenario);
 
         @Headers({ "x-ms-logging-context: fixtures.header.Headers paramEnum" })
         @POST("header/param/prim/enum")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> paramEnum(@HeaderParam("scenario") String scenario, @HeaderParam("value") GreyscaleColors value);
+        Single<RestResponse<Void, Void>> paramEnum(@HeaderParam("scenario") String scenario, @HeaderParam("value") GreyscaleColors value);
 
         @Headers({ "x-ms-logging-context: fixtures.header.Headers responseEnum" })
         @POST("header/response/prim/enum")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> responseEnum(@HeaderParam("scenario") String scenario);
+        Single<RestResponse<HeaderResponseEnumHeaders, Void>> responseEnum(@HeaderParam("scenario") String scenario);
 
         @Headers({ "x-ms-logging-context: fixtures.header.Headers customRequestId" })
         @POST("header/custom/x-ms-client-request-id/9C4D50EE-2D56-4CD3-8152-34347DC9F2B0")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> customRequestId();
+        Single<RestResponse<Void, Void>> customRequestId();
 
     }
 
@@ -256,6 +257,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void paramExistingKey(String userAgent) {
         paramExistingKeyAsync(userAgent).toBlocking().value();
@@ -269,7 +271,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> paramExistingKeyAsync(String userAgent, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> paramExistingKeyAsync(String userAgent, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(paramExistingKeyAsync(userAgent), serviceCallback);
     }
 
@@ -278,14 +280,26 @@ public class HeadersImpl implements fixtures.header.Headers {
      *
      * @param userAgent Send a post request with header value "User-Agent": "overwrite"
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> paramExistingKeyAsync(String userAgent) {
+    public Single<RestResponse<Void, Void>> paramExistingKeyWithRestResponseAsync(String userAgent) {
         if (userAgent == null) {
             throw new IllegalArgumentException("Parameter userAgent is required and cannot be null.");
         }
         return service.paramExistingKey(userAgent);
     }
+
+    /**
+     * Send a post request with header value "User-Agent": "overwrite".
+     *
+     * @param userAgent Send a post request with header value "User-Agent": "overwrite"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> paramExistingKeyAsync(String userAgent) {
+        return paramExistingKeyWithRestResponseAsync(userAgent)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -294,6 +308,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void responseExistingKey() {
         responseExistingKeyAsync().toBlocking().value();
@@ -306,19 +321,30 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> responseExistingKeyAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(responseExistingKeyAsync(), serviceCallback);
+    public ServiceFuture<Void> responseExistingKeyAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(responseExistingKeyAsync(), serviceCallback);
     }
 
     /**
      * Get a response with header value "User-Agent": "overwrite".
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HeaderResponseExistingKeyHeaders, Void> object
      */
-    public Single<Void> responseExistingKeyAsync() {
+    public Single<RestResponse<HeaderResponseExistingKeyHeaders, Void>> responseExistingKeyWithRestResponseAsync() {
         return service.responseExistingKey();
     }
+
+    /**
+     * Get a response with header value "User-Agent": "overwrite".
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HeaderResponseExistingKeyHeaders, Void> object
+     */
+    public Single<Void> responseExistingKeyAsync() {
+        return responseExistingKeyWithRestResponseAsync()
+            .map(new Func1<RestResponse<HeaderResponseExistingKeyHeaders, Void>, Void>() { public Void call(RestResponse<HeaderResponseExistingKeyHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -328,6 +354,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void paramProtectedKey(String contentType) {
         paramProtectedKeyAsync(contentType).toBlocking().value();
@@ -341,7 +368,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> paramProtectedKeyAsync(String contentType, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> paramProtectedKeyAsync(String contentType, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(paramProtectedKeyAsync(contentType), serviceCallback);
     }
 
@@ -350,14 +377,26 @@ public class HeadersImpl implements fixtures.header.Headers {
      *
      * @param contentType Send a post request with header value "Content-Type": "text/html"
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> paramProtectedKeyAsync(String contentType) {
+    public Single<RestResponse<Void, Void>> paramProtectedKeyWithRestResponseAsync(String contentType) {
         if (contentType == null) {
             throw new IllegalArgumentException("Parameter contentType is required and cannot be null.");
         }
         return service.paramProtectedKey(contentType);
     }
+
+    /**
+     * Send a post request with header value "Content-Type": "text/html".
+     *
+     * @param contentType Send a post request with header value "Content-Type": "text/html"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> paramProtectedKeyAsync(String contentType) {
+        return paramProtectedKeyWithRestResponseAsync(contentType)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -366,6 +405,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void responseProtectedKey() {
         responseProtectedKeyAsync().toBlocking().value();
@@ -378,19 +418,30 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> responseProtectedKeyAsync(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(responseProtectedKeyAsync(), serviceCallback);
+    public ServiceFuture<Void> responseProtectedKeyAsync(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(responseProtectedKeyAsync(), serviceCallback);
     }
 
     /**
      * Get a response with header value "Content-Type": "text/html".
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HeaderResponseProtectedKeyHeaders, Void> object
      */
-    public Single<Void> responseProtectedKeyAsync() {
+    public Single<RestResponse<HeaderResponseProtectedKeyHeaders, Void>> responseProtectedKeyWithRestResponseAsync() {
         return service.responseProtectedKey();
     }
+
+    /**
+     * Get a response with header value "Content-Type": "text/html".
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HeaderResponseProtectedKeyHeaders, Void> object
+     */
+    public Single<Void> responseProtectedKeyAsync() {
+        return responseProtectedKeyWithRestResponseAsync()
+            .map(new Func1<RestResponse<HeaderResponseProtectedKeyHeaders, Void>, Void>() { public Void call(RestResponse<HeaderResponseProtectedKeyHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -401,6 +452,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void paramInteger(String scenario, int value) {
         paramIntegerAsync(scenario, value).toBlocking().value();
@@ -415,7 +467,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> paramIntegerAsync(String scenario, int value, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> paramIntegerAsync(String scenario, int value, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(paramIntegerAsync(scenario, value), serviceCallback);
     }
 
@@ -425,14 +477,27 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "positive" or "negative"
      * @param value Send a post request with header values 1 or -2
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> paramIntegerAsync(String scenario, int value) {
+    public Single<RestResponse<Void, Void>> paramIntegerWithRestResponseAsync(String scenario, int value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
         return service.paramInteger(scenario, value);
     }
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 1 or "scenario": "negative", "value": -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+     * @param value Send a post request with header values 1 or -2
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> paramIntegerAsync(String scenario, int value) {
+        return paramIntegerWithRestResponseAsync(scenario, value)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -442,6 +507,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void responseInteger(String scenario) {
         responseIntegerAsync(scenario).toBlocking().value();
@@ -455,8 +521,8 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> responseIntegerAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(responseIntegerAsync(scenario), serviceCallback);
+    public ServiceFuture<Void> responseIntegerAsync(String scenario, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(responseIntegerAsync(scenario), serviceCallback);
     }
 
     /**
@@ -464,14 +530,26 @@ public class HeadersImpl implements fixtures.header.Headers {
      *
      * @param scenario Send a post request with header values "scenario": "positive" or "negative"
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HeaderResponseIntegerHeaders, Void> object
      */
-    public Single<Void> responseIntegerAsync(String scenario) {
+    public Single<RestResponse<HeaderResponseIntegerHeaders, Void>> responseIntegerWithRestResponseAsync(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
         return service.responseInteger(scenario);
     }
+
+    /**
+     * Get a response with header value "value": 1 or -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HeaderResponseIntegerHeaders, Void> object
+     */
+    public Single<Void> responseIntegerAsync(String scenario) {
+        return responseIntegerWithRestResponseAsync(scenario)
+            .map(new Func1<RestResponse<HeaderResponseIntegerHeaders, Void>, Void>() { public Void call(RestResponse<HeaderResponseIntegerHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -482,6 +560,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void paramLong(String scenario, long value) {
         paramLongAsync(scenario, value).toBlocking().value();
@@ -496,7 +575,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> paramLongAsync(String scenario, long value, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> paramLongAsync(String scenario, long value, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(paramLongAsync(scenario, value), serviceCallback);
     }
 
@@ -506,14 +585,27 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "positive" or "negative"
      * @param value Send a post request with header values 105 or -2
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> paramLongAsync(String scenario, long value) {
+    public Single<RestResponse<Void, Void>> paramLongWithRestResponseAsync(String scenario, long value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
         return service.paramLong(scenario, value);
     }
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 105 or "scenario": "negative", "value": -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+     * @param value Send a post request with header values 105 or -2
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> paramLongAsync(String scenario, long value) {
+        return paramLongWithRestResponseAsync(scenario, value)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -523,6 +615,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void responseLong(String scenario) {
         responseLongAsync(scenario).toBlocking().value();
@@ -536,8 +629,8 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> responseLongAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(responseLongAsync(scenario), serviceCallback);
+    public ServiceFuture<Void> responseLongAsync(String scenario, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(responseLongAsync(scenario), serviceCallback);
     }
 
     /**
@@ -545,14 +638,26 @@ public class HeadersImpl implements fixtures.header.Headers {
      *
      * @param scenario Send a post request with header values "scenario": "positive" or "negative"
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HeaderResponseLongHeaders, Void> object
      */
-    public Single<Void> responseLongAsync(String scenario) {
+    public Single<RestResponse<HeaderResponseLongHeaders, Void>> responseLongWithRestResponseAsync(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
         return service.responseLong(scenario);
     }
+
+    /**
+     * Get a response with header value "value": 105 or -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HeaderResponseLongHeaders, Void> object
+     */
+    public Single<Void> responseLongAsync(String scenario) {
+        return responseLongWithRestResponseAsync(scenario)
+            .map(new Func1<RestResponse<HeaderResponseLongHeaders, Void>, Void>() { public Void call(RestResponse<HeaderResponseLongHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -563,6 +668,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void paramFloat(String scenario, double value) {
         paramFloatAsync(scenario, value).toBlocking().value();
@@ -577,7 +683,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> paramFloatAsync(String scenario, double value, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> paramFloatAsync(String scenario, double value, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(paramFloatAsync(scenario, value), serviceCallback);
     }
 
@@ -587,14 +693,27 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "positive" or "negative"
      * @param value Send a post request with header values 0.07 or -3.0
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> paramFloatAsync(String scenario, double value) {
+    public Single<RestResponse<Void, Void>> paramFloatWithRestResponseAsync(String scenario, double value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
         return service.paramFloat(scenario, value);
     }
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 0.07 or "scenario": "negative", "value": -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+     * @param value Send a post request with header values 0.07 or -3.0
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> paramFloatAsync(String scenario, double value) {
+        return paramFloatWithRestResponseAsync(scenario, value)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -604,6 +723,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void responseFloat(String scenario) {
         responseFloatAsync(scenario).toBlocking().value();
@@ -617,8 +737,8 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> responseFloatAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(responseFloatAsync(scenario), serviceCallback);
+    public ServiceFuture<Void> responseFloatAsync(String scenario, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(responseFloatAsync(scenario), serviceCallback);
     }
 
     /**
@@ -626,14 +746,26 @@ public class HeadersImpl implements fixtures.header.Headers {
      *
      * @param scenario Send a post request with header values "scenario": "positive" or "negative"
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HeaderResponseFloatHeaders, Void> object
      */
-    public Single<Void> responseFloatAsync(String scenario) {
+    public Single<RestResponse<HeaderResponseFloatHeaders, Void>> responseFloatWithRestResponseAsync(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
         return service.responseFloat(scenario);
     }
+
+    /**
+     * Get a response with header value "value": 0.07 or -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HeaderResponseFloatHeaders, Void> object
+     */
+    public Single<Void> responseFloatAsync(String scenario) {
+        return responseFloatWithRestResponseAsync(scenario)
+            .map(new Func1<RestResponse<HeaderResponseFloatHeaders, Void>, Void>() { public Void call(RestResponse<HeaderResponseFloatHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -644,6 +776,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void paramDouble(String scenario, double value) {
         paramDoubleAsync(scenario, value).toBlocking().value();
@@ -658,7 +791,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> paramDoubleAsync(String scenario, double value, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> paramDoubleAsync(String scenario, double value, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(paramDoubleAsync(scenario, value), serviceCallback);
     }
 
@@ -668,14 +801,27 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "positive" or "negative"
      * @param value Send a post request with header values 7e120 or -3.0
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> paramDoubleAsync(String scenario, double value) {
+    public Single<RestResponse<Void, Void>> paramDoubleWithRestResponseAsync(String scenario, double value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
         return service.paramDouble(scenario, value);
     }
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 7e120 or "scenario": "negative", "value": -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+     * @param value Send a post request with header values 7e120 or -3.0
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> paramDoubleAsync(String scenario, double value) {
+        return paramDoubleWithRestResponseAsync(scenario, value)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -685,6 +831,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void responseDouble(String scenario) {
         responseDoubleAsync(scenario).toBlocking().value();
@@ -698,8 +845,8 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> responseDoubleAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(responseDoubleAsync(scenario), serviceCallback);
+    public ServiceFuture<Void> responseDoubleAsync(String scenario, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(responseDoubleAsync(scenario), serviceCallback);
     }
 
     /**
@@ -707,14 +854,26 @@ public class HeadersImpl implements fixtures.header.Headers {
      *
      * @param scenario Send a post request with header values "scenario": "positive" or "negative"
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HeaderResponseDoubleHeaders, Void> object
      */
-    public Single<Void> responseDoubleAsync(String scenario) {
+    public Single<RestResponse<HeaderResponseDoubleHeaders, Void>> responseDoubleWithRestResponseAsync(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
         return service.responseDouble(scenario);
     }
+
+    /**
+     * Get a response with header value "value": 7e120 or -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HeaderResponseDoubleHeaders, Void> object
+     */
+    public Single<Void> responseDoubleAsync(String scenario) {
+        return responseDoubleWithRestResponseAsync(scenario)
+            .map(new Func1<RestResponse<HeaderResponseDoubleHeaders, Void>, Void>() { public Void call(RestResponse<HeaderResponseDoubleHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -725,6 +884,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void paramBool(String scenario, boolean value) {
         paramBoolAsync(scenario, value).toBlocking().value();
@@ -739,7 +899,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> paramBoolAsync(String scenario, boolean value, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> paramBoolAsync(String scenario, boolean value, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(paramBoolAsync(scenario, value), serviceCallback);
     }
 
@@ -749,14 +909,27 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "true" or "false"
      * @param value Send a post request with header values true or false
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> paramBoolAsync(String scenario, boolean value) {
+    public Single<RestResponse<Void, Void>> paramBoolWithRestResponseAsync(String scenario, boolean value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
         return service.paramBool(scenario, value);
     }
+
+    /**
+     * Send a post request with header values "scenario": "true", "value": true or "scenario": "false", "value": false.
+     *
+     * @param scenario Send a post request with header values "scenario": "true" or "false"
+     * @param value Send a post request with header values true or false
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> paramBoolAsync(String scenario, boolean value) {
+        return paramBoolWithRestResponseAsync(scenario, value)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -766,6 +939,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void responseBool(String scenario) {
         responseBoolAsync(scenario).toBlocking().value();
@@ -779,8 +953,8 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> responseBoolAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(responseBoolAsync(scenario), serviceCallback);
+    public ServiceFuture<Void> responseBoolAsync(String scenario, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(responseBoolAsync(scenario), serviceCallback);
     }
 
     /**
@@ -788,14 +962,26 @@ public class HeadersImpl implements fixtures.header.Headers {
      *
      * @param scenario Send a post request with header values "scenario": "true" or "false"
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HeaderResponseBoolHeaders, Void> object
      */
-    public Single<Void> responseBoolAsync(String scenario) {
+    public Single<RestResponse<HeaderResponseBoolHeaders, Void>> responseBoolWithRestResponseAsync(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
         return service.responseBool(scenario);
     }
+
+    /**
+     * Get a response with header value "value": true or false.
+     *
+     * @param scenario Send a post request with header values "scenario": "true" or "false"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HeaderResponseBoolHeaders, Void> object
+     */
+    public Single<Void> responseBoolAsync(String scenario) {
+        return responseBoolWithRestResponseAsync(scenario)
+            .map(new Func1<RestResponse<HeaderResponseBoolHeaders, Void>, Void>() { public Void call(RestResponse<HeaderResponseBoolHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -805,6 +991,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void paramString(String scenario) {
         paramStringAsync(scenario).toBlocking().value();
@@ -818,7 +1005,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> paramStringAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> paramStringAsync(String scenario, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(paramStringAsync(scenario), serviceCallback);
     }
 
@@ -827,9 +1014,9 @@ public class HeadersImpl implements fixtures.header.Headers {
      *
      * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> paramStringAsync(String scenario) {
+    public Single<RestResponse<Void, Void>> paramStringWithRestResponseAsync(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -841,10 +1028,23 @@ public class HeadersImpl implements fixtures.header.Headers {
      * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": "".
      *
      * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> paramStringAsync(String scenario) {
+        return paramStringWithRestResponseAsync(scenario)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": "".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
      * @param value Send a post request with header values "The quick brown fox jumps over the lazy dog" or null or ""
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void paramString(String scenario, String value) {
         paramStringAsync(scenario, value).toBlocking().value();
@@ -859,7 +1059,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> paramStringAsync(String scenario, String value, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> paramStringAsync(String scenario, String value, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(paramStringAsync(scenario, value), serviceCallback);
     }
 
@@ -869,14 +1069,27 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
      * @param value Send a post request with header values "The quick brown fox jumps over the lazy dog" or null or ""
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> paramStringAsync(String scenario, String value) {
+    public Single<RestResponse<Void, Void>> paramStringWithRestResponseAsync(String scenario, String value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
         return service.paramString(scenario, value);
     }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": "".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
+     * @param value Send a post request with header values "The quick brown fox jumps over the lazy dog" or null or ""
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> paramStringAsync(String scenario, String value) {
+        return paramStringWithRestResponseAsync(scenario, value)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -886,6 +1099,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void responseString(String scenario) {
         responseStringAsync(scenario).toBlocking().value();
@@ -899,8 +1113,8 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> responseStringAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(responseStringAsync(scenario), serviceCallback);
+    public ServiceFuture<Void> responseStringAsync(String scenario, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(responseStringAsync(scenario), serviceCallback);
     }
 
     /**
@@ -908,14 +1122,26 @@ public class HeadersImpl implements fixtures.header.Headers {
      *
      * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HeaderResponseStringHeaders, Void> object
      */
-    public Single<Void> responseStringAsync(String scenario) {
+    public Single<RestResponse<HeaderResponseStringHeaders, Void>> responseStringWithRestResponseAsync(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
         return service.responseString(scenario);
     }
+
+    /**
+     * Get a response with header values "The quick brown fox jumps over the lazy dog" or null or "".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HeaderResponseStringHeaders, Void> object
+     */
+    public Single<Void> responseStringAsync(String scenario) {
+        return responseStringWithRestResponseAsync(scenario)
+            .map(new Func1<RestResponse<HeaderResponseStringHeaders, Void>, Void>() { public Void call(RestResponse<HeaderResponseStringHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -926,6 +1152,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void paramDate(String scenario, LocalDate value) {
         paramDateAsync(scenario, value).toBlocking().value();
@@ -940,7 +1167,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> paramDateAsync(String scenario, LocalDate value, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> paramDateAsync(String scenario, LocalDate value, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(paramDateAsync(scenario, value), serviceCallback);
     }
 
@@ -950,9 +1177,9 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "valid" or "min"
      * @param value Send a post request with header values "2010-01-01" or "0001-01-01"
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> paramDateAsync(String scenario, LocalDate value) {
+    public Single<RestResponse<Void, Void>> paramDateWithRestResponseAsync(String scenario, LocalDate value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -962,6 +1189,19 @@ public class HeadersImpl implements fixtures.header.Headers {
         return service.paramDate(scenario, value);
     }
 
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "2010-01-01" or "scenario": "min", "value": "0001-01-01".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min"
+     * @param value Send a post request with header values "2010-01-01" or "0001-01-01"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> paramDateAsync(String scenario, LocalDate value) {
+        return paramDateWithRestResponseAsync(scenario, value)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
+
 
     /**
      * Get a response with header values "2010-01-01" or "0001-01-01".
@@ -970,6 +1210,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void responseDate(String scenario) {
         responseDateAsync(scenario).toBlocking().value();
@@ -983,8 +1224,8 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> responseDateAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(responseDateAsync(scenario), serviceCallback);
+    public ServiceFuture<Void> responseDateAsync(String scenario, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(responseDateAsync(scenario), serviceCallback);
     }
 
     /**
@@ -992,14 +1233,26 @@ public class HeadersImpl implements fixtures.header.Headers {
      *
      * @param scenario Send a post request with header values "scenario": "valid" or "min"
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HeaderResponseDateHeaders, Void> object
      */
-    public Single<Void> responseDateAsync(String scenario) {
+    public Single<RestResponse<HeaderResponseDateHeaders, Void>> responseDateWithRestResponseAsync(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
         return service.responseDate(scenario);
     }
+
+    /**
+     * Get a response with header values "2010-01-01" or "0001-01-01".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HeaderResponseDateHeaders, Void> object
+     */
+    public Single<Void> responseDateAsync(String scenario) {
+        return responseDateWithRestResponseAsync(scenario)
+            .map(new Func1<RestResponse<HeaderResponseDateHeaders, Void>, Void>() { public Void call(RestResponse<HeaderResponseDateHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1010,6 +1263,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void paramDatetime(String scenario, DateTime value) {
         paramDatetimeAsync(scenario, value).toBlocking().value();
@@ -1024,7 +1278,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> paramDatetimeAsync(String scenario, DateTime value, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> paramDatetimeAsync(String scenario, DateTime value, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(paramDatetimeAsync(scenario, value), serviceCallback);
     }
 
@@ -1034,9 +1288,9 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "valid" or "min"
      * @param value Send a post request with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z"
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> paramDatetimeAsync(String scenario, DateTime value) {
+    public Single<RestResponse<Void, Void>> paramDatetimeWithRestResponseAsync(String scenario, DateTime value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -1046,6 +1300,19 @@ public class HeadersImpl implements fixtures.header.Headers {
         return service.paramDatetime(scenario, value);
     }
 
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "2010-01-01T12:34:56Z" or "scenario": "min", "value": "0001-01-01T00:00:00Z".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min"
+     * @param value Send a post request with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> paramDatetimeAsync(String scenario, DateTime value) {
+        return paramDatetimeWithRestResponseAsync(scenario, value)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
+
 
     /**
      * Get a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z".
@@ -1054,6 +1321,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void responseDatetime(String scenario) {
         responseDatetimeAsync(scenario).toBlocking().value();
@@ -1067,8 +1335,8 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> responseDatetimeAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(responseDatetimeAsync(scenario), serviceCallback);
+    public ServiceFuture<Void> responseDatetimeAsync(String scenario, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(responseDatetimeAsync(scenario), serviceCallback);
     }
 
     /**
@@ -1076,14 +1344,26 @@ public class HeadersImpl implements fixtures.header.Headers {
      *
      * @param scenario Send a post request with header values "scenario": "valid" or "min"
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HeaderResponseDatetimeHeaders, Void> object
      */
-    public Single<Void> responseDatetimeAsync(String scenario) {
+    public Single<RestResponse<HeaderResponseDatetimeHeaders, Void>> responseDatetimeWithRestResponseAsync(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
         return service.responseDatetime(scenario);
     }
+
+    /**
+     * Get a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HeaderResponseDatetimeHeaders, Void> object
+     */
+    public Single<Void> responseDatetimeAsync(String scenario) {
+        return responseDatetimeWithRestResponseAsync(scenario)
+            .map(new Func1<RestResponse<HeaderResponseDatetimeHeaders, Void>, Void>() { public Void call(RestResponse<HeaderResponseDatetimeHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1093,6 +1373,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void paramDatetimeRfc1123(String scenario) {
         paramDatetimeRfc1123Async(scenario).toBlocking().value();
@@ -1106,7 +1387,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> paramDatetimeRfc1123Async(String scenario, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> paramDatetimeRfc1123Async(String scenario, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(paramDatetimeRfc1123Async(scenario), serviceCallback);
     }
 
@@ -1115,19 +1396,31 @@ public class HeadersImpl implements fixtures.header.Headers {
      *
      * @param scenario Send a post request with header values "scenario": "valid" or "min"
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> paramDatetimeRfc1123Async(String scenario) {
+    public Single<RestResponse<Void, Void>> paramDatetimeRfc1123WithRestResponseAsync(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
         final DateTime value = null;
-        DateTimeRfc1123 valueConverted = null;
-        if (value != null) {
-            valueConverted = new DateTimeRfc1123(value);
-        }
+    DateTimeRfc1123 valueConverted = null;
+    if (value != null) {
+        valueConverted = new DateTimeRfc1123(value);
+    }
         return service.paramDatetimeRfc1123(scenario, valueConverted);
     }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> paramDatetimeRfc1123Async(String scenario) {
+        return paramDatetimeRfc1123WithRestResponseAsync(scenario)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT".
@@ -1137,6 +1430,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void paramDatetimeRfc1123(String scenario, DateTime value) {
         paramDatetimeRfc1123Async(scenario, value).toBlocking().value();
@@ -1151,7 +1445,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> paramDatetimeRfc1123Async(String scenario, DateTime value, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> paramDatetimeRfc1123Async(String scenario, DateTime value, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(paramDatetimeRfc1123Async(scenario, value), serviceCallback);
     }
 
@@ -1161,18 +1455,31 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "valid" or "min"
      * @param value Send a post request with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT"
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> paramDatetimeRfc1123Async(String scenario, DateTime value) {
+    public Single<RestResponse<Void, Void>> paramDatetimeRfc1123WithRestResponseAsync(String scenario, DateTime value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
-        DateTimeRfc1123 valueConverted = null;
-        if (value != null) {
-            valueConverted = new DateTimeRfc1123(value);
-        }
+    DateTimeRfc1123 valueConverted = null;
+    if (value != null) {
+        valueConverted = new DateTimeRfc1123(value);
+    }
         return service.paramDatetimeRfc1123(scenario, valueConverted);
     }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min"
+     * @param value Send a post request with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> paramDatetimeRfc1123Async(String scenario, DateTime value) {
+        return paramDatetimeRfc1123WithRestResponseAsync(scenario, value)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1182,6 +1489,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void responseDatetimeRfc1123(String scenario) {
         responseDatetimeRfc1123Async(scenario).toBlocking().value();
@@ -1195,8 +1503,8 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> responseDatetimeRfc1123Async(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(responseDatetimeRfc1123Async(scenario), serviceCallback);
+    public ServiceFuture<Void> responseDatetimeRfc1123Async(String scenario, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(responseDatetimeRfc1123Async(scenario), serviceCallback);
     }
 
     /**
@@ -1204,14 +1512,26 @@ public class HeadersImpl implements fixtures.header.Headers {
      *
      * @param scenario Send a post request with header values "scenario": "valid" or "min"
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HeaderResponseDatetimeRfc1123Headers, Void> object
      */
-    public Single<Void> responseDatetimeRfc1123Async(String scenario) {
+    public Single<RestResponse<HeaderResponseDatetimeRfc1123Headers, Void>> responseDatetimeRfc1123WithRestResponseAsync(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
         return service.responseDatetimeRfc1123(scenario);
     }
+
+    /**
+     * Get a response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HeaderResponseDatetimeRfc1123Headers, Void> object
+     */
+    public Single<Void> responseDatetimeRfc1123Async(String scenario) {
+        return responseDatetimeRfc1123WithRestResponseAsync(scenario)
+            .map(new Func1<RestResponse<HeaderResponseDatetimeRfc1123Headers, Void>, Void>() { public Void call(RestResponse<HeaderResponseDatetimeRfc1123Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1222,6 +1542,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void paramDuration(String scenario, Period value) {
         paramDurationAsync(scenario, value).toBlocking().value();
@@ -1236,7 +1557,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> paramDurationAsync(String scenario, Period value, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> paramDurationAsync(String scenario, Period value, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(paramDurationAsync(scenario, value), serviceCallback);
     }
 
@@ -1246,9 +1567,9 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "valid"
      * @param value Send a post request with header values "P123DT22H14M12.011S"
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> paramDurationAsync(String scenario, Period value) {
+    public Single<RestResponse<Void, Void>> paramDurationWithRestResponseAsync(String scenario, Period value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -1258,6 +1579,19 @@ public class HeadersImpl implements fixtures.header.Headers {
         return service.paramDuration(scenario, value);
     }
 
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "P123DT22H14M12.011S".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid"
+     * @param value Send a post request with header values "P123DT22H14M12.011S"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> paramDurationAsync(String scenario, Period value) {
+        return paramDurationWithRestResponseAsync(scenario, value)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
+
 
     /**
      * Get a response with header values "P123DT22H14M12.011S".
@@ -1266,6 +1600,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void responseDuration(String scenario) {
         responseDurationAsync(scenario).toBlocking().value();
@@ -1279,8 +1614,8 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> responseDurationAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(responseDurationAsync(scenario), serviceCallback);
+    public ServiceFuture<Void> responseDurationAsync(String scenario, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(responseDurationAsync(scenario), serviceCallback);
     }
 
     /**
@@ -1288,14 +1623,26 @@ public class HeadersImpl implements fixtures.header.Headers {
      *
      * @param scenario Send a post request with header values "scenario": "valid"
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HeaderResponseDurationHeaders, Void> object
      */
-    public Single<Void> responseDurationAsync(String scenario) {
+    public Single<RestResponse<HeaderResponseDurationHeaders, Void>> responseDurationWithRestResponseAsync(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
         return service.responseDuration(scenario);
     }
+
+    /**
+     * Get a response with header values "P123DT22H14M12.011S".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HeaderResponseDurationHeaders, Void> object
+     */
+    public Single<Void> responseDurationAsync(String scenario) {
+        return responseDurationWithRestResponseAsync(scenario)
+            .map(new Func1<RestResponse<HeaderResponseDurationHeaders, Void>, Void>() { public Void call(RestResponse<HeaderResponseDurationHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1306,6 +1653,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void paramByte(String scenario, byte[] value) {
         paramByteAsync(scenario, value).toBlocking().value();
@@ -1320,7 +1668,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> paramByteAsync(String scenario, byte[] value, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> paramByteAsync(String scenario, byte[] value, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(paramByteAsync(scenario, value), serviceCallback);
     }
 
@@ -1330,18 +1678,31 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "valid"
      * @param value Send a post request with header values "啊齄丂狛狜隣郎隣兀﨩"
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> paramByteAsync(String scenario, byte[] value) {
+    public Single<RestResponse<Void, Void>> paramByteWithRestResponseAsync(String scenario, byte[] value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
         if (value == null) {
             throw new IllegalArgumentException("Parameter value is required and cannot be null.");
         }
-        String valueConverted = Base64.encodeBase64String(value);
+    String valueConverted = Base64.encodeBase64String(value);
         return service.paramByte(scenario, valueConverted);
     }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "啊齄丂狛狜隣郎隣兀﨩".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid"
+     * @param value Send a post request with header values "啊齄丂狛狜隣郎隣兀﨩"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> paramByteAsync(String scenario, byte[] value) {
+        return paramByteWithRestResponseAsync(scenario, value)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1351,6 +1712,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void responseByte(String scenario) {
         responseByteAsync(scenario).toBlocking().value();
@@ -1364,8 +1726,8 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> responseByteAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(responseByteAsync(scenario), serviceCallback);
+    public ServiceFuture<Void> responseByteAsync(String scenario, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(responseByteAsync(scenario), serviceCallback);
     }
 
     /**
@@ -1373,14 +1735,26 @@ public class HeadersImpl implements fixtures.header.Headers {
      *
      * @param scenario Send a post request with header values "scenario": "valid"
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HeaderResponseByteHeaders, Void> object
      */
-    public Single<Void> responseByteAsync(String scenario) {
+    public Single<RestResponse<HeaderResponseByteHeaders, Void>> responseByteWithRestResponseAsync(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
         return service.responseByte(scenario);
     }
+
+    /**
+     * Get a response with header values "啊齄丂狛狜隣郎隣兀﨩".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HeaderResponseByteHeaders, Void> object
+     */
+    public Single<Void> responseByteAsync(String scenario) {
+        return responseByteWithRestResponseAsync(scenario)
+            .map(new Func1<RestResponse<HeaderResponseByteHeaders, Void>, Void>() { public Void call(RestResponse<HeaderResponseByteHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1390,6 +1764,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void paramEnum(String scenario) {
         paramEnumAsync(scenario).toBlocking().value();
@@ -1403,7 +1778,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> paramEnumAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> paramEnumAsync(String scenario, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(paramEnumAsync(scenario), serviceCallback);
     }
 
@@ -1412,9 +1787,9 @@ public class HeadersImpl implements fixtures.header.Headers {
      *
      * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> paramEnumAsync(String scenario) {
+    public Single<RestResponse<Void, Void>> paramEnumWithRestResponseAsync(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
@@ -1426,10 +1801,23 @@ public class HeadersImpl implements fixtures.header.Headers {
      * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null.
      *
      * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> paramEnumAsync(String scenario) {
+        return paramEnumWithRestResponseAsync(scenario)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null.
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
      * @param value Send a post request with header values 'GREY'. Possible values include: 'White', 'black', 'GREY'
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void paramEnum(String scenario, GreyscaleColors value) {
         paramEnumAsync(scenario, value).toBlocking().value();
@@ -1444,7 +1832,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> paramEnumAsync(String scenario, GreyscaleColors value, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> paramEnumAsync(String scenario, GreyscaleColors value, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(paramEnumAsync(scenario, value), serviceCallback);
     }
 
@@ -1454,14 +1842,27 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
      * @param value Send a post request with header values 'GREY'. Possible values include: 'White', 'black', 'GREY'
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> paramEnumAsync(String scenario, GreyscaleColors value) {
+    public Single<RestResponse<Void, Void>> paramEnumWithRestResponseAsync(String scenario, GreyscaleColors value) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
         return service.paramEnum(scenario, value);
     }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null.
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
+     * @param value Send a post request with header values 'GREY'. Possible values include: 'White', 'black', 'GREY'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> paramEnumAsync(String scenario, GreyscaleColors value) {
+        return paramEnumWithRestResponseAsync(scenario, value)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1471,6 +1872,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void responseEnum(String scenario) {
         responseEnumAsync(scenario).toBlocking().value();
@@ -1484,8 +1886,8 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> responseEnumAsync(String scenario, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(responseEnumAsync(scenario), serviceCallback);
+    public ServiceFuture<Void> responseEnumAsync(String scenario, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(responseEnumAsync(scenario), serviceCallback);
     }
 
     /**
@@ -1493,14 +1895,26 @@ public class HeadersImpl implements fixtures.header.Headers {
      *
      * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HeaderResponseEnumHeaders, Void> object
      */
-    public Single<Void> responseEnumAsync(String scenario) {
+    public Single<RestResponse<HeaderResponseEnumHeaders, Void>> responseEnumWithRestResponseAsync(String scenario) {
         if (scenario == null) {
             throw new IllegalArgumentException("Parameter scenario is required and cannot be null.");
         }
         return service.responseEnum(scenario);
     }
+
+    /**
+     * Get a response with header values "GREY" or null.
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HeaderResponseEnumHeaders, Void> object
+     */
+    public Single<Void> responseEnumAsync(String scenario) {
+        return responseEnumWithRestResponseAsync(scenario)
+            .map(new Func1<RestResponse<HeaderResponseEnumHeaders, Void>, Void>() { public Void call(RestResponse<HeaderResponseEnumHeaders, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1509,6 +1923,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void customRequestId() {
         customRequestIdAsync().toBlocking().value();
@@ -1521,7 +1936,7 @@ public class HeadersImpl implements fixtures.header.Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> customRequestIdAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> customRequestIdAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(customRequestIdAsync(), serviceCallback);
     }
 
@@ -1529,11 +1944,22 @@ public class HeadersImpl implements fixtures.header.Headers {
      * Send x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> customRequestIdAsync() {
+    public Single<RestResponse<Void, Void>> customRequestIdWithRestResponseAsync() {
         return service.customRequestId();
     }
+
+    /**
+     * Send x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> customRequestIdAsync() {
+        return customRequestIdWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/http/HttpClientFailures.java
+++ b/test/vanilla/src/main/java/fixtures/http/HttpClientFailures.java
@@ -10,6 +10,7 @@
 
 package fixtures.http;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.http.models.Error;
@@ -49,6 +50,13 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> head400Async();
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> head400WithRestResponseAsync();
 
 
     /**
@@ -77,6 +85,13 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> get400Async();
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> get400WithRestResponseAsync();
 
 
     /**
@@ -105,6 +120,14 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> put400Async();
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> put400WithRestResponseAsync();
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
@@ -134,6 +157,14 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> put400Async(Boolean booleanValue);
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> put400WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -162,6 +193,14 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> patch400Async();
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> patch400WithRestResponseAsync();
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
@@ -191,6 +230,14 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> patch400Async(Boolean booleanValue);
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> patch400WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -219,6 +266,14 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> post400Async();
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> post400WithRestResponseAsync();
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
@@ -248,6 +303,14 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> post400Async(Boolean booleanValue);
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> post400WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -276,6 +339,14 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> delete400Async();
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> delete400WithRestResponseAsync();
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
@@ -305,6 +376,14 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> delete400Async(Boolean booleanValue);
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> delete400WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -333,6 +412,13 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> head401Async();
+    /**
+     * Return 401 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> head401WithRestResponseAsync();
 
 
     /**
@@ -361,6 +447,13 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> get402Async();
+    /**
+     * Return 402 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> get402WithRestResponseAsync();
 
 
     /**
@@ -389,6 +482,13 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> get403Async();
+    /**
+     * Return 403 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> get403WithRestResponseAsync();
 
 
     /**
@@ -417,6 +517,14 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> put404Async();
+
+    /**
+     * Return 404 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> put404WithRestResponseAsync();
     /**
      * Return 404 status code - should be represented in the client as an error.
      *
@@ -446,6 +554,14 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> put404Async(Boolean booleanValue);
+    /**
+     * Return 404 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> put404WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -474,6 +590,14 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> patch405Async();
+
+    /**
+     * Return 405 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> patch405WithRestResponseAsync();
     /**
      * Return 405 status code - should be represented in the client as an error.
      *
@@ -503,6 +627,14 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> patch405Async(Boolean booleanValue);
+    /**
+     * Return 405 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> patch405WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -531,6 +663,14 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> post406Async();
+
+    /**
+     * Return 406 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> post406WithRestResponseAsync();
     /**
      * Return 406 status code - should be represented in the client as an error.
      *
@@ -560,6 +700,14 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> post406Async(Boolean booleanValue);
+    /**
+     * Return 406 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> post406WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -588,6 +736,14 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> delete407Async();
+
+    /**
+     * Return 407 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> delete407WithRestResponseAsync();
     /**
      * Return 407 status code - should be represented in the client as an error.
      *
@@ -617,6 +773,14 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> delete407Async(Boolean booleanValue);
+    /**
+     * Return 407 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> delete407WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -645,6 +809,14 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> put409Async();
+
+    /**
+     * Return 409 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> put409WithRestResponseAsync();
     /**
      * Return 409 status code - should be represented in the client as an error.
      *
@@ -674,6 +846,14 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> put409Async(Boolean booleanValue);
+    /**
+     * Return 409 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> put409WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -702,6 +882,13 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> head410Async();
+    /**
+     * Return 410 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> head410WithRestResponseAsync();
 
 
     /**
@@ -730,6 +917,13 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> get411Async();
+    /**
+     * Return 411 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> get411WithRestResponseAsync();
 
 
     /**
@@ -758,6 +952,13 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> get412Async();
+    /**
+     * Return 412 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> get412WithRestResponseAsync();
 
 
     /**
@@ -786,6 +987,14 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> put413Async();
+
+    /**
+     * Return 413 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> put413WithRestResponseAsync();
     /**
      * Return 413 status code - should be represented in the client as an error.
      *
@@ -815,6 +1024,14 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> put413Async(Boolean booleanValue);
+    /**
+     * Return 413 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> put413WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -843,6 +1060,14 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> patch414Async();
+
+    /**
+     * Return 414 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> patch414WithRestResponseAsync();
     /**
      * Return 414 status code - should be represented in the client as an error.
      *
@@ -872,6 +1097,14 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> patch414Async(Boolean booleanValue);
+    /**
+     * Return 414 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> patch414WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -900,6 +1133,14 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> post415Async();
+
+    /**
+     * Return 415 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> post415WithRestResponseAsync();
     /**
      * Return 415 status code - should be represented in the client as an error.
      *
@@ -929,6 +1170,14 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> post415Async(Boolean booleanValue);
+    /**
+     * Return 415 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> post415WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -957,6 +1206,13 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> get416Async();
+    /**
+     * Return 416 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> get416WithRestResponseAsync();
 
 
     /**
@@ -985,6 +1241,14 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> delete417Async();
+
+    /**
+     * Return 417 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> delete417WithRestResponseAsync();
     /**
      * Return 417 status code - should be represented in the client as an error.
      *
@@ -1014,6 +1278,14 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> delete417Async(Boolean booleanValue);
+    /**
+     * Return 417 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> delete417WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -1042,6 +1314,13 @@ public interface HttpClientFailures {
      * @return the observable to the Error object
      */
     Single<Error> head429Async();
+    /**
+     * Return 429 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> head429WithRestResponseAsync();
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/http/HttpFailures.java
+++ b/test/vanilla/src/main/java/fixtures/http/HttpFailures.java
@@ -11,6 +11,7 @@
 package fixtures.http;
 
 import com.microsoft.rest.RestException;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.http.models.ErrorException;
@@ -49,6 +50,13 @@ public interface HttpFailures {
      * @return the observable to the boolean object
      */
     Single<Boolean> getEmptyErrorAsync();
+    /**
+     * Get empty error form server.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the boolean object
+     */
+    Single<RestResponse<Void, Boolean>> getEmptyErrorWithRestResponseAsync();
 
 
     /**
@@ -77,6 +85,13 @@ public interface HttpFailures {
      * @return the observable to the boolean object
      */
     Single<Boolean> getNoModelErrorAsync();
+    /**
+     * Get empty error form server.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the boolean object
+     */
+    Single<RestResponse<Void, Boolean>> getNoModelErrorWithRestResponseAsync();
 
 
     /**
@@ -105,6 +120,13 @@ public interface HttpFailures {
      * @return the observable to the boolean object
      */
     Single<Boolean> getNoModelEmptyAsync();
+    /**
+     * Get empty response from server.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the boolean object
+     */
+    Single<RestResponse<Void, Boolean>> getNoModelEmptyWithRestResponseAsync();
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/http/HttpRedirects.java
+++ b/test/vanilla/src/main/java/fixtures/http/HttpRedirects.java
@@ -10,6 +10,7 @@
 
 package fixtures.http;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.http.models.ErrorException;
@@ -63,6 +64,13 @@ public interface HttpRedirects {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> head300Async();
+    /**
+     * Return 300 status code and redirect to /http/success/200.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HttpRedirectsHead300Headers, Void>> head300WithRestResponseAsync();
 
 
     /**
@@ -91,6 +99,13 @@ public interface HttpRedirects {
      * @return the observable to the List&lt;String&gt; object
      */
     Single<List<String>> get300Async();
+    /**
+     * Return 300 status code and redirect to /http/success/200.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;String&gt; object
+     */
+    Single<RestResponse<HttpRedirectsGet300Headers, List<String>>> get300WithRestResponseAsync();
 
 
     /**
@@ -118,6 +133,13 @@ public interface HttpRedirects {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> head301Async();
+    /**
+     * Return 301 status code and redirect to /http/success/200.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HttpRedirectsHead301Headers, Void>> head301WithRestResponseAsync();
 
 
     /**
@@ -145,6 +167,13 @@ public interface HttpRedirects {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> get301Async();
+    /**
+     * Return 301 status code and redirect to /http/success/200.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HttpRedirectsGet301Headers, Void>> get301WithRestResponseAsync();
 
 
     /**
@@ -172,6 +201,14 @@ public interface HttpRedirects {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> put301Async();
+
+    /**
+     * Put true Boolean value in request returns 301.  This request should not be automatically redirected, but should return the received 301 to the caller for evaluation.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HttpRedirectsPut301Headers, Void>> put301WithRestResponseAsync();
     /**
      * Put true Boolean value in request returns 301.  This request should not be automatically redirected, but should return the received 301 to the caller for evaluation.
      *
@@ -200,6 +237,14 @@ public interface HttpRedirects {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> put301Async(Boolean booleanValue);
+    /**
+     * Put true Boolean value in request returns 301.  This request should not be automatically redirected, but should return the received 301 to the caller for evaluation.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HttpRedirectsPut301Headers, Void>> put301WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -227,6 +272,13 @@ public interface HttpRedirects {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> head302Async();
+    /**
+     * Return 302 status code and redirect to /http/success/200.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HttpRedirectsHead302Headers, Void>> head302WithRestResponseAsync();
 
 
     /**
@@ -254,6 +306,13 @@ public interface HttpRedirects {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> get302Async();
+    /**
+     * Return 302 status code and redirect to /http/success/200.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HttpRedirectsGet302Headers, Void>> get302WithRestResponseAsync();
 
 
     /**
@@ -281,6 +340,14 @@ public interface HttpRedirects {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> patch302Async();
+
+    /**
+     * Patch true Boolean value in request returns 302.  This request should not be automatically redirected, but should return the received 302 to the caller for evaluation.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HttpRedirectsPatch302Headers, Void>> patch302WithRestResponseAsync();
     /**
      * Patch true Boolean value in request returns 302.  This request should not be automatically redirected, but should return the received 302 to the caller for evaluation.
      *
@@ -309,6 +376,14 @@ public interface HttpRedirects {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> patch302Async(Boolean booleanValue);
+    /**
+     * Patch true Boolean value in request returns 302.  This request should not be automatically redirected, but should return the received 302 to the caller for evaluation.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HttpRedirectsPatch302Headers, Void>> patch302WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -336,6 +411,14 @@ public interface HttpRedirects {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> post303Async();
+
+    /**
+     * Post true Boolean value in request returns 303.  This request should be automatically redirected usign a get, ultimately returning a 200 status code.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HttpRedirectsPost303Headers, Void>> post303WithRestResponseAsync();
     /**
      * Post true Boolean value in request returns 303.  This request should be automatically redirected usign a get, ultimately returning a 200 status code.
      *
@@ -364,6 +447,14 @@ public interface HttpRedirects {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> post303Async(Boolean booleanValue);
+    /**
+     * Post true Boolean value in request returns 303.  This request should be automatically redirected usign a get, ultimately returning a 200 status code.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HttpRedirectsPost303Headers, Void>> post303WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -391,6 +482,13 @@ public interface HttpRedirects {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> head307Async();
+    /**
+     * Redirect with 307, resulting in a 200 success.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HttpRedirectsHead307Headers, Void>> head307WithRestResponseAsync();
 
 
     /**
@@ -418,6 +516,13 @@ public interface HttpRedirects {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> get307Async();
+    /**
+     * Redirect get with 307, resulting in a 200 success.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HttpRedirectsGet307Headers, Void>> get307WithRestResponseAsync();
 
 
     /**
@@ -445,6 +550,14 @@ public interface HttpRedirects {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> put307Async();
+
+    /**
+     * Put redirected with 307, resulting in a 200 after redirect.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HttpRedirectsPut307Headers, Void>> put307WithRestResponseAsync();
     /**
      * Put redirected with 307, resulting in a 200 after redirect.
      *
@@ -473,6 +586,14 @@ public interface HttpRedirects {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> put307Async(Boolean booleanValue);
+    /**
+     * Put redirected with 307, resulting in a 200 after redirect.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HttpRedirectsPut307Headers, Void>> put307WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -500,6 +621,14 @@ public interface HttpRedirects {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> patch307Async();
+
+    /**
+     * Patch redirected with 307, resulting in a 200 after redirect.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HttpRedirectsPatch307Headers, Void>> patch307WithRestResponseAsync();
     /**
      * Patch redirected with 307, resulting in a 200 after redirect.
      *
@@ -528,6 +657,14 @@ public interface HttpRedirects {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> patch307Async(Boolean booleanValue);
+    /**
+     * Patch redirected with 307, resulting in a 200 after redirect.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HttpRedirectsPatch307Headers, Void>> patch307WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -555,6 +692,14 @@ public interface HttpRedirects {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> post307Async();
+
+    /**
+     * Post redirected with 307, resulting in a 200 after redirect.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HttpRedirectsPost307Headers, Void>> post307WithRestResponseAsync();
     /**
      * Post redirected with 307, resulting in a 200 after redirect.
      *
@@ -583,6 +728,14 @@ public interface HttpRedirects {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> post307Async(Boolean booleanValue);
+    /**
+     * Post redirected with 307, resulting in a 200 after redirect.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HttpRedirectsPost307Headers, Void>> post307WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -610,6 +763,14 @@ public interface HttpRedirects {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> delete307Async();
+
+    /**
+     * Delete redirected with 307, resulting in a 200 after redirect.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HttpRedirectsDelete307Headers, Void>> delete307WithRestResponseAsync();
     /**
      * Delete redirected with 307, resulting in a 200 after redirect.
      *
@@ -638,6 +799,14 @@ public interface HttpRedirects {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> delete307Async(Boolean booleanValue);
+    /**
+     * Delete redirected with 307, resulting in a 200 after redirect.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<HttpRedirectsDelete307Headers, Void>> delete307WithRestResponseAsync(Boolean booleanValue);
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/http/HttpRetrys.java
+++ b/test/vanilla/src/main/java/fixtures/http/HttpRetrys.java
@@ -10,6 +10,7 @@
 
 package fixtures.http;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.http.models.ErrorException;
@@ -47,6 +48,13 @@ public interface HttpRetrys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> head408Async();
+    /**
+     * Return 408 status code, then 200 after retry.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> head408WithRestResponseAsync();
 
 
     /**
@@ -74,6 +82,14 @@ public interface HttpRetrys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> put500Async();
+
+    /**
+     * Return 500 status code, then 200 after retry.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> put500WithRestResponseAsync();
     /**
      * Return 500 status code, then 200 after retry.
      *
@@ -102,6 +118,14 @@ public interface HttpRetrys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> put500Async(Boolean booleanValue);
+    /**
+     * Return 500 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> put500WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -129,6 +153,14 @@ public interface HttpRetrys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> patch500Async();
+
+    /**
+     * Return 500 status code, then 200 after retry.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> patch500WithRestResponseAsync();
     /**
      * Return 500 status code, then 200 after retry.
      *
@@ -157,6 +189,14 @@ public interface HttpRetrys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> patch500Async(Boolean booleanValue);
+    /**
+     * Return 500 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> patch500WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -184,6 +224,13 @@ public interface HttpRetrys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> get502Async();
+    /**
+     * Return 502 status code, then 200 after retry.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> get502WithRestResponseAsync();
 
 
     /**
@@ -211,6 +258,14 @@ public interface HttpRetrys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> post503Async();
+
+    /**
+     * Return 503 status code, then 200 after retry.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> post503WithRestResponseAsync();
     /**
      * Return 503 status code, then 200 after retry.
      *
@@ -239,6 +294,14 @@ public interface HttpRetrys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> post503Async(Boolean booleanValue);
+    /**
+     * Return 503 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> post503WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -266,6 +329,14 @@ public interface HttpRetrys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> delete503Async();
+
+    /**
+     * Return 503 status code, then 200 after retry.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> delete503WithRestResponseAsync();
     /**
      * Return 503 status code, then 200 after retry.
      *
@@ -294,6 +365,14 @@ public interface HttpRetrys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> delete503Async(Boolean booleanValue);
+    /**
+     * Return 503 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> delete503WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -321,6 +400,14 @@ public interface HttpRetrys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> put504Async();
+
+    /**
+     * Return 504 status code, then 200 after retry.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> put504WithRestResponseAsync();
     /**
      * Return 504 status code, then 200 after retry.
      *
@@ -349,6 +436,14 @@ public interface HttpRetrys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> put504Async(Boolean booleanValue);
+    /**
+     * Return 504 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> put504WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -376,6 +471,14 @@ public interface HttpRetrys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> patch504Async();
+
+    /**
+     * Return 504 status code, then 200 after retry.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> patch504WithRestResponseAsync();
     /**
      * Return 504 status code, then 200 after retry.
      *
@@ -404,6 +507,14 @@ public interface HttpRetrys {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> patch504Async(Boolean booleanValue);
+    /**
+     * Return 504 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> patch504WithRestResponseAsync(Boolean booleanValue);
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/http/HttpServerFailures.java
+++ b/test/vanilla/src/main/java/fixtures/http/HttpServerFailures.java
@@ -10,6 +10,7 @@
 
 package fixtures.http;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.http.models.Error;
@@ -49,6 +50,13 @@ public interface HttpServerFailures {
      * @return the observable to the Error object
      */
     Single<Error> head501Async();
+    /**
+     * Return 501 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> head501WithRestResponseAsync();
 
 
     /**
@@ -77,6 +85,13 @@ public interface HttpServerFailures {
      * @return the observable to the Error object
      */
     Single<Error> get501Async();
+    /**
+     * Return 501 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> get501WithRestResponseAsync();
 
 
     /**
@@ -105,6 +120,14 @@ public interface HttpServerFailures {
      * @return the observable to the Error object
      */
     Single<Error> post505Async();
+
+    /**
+     * Return 505 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> post505WithRestResponseAsync();
     /**
      * Return 505 status code - should be represented in the client as an error.
      *
@@ -134,6 +157,14 @@ public interface HttpServerFailures {
      * @return the observable to the Error object
      */
     Single<Error> post505Async(Boolean booleanValue);
+    /**
+     * Return 505 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> post505WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -162,6 +193,14 @@ public interface HttpServerFailures {
      * @return the observable to the Error object
      */
     Single<Error> delete505Async();
+
+    /**
+     * Return 505 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> delete505WithRestResponseAsync();
     /**
      * Return 505 status code - should be represented in the client as an error.
      *
@@ -191,6 +230,14 @@ public interface HttpServerFailures {
      * @return the observable to the Error object
      */
     Single<Error> delete505Async(Boolean booleanValue);
+    /**
+     * Return 505 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> delete505WithRestResponseAsync(Boolean booleanValue);
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/http/HttpSuccess.java
+++ b/test/vanilla/src/main/java/fixtures/http/HttpSuccess.java
@@ -10,6 +10,7 @@
 
 package fixtures.http;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.http.models.ErrorException;
@@ -47,6 +48,13 @@ public interface HttpSuccess {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> head200Async();
+    /**
+     * Return 200 status code if successful.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> head200WithRestResponseAsync();
 
 
     /**
@@ -75,6 +83,13 @@ public interface HttpSuccess {
      * @return the observable to the boolean object
      */
     Single<Boolean> get200Async();
+    /**
+     * Get 200 success.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the boolean object
+     */
+    Single<RestResponse<Void, Boolean>> get200WithRestResponseAsync();
 
 
     /**
@@ -102,6 +117,14 @@ public interface HttpSuccess {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> put200Async();
+
+    /**
+     * Put boolean value true returning 200 success.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> put200WithRestResponseAsync();
     /**
      * Put boolean value true returning 200 success.
      *
@@ -130,6 +153,14 @@ public interface HttpSuccess {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> put200Async(Boolean booleanValue);
+    /**
+     * Put boolean value true returning 200 success.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> put200WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -157,6 +188,14 @@ public interface HttpSuccess {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> patch200Async();
+
+    /**
+     * Patch true Boolean value in request returning 200.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> patch200WithRestResponseAsync();
     /**
      * Patch true Boolean value in request returning 200.
      *
@@ -185,6 +224,14 @@ public interface HttpSuccess {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> patch200Async(Boolean booleanValue);
+    /**
+     * Patch true Boolean value in request returning 200.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> patch200WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -212,6 +259,14 @@ public interface HttpSuccess {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> post200Async();
+
+    /**
+     * Post bollean value true in request that returns a 200.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> post200WithRestResponseAsync();
     /**
      * Post bollean value true in request that returns a 200.
      *
@@ -240,6 +295,14 @@ public interface HttpSuccess {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> post200Async(Boolean booleanValue);
+    /**
+     * Post bollean value true in request that returns a 200.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> post200WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -267,6 +330,14 @@ public interface HttpSuccess {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> delete200Async();
+
+    /**
+     * Delete simple boolean value true returns 200.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> delete200WithRestResponseAsync();
     /**
      * Delete simple boolean value true returns 200.
      *
@@ -295,6 +366,14 @@ public interface HttpSuccess {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> delete200Async(Boolean booleanValue);
+    /**
+     * Delete simple boolean value true returns 200.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> delete200WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -322,6 +401,14 @@ public interface HttpSuccess {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> put201Async();
+
+    /**
+     * Put true Boolean value in request returns 201.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> put201WithRestResponseAsync();
     /**
      * Put true Boolean value in request returns 201.
      *
@@ -350,6 +437,14 @@ public interface HttpSuccess {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> put201Async(Boolean booleanValue);
+    /**
+     * Put true Boolean value in request returns 201.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> put201WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -377,6 +472,14 @@ public interface HttpSuccess {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> post201Async();
+
+    /**
+     * Post true Boolean value in request returns 201 (Created).
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> post201WithRestResponseAsync();
     /**
      * Post true Boolean value in request returns 201 (Created).
      *
@@ -405,6 +508,14 @@ public interface HttpSuccess {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> post201Async(Boolean booleanValue);
+    /**
+     * Post true Boolean value in request returns 201 (Created).
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> post201WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -432,6 +543,14 @@ public interface HttpSuccess {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> put202Async();
+
+    /**
+     * Put true Boolean value in request returns 202 (Accepted).
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> put202WithRestResponseAsync();
     /**
      * Put true Boolean value in request returns 202 (Accepted).
      *
@@ -460,6 +579,14 @@ public interface HttpSuccess {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> put202Async(Boolean booleanValue);
+    /**
+     * Put true Boolean value in request returns 202 (Accepted).
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> put202WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -487,6 +614,14 @@ public interface HttpSuccess {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> patch202Async();
+
+    /**
+     * Patch true Boolean value in request returns 202.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> patch202WithRestResponseAsync();
     /**
      * Patch true Boolean value in request returns 202.
      *
@@ -515,6 +650,14 @@ public interface HttpSuccess {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> patch202Async(Boolean booleanValue);
+    /**
+     * Patch true Boolean value in request returns 202.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> patch202WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -542,6 +685,14 @@ public interface HttpSuccess {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> post202Async();
+
+    /**
+     * Post true Boolean value in request returns 202 (Accepted).
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> post202WithRestResponseAsync();
     /**
      * Post true Boolean value in request returns 202 (Accepted).
      *
@@ -570,6 +721,14 @@ public interface HttpSuccess {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> post202Async(Boolean booleanValue);
+    /**
+     * Post true Boolean value in request returns 202 (Accepted).
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> post202WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -597,6 +756,14 @@ public interface HttpSuccess {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> delete202Async();
+
+    /**
+     * Delete true Boolean value in request returns 202 (accepted).
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> delete202WithRestResponseAsync();
     /**
      * Delete true Boolean value in request returns 202 (accepted).
      *
@@ -625,6 +792,14 @@ public interface HttpSuccess {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> delete202Async(Boolean booleanValue);
+    /**
+     * Delete true Boolean value in request returns 202 (accepted).
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> delete202WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -652,6 +827,13 @@ public interface HttpSuccess {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> head204Async();
+    /**
+     * Return 204 status code if successful.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> head204WithRestResponseAsync();
 
 
     /**
@@ -679,6 +861,14 @@ public interface HttpSuccess {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> put204Async();
+
+    /**
+     * Put true Boolean value in request returns 204 (no content).
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> put204WithRestResponseAsync();
     /**
      * Put true Boolean value in request returns 204 (no content).
      *
@@ -707,6 +897,14 @@ public interface HttpSuccess {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> put204Async(Boolean booleanValue);
+    /**
+     * Put true Boolean value in request returns 204 (no content).
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> put204WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -734,6 +932,14 @@ public interface HttpSuccess {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> patch204Async();
+
+    /**
+     * Patch true Boolean value in request returns 204 (no content).
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> patch204WithRestResponseAsync();
     /**
      * Patch true Boolean value in request returns 204 (no content).
      *
@@ -762,6 +968,14 @@ public interface HttpSuccess {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> patch204Async(Boolean booleanValue);
+    /**
+     * Patch true Boolean value in request returns 204 (no content).
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> patch204WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -789,6 +1003,14 @@ public interface HttpSuccess {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> post204Async();
+
+    /**
+     * Post true Boolean value in request returns 204 (no content).
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> post204WithRestResponseAsync();
     /**
      * Post true Boolean value in request returns 204 (no content).
      *
@@ -817,6 +1039,14 @@ public interface HttpSuccess {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> post204Async(Boolean booleanValue);
+    /**
+     * Post true Boolean value in request returns 204 (no content).
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> post204WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -844,6 +1074,14 @@ public interface HttpSuccess {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> delete204Async();
+
+    /**
+     * Delete true Boolean value in request returns 204 (no content).
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> delete204WithRestResponseAsync();
     /**
      * Delete true Boolean value in request returns 204 (no content).
      *
@@ -872,6 +1110,14 @@ public interface HttpSuccess {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> delete204Async(Boolean booleanValue);
+    /**
+     * Delete true Boolean value in request returns 204 (no content).
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> delete204WithRestResponseAsync(Boolean booleanValue);
 
 
     /**
@@ -899,6 +1145,13 @@ public interface HttpSuccess {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> head404Async();
+    /**
+     * Return 404 status code.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> head404WithRestResponseAsync();
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/http/MultipleResponses.java
+++ b/test/vanilla/src/main/java/fixtures/http/MultipleResponses.java
@@ -11,6 +11,7 @@
 package fixtures.http;
 
 import com.microsoft.rest.RestException;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.http.models.A;
@@ -51,6 +52,13 @@ public interface MultipleResponses {
      * @return the observable to the A object
      */
     Single<A> get200Model204NoModelDefaultError200ValidAsync();
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the A object
+     */
+    Single<RestResponse<Void, A>> get200Model204NoModelDefaultError200ValidWithRestResponseAsync();
 
 
     /**
@@ -79,6 +87,13 @@ public interface MultipleResponses {
      * @return the observable to the A object
      */
     Single<A> get200Model204NoModelDefaultError204ValidAsync();
+    /**
+     * Send a 204 response with no payload.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the A object
+     */
+    Single<RestResponse<Void, A>> get200Model204NoModelDefaultError204ValidWithRestResponseAsync();
 
 
     /**
@@ -107,6 +122,13 @@ public interface MultipleResponses {
      * @return the observable to the A object
      */
     Single<A> get200Model204NoModelDefaultError201InvalidAsync();
+    /**
+     * Send a 201 response with valid payload: {'statusCode': '201'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the A object
+     */
+    Single<RestResponse<Void, A>> get200Model204NoModelDefaultError201InvalidWithRestResponseAsync();
 
 
     /**
@@ -135,6 +157,13 @@ public interface MultipleResponses {
      * @return the observable to the A object
      */
     Single<A> get200Model204NoModelDefaultError202NoneAsync();
+    /**
+     * Send a 202 response with no payload:.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the A object
+     */
+    Single<RestResponse<Void, A>> get200Model204NoModelDefaultError202NoneWithRestResponseAsync();
 
 
     /**
@@ -163,6 +192,13 @@ public interface MultipleResponses {
      * @return the observable to the A object
      */
     Single<A> get200Model204NoModelDefaultError400ValidAsync();
+    /**
+     * Send a 400 response with valid error payload: {'status': 400, 'message': 'client error'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the A object
+     */
+    Single<RestResponse<Void, A>> get200Model204NoModelDefaultError400ValidWithRestResponseAsync();
 
 
     /**
@@ -191,6 +227,13 @@ public interface MultipleResponses {
      * @return the observable to the A object
      */
     Single<A> get200Model201ModelDefaultError200ValidAsync();
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the A object
+     */
+    Single<RestResponse<Void, A>> get200Model201ModelDefaultError200ValidWithRestResponseAsync();
 
 
     /**
@@ -219,6 +262,13 @@ public interface MultipleResponses {
      * @return the observable to the A object
      */
     Single<A> get200Model201ModelDefaultError201ValidAsync();
+    /**
+     * Send a 201 response with valid payload: {'statusCode': '201', 'textStatusCode': 'Created'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the A object
+     */
+    Single<RestResponse<Void, A>> get200Model201ModelDefaultError201ValidWithRestResponseAsync();
 
 
     /**
@@ -247,6 +297,13 @@ public interface MultipleResponses {
      * @return the observable to the A object
      */
     Single<A> get200Model201ModelDefaultError400ValidAsync();
+    /**
+     * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the A object
+     */
+    Single<RestResponse<Void, A>> get200Model201ModelDefaultError400ValidWithRestResponseAsync();
 
 
     /**
@@ -275,6 +332,13 @@ public interface MultipleResponses {
      * @return the observable to the Object object
      */
     Single<Object> get200ModelA201ModelC404ModelDDefaultError200ValidAsync();
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Object object
+     */
+    Single<RestResponse<Void, Object>> get200ModelA201ModelC404ModelDDefaultError200ValidWithRestResponseAsync();
 
 
     /**
@@ -303,6 +367,13 @@ public interface MultipleResponses {
      * @return the observable to the Object object
      */
     Single<Object> get200ModelA201ModelC404ModelDDefaultError201ValidAsync();
+    /**
+     * Send a 200 response with valid payload: {'httpCode': '201'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Object object
+     */
+    Single<RestResponse<Void, Object>> get200ModelA201ModelC404ModelDDefaultError201ValidWithRestResponseAsync();
 
 
     /**
@@ -331,6 +402,13 @@ public interface MultipleResponses {
      * @return the observable to the Object object
      */
     Single<Object> get200ModelA201ModelC404ModelDDefaultError404ValidAsync();
+    /**
+     * Send a 200 response with valid payload: {'httpStatusCode': '404'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Object object
+     */
+    Single<RestResponse<Void, Object>> get200ModelA201ModelC404ModelDDefaultError404ValidWithRestResponseAsync();
 
 
     /**
@@ -359,6 +437,13 @@ public interface MultipleResponses {
      * @return the observable to the Object object
      */
     Single<Object> get200ModelA201ModelC404ModelDDefaultError400ValidAsync();
+    /**
+     * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Object object
+     */
+    Single<RestResponse<Void, Object>> get200ModelA201ModelC404ModelDDefaultError400ValidWithRestResponseAsync();
 
 
     /**
@@ -386,6 +471,13 @@ public interface MultipleResponses {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> get202None204NoneDefaultError202NoneAsync();
+    /**
+     * Send a 202 response with no payload.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> get202None204NoneDefaultError202NoneWithRestResponseAsync();
 
 
     /**
@@ -413,6 +505,13 @@ public interface MultipleResponses {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> get202None204NoneDefaultError204NoneAsync();
+    /**
+     * Send a 204 response with no payload.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> get202None204NoneDefaultError204NoneWithRestResponseAsync();
 
 
     /**
@@ -440,6 +539,13 @@ public interface MultipleResponses {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> get202None204NoneDefaultError400ValidAsync();
+    /**
+     * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> get202None204NoneDefaultError400ValidWithRestResponseAsync();
 
 
     /**
@@ -467,6 +573,13 @@ public interface MultipleResponses {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> get202None204NoneDefaultNone202InvalidAsync();
+    /**
+     * Send a 202 response with an unexpected payload {'property': 'value'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> get202None204NoneDefaultNone202InvalidWithRestResponseAsync();
 
 
     /**
@@ -494,6 +607,13 @@ public interface MultipleResponses {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> get202None204NoneDefaultNone204NoneAsync();
+    /**
+     * Send a 204 response with no payload.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> get202None204NoneDefaultNone204NoneWithRestResponseAsync();
 
 
     /**
@@ -521,6 +641,13 @@ public interface MultipleResponses {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> get202None204NoneDefaultNone400NoneAsync();
+    /**
+     * Send a 400 response with no payload.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> get202None204NoneDefaultNone400NoneWithRestResponseAsync();
 
 
     /**
@@ -548,6 +675,13 @@ public interface MultipleResponses {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> get202None204NoneDefaultNone400InvalidAsync();
+    /**
+     * Send a 400 response with an unexpected payload {'property': 'value'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> get202None204NoneDefaultNone400InvalidWithRestResponseAsync();
 
 
     /**
@@ -576,6 +710,13 @@ public interface MultipleResponses {
      * @return the observable to the A object
      */
     Single<A> getDefaultModelA200ValidAsync();
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the A object
+     */
+    Single<RestResponse<Void, A>> getDefaultModelA200ValidWithRestResponseAsync();
 
 
     /**
@@ -604,6 +745,13 @@ public interface MultipleResponses {
      * @return the observable to the A object
      */
     Single<A> getDefaultModelA200NoneAsync();
+    /**
+     * Send a 200 response with no payload.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the A object
+     */
+    Single<RestResponse<Void, A>> getDefaultModelA200NoneWithRestResponseAsync();
 
 
     /**
@@ -632,6 +780,13 @@ public interface MultipleResponses {
      * @return the observable to the A object
      */
     Single<A> getDefaultModelA400ValidAsync();
+    /**
+     * Send a 400 response with valid payload: {'statusCode': '400'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the A object
+     */
+    Single<RestResponse<Void, A>> getDefaultModelA400ValidWithRestResponseAsync();
 
 
     /**
@@ -660,6 +815,13 @@ public interface MultipleResponses {
      * @return the observable to the A object
      */
     Single<A> getDefaultModelA400NoneAsync();
+    /**
+     * Send a 400 response with no payload.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the A object
+     */
+    Single<RestResponse<Void, A>> getDefaultModelA400NoneWithRestResponseAsync();
 
 
     /**
@@ -687,6 +849,13 @@ public interface MultipleResponses {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getDefaultNone200InvalidAsync();
+    /**
+     * Send a 200 response with invalid payload: {'statusCode': '200'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> getDefaultNone200InvalidWithRestResponseAsync();
 
 
     /**
@@ -714,6 +883,13 @@ public interface MultipleResponses {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getDefaultNone200NoneAsync();
+    /**
+     * Send a 200 response with no payload.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> getDefaultNone200NoneWithRestResponseAsync();
 
 
     /**
@@ -741,6 +917,13 @@ public interface MultipleResponses {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getDefaultNone400InvalidAsync();
+    /**
+     * Send a 400 response with valid payload: {'statusCode': '400'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> getDefaultNone400InvalidWithRestResponseAsync();
 
 
     /**
@@ -768,6 +951,13 @@ public interface MultipleResponses {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getDefaultNone400NoneAsync();
+    /**
+     * Send a 400 response with no payload.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> getDefaultNone400NoneWithRestResponseAsync();
 
 
     /**
@@ -796,6 +986,13 @@ public interface MultipleResponses {
      * @return the observable to the A object
      */
     Single<A> get200ModelA200NoneAsync();
+    /**
+     * Send a 200 response with no payload, when a payload is expected - client should return a null object of thde type for model A.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the A object
+     */
+    Single<RestResponse<Void, A>> get200ModelA200NoneWithRestResponseAsync();
 
 
     /**
@@ -824,6 +1021,13 @@ public interface MultipleResponses {
      * @return the observable to the A object
      */
     Single<A> get200ModelA200ValidAsync();
+    /**
+     * Send a 200 response with payload {'statusCode': '200'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the A object
+     */
+    Single<RestResponse<Void, A>> get200ModelA200ValidWithRestResponseAsync();
 
 
     /**
@@ -852,6 +1056,13 @@ public interface MultipleResponses {
      * @return the observable to the A object
      */
     Single<A> get200ModelA200InvalidAsync();
+    /**
+     * Send a 200 response with invalid payload {'statusCodeInvalid': '200'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the A object
+     */
+    Single<RestResponse<Void, A>> get200ModelA200InvalidWithRestResponseAsync();
 
 
     /**
@@ -880,6 +1091,13 @@ public interface MultipleResponses {
      * @return the observable to the A object
      */
     Single<A> get200ModelA400NoneAsync();
+    /**
+     * Send a 400 response with no payload client should treat as an http error with no error model.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the A object
+     */
+    Single<RestResponse<Void, A>> get200ModelA400NoneWithRestResponseAsync();
 
 
     /**
@@ -908,6 +1126,13 @@ public interface MultipleResponses {
      * @return the observable to the A object
      */
     Single<A> get200ModelA400ValidAsync();
+    /**
+     * Send a 200 response with payload {'statusCode': '400'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the A object
+     */
+    Single<RestResponse<Void, A>> get200ModelA400ValidWithRestResponseAsync();
 
 
     /**
@@ -936,6 +1161,13 @@ public interface MultipleResponses {
      * @return the observable to the A object
      */
     Single<A> get200ModelA400InvalidAsync();
+    /**
+     * Send a 200 response with invalid payload {'statusCodeInvalid': '400'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the A object
+     */
+    Single<RestResponse<Void, A>> get200ModelA400InvalidWithRestResponseAsync();
 
 
     /**
@@ -964,6 +1196,13 @@ public interface MultipleResponses {
      * @return the observable to the A object
      */
     Single<A> get200ModelA202ValidAsync();
+    /**
+     * Send a 202 response with payload {'statusCode': '202'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the A object
+     */
+    Single<RestResponse<Void, A>> get200ModelA202ValidWithRestResponseAsync();
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/http/implementation/AutoRestHttpInfrastructureTestServiceImpl.java
+++ b/test/vanilla/src/main/java/fixtures/http/implementation/AutoRestHttpInfrastructureTestServiceImpl.java
@@ -19,6 +19,7 @@ import fixtures.http.HttpServerFailures;
 import fixtures.http.HttpRetrys;
 import fixtures.http.MultipleResponses;
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceClient;
 import com.microsoft.rest.RestClient;
 import rx.Single;

--- a/test/vanilla/src/main/java/fixtures/http/implementation/HttpClientFailuresImpl.java
+++ b/test/vanilla/src/main/java/fixtures/http/implementation/HttpClientFailuresImpl.java
@@ -11,6 +11,7 @@
 package fixtures.http.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.http.HttpClientFailures;
 import com.microsoft.rest.annotations.BodyParam;
 import com.microsoft.rest.annotations.DELETE;
@@ -62,117 +63,117 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
         @Headers({ "x-ms-logging-context: fixtures.http.HttpClientFailures head400" })
         @HEAD("http/failure/client/400")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> head400();
+        Single<RestResponse<Void, Error>> head400();
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpClientFailures get400" })
         @GET("http/failure/client/400")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> get400();
+        Single<RestResponse<Void, Error>> get400();
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpClientFailures put400" })
         @PUT("http/failure/client/400")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> put400(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Error>> put400(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpClientFailures patch400" })
         @PATCH("http/failure/client/400")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> patch400(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Error>> patch400(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpClientFailures post400" })
         @POST("http/failure/client/400")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> post400(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Error>> post400(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpClientFailures delete400" })
         @DELETE("http/failure/client/400")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> delete400(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Error>> delete400(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpClientFailures head401" })
         @HEAD("http/failure/client/401")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> head401();
+        Single<RestResponse<Void, Error>> head401();
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpClientFailures get402" })
         @GET("http/failure/client/402")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> get402();
+        Single<RestResponse<Void, Error>> get402();
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpClientFailures get403" })
         @GET("http/failure/client/403")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> get403();
+        Single<RestResponse<Void, Error>> get403();
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpClientFailures put404" })
         @PUT("http/failure/client/404")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> put404(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Error>> put404(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpClientFailures patch405" })
         @PATCH("http/failure/client/405")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> patch405(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Error>> patch405(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpClientFailures post406" })
         @POST("http/failure/client/406")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> post406(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Error>> post406(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpClientFailures delete407" })
         @DELETE("http/failure/client/407")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> delete407(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Error>> delete407(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpClientFailures put409" })
         @PUT("http/failure/client/409")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> put409(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Error>> put409(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpClientFailures head410" })
         @HEAD("http/failure/client/410")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> head410();
+        Single<RestResponse<Void, Error>> head410();
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpClientFailures get411" })
         @GET("http/failure/client/411")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> get411();
+        Single<RestResponse<Void, Error>> get411();
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpClientFailures get412" })
         @GET("http/failure/client/412")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> get412();
+        Single<RestResponse<Void, Error>> get412();
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpClientFailures put413" })
         @PUT("http/failure/client/413")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> put413(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Error>> put413(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpClientFailures patch414" })
         @PATCH("http/failure/client/414")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> patch414(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Error>> patch414(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpClientFailures post415" })
         @POST("http/failure/client/415")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> post415(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Error>> post415(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpClientFailures get416" })
         @GET("http/failure/client/416")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> get416();
+        Single<RestResponse<Void, Error>> get416();
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpClientFailures delete417" })
         @DELETE("http/failure/client/417")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> delete417(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Error>> delete417(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpClientFailures head429" })
         @HEAD("http/failure/client/429")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> head429();
+        Single<RestResponse<Void, Error>> head429();
 
     }
 
@@ -195,7 +196,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> head400Async(final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> head400Async(ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(head400Async(), serviceCallback);
     }
 
@@ -203,11 +204,22 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * Return 400 status code - should be represented in the client as an error.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> head400Async() {
+    public Single<RestResponse<Void, Error>> head400WithRestResponseAsync() {
         return service.head400();
     }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> head400Async() {
+        return head400WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -229,7 +241,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> get400Async(final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> get400Async(ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(get400Async(), serviceCallback);
     }
 
@@ -237,11 +249,22 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * Return 400 status code - should be represented in the client as an error.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> get400Async() {
+    public Single<RestResponse<Void, Error>> get400WithRestResponseAsync() {
         return service.get400();
     }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> get400Async() {
+        return get400WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -263,7 +286,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> put400Async(final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> put400Async(ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(put400Async(), serviceCallback);
     }
 
@@ -271,12 +294,23 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * Return 400 status code - should be represented in the client as an error.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> put400Async() {
+    public Single<RestResponse<Void, Error>> put400WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.put400(booleanValue);
     }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> put400Async() {
+        return put400WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Return 400 status code - should be represented in the client as an error.
@@ -299,7 +333,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> put400Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> put400Async(Boolean booleanValue, ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(put400Async(booleanValue), serviceCallback);
     }
 
@@ -308,11 +342,23 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> put400Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Error>> put400WithRestResponseAsync(Boolean booleanValue) {
         return service.put400(booleanValue);
     }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> put400Async(Boolean booleanValue) {
+        return put400WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -334,7 +380,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> patch400Async(final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> patch400Async(ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(patch400Async(), serviceCallback);
     }
 
@@ -342,12 +388,23 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * Return 400 status code - should be represented in the client as an error.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> patch400Async() {
+    public Single<RestResponse<Void, Error>> patch400WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.patch400(booleanValue);
     }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> patch400Async() {
+        return patch400WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Return 400 status code - should be represented in the client as an error.
@@ -370,7 +427,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> patch400Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> patch400Async(Boolean booleanValue, ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(patch400Async(booleanValue), serviceCallback);
     }
 
@@ -379,11 +436,23 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> patch400Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Error>> patch400WithRestResponseAsync(Boolean booleanValue) {
         return service.patch400(booleanValue);
     }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> patch400Async(Boolean booleanValue) {
+        return patch400WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -405,7 +474,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> post400Async(final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> post400Async(ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(post400Async(), serviceCallback);
     }
 
@@ -413,12 +482,23 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * Return 400 status code - should be represented in the client as an error.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> post400Async() {
+    public Single<RestResponse<Void, Error>> post400WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.post400(booleanValue);
     }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> post400Async() {
+        return post400WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Return 400 status code - should be represented in the client as an error.
@@ -441,7 +521,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> post400Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> post400Async(Boolean booleanValue, ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(post400Async(booleanValue), serviceCallback);
     }
 
@@ -450,11 +530,23 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> post400Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Error>> post400WithRestResponseAsync(Boolean booleanValue) {
         return service.post400(booleanValue);
     }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> post400Async(Boolean booleanValue) {
+        return post400WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -476,7 +568,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> delete400Async(final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> delete400Async(ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(delete400Async(), serviceCallback);
     }
 
@@ -484,12 +576,23 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * Return 400 status code - should be represented in the client as an error.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> delete400Async() {
+    public Single<RestResponse<Void, Error>> delete400WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.delete400(booleanValue);
     }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> delete400Async() {
+        return delete400WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Return 400 status code - should be represented in the client as an error.
@@ -512,7 +615,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> delete400Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> delete400Async(Boolean booleanValue, ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(delete400Async(booleanValue), serviceCallback);
     }
 
@@ -521,11 +624,23 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> delete400Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Error>> delete400WithRestResponseAsync(Boolean booleanValue) {
         return service.delete400(booleanValue);
     }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> delete400Async(Boolean booleanValue) {
+        return delete400WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -547,7 +662,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> head401Async(final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> head401Async(ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(head401Async(), serviceCallback);
     }
 
@@ -555,11 +670,22 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * Return 401 status code - should be represented in the client as an error.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> head401Async() {
+    public Single<RestResponse<Void, Error>> head401WithRestResponseAsync() {
         return service.head401();
     }
+
+    /**
+     * Return 401 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> head401Async() {
+        return head401WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -581,7 +707,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> get402Async(final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> get402Async(ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(get402Async(), serviceCallback);
     }
 
@@ -589,11 +715,22 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * Return 402 status code - should be represented in the client as an error.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> get402Async() {
+    public Single<RestResponse<Void, Error>> get402WithRestResponseAsync() {
         return service.get402();
     }
+
+    /**
+     * Return 402 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> get402Async() {
+        return get402WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -615,7 +752,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> get403Async(final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> get403Async(ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(get403Async(), serviceCallback);
     }
 
@@ -623,11 +760,22 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * Return 403 status code - should be represented in the client as an error.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> get403Async() {
+    public Single<RestResponse<Void, Error>> get403WithRestResponseAsync() {
         return service.get403();
     }
+
+    /**
+     * Return 403 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> get403Async() {
+        return get403WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -649,7 +797,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> put404Async(final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> put404Async(ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(put404Async(), serviceCallback);
     }
 
@@ -657,12 +805,23 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * Return 404 status code - should be represented in the client as an error.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> put404Async() {
+    public Single<RestResponse<Void, Error>> put404WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.put404(booleanValue);
     }
+
+    /**
+     * Return 404 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> put404Async() {
+        return put404WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Return 404 status code - should be represented in the client as an error.
@@ -685,7 +844,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> put404Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> put404Async(Boolean booleanValue, ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(put404Async(booleanValue), serviceCallback);
     }
 
@@ -694,11 +853,23 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> put404Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Error>> put404WithRestResponseAsync(Boolean booleanValue) {
         return service.put404(booleanValue);
     }
+
+    /**
+     * Return 404 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> put404Async(Boolean booleanValue) {
+        return put404WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -720,7 +891,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> patch405Async(final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> patch405Async(ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(patch405Async(), serviceCallback);
     }
 
@@ -728,12 +899,23 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * Return 405 status code - should be represented in the client as an error.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> patch405Async() {
+    public Single<RestResponse<Void, Error>> patch405WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.patch405(booleanValue);
     }
+
+    /**
+     * Return 405 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> patch405Async() {
+        return patch405WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Return 405 status code - should be represented in the client as an error.
@@ -756,7 +938,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> patch405Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> patch405Async(Boolean booleanValue, ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(patch405Async(booleanValue), serviceCallback);
     }
 
@@ -765,11 +947,23 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> patch405Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Error>> patch405WithRestResponseAsync(Boolean booleanValue) {
         return service.patch405(booleanValue);
     }
+
+    /**
+     * Return 405 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> patch405Async(Boolean booleanValue) {
+        return patch405WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -791,7 +985,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> post406Async(final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> post406Async(ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(post406Async(), serviceCallback);
     }
 
@@ -799,12 +993,23 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * Return 406 status code - should be represented in the client as an error.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> post406Async() {
+    public Single<RestResponse<Void, Error>> post406WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.post406(booleanValue);
     }
+
+    /**
+     * Return 406 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> post406Async() {
+        return post406WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Return 406 status code - should be represented in the client as an error.
@@ -827,7 +1032,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> post406Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> post406Async(Boolean booleanValue, ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(post406Async(booleanValue), serviceCallback);
     }
 
@@ -836,11 +1041,23 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> post406Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Error>> post406WithRestResponseAsync(Boolean booleanValue) {
         return service.post406(booleanValue);
     }
+
+    /**
+     * Return 406 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> post406Async(Boolean booleanValue) {
+        return post406WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -862,7 +1079,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> delete407Async(final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> delete407Async(ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(delete407Async(), serviceCallback);
     }
 
@@ -870,12 +1087,23 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * Return 407 status code - should be represented in the client as an error.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> delete407Async() {
+    public Single<RestResponse<Void, Error>> delete407WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.delete407(booleanValue);
     }
+
+    /**
+     * Return 407 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> delete407Async() {
+        return delete407WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Return 407 status code - should be represented in the client as an error.
@@ -898,7 +1126,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> delete407Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> delete407Async(Boolean booleanValue, ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(delete407Async(booleanValue), serviceCallback);
     }
 
@@ -907,11 +1135,23 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> delete407Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Error>> delete407WithRestResponseAsync(Boolean booleanValue) {
         return service.delete407(booleanValue);
     }
+
+    /**
+     * Return 407 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> delete407Async(Boolean booleanValue) {
+        return delete407WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -933,7 +1173,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> put409Async(final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> put409Async(ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(put409Async(), serviceCallback);
     }
 
@@ -941,12 +1181,23 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * Return 409 status code - should be represented in the client as an error.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> put409Async() {
+    public Single<RestResponse<Void, Error>> put409WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.put409(booleanValue);
     }
+
+    /**
+     * Return 409 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> put409Async() {
+        return put409WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Return 409 status code - should be represented in the client as an error.
@@ -969,7 +1220,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> put409Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> put409Async(Boolean booleanValue, ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(put409Async(booleanValue), serviceCallback);
     }
 
@@ -978,11 +1229,23 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> put409Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Error>> put409WithRestResponseAsync(Boolean booleanValue) {
         return service.put409(booleanValue);
     }
+
+    /**
+     * Return 409 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> put409Async(Boolean booleanValue) {
+        return put409WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1004,7 +1267,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> head410Async(final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> head410Async(ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(head410Async(), serviceCallback);
     }
 
@@ -1012,11 +1275,22 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * Return 410 status code - should be represented in the client as an error.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> head410Async() {
+    public Single<RestResponse<Void, Error>> head410WithRestResponseAsync() {
         return service.head410();
     }
+
+    /**
+     * Return 410 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> head410Async() {
+        return head410WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1038,7 +1312,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> get411Async(final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> get411Async(ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(get411Async(), serviceCallback);
     }
 
@@ -1046,11 +1320,22 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * Return 411 status code - should be represented in the client as an error.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> get411Async() {
+    public Single<RestResponse<Void, Error>> get411WithRestResponseAsync() {
         return service.get411();
     }
+
+    /**
+     * Return 411 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> get411Async() {
+        return get411WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1072,7 +1357,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> get412Async(final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> get412Async(ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(get412Async(), serviceCallback);
     }
 
@@ -1080,11 +1365,22 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * Return 412 status code - should be represented in the client as an error.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> get412Async() {
+    public Single<RestResponse<Void, Error>> get412WithRestResponseAsync() {
         return service.get412();
     }
+
+    /**
+     * Return 412 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> get412Async() {
+        return get412WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1106,7 +1402,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> put413Async(final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> put413Async(ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(put413Async(), serviceCallback);
     }
 
@@ -1114,12 +1410,23 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * Return 413 status code - should be represented in the client as an error.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> put413Async() {
+    public Single<RestResponse<Void, Error>> put413WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.put413(booleanValue);
     }
+
+    /**
+     * Return 413 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> put413Async() {
+        return put413WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Return 413 status code - should be represented in the client as an error.
@@ -1142,7 +1449,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> put413Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> put413Async(Boolean booleanValue, ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(put413Async(booleanValue), serviceCallback);
     }
 
@@ -1151,11 +1458,23 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> put413Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Error>> put413WithRestResponseAsync(Boolean booleanValue) {
         return service.put413(booleanValue);
     }
+
+    /**
+     * Return 413 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> put413Async(Boolean booleanValue) {
+        return put413WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1177,7 +1496,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> patch414Async(final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> patch414Async(ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(patch414Async(), serviceCallback);
     }
 
@@ -1185,12 +1504,23 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * Return 414 status code - should be represented in the client as an error.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> patch414Async() {
+    public Single<RestResponse<Void, Error>> patch414WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.patch414(booleanValue);
     }
+
+    /**
+     * Return 414 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> patch414Async() {
+        return patch414WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Return 414 status code - should be represented in the client as an error.
@@ -1213,7 +1543,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> patch414Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> patch414Async(Boolean booleanValue, ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(patch414Async(booleanValue), serviceCallback);
     }
 
@@ -1222,11 +1552,23 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> patch414Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Error>> patch414WithRestResponseAsync(Boolean booleanValue) {
         return service.patch414(booleanValue);
     }
+
+    /**
+     * Return 414 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> patch414Async(Boolean booleanValue) {
+        return patch414WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1248,7 +1590,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> post415Async(final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> post415Async(ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(post415Async(), serviceCallback);
     }
 
@@ -1256,12 +1598,23 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * Return 415 status code - should be represented in the client as an error.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> post415Async() {
+    public Single<RestResponse<Void, Error>> post415WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.post415(booleanValue);
     }
+
+    /**
+     * Return 415 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> post415Async() {
+        return post415WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Return 415 status code - should be represented in the client as an error.
@@ -1284,7 +1637,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> post415Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> post415Async(Boolean booleanValue, ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(post415Async(booleanValue), serviceCallback);
     }
 
@@ -1293,11 +1646,23 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> post415Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Error>> post415WithRestResponseAsync(Boolean booleanValue) {
         return service.post415(booleanValue);
     }
+
+    /**
+     * Return 415 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> post415Async(Boolean booleanValue) {
+        return post415WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1319,7 +1684,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> get416Async(final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> get416Async(ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(get416Async(), serviceCallback);
     }
 
@@ -1327,11 +1692,22 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * Return 416 status code - should be represented in the client as an error.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> get416Async() {
+    public Single<RestResponse<Void, Error>> get416WithRestResponseAsync() {
         return service.get416();
     }
+
+    /**
+     * Return 416 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> get416Async() {
+        return get416WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1353,7 +1729,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> delete417Async(final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> delete417Async(ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(delete417Async(), serviceCallback);
     }
 
@@ -1361,12 +1737,23 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * Return 417 status code - should be represented in the client as an error.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> delete417Async() {
+    public Single<RestResponse<Void, Error>> delete417WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.delete417(booleanValue);
     }
+
+    /**
+     * Return 417 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> delete417Async() {
+        return delete417WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Return 417 status code - should be represented in the client as an error.
@@ -1389,7 +1776,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> delete417Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> delete417Async(Boolean booleanValue, ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(delete417Async(booleanValue), serviceCallback);
     }
 
@@ -1398,11 +1785,23 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> delete417Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Error>> delete417WithRestResponseAsync(Boolean booleanValue) {
         return service.delete417(booleanValue);
     }
+
+    /**
+     * Return 417 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> delete417Async(Boolean booleanValue) {
+        return delete417WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1424,7 +1823,7 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> head429Async(final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> head429Async(ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(head429Async(), serviceCallback);
     }
 
@@ -1432,11 +1831,22 @@ public class HttpClientFailuresImpl implements HttpClientFailures {
      * Return 429 status code - should be represented in the client as an error.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> head429Async() {
+    public Single<RestResponse<Void, Error>> head429WithRestResponseAsync() {
         return service.head429();
     }
+
+    /**
+     * Return 429 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> head429Async() {
+        return head429WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/http/implementation/HttpFailuresImpl.java
+++ b/test/vanilla/src/main/java/fixtures/http/implementation/HttpFailuresImpl.java
@@ -11,6 +11,7 @@
 package fixtures.http.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.http.HttpFailures;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.ExpectedResponses;
@@ -58,17 +59,17 @@ public class HttpFailuresImpl implements HttpFailures {
         @GET("http/failure/emptybody/error")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Boolean> getEmptyError();
+        Single<RestResponse<Void, Boolean>> getEmptyError();
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpFailures getNoModelError" })
         @GET("http/failure/nomodel/error")
         @ExpectedResponses({200})
-        Single<Boolean> getNoModelError();
+        Single<RestResponse<Void, Boolean>> getNoModelError();
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpFailures getNoModelEmpty" })
         @GET("http/failure/nomodel/empty")
         @ExpectedResponses({200})
-        Single<Boolean> getNoModelEmpty();
+        Single<RestResponse<Void, Boolean>> getNoModelEmpty();
 
     }
 
@@ -91,7 +92,7 @@ public class HttpFailuresImpl implements HttpFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Boolean> getEmptyErrorAsync(final ServiceCallback<Boolean> serviceCallback) {
+    public ServiceFuture<Boolean> getEmptyErrorAsync(ServiceCallback<Boolean> serviceCallback) {
         return ServiceFuture.fromBody(getEmptyErrorAsync(), serviceCallback);
     }
 
@@ -99,11 +100,22 @@ public class HttpFailuresImpl implements HttpFailures {
      * Get empty error form server.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Boolean object
+     * @return a {@link Single} emitting the RestResponse<Void, Boolean> object
      */
-    public Single<Boolean> getEmptyErrorAsync() {
+    public Single<RestResponse<Void, Boolean>> getEmptyErrorWithRestResponseAsync() {
         return service.getEmptyError();
     }
+
+    /**
+     * Get empty error form server.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Boolean> object
+     */
+    public Single<Boolean> getEmptyErrorAsync() {
+        return getEmptyErrorWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Boolean>, Boolean>() { public Boolean call(RestResponse<Void, Boolean> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -125,7 +137,7 @@ public class HttpFailuresImpl implements HttpFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Boolean> getNoModelErrorAsync(final ServiceCallback<Boolean> serviceCallback) {
+    public ServiceFuture<Boolean> getNoModelErrorAsync(ServiceCallback<Boolean> serviceCallback) {
         return ServiceFuture.fromBody(getNoModelErrorAsync(), serviceCallback);
     }
 
@@ -133,11 +145,22 @@ public class HttpFailuresImpl implements HttpFailures {
      * Get empty error form server.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Boolean object
+     * @return a {@link Single} emitting the RestResponse<Void, Boolean> object
      */
-    public Single<Boolean> getNoModelErrorAsync() {
+    public Single<RestResponse<Void, Boolean>> getNoModelErrorWithRestResponseAsync() {
         return service.getNoModelError();
     }
+
+    /**
+     * Get empty error form server.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Boolean> object
+     */
+    public Single<Boolean> getNoModelErrorAsync() {
+        return getNoModelErrorWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Boolean>, Boolean>() { public Boolean call(RestResponse<Void, Boolean> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -159,7 +182,7 @@ public class HttpFailuresImpl implements HttpFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Boolean> getNoModelEmptyAsync(final ServiceCallback<Boolean> serviceCallback) {
+    public ServiceFuture<Boolean> getNoModelEmptyAsync(ServiceCallback<Boolean> serviceCallback) {
         return ServiceFuture.fromBody(getNoModelEmptyAsync(), serviceCallback);
     }
 
@@ -167,11 +190,22 @@ public class HttpFailuresImpl implements HttpFailures {
      * Get empty response from server.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Boolean object
+     * @return a {@link Single} emitting the RestResponse<Void, Boolean> object
      */
-    public Single<Boolean> getNoModelEmptyAsync() {
+    public Single<RestResponse<Void, Boolean>> getNoModelEmptyWithRestResponseAsync() {
         return service.getNoModelEmpty();
     }
+
+    /**
+     * Get empty response from server.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Boolean> object
+     */
+    public Single<Boolean> getNoModelEmptyAsync() {
+        return getNoModelEmptyWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Boolean>, Boolean>() { public Boolean call(RestResponse<Void, Boolean> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/http/implementation/HttpRedirectsImpl.java
+++ b/test/vanilla/src/main/java/fixtures/http/implementation/HttpRedirectsImpl.java
@@ -11,6 +11,7 @@
 package fixtures.http.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.http.HttpRedirects;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.BodyParam;
@@ -79,91 +80,91 @@ public class HttpRedirectsImpl implements HttpRedirects {
         @HEAD("http/redirect/300")
         @ExpectedResponses({200, 300})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> head300();
+        Single<RestResponse<HttpRedirectsHead300Headers, Void>> head300();
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpRedirects get300" })
         @GET("http/redirect/300")
         @ExpectedResponses({200, 300})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<String>> get300();
+        Single<RestResponse<HttpRedirectsGet300Headers, List<String>>> get300();
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpRedirects head301" })
         @HEAD("http/redirect/301")
         @ExpectedResponses({200, 301})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> head301();
+        Single<RestResponse<HttpRedirectsHead301Headers, Void>> head301();
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpRedirects get301" })
         @GET("http/redirect/301")
         @ExpectedResponses({200, 301})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> get301();
+        Single<RestResponse<HttpRedirectsGet301Headers, Void>> get301();
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpRedirects put301" })
         @PUT("http/redirect/301")
         @ExpectedResponses({301})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> put301(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<HttpRedirectsPut301Headers, Void>> put301(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpRedirects head302" })
         @HEAD("http/redirect/302")
         @ExpectedResponses({200, 302})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> head302();
+        Single<RestResponse<HttpRedirectsHead302Headers, Void>> head302();
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpRedirects get302" })
         @GET("http/redirect/302")
         @ExpectedResponses({200, 302})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> get302();
+        Single<RestResponse<HttpRedirectsGet302Headers, Void>> get302();
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpRedirects patch302" })
         @PATCH("http/redirect/302")
         @ExpectedResponses({302})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> patch302(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<HttpRedirectsPatch302Headers, Void>> patch302(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpRedirects post303" })
         @POST("http/redirect/303")
         @ExpectedResponses({200, 303})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> post303(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<HttpRedirectsPost303Headers, Void>> post303(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpRedirects head307" })
         @HEAD("http/redirect/307")
         @ExpectedResponses({200, 307})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> head307();
+        Single<RestResponse<HttpRedirectsHead307Headers, Void>> head307();
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpRedirects get307" })
         @GET("http/redirect/307")
         @ExpectedResponses({200, 307})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> get307();
+        Single<RestResponse<HttpRedirectsGet307Headers, Void>> get307();
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpRedirects put307" })
         @PUT("http/redirect/307")
         @ExpectedResponses({200, 307})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> put307(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<HttpRedirectsPut307Headers, Void>> put307(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpRedirects patch307" })
         @PATCH("http/redirect/307")
         @ExpectedResponses({200, 307})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> patch307(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<HttpRedirectsPatch307Headers, Void>> patch307(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpRedirects post307" })
         @POST("http/redirect/307")
         @ExpectedResponses({200, 307})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> post307(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<HttpRedirectsPost307Headers, Void>> post307(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpRedirects delete307" })
         @DELETE("http/redirect/307")
         @ExpectedResponses({200, 307})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> delete307(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<HttpRedirectsDelete307Headers, Void>> delete307(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
     }
 
@@ -173,6 +174,7 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void head300() {
         head300Async().toBlocking().value();
@@ -185,19 +187,30 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> head300Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(head300Async(), serviceCallback);
+    public ServiceFuture<Void> head300Async(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(head300Async(), serviceCallback);
     }
 
     /**
      * Return 300 status code and redirect to /http/success/200.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsHead300Headers, Void> object
      */
-    public Single<Void> head300Async() {
+    public Single<RestResponse<HttpRedirectsHead300Headers, Void>> head300WithRestResponseAsync() {
         return service.head300();
     }
+
+    /**
+     * Return 300 status code and redirect to /http/success/200.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsHead300Headers, Void> object
+     */
+    public Single<Void> head300Async() {
+        return head300WithRestResponseAsync()
+            .map(new Func1<RestResponse<HttpRedirectsHead300Headers, Void>, Void>() { public Void call(RestResponse<HttpRedirectsHead300Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -219,19 +232,30 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<String>> get300Async(final ServiceCallback<List<String>> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(get300Async(), serviceCallback);
+    public ServiceFuture<List<String>> get300Async(ServiceCallback<List<String>> serviceCallback) {
+        return ServiceFuture.fromBody(get300Async(), serviceCallback);
     }
 
     /**
      * Return 300 status code and redirect to /http/success/200.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;String&gt; object
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsGet300Headers, List<String>> object
      */
-    public Single<List<String>> get300Async() {
+    public Single<RestResponse<HttpRedirectsGet300Headers, List<String>>> get300WithRestResponseAsync() {
         return service.get300();
     }
+
+    /**
+     * Return 300 status code and redirect to /http/success/200.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsGet300Headers, List<String>> object
+     */
+    public Single<List<String>> get300Async() {
+        return get300WithRestResponseAsync()
+            .map(new Func1<RestResponse<HttpRedirectsGet300Headers, List<String>>, List<String>>() { public List<String> call(RestResponse<HttpRedirectsGet300Headers, List<String>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -240,6 +264,7 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void head301() {
         head301Async().toBlocking().value();
@@ -252,19 +277,30 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> head301Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(head301Async(), serviceCallback);
+    public ServiceFuture<Void> head301Async(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(head301Async(), serviceCallback);
     }
 
     /**
      * Return 301 status code and redirect to /http/success/200.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsHead301Headers, Void> object
      */
-    public Single<Void> head301Async() {
+    public Single<RestResponse<HttpRedirectsHead301Headers, Void>> head301WithRestResponseAsync() {
         return service.head301();
     }
+
+    /**
+     * Return 301 status code and redirect to /http/success/200.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsHead301Headers, Void> object
+     */
+    public Single<Void> head301Async() {
+        return head301WithRestResponseAsync()
+            .map(new Func1<RestResponse<HttpRedirectsHead301Headers, Void>, Void>() { public Void call(RestResponse<HttpRedirectsHead301Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -273,6 +309,7 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void get301() {
         get301Async().toBlocking().value();
@@ -285,19 +322,30 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> get301Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(get301Async(), serviceCallback);
+    public ServiceFuture<Void> get301Async(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(get301Async(), serviceCallback);
     }
 
     /**
      * Return 301 status code and redirect to /http/success/200.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsGet301Headers, Void> object
      */
-    public Single<Void> get301Async() {
+    public Single<RestResponse<HttpRedirectsGet301Headers, Void>> get301WithRestResponseAsync() {
         return service.get301();
     }
+
+    /**
+     * Return 301 status code and redirect to /http/success/200.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsGet301Headers, Void> object
+     */
+    public Single<Void> get301Async() {
+        return get301WithRestResponseAsync()
+            .map(new Func1<RestResponse<HttpRedirectsGet301Headers, Void>, Void>() { public Void call(RestResponse<HttpRedirectsGet301Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -306,6 +354,7 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void put301() {
         put301Async().toBlocking().value();
@@ -318,20 +367,31 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> put301Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(put301Async(), serviceCallback);
+    public ServiceFuture<Void> put301Async(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(put301Async(), serviceCallback);
     }
 
     /**
      * Put true Boolean value in request returns 301.  This request should not be automatically redirected, but should return the received 301 to the caller for evaluation.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsPut301Headers, Void> object
      */
-    public Single<Void> put301Async() {
+    public Single<RestResponse<HttpRedirectsPut301Headers, Void>> put301WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.put301(booleanValue);
     }
+
+    /**
+     * Put true Boolean value in request returns 301.  This request should not be automatically redirected, but should return the received 301 to the caller for evaluation.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsPut301Headers, Void> object
+     */
+    public Single<Void> put301Async() {
+        return put301WithRestResponseAsync()
+            .map(new Func1<RestResponse<HttpRedirectsPut301Headers, Void>, Void>() { public Void call(RestResponse<HttpRedirectsPut301Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Put true Boolean value in request returns 301.  This request should not be automatically redirected, but should return the received 301 to the caller for evaluation.
@@ -340,6 +400,7 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void put301(Boolean booleanValue) {
         put301Async(booleanValue).toBlocking().value();
@@ -353,8 +414,8 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> put301Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(put301Async(booleanValue), serviceCallback);
+    public ServiceFuture<Void> put301Async(Boolean booleanValue, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(put301Async(booleanValue), serviceCallback);
     }
 
     /**
@@ -362,11 +423,23 @@ public class HttpRedirectsImpl implements HttpRedirects {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsPut301Headers, Void> object
      */
-    public Single<Void> put301Async(Boolean booleanValue) {
+    public Single<RestResponse<HttpRedirectsPut301Headers, Void>> put301WithRestResponseAsync(Boolean booleanValue) {
         return service.put301(booleanValue);
     }
+
+    /**
+     * Put true Boolean value in request returns 301.  This request should not be automatically redirected, but should return the received 301 to the caller for evaluation.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsPut301Headers, Void> object
+     */
+    public Single<Void> put301Async(Boolean booleanValue) {
+        return put301WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<HttpRedirectsPut301Headers, Void>, Void>() { public Void call(RestResponse<HttpRedirectsPut301Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -375,6 +448,7 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void head302() {
         head302Async().toBlocking().value();
@@ -387,19 +461,30 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> head302Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(head302Async(), serviceCallback);
+    public ServiceFuture<Void> head302Async(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(head302Async(), serviceCallback);
     }
 
     /**
      * Return 302 status code and redirect to /http/success/200.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsHead302Headers, Void> object
      */
-    public Single<Void> head302Async() {
+    public Single<RestResponse<HttpRedirectsHead302Headers, Void>> head302WithRestResponseAsync() {
         return service.head302();
     }
+
+    /**
+     * Return 302 status code and redirect to /http/success/200.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsHead302Headers, Void> object
+     */
+    public Single<Void> head302Async() {
+        return head302WithRestResponseAsync()
+            .map(new Func1<RestResponse<HttpRedirectsHead302Headers, Void>, Void>() { public Void call(RestResponse<HttpRedirectsHead302Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -408,6 +493,7 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void get302() {
         get302Async().toBlocking().value();
@@ -420,19 +506,30 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> get302Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(get302Async(), serviceCallback);
+    public ServiceFuture<Void> get302Async(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(get302Async(), serviceCallback);
     }
 
     /**
      * Return 302 status code and redirect to /http/success/200.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsGet302Headers, Void> object
      */
-    public Single<Void> get302Async() {
+    public Single<RestResponse<HttpRedirectsGet302Headers, Void>> get302WithRestResponseAsync() {
         return service.get302();
     }
+
+    /**
+     * Return 302 status code and redirect to /http/success/200.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsGet302Headers, Void> object
+     */
+    public Single<Void> get302Async() {
+        return get302WithRestResponseAsync()
+            .map(new Func1<RestResponse<HttpRedirectsGet302Headers, Void>, Void>() { public Void call(RestResponse<HttpRedirectsGet302Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -441,6 +538,7 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void patch302() {
         patch302Async().toBlocking().value();
@@ -453,20 +551,31 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> patch302Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(patch302Async(), serviceCallback);
+    public ServiceFuture<Void> patch302Async(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(patch302Async(), serviceCallback);
     }
 
     /**
      * Patch true Boolean value in request returns 302.  This request should not be automatically redirected, but should return the received 302 to the caller for evaluation.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsPatch302Headers, Void> object
      */
-    public Single<Void> patch302Async() {
+    public Single<RestResponse<HttpRedirectsPatch302Headers, Void>> patch302WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.patch302(booleanValue);
     }
+
+    /**
+     * Patch true Boolean value in request returns 302.  This request should not be automatically redirected, but should return the received 302 to the caller for evaluation.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsPatch302Headers, Void> object
+     */
+    public Single<Void> patch302Async() {
+        return patch302WithRestResponseAsync()
+            .map(new Func1<RestResponse<HttpRedirectsPatch302Headers, Void>, Void>() { public Void call(RestResponse<HttpRedirectsPatch302Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Patch true Boolean value in request returns 302.  This request should not be automatically redirected, but should return the received 302 to the caller for evaluation.
@@ -475,6 +584,7 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void patch302(Boolean booleanValue) {
         patch302Async(booleanValue).toBlocking().value();
@@ -488,8 +598,8 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> patch302Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(patch302Async(booleanValue), serviceCallback);
+    public ServiceFuture<Void> patch302Async(Boolean booleanValue, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(patch302Async(booleanValue), serviceCallback);
     }
 
     /**
@@ -497,11 +607,23 @@ public class HttpRedirectsImpl implements HttpRedirects {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsPatch302Headers, Void> object
      */
-    public Single<Void> patch302Async(Boolean booleanValue) {
+    public Single<RestResponse<HttpRedirectsPatch302Headers, Void>> patch302WithRestResponseAsync(Boolean booleanValue) {
         return service.patch302(booleanValue);
     }
+
+    /**
+     * Patch true Boolean value in request returns 302.  This request should not be automatically redirected, but should return the received 302 to the caller for evaluation.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsPatch302Headers, Void> object
+     */
+    public Single<Void> patch302Async(Boolean booleanValue) {
+        return patch302WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<HttpRedirectsPatch302Headers, Void>, Void>() { public Void call(RestResponse<HttpRedirectsPatch302Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -510,6 +632,7 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post303() {
         post303Async().toBlocking().value();
@@ -522,20 +645,31 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post303Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(post303Async(), serviceCallback);
+    public ServiceFuture<Void> post303Async(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(post303Async(), serviceCallback);
     }
 
     /**
      * Post true Boolean value in request returns 303.  This request should be automatically redirected usign a get, ultimately returning a 200 status code.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsPost303Headers, Void> object
      */
-    public Single<Void> post303Async() {
+    public Single<RestResponse<HttpRedirectsPost303Headers, Void>> post303WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.post303(booleanValue);
     }
+
+    /**
+     * Post true Boolean value in request returns 303.  This request should be automatically redirected usign a get, ultimately returning a 200 status code.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsPost303Headers, Void> object
+     */
+    public Single<Void> post303Async() {
+        return post303WithRestResponseAsync()
+            .map(new Func1<RestResponse<HttpRedirectsPost303Headers, Void>, Void>() { public Void call(RestResponse<HttpRedirectsPost303Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Post true Boolean value in request returns 303.  This request should be automatically redirected usign a get, ultimately returning a 200 status code.
@@ -544,6 +678,7 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post303(Boolean booleanValue) {
         post303Async(booleanValue).toBlocking().value();
@@ -557,8 +692,8 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post303Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(post303Async(booleanValue), serviceCallback);
+    public ServiceFuture<Void> post303Async(Boolean booleanValue, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(post303Async(booleanValue), serviceCallback);
     }
 
     /**
@@ -566,11 +701,23 @@ public class HttpRedirectsImpl implements HttpRedirects {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsPost303Headers, Void> object
      */
-    public Single<Void> post303Async(Boolean booleanValue) {
+    public Single<RestResponse<HttpRedirectsPost303Headers, Void>> post303WithRestResponseAsync(Boolean booleanValue) {
         return service.post303(booleanValue);
     }
+
+    /**
+     * Post true Boolean value in request returns 303.  This request should be automatically redirected usign a get, ultimately returning a 200 status code.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsPost303Headers, Void> object
+     */
+    public Single<Void> post303Async(Boolean booleanValue) {
+        return post303WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<HttpRedirectsPost303Headers, Void>, Void>() { public Void call(RestResponse<HttpRedirectsPost303Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -579,6 +726,7 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void head307() {
         head307Async().toBlocking().value();
@@ -591,19 +739,30 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> head307Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(head307Async(), serviceCallback);
+    public ServiceFuture<Void> head307Async(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(head307Async(), serviceCallback);
     }
 
     /**
      * Redirect with 307, resulting in a 200 success.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsHead307Headers, Void> object
      */
-    public Single<Void> head307Async() {
+    public Single<RestResponse<HttpRedirectsHead307Headers, Void>> head307WithRestResponseAsync() {
         return service.head307();
     }
+
+    /**
+     * Redirect with 307, resulting in a 200 success.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsHead307Headers, Void> object
+     */
+    public Single<Void> head307Async() {
+        return head307WithRestResponseAsync()
+            .map(new Func1<RestResponse<HttpRedirectsHead307Headers, Void>, Void>() { public Void call(RestResponse<HttpRedirectsHead307Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -612,6 +771,7 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void get307() {
         get307Async().toBlocking().value();
@@ -624,19 +784,30 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> get307Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(get307Async(), serviceCallback);
+    public ServiceFuture<Void> get307Async(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(get307Async(), serviceCallback);
     }
 
     /**
      * Redirect get with 307, resulting in a 200 success.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsGet307Headers, Void> object
      */
-    public Single<Void> get307Async() {
+    public Single<RestResponse<HttpRedirectsGet307Headers, Void>> get307WithRestResponseAsync() {
         return service.get307();
     }
+
+    /**
+     * Redirect get with 307, resulting in a 200 success.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsGet307Headers, Void> object
+     */
+    public Single<Void> get307Async() {
+        return get307WithRestResponseAsync()
+            .map(new Func1<RestResponse<HttpRedirectsGet307Headers, Void>, Void>() { public Void call(RestResponse<HttpRedirectsGet307Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -645,6 +816,7 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void put307() {
         put307Async().toBlocking().value();
@@ -657,20 +829,31 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> put307Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(put307Async(), serviceCallback);
+    public ServiceFuture<Void> put307Async(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(put307Async(), serviceCallback);
     }
 
     /**
      * Put redirected with 307, resulting in a 200 after redirect.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsPut307Headers, Void> object
      */
-    public Single<Void> put307Async() {
+    public Single<RestResponse<HttpRedirectsPut307Headers, Void>> put307WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.put307(booleanValue);
     }
+
+    /**
+     * Put redirected with 307, resulting in a 200 after redirect.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsPut307Headers, Void> object
+     */
+    public Single<Void> put307Async() {
+        return put307WithRestResponseAsync()
+            .map(new Func1<RestResponse<HttpRedirectsPut307Headers, Void>, Void>() { public Void call(RestResponse<HttpRedirectsPut307Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Put redirected with 307, resulting in a 200 after redirect.
@@ -679,6 +862,7 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void put307(Boolean booleanValue) {
         put307Async(booleanValue).toBlocking().value();
@@ -692,8 +876,8 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> put307Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(put307Async(booleanValue), serviceCallback);
+    public ServiceFuture<Void> put307Async(Boolean booleanValue, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(put307Async(booleanValue), serviceCallback);
     }
 
     /**
@@ -701,11 +885,23 @@ public class HttpRedirectsImpl implements HttpRedirects {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsPut307Headers, Void> object
      */
-    public Single<Void> put307Async(Boolean booleanValue) {
+    public Single<RestResponse<HttpRedirectsPut307Headers, Void>> put307WithRestResponseAsync(Boolean booleanValue) {
         return service.put307(booleanValue);
     }
+
+    /**
+     * Put redirected with 307, resulting in a 200 after redirect.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsPut307Headers, Void> object
+     */
+    public Single<Void> put307Async(Boolean booleanValue) {
+        return put307WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<HttpRedirectsPut307Headers, Void>, Void>() { public Void call(RestResponse<HttpRedirectsPut307Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -714,6 +910,7 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void patch307() {
         patch307Async().toBlocking().value();
@@ -726,20 +923,31 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> patch307Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(patch307Async(), serviceCallback);
+    public ServiceFuture<Void> patch307Async(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(patch307Async(), serviceCallback);
     }
 
     /**
      * Patch redirected with 307, resulting in a 200 after redirect.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsPatch307Headers, Void> object
      */
-    public Single<Void> patch307Async() {
+    public Single<RestResponse<HttpRedirectsPatch307Headers, Void>> patch307WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.patch307(booleanValue);
     }
+
+    /**
+     * Patch redirected with 307, resulting in a 200 after redirect.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsPatch307Headers, Void> object
+     */
+    public Single<Void> patch307Async() {
+        return patch307WithRestResponseAsync()
+            .map(new Func1<RestResponse<HttpRedirectsPatch307Headers, Void>, Void>() { public Void call(RestResponse<HttpRedirectsPatch307Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Patch redirected with 307, resulting in a 200 after redirect.
@@ -748,6 +956,7 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void patch307(Boolean booleanValue) {
         patch307Async(booleanValue).toBlocking().value();
@@ -761,8 +970,8 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> patch307Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(patch307Async(booleanValue), serviceCallback);
+    public ServiceFuture<Void> patch307Async(Boolean booleanValue, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(patch307Async(booleanValue), serviceCallback);
     }
 
     /**
@@ -770,11 +979,23 @@ public class HttpRedirectsImpl implements HttpRedirects {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsPatch307Headers, Void> object
      */
-    public Single<Void> patch307Async(Boolean booleanValue) {
+    public Single<RestResponse<HttpRedirectsPatch307Headers, Void>> patch307WithRestResponseAsync(Boolean booleanValue) {
         return service.patch307(booleanValue);
     }
+
+    /**
+     * Patch redirected with 307, resulting in a 200 after redirect.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsPatch307Headers, Void> object
+     */
+    public Single<Void> patch307Async(Boolean booleanValue) {
+        return patch307WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<HttpRedirectsPatch307Headers, Void>, Void>() { public Void call(RestResponse<HttpRedirectsPatch307Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -783,6 +1004,7 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post307() {
         post307Async().toBlocking().value();
@@ -795,20 +1017,31 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post307Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(post307Async(), serviceCallback);
+    public ServiceFuture<Void> post307Async(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(post307Async(), serviceCallback);
     }
 
     /**
      * Post redirected with 307, resulting in a 200 after redirect.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsPost307Headers, Void> object
      */
-    public Single<Void> post307Async() {
+    public Single<RestResponse<HttpRedirectsPost307Headers, Void>> post307WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.post307(booleanValue);
     }
+
+    /**
+     * Post redirected with 307, resulting in a 200 after redirect.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsPost307Headers, Void> object
+     */
+    public Single<Void> post307Async() {
+        return post307WithRestResponseAsync()
+            .map(new Func1<RestResponse<HttpRedirectsPost307Headers, Void>, Void>() { public Void call(RestResponse<HttpRedirectsPost307Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Post redirected with 307, resulting in a 200 after redirect.
@@ -817,6 +1050,7 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post307(Boolean booleanValue) {
         post307Async(booleanValue).toBlocking().value();
@@ -830,8 +1064,8 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post307Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(post307Async(booleanValue), serviceCallback);
+    public ServiceFuture<Void> post307Async(Boolean booleanValue, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(post307Async(booleanValue), serviceCallback);
     }
 
     /**
@@ -839,11 +1073,23 @@ public class HttpRedirectsImpl implements HttpRedirects {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsPost307Headers, Void> object
      */
-    public Single<Void> post307Async(Boolean booleanValue) {
+    public Single<RestResponse<HttpRedirectsPost307Headers, Void>> post307WithRestResponseAsync(Boolean booleanValue) {
         return service.post307(booleanValue);
     }
+
+    /**
+     * Post redirected with 307, resulting in a 200 after redirect.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsPost307Headers, Void> object
+     */
+    public Single<Void> post307Async(Boolean booleanValue) {
+        return post307WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<HttpRedirectsPost307Headers, Void>, Void>() { public Void call(RestResponse<HttpRedirectsPost307Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -852,6 +1098,7 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void delete307() {
         delete307Async().toBlocking().value();
@@ -864,20 +1111,31 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> delete307Async(final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(delete307Async(), serviceCallback);
+    public ServiceFuture<Void> delete307Async(ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(delete307Async(), serviceCallback);
     }
 
     /**
      * Delete redirected with 307, resulting in a 200 after redirect.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsDelete307Headers, Void> object
      */
-    public Single<Void> delete307Async() {
+    public Single<RestResponse<HttpRedirectsDelete307Headers, Void>> delete307WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.delete307(booleanValue);
     }
+
+    /**
+     * Delete redirected with 307, resulting in a 200 after redirect.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsDelete307Headers, Void> object
+     */
+    public Single<Void> delete307Async() {
+        return delete307WithRestResponseAsync()
+            .map(new Func1<RestResponse<HttpRedirectsDelete307Headers, Void>, Void>() { public Void call(RestResponse<HttpRedirectsDelete307Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Delete redirected with 307, resulting in a 200 after redirect.
@@ -886,6 +1144,7 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void delete307(Boolean booleanValue) {
         delete307Async(booleanValue).toBlocking().value();
@@ -899,8 +1158,8 @@ public class HttpRedirectsImpl implements HttpRedirects {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> delete307Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromBody/* RestProxy doesn't support headers */(delete307Async(booleanValue), serviceCallback);
+    public ServiceFuture<Void> delete307Async(Boolean booleanValue, ServiceCallback<Void> serviceCallback) {
+        return ServiceFuture.fromBody(delete307Async(booleanValue), serviceCallback);
     }
 
     /**
@@ -908,11 +1167,23 @@ public class HttpRedirectsImpl implements HttpRedirects {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsDelete307Headers, Void> object
      */
-    public Single<Void> delete307Async(Boolean booleanValue) {
+    public Single<RestResponse<HttpRedirectsDelete307Headers, Void>> delete307WithRestResponseAsync(Boolean booleanValue) {
         return service.delete307(booleanValue);
     }
+
+    /**
+     * Delete redirected with 307, resulting in a 200 after redirect.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<HttpRedirectsDelete307Headers, Void> object
+     */
+    public Single<Void> delete307Async(Boolean booleanValue) {
+        return delete307WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<HttpRedirectsDelete307Headers, Void>, Void>() { public Void call(RestResponse<HttpRedirectsDelete307Headers, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/http/implementation/HttpRetrysImpl.java
+++ b/test/vanilla/src/main/java/fixtures/http/implementation/HttpRetrysImpl.java
@@ -11,6 +11,7 @@
 package fixtures.http.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.http.HttpRetrys;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.BodyParam;
@@ -63,49 +64,49 @@ public class HttpRetrysImpl implements HttpRetrys {
         @HEAD("http/retry/408")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> head408();
+        Single<RestResponse<Void, Void>> head408();
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpRetrys put500" })
         @PUT("http/retry/500")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> put500(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Void>> put500(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpRetrys patch500" })
         @PATCH("http/retry/500")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> patch500(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Void>> patch500(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpRetrys get502" })
         @GET("http/retry/502")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> get502();
+        Single<RestResponse<Void, Void>> get502();
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpRetrys post503" })
         @POST("http/retry/503")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> post503(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Void>> post503(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpRetrys delete503" })
         @DELETE("http/retry/503")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> delete503(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Void>> delete503(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpRetrys put504" })
         @PUT("http/retry/504")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> put504(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Void>> put504(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpRetrys patch504" })
         @PATCH("http/retry/504")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> patch504(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Void>> patch504(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
     }
 
@@ -115,6 +116,7 @@ public class HttpRetrysImpl implements HttpRetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void head408() {
         head408Async().toBlocking().value();
@@ -127,7 +129,7 @@ public class HttpRetrysImpl implements HttpRetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> head408Async(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> head408Async(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(head408Async(), serviceCallback);
     }
 
@@ -135,11 +137,22 @@ public class HttpRetrysImpl implements HttpRetrys {
      * Return 408 status code, then 200 after retry.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> head408Async() {
+    public Single<RestResponse<Void, Void>> head408WithRestResponseAsync() {
         return service.head408();
     }
+
+    /**
+     * Return 408 status code, then 200 after retry.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> head408Async() {
+        return head408WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -148,6 +161,7 @@ public class HttpRetrysImpl implements HttpRetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void put500() {
         put500Async().toBlocking().value();
@@ -160,7 +174,7 @@ public class HttpRetrysImpl implements HttpRetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> put500Async(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> put500Async(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(put500Async(), serviceCallback);
     }
 
@@ -168,12 +182,23 @@ public class HttpRetrysImpl implements HttpRetrys {
      * Return 500 status code, then 200 after retry.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> put500Async() {
+    public Single<RestResponse<Void, Void>> put500WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.put500(booleanValue);
     }
+
+    /**
+     * Return 500 status code, then 200 after retry.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> put500Async() {
+        return put500WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Return 500 status code, then 200 after retry.
@@ -182,6 +207,7 @@ public class HttpRetrysImpl implements HttpRetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void put500(Boolean booleanValue) {
         put500Async(booleanValue).toBlocking().value();
@@ -195,7 +221,7 @@ public class HttpRetrysImpl implements HttpRetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> put500Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> put500Async(Boolean booleanValue, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(put500Async(booleanValue), serviceCallback);
     }
 
@@ -204,11 +230,23 @@ public class HttpRetrysImpl implements HttpRetrys {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> put500Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Void>> put500WithRestResponseAsync(Boolean booleanValue) {
         return service.put500(booleanValue);
     }
+
+    /**
+     * Return 500 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> put500Async(Boolean booleanValue) {
+        return put500WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -217,6 +255,7 @@ public class HttpRetrysImpl implements HttpRetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void patch500() {
         patch500Async().toBlocking().value();
@@ -229,7 +268,7 @@ public class HttpRetrysImpl implements HttpRetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> patch500Async(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> patch500Async(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(patch500Async(), serviceCallback);
     }
 
@@ -237,12 +276,23 @@ public class HttpRetrysImpl implements HttpRetrys {
      * Return 500 status code, then 200 after retry.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> patch500Async() {
+    public Single<RestResponse<Void, Void>> patch500WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.patch500(booleanValue);
     }
+
+    /**
+     * Return 500 status code, then 200 after retry.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> patch500Async() {
+        return patch500WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Return 500 status code, then 200 after retry.
@@ -251,6 +301,7 @@ public class HttpRetrysImpl implements HttpRetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void patch500(Boolean booleanValue) {
         patch500Async(booleanValue).toBlocking().value();
@@ -264,7 +315,7 @@ public class HttpRetrysImpl implements HttpRetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> patch500Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> patch500Async(Boolean booleanValue, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(patch500Async(booleanValue), serviceCallback);
     }
 
@@ -273,11 +324,23 @@ public class HttpRetrysImpl implements HttpRetrys {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> patch500Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Void>> patch500WithRestResponseAsync(Boolean booleanValue) {
         return service.patch500(booleanValue);
     }
+
+    /**
+     * Return 500 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> patch500Async(Boolean booleanValue) {
+        return patch500WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -286,6 +349,7 @@ public class HttpRetrysImpl implements HttpRetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void get502() {
         get502Async().toBlocking().value();
@@ -298,7 +362,7 @@ public class HttpRetrysImpl implements HttpRetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> get502Async(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> get502Async(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(get502Async(), serviceCallback);
     }
 
@@ -306,11 +370,22 @@ public class HttpRetrysImpl implements HttpRetrys {
      * Return 502 status code, then 200 after retry.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> get502Async() {
+    public Single<RestResponse<Void, Void>> get502WithRestResponseAsync() {
         return service.get502();
     }
+
+    /**
+     * Return 502 status code, then 200 after retry.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> get502Async() {
+        return get502WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -319,6 +394,7 @@ public class HttpRetrysImpl implements HttpRetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post503() {
         post503Async().toBlocking().value();
@@ -331,7 +407,7 @@ public class HttpRetrysImpl implements HttpRetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post503Async(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> post503Async(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(post503Async(), serviceCallback);
     }
 
@@ -339,12 +415,23 @@ public class HttpRetrysImpl implements HttpRetrys {
      * Return 503 status code, then 200 after retry.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> post503Async() {
+    public Single<RestResponse<Void, Void>> post503WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.post503(booleanValue);
     }
+
+    /**
+     * Return 503 status code, then 200 after retry.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> post503Async() {
+        return post503WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Return 503 status code, then 200 after retry.
@@ -353,6 +440,7 @@ public class HttpRetrysImpl implements HttpRetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post503(Boolean booleanValue) {
         post503Async(booleanValue).toBlocking().value();
@@ -366,7 +454,7 @@ public class HttpRetrysImpl implements HttpRetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post503Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> post503Async(Boolean booleanValue, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(post503Async(booleanValue), serviceCallback);
     }
 
@@ -375,11 +463,23 @@ public class HttpRetrysImpl implements HttpRetrys {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> post503Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Void>> post503WithRestResponseAsync(Boolean booleanValue) {
         return service.post503(booleanValue);
     }
+
+    /**
+     * Return 503 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> post503Async(Boolean booleanValue) {
+        return post503WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -388,6 +488,7 @@ public class HttpRetrysImpl implements HttpRetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void delete503() {
         delete503Async().toBlocking().value();
@@ -400,7 +501,7 @@ public class HttpRetrysImpl implements HttpRetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> delete503Async(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> delete503Async(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(delete503Async(), serviceCallback);
     }
 
@@ -408,12 +509,23 @@ public class HttpRetrysImpl implements HttpRetrys {
      * Return 503 status code, then 200 after retry.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> delete503Async() {
+    public Single<RestResponse<Void, Void>> delete503WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.delete503(booleanValue);
     }
+
+    /**
+     * Return 503 status code, then 200 after retry.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> delete503Async() {
+        return delete503WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Return 503 status code, then 200 after retry.
@@ -422,6 +534,7 @@ public class HttpRetrysImpl implements HttpRetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void delete503(Boolean booleanValue) {
         delete503Async(booleanValue).toBlocking().value();
@@ -435,7 +548,7 @@ public class HttpRetrysImpl implements HttpRetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> delete503Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> delete503Async(Boolean booleanValue, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(delete503Async(booleanValue), serviceCallback);
     }
 
@@ -444,11 +557,23 @@ public class HttpRetrysImpl implements HttpRetrys {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> delete503Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Void>> delete503WithRestResponseAsync(Boolean booleanValue) {
         return service.delete503(booleanValue);
     }
+
+    /**
+     * Return 503 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> delete503Async(Boolean booleanValue) {
+        return delete503WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -457,6 +582,7 @@ public class HttpRetrysImpl implements HttpRetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void put504() {
         put504Async().toBlocking().value();
@@ -469,7 +595,7 @@ public class HttpRetrysImpl implements HttpRetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> put504Async(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> put504Async(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(put504Async(), serviceCallback);
     }
 
@@ -477,12 +603,23 @@ public class HttpRetrysImpl implements HttpRetrys {
      * Return 504 status code, then 200 after retry.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> put504Async() {
+    public Single<RestResponse<Void, Void>> put504WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.put504(booleanValue);
     }
+
+    /**
+     * Return 504 status code, then 200 after retry.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> put504Async() {
+        return put504WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Return 504 status code, then 200 after retry.
@@ -491,6 +628,7 @@ public class HttpRetrysImpl implements HttpRetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void put504(Boolean booleanValue) {
         put504Async(booleanValue).toBlocking().value();
@@ -504,7 +642,7 @@ public class HttpRetrysImpl implements HttpRetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> put504Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> put504Async(Boolean booleanValue, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(put504Async(booleanValue), serviceCallback);
     }
 
@@ -513,11 +651,23 @@ public class HttpRetrysImpl implements HttpRetrys {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> put504Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Void>> put504WithRestResponseAsync(Boolean booleanValue) {
         return service.put504(booleanValue);
     }
+
+    /**
+     * Return 504 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> put504Async(Boolean booleanValue) {
+        return put504WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -526,6 +676,7 @@ public class HttpRetrysImpl implements HttpRetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void patch504() {
         patch504Async().toBlocking().value();
@@ -538,7 +689,7 @@ public class HttpRetrysImpl implements HttpRetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> patch504Async(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> patch504Async(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(patch504Async(), serviceCallback);
     }
 
@@ -546,12 +697,23 @@ public class HttpRetrysImpl implements HttpRetrys {
      * Return 504 status code, then 200 after retry.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> patch504Async() {
+    public Single<RestResponse<Void, Void>> patch504WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.patch504(booleanValue);
     }
+
+    /**
+     * Return 504 status code, then 200 after retry.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> patch504Async() {
+        return patch504WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Return 504 status code, then 200 after retry.
@@ -560,6 +722,7 @@ public class HttpRetrysImpl implements HttpRetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void patch504(Boolean booleanValue) {
         patch504Async(booleanValue).toBlocking().value();
@@ -573,7 +736,7 @@ public class HttpRetrysImpl implements HttpRetrys {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> patch504Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> patch504Async(Boolean booleanValue, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(patch504Async(booleanValue), serviceCallback);
     }
 
@@ -582,11 +745,23 @@ public class HttpRetrysImpl implements HttpRetrys {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> patch504Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Void>> patch504WithRestResponseAsync(Boolean booleanValue) {
         return service.patch504(booleanValue);
     }
+
+    /**
+     * Return 504 status code, then 200 after retry.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> patch504Async(Boolean booleanValue) {
+        return patch504WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/http/implementation/HttpServerFailuresImpl.java
+++ b/test/vanilla/src/main/java/fixtures/http/implementation/HttpServerFailuresImpl.java
@@ -11,6 +11,7 @@
 package fixtures.http.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.http.HttpServerFailures;
 import com.microsoft.rest.annotations.BodyParam;
 import com.microsoft.rest.annotations.DELETE;
@@ -60,22 +61,22 @@ public class HttpServerFailuresImpl implements HttpServerFailures {
         @Headers({ "x-ms-logging-context: fixtures.http.HttpServerFailures head501" })
         @HEAD("http/failure/server/501")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> head501();
+        Single<RestResponse<Void, Error>> head501();
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpServerFailures get501" })
         @GET("http/failure/server/501")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> get501();
+        Single<RestResponse<Void, Error>> get501();
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpServerFailures post505" })
         @POST("http/failure/server/505")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> post505(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Error>> post505(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpServerFailures delete505" })
         @DELETE("http/failure/server/505")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> delete505(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Error>> delete505(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
     }
 
@@ -98,7 +99,7 @@ public class HttpServerFailuresImpl implements HttpServerFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> head501Async(final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> head501Async(ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(head501Async(), serviceCallback);
     }
 
@@ -106,11 +107,22 @@ public class HttpServerFailuresImpl implements HttpServerFailures {
      * Return 501 status code - should be represented in the client as an error.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> head501Async() {
+    public Single<RestResponse<Void, Error>> head501WithRestResponseAsync() {
         return service.head501();
     }
+
+    /**
+     * Return 501 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> head501Async() {
+        return head501WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -132,7 +144,7 @@ public class HttpServerFailuresImpl implements HttpServerFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> get501Async(final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> get501Async(ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(get501Async(), serviceCallback);
     }
 
@@ -140,11 +152,22 @@ public class HttpServerFailuresImpl implements HttpServerFailures {
      * Return 501 status code - should be represented in the client as an error.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> get501Async() {
+    public Single<RestResponse<Void, Error>> get501WithRestResponseAsync() {
         return service.get501();
     }
+
+    /**
+     * Return 501 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> get501Async() {
+        return get501WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -166,7 +189,7 @@ public class HttpServerFailuresImpl implements HttpServerFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> post505Async(final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> post505Async(ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(post505Async(), serviceCallback);
     }
 
@@ -174,12 +197,23 @@ public class HttpServerFailuresImpl implements HttpServerFailures {
      * Return 505 status code - should be represented in the client as an error.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> post505Async() {
+    public Single<RestResponse<Void, Error>> post505WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.post505(booleanValue);
     }
+
+    /**
+     * Return 505 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> post505Async() {
+        return post505WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Return 505 status code - should be represented in the client as an error.
@@ -202,7 +236,7 @@ public class HttpServerFailuresImpl implements HttpServerFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> post505Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> post505Async(Boolean booleanValue, ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(post505Async(booleanValue), serviceCallback);
     }
 
@@ -211,11 +245,23 @@ public class HttpServerFailuresImpl implements HttpServerFailures {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> post505Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Error>> post505WithRestResponseAsync(Boolean booleanValue) {
         return service.post505(booleanValue);
     }
+
+    /**
+     * Return 505 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> post505Async(Boolean booleanValue) {
+        return post505WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -237,7 +283,7 @@ public class HttpServerFailuresImpl implements HttpServerFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> delete505Async(final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> delete505Async(ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(delete505Async(), serviceCallback);
     }
 
@@ -245,12 +291,23 @@ public class HttpServerFailuresImpl implements HttpServerFailures {
      * Return 505 status code - should be represented in the client as an error.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> delete505Async() {
+    public Single<RestResponse<Void, Error>> delete505WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.delete505(booleanValue);
     }
+
+    /**
+     * Return 505 status code - should be represented in the client as an error.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> delete505Async() {
+        return delete505WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Return 505 status code - should be represented in the client as an error.
@@ -273,7 +330,7 @@ public class HttpServerFailuresImpl implements HttpServerFailures {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> delete505Async(Boolean booleanValue, final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> delete505Async(Boolean booleanValue, ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(delete505Async(booleanValue), serviceCallback);
     }
 
@@ -282,11 +339,23 @@ public class HttpServerFailuresImpl implements HttpServerFailures {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> delete505Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Error>> delete505WithRestResponseAsync(Boolean booleanValue) {
         return service.delete505(booleanValue);
     }
+
+    /**
+     * Return 505 status code - should be represented in the client as an error.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> delete505Async(Boolean booleanValue) {
+        return delete505WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/http/implementation/HttpSuccessImpl.java
+++ b/test/vanilla/src/main/java/fixtures/http/implementation/HttpSuccessImpl.java
@@ -11,6 +11,7 @@
 package fixtures.http.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.http.HttpSuccess;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.BodyParam;
@@ -63,109 +64,109 @@ public class HttpSuccessImpl implements HttpSuccess {
         @HEAD("http/success/200")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> head200();
+        Single<RestResponse<Void, Void>> head200();
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpSuccess get200" })
         @GET("http/success/200")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Boolean> get200();
+        Single<RestResponse<Void, Boolean>> get200();
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpSuccess put200" })
         @PUT("http/success/200")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> put200(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Void>> put200(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpSuccess patch200" })
         @PATCH("http/success/200")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> patch200(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Void>> patch200(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpSuccess post200" })
         @POST("http/success/200")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> post200(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Void>> post200(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpSuccess delete200" })
         @DELETE("http/success/200")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> delete200(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Void>> delete200(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpSuccess put201" })
         @PUT("http/success/201")
         @ExpectedResponses({201})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> put201(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Void>> put201(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpSuccess post201" })
         @POST("http/success/201")
         @ExpectedResponses({201})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> post201(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Void>> post201(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpSuccess put202" })
         @PUT("http/success/202")
         @ExpectedResponses({202})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> put202(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Void>> put202(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpSuccess patch202" })
         @PATCH("http/success/202")
         @ExpectedResponses({202})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> patch202(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Void>> patch202(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpSuccess post202" })
         @POST("http/success/202")
         @ExpectedResponses({202})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> post202(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Void>> post202(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpSuccess delete202" })
         @DELETE("http/success/202")
         @ExpectedResponses({202})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> delete202(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Void>> delete202(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpSuccess head204" })
         @HEAD("http/success/204")
         @ExpectedResponses({204})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> head204();
+        Single<RestResponse<Void, Void>> head204();
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpSuccess put204" })
         @PUT("http/success/204")
         @ExpectedResponses({204})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> put204(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Void>> put204(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpSuccess patch204" })
         @PATCH("http/success/204")
         @ExpectedResponses({204})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> patch204(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Void>> patch204(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpSuccess post204" })
         @POST("http/success/204")
         @ExpectedResponses({204})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> post204(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Void>> post204(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpSuccess delete204" })
         @DELETE("http/success/204")
         @ExpectedResponses({204})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> delete204(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
+        Single<RestResponse<Void, Void>> delete204(@BodyParam("application/json; charset=utf-8") Boolean booleanValue);
 
         @Headers({ "x-ms-logging-context: fixtures.http.HttpSuccess head404" })
         @HEAD("http/success/404")
         @ExpectedResponses({204, 404})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> head404();
+        Single<RestResponse<Void, Void>> head404();
 
     }
 
@@ -175,6 +176,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void head200() {
         head200Async().toBlocking().value();
@@ -187,7 +189,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> head200Async(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> head200Async(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(head200Async(), serviceCallback);
     }
 
@@ -195,11 +197,22 @@ public class HttpSuccessImpl implements HttpSuccess {
      * Return 200 status code if successful.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> head200Async() {
+    public Single<RestResponse<Void, Void>> head200WithRestResponseAsync() {
         return service.head200();
     }
+
+    /**
+     * Return 200 status code if successful.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> head200Async() {
+        return head200WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -221,7 +234,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Boolean> get200Async(final ServiceCallback<Boolean> serviceCallback) {
+    public ServiceFuture<Boolean> get200Async(ServiceCallback<Boolean> serviceCallback) {
         return ServiceFuture.fromBody(get200Async(), serviceCallback);
     }
 
@@ -229,11 +242,22 @@ public class HttpSuccessImpl implements HttpSuccess {
      * Get 200 success.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Boolean object
+     * @return a {@link Single} emitting the RestResponse<Void, Boolean> object
      */
-    public Single<Boolean> get200Async() {
+    public Single<RestResponse<Void, Boolean>> get200WithRestResponseAsync() {
         return service.get200();
     }
+
+    /**
+     * Get 200 success.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Boolean> object
+     */
+    public Single<Boolean> get200Async() {
+        return get200WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Boolean>, Boolean>() { public Boolean call(RestResponse<Void, Boolean> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -242,6 +266,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void put200() {
         put200Async().toBlocking().value();
@@ -254,7 +279,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> put200Async(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> put200Async(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(put200Async(), serviceCallback);
     }
 
@@ -262,12 +287,23 @@ public class HttpSuccessImpl implements HttpSuccess {
      * Put boolean value true returning 200 success.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> put200Async() {
+    public Single<RestResponse<Void, Void>> put200WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.put200(booleanValue);
     }
+
+    /**
+     * Put boolean value true returning 200 success.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> put200Async() {
+        return put200WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Put boolean value true returning 200 success.
@@ -276,6 +312,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void put200(Boolean booleanValue) {
         put200Async(booleanValue).toBlocking().value();
@@ -289,7 +326,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> put200Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> put200Async(Boolean booleanValue, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(put200Async(booleanValue), serviceCallback);
     }
 
@@ -298,11 +335,23 @@ public class HttpSuccessImpl implements HttpSuccess {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> put200Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Void>> put200WithRestResponseAsync(Boolean booleanValue) {
         return service.put200(booleanValue);
     }
+
+    /**
+     * Put boolean value true returning 200 success.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> put200Async(Boolean booleanValue) {
+        return put200WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -311,6 +360,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void patch200() {
         patch200Async().toBlocking().value();
@@ -323,7 +373,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> patch200Async(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> patch200Async(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(patch200Async(), serviceCallback);
     }
 
@@ -331,12 +381,23 @@ public class HttpSuccessImpl implements HttpSuccess {
      * Patch true Boolean value in request returning 200.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> patch200Async() {
+    public Single<RestResponse<Void, Void>> patch200WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.patch200(booleanValue);
     }
+
+    /**
+     * Patch true Boolean value in request returning 200.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> patch200Async() {
+        return patch200WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Patch true Boolean value in request returning 200.
@@ -345,6 +406,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void patch200(Boolean booleanValue) {
         patch200Async(booleanValue).toBlocking().value();
@@ -358,7 +420,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> patch200Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> patch200Async(Boolean booleanValue, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(patch200Async(booleanValue), serviceCallback);
     }
 
@@ -367,11 +429,23 @@ public class HttpSuccessImpl implements HttpSuccess {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> patch200Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Void>> patch200WithRestResponseAsync(Boolean booleanValue) {
         return service.patch200(booleanValue);
     }
+
+    /**
+     * Patch true Boolean value in request returning 200.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> patch200Async(Boolean booleanValue) {
+        return patch200WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -380,6 +454,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post200() {
         post200Async().toBlocking().value();
@@ -392,7 +467,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post200Async(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> post200Async(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(post200Async(), serviceCallback);
     }
 
@@ -400,12 +475,23 @@ public class HttpSuccessImpl implements HttpSuccess {
      * Post bollean value true in request that returns a 200.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> post200Async() {
+    public Single<RestResponse<Void, Void>> post200WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.post200(booleanValue);
     }
+
+    /**
+     * Post bollean value true in request that returns a 200.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> post200Async() {
+        return post200WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Post bollean value true in request that returns a 200.
@@ -414,6 +500,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post200(Boolean booleanValue) {
         post200Async(booleanValue).toBlocking().value();
@@ -427,7 +514,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post200Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> post200Async(Boolean booleanValue, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(post200Async(booleanValue), serviceCallback);
     }
 
@@ -436,11 +523,23 @@ public class HttpSuccessImpl implements HttpSuccess {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> post200Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Void>> post200WithRestResponseAsync(Boolean booleanValue) {
         return service.post200(booleanValue);
     }
+
+    /**
+     * Post bollean value true in request that returns a 200.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> post200Async(Boolean booleanValue) {
+        return post200WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -449,6 +548,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void delete200() {
         delete200Async().toBlocking().value();
@@ -461,7 +561,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> delete200Async(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> delete200Async(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(delete200Async(), serviceCallback);
     }
 
@@ -469,12 +569,23 @@ public class HttpSuccessImpl implements HttpSuccess {
      * Delete simple boolean value true returns 200.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> delete200Async() {
+    public Single<RestResponse<Void, Void>> delete200WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.delete200(booleanValue);
     }
+
+    /**
+     * Delete simple boolean value true returns 200.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> delete200Async() {
+        return delete200WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Delete simple boolean value true returns 200.
@@ -483,6 +594,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void delete200(Boolean booleanValue) {
         delete200Async(booleanValue).toBlocking().value();
@@ -496,7 +608,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> delete200Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> delete200Async(Boolean booleanValue, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(delete200Async(booleanValue), serviceCallback);
     }
 
@@ -505,11 +617,23 @@ public class HttpSuccessImpl implements HttpSuccess {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> delete200Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Void>> delete200WithRestResponseAsync(Boolean booleanValue) {
         return service.delete200(booleanValue);
     }
+
+    /**
+     * Delete simple boolean value true returns 200.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> delete200Async(Boolean booleanValue) {
+        return delete200WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -518,6 +642,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void put201() {
         put201Async().toBlocking().value();
@@ -530,7 +655,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> put201Async(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> put201Async(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(put201Async(), serviceCallback);
     }
 
@@ -538,12 +663,23 @@ public class HttpSuccessImpl implements HttpSuccess {
      * Put true Boolean value in request returns 201.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> put201Async() {
+    public Single<RestResponse<Void, Void>> put201WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.put201(booleanValue);
     }
+
+    /**
+     * Put true Boolean value in request returns 201.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> put201Async() {
+        return put201WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Put true Boolean value in request returns 201.
@@ -552,6 +688,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void put201(Boolean booleanValue) {
         put201Async(booleanValue).toBlocking().value();
@@ -565,7 +702,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> put201Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> put201Async(Boolean booleanValue, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(put201Async(booleanValue), serviceCallback);
     }
 
@@ -574,11 +711,23 @@ public class HttpSuccessImpl implements HttpSuccess {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> put201Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Void>> put201WithRestResponseAsync(Boolean booleanValue) {
         return service.put201(booleanValue);
     }
+
+    /**
+     * Put true Boolean value in request returns 201.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> put201Async(Boolean booleanValue) {
+        return put201WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -587,6 +736,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post201() {
         post201Async().toBlocking().value();
@@ -599,7 +749,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post201Async(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> post201Async(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(post201Async(), serviceCallback);
     }
 
@@ -607,12 +757,23 @@ public class HttpSuccessImpl implements HttpSuccess {
      * Post true Boolean value in request returns 201 (Created).
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> post201Async() {
+    public Single<RestResponse<Void, Void>> post201WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.post201(booleanValue);
     }
+
+    /**
+     * Post true Boolean value in request returns 201 (Created).
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> post201Async() {
+        return post201WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Post true Boolean value in request returns 201 (Created).
@@ -621,6 +782,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post201(Boolean booleanValue) {
         post201Async(booleanValue).toBlocking().value();
@@ -634,7 +796,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post201Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> post201Async(Boolean booleanValue, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(post201Async(booleanValue), serviceCallback);
     }
 
@@ -643,11 +805,23 @@ public class HttpSuccessImpl implements HttpSuccess {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> post201Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Void>> post201WithRestResponseAsync(Boolean booleanValue) {
         return service.post201(booleanValue);
     }
+
+    /**
+     * Post true Boolean value in request returns 201 (Created).
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> post201Async(Boolean booleanValue) {
+        return post201WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -656,6 +830,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void put202() {
         put202Async().toBlocking().value();
@@ -668,7 +843,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> put202Async(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> put202Async(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(put202Async(), serviceCallback);
     }
 
@@ -676,12 +851,23 @@ public class HttpSuccessImpl implements HttpSuccess {
      * Put true Boolean value in request returns 202 (Accepted).
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> put202Async() {
+    public Single<RestResponse<Void, Void>> put202WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.put202(booleanValue);
     }
+
+    /**
+     * Put true Boolean value in request returns 202 (Accepted).
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> put202Async() {
+        return put202WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Put true Boolean value in request returns 202 (Accepted).
@@ -690,6 +876,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void put202(Boolean booleanValue) {
         put202Async(booleanValue).toBlocking().value();
@@ -703,7 +890,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> put202Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> put202Async(Boolean booleanValue, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(put202Async(booleanValue), serviceCallback);
     }
 
@@ -712,11 +899,23 @@ public class HttpSuccessImpl implements HttpSuccess {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> put202Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Void>> put202WithRestResponseAsync(Boolean booleanValue) {
         return service.put202(booleanValue);
     }
+
+    /**
+     * Put true Boolean value in request returns 202 (Accepted).
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> put202Async(Boolean booleanValue) {
+        return put202WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -725,6 +924,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void patch202() {
         patch202Async().toBlocking().value();
@@ -737,7 +937,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> patch202Async(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> patch202Async(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(patch202Async(), serviceCallback);
     }
 
@@ -745,12 +945,23 @@ public class HttpSuccessImpl implements HttpSuccess {
      * Patch true Boolean value in request returns 202.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> patch202Async() {
+    public Single<RestResponse<Void, Void>> patch202WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.patch202(booleanValue);
     }
+
+    /**
+     * Patch true Boolean value in request returns 202.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> patch202Async() {
+        return patch202WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Patch true Boolean value in request returns 202.
@@ -759,6 +970,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void patch202(Boolean booleanValue) {
         patch202Async(booleanValue).toBlocking().value();
@@ -772,7 +984,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> patch202Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> patch202Async(Boolean booleanValue, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(patch202Async(booleanValue), serviceCallback);
     }
 
@@ -781,11 +993,23 @@ public class HttpSuccessImpl implements HttpSuccess {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> patch202Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Void>> patch202WithRestResponseAsync(Boolean booleanValue) {
         return service.patch202(booleanValue);
     }
+
+    /**
+     * Patch true Boolean value in request returns 202.
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> patch202Async(Boolean booleanValue) {
+        return patch202WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -794,6 +1018,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post202() {
         post202Async().toBlocking().value();
@@ -806,7 +1031,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post202Async(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> post202Async(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(post202Async(), serviceCallback);
     }
 
@@ -814,12 +1039,23 @@ public class HttpSuccessImpl implements HttpSuccess {
      * Post true Boolean value in request returns 202 (Accepted).
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> post202Async() {
+    public Single<RestResponse<Void, Void>> post202WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.post202(booleanValue);
     }
+
+    /**
+     * Post true Boolean value in request returns 202 (Accepted).
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> post202Async() {
+        return post202WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Post true Boolean value in request returns 202 (Accepted).
@@ -828,6 +1064,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post202(Boolean booleanValue) {
         post202Async(booleanValue).toBlocking().value();
@@ -841,7 +1078,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post202Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> post202Async(Boolean booleanValue, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(post202Async(booleanValue), serviceCallback);
     }
 
@@ -850,11 +1087,23 @@ public class HttpSuccessImpl implements HttpSuccess {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> post202Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Void>> post202WithRestResponseAsync(Boolean booleanValue) {
         return service.post202(booleanValue);
     }
+
+    /**
+     * Post true Boolean value in request returns 202 (Accepted).
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> post202Async(Boolean booleanValue) {
+        return post202WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -863,6 +1112,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void delete202() {
         delete202Async().toBlocking().value();
@@ -875,7 +1125,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> delete202Async(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> delete202Async(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(delete202Async(), serviceCallback);
     }
 
@@ -883,12 +1133,23 @@ public class HttpSuccessImpl implements HttpSuccess {
      * Delete true Boolean value in request returns 202 (accepted).
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> delete202Async() {
+    public Single<RestResponse<Void, Void>> delete202WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.delete202(booleanValue);
     }
+
+    /**
+     * Delete true Boolean value in request returns 202 (accepted).
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> delete202Async() {
+        return delete202WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Delete true Boolean value in request returns 202 (accepted).
@@ -897,6 +1158,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void delete202(Boolean booleanValue) {
         delete202Async(booleanValue).toBlocking().value();
@@ -910,7 +1172,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> delete202Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> delete202Async(Boolean booleanValue, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(delete202Async(booleanValue), serviceCallback);
     }
 
@@ -919,11 +1181,23 @@ public class HttpSuccessImpl implements HttpSuccess {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> delete202Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Void>> delete202WithRestResponseAsync(Boolean booleanValue) {
         return service.delete202(booleanValue);
     }
+
+    /**
+     * Delete true Boolean value in request returns 202 (accepted).
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> delete202Async(Boolean booleanValue) {
+        return delete202WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -932,6 +1206,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void head204() {
         head204Async().toBlocking().value();
@@ -944,7 +1219,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> head204Async(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> head204Async(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(head204Async(), serviceCallback);
     }
 
@@ -952,11 +1227,22 @@ public class HttpSuccessImpl implements HttpSuccess {
      * Return 204 status code if successful.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> head204Async() {
+    public Single<RestResponse<Void, Void>> head204WithRestResponseAsync() {
         return service.head204();
     }
+
+    /**
+     * Return 204 status code if successful.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> head204Async() {
+        return head204WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -965,6 +1251,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void put204() {
         put204Async().toBlocking().value();
@@ -977,7 +1264,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> put204Async(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> put204Async(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(put204Async(), serviceCallback);
     }
 
@@ -985,12 +1272,23 @@ public class HttpSuccessImpl implements HttpSuccess {
      * Put true Boolean value in request returns 204 (no content).
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> put204Async() {
+    public Single<RestResponse<Void, Void>> put204WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.put204(booleanValue);
     }
+
+    /**
+     * Put true Boolean value in request returns 204 (no content).
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> put204Async() {
+        return put204WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Put true Boolean value in request returns 204 (no content).
@@ -999,6 +1297,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void put204(Boolean booleanValue) {
         put204Async(booleanValue).toBlocking().value();
@@ -1012,7 +1311,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> put204Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> put204Async(Boolean booleanValue, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(put204Async(booleanValue), serviceCallback);
     }
 
@@ -1021,11 +1320,23 @@ public class HttpSuccessImpl implements HttpSuccess {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> put204Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Void>> put204WithRestResponseAsync(Boolean booleanValue) {
         return service.put204(booleanValue);
     }
+
+    /**
+     * Put true Boolean value in request returns 204 (no content).
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> put204Async(Boolean booleanValue) {
+        return put204WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1034,6 +1345,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void patch204() {
         patch204Async().toBlocking().value();
@@ -1046,7 +1358,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> patch204Async(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> patch204Async(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(patch204Async(), serviceCallback);
     }
 
@@ -1054,12 +1366,23 @@ public class HttpSuccessImpl implements HttpSuccess {
      * Patch true Boolean value in request returns 204 (no content).
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> patch204Async() {
+    public Single<RestResponse<Void, Void>> patch204WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.patch204(booleanValue);
     }
+
+    /**
+     * Patch true Boolean value in request returns 204 (no content).
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> patch204Async() {
+        return patch204WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Patch true Boolean value in request returns 204 (no content).
@@ -1068,6 +1391,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void patch204(Boolean booleanValue) {
         patch204Async(booleanValue).toBlocking().value();
@@ -1081,7 +1405,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> patch204Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> patch204Async(Boolean booleanValue, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(patch204Async(booleanValue), serviceCallback);
     }
 
@@ -1090,11 +1414,23 @@ public class HttpSuccessImpl implements HttpSuccess {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> patch204Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Void>> patch204WithRestResponseAsync(Boolean booleanValue) {
         return service.patch204(booleanValue);
     }
+
+    /**
+     * Patch true Boolean value in request returns 204 (no content).
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> patch204Async(Boolean booleanValue) {
+        return patch204WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1103,6 +1439,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post204() {
         post204Async().toBlocking().value();
@@ -1115,7 +1452,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post204Async(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> post204Async(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(post204Async(), serviceCallback);
     }
 
@@ -1123,12 +1460,23 @@ public class HttpSuccessImpl implements HttpSuccess {
      * Post true Boolean value in request returns 204 (no content).
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> post204Async() {
+    public Single<RestResponse<Void, Void>> post204WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.post204(booleanValue);
     }
+
+    /**
+     * Post true Boolean value in request returns 204 (no content).
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> post204Async() {
+        return post204WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Post true Boolean value in request returns 204 (no content).
@@ -1137,6 +1485,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void post204(Boolean booleanValue) {
         post204Async(booleanValue).toBlocking().value();
@@ -1150,7 +1499,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> post204Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> post204Async(Boolean booleanValue, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(post204Async(booleanValue), serviceCallback);
     }
 
@@ -1159,11 +1508,23 @@ public class HttpSuccessImpl implements HttpSuccess {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> post204Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Void>> post204WithRestResponseAsync(Boolean booleanValue) {
         return service.post204(booleanValue);
     }
+
+    /**
+     * Post true Boolean value in request returns 204 (no content).
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> post204Async(Boolean booleanValue) {
+        return post204WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1172,6 +1533,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void delete204() {
         delete204Async().toBlocking().value();
@@ -1184,7 +1546,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> delete204Async(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> delete204Async(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(delete204Async(), serviceCallback);
     }
 
@@ -1192,12 +1554,23 @@ public class HttpSuccessImpl implements HttpSuccess {
      * Delete true Boolean value in request returns 204 (no content).
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> delete204Async() {
+    public Single<RestResponse<Void, Void>> delete204WithRestResponseAsync() {
         final Boolean booleanValue = null;
         return service.delete204(booleanValue);
     }
+
+    /**
+     * Delete true Boolean value in request returns 204 (no content).
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> delete204Async() {
+        return delete204WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Delete true Boolean value in request returns 204 (no content).
@@ -1206,6 +1579,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void delete204(Boolean booleanValue) {
         delete204Async(booleanValue).toBlocking().value();
@@ -1219,7 +1593,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> delete204Async(Boolean booleanValue, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> delete204Async(Boolean booleanValue, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(delete204Async(booleanValue), serviceCallback);
     }
 
@@ -1228,11 +1602,23 @@ public class HttpSuccessImpl implements HttpSuccess {
      *
      * @param booleanValue Simple boolean value true
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> delete204Async(Boolean booleanValue) {
+    public Single<RestResponse<Void, Void>> delete204WithRestResponseAsync(Boolean booleanValue) {
         return service.delete204(booleanValue);
     }
+
+    /**
+     * Delete true Boolean value in request returns 204 (no content).
+     *
+     * @param booleanValue Simple boolean value true
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> delete204Async(Boolean booleanValue) {
+        return delete204WithRestResponseAsync(booleanValue)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1241,6 +1627,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void head404() {
         head404Async().toBlocking().value();
@@ -1253,7 +1640,7 @@ public class HttpSuccessImpl implements HttpSuccess {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> head404Async(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> head404Async(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(head404Async(), serviceCallback);
     }
 
@@ -1261,11 +1648,22 @@ public class HttpSuccessImpl implements HttpSuccess {
      * Return 404 status code.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> head404Async() {
+    public Single<RestResponse<Void, Void>> head404WithRestResponseAsync() {
         return service.head404();
     }
+
+    /**
+     * Return 404 status code.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> head404Async() {
+        return head404WithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/http/implementation/MultipleResponsesImpl.java
+++ b/test/vanilla/src/main/java/fixtures/http/implementation/MultipleResponsesImpl.java
@@ -11,6 +11,7 @@
 package fixtures.http.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.http.MultipleResponses;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.ExpectedResponses;
@@ -63,182 +64,182 @@ public class MultipleResponsesImpl implements MultipleResponses {
         @GET("http/payloads/200/A/204/none/default/Error/response/200/valid")
         @ExpectedResponses({200, 204})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<A> get200Model204NoModelDefaultError200Valid();
+        Single<RestResponse<Void, A>> get200Model204NoModelDefaultError200Valid();
 
         @Headers({ "x-ms-logging-context: fixtures.http.MultipleResponses get200Model204NoModelDefaultError204Valid" })
         @GET("http/payloads/200/A/204/none/default/Error/response/204/none")
         @ExpectedResponses({200, 204})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<A> get200Model204NoModelDefaultError204Valid();
+        Single<RestResponse<Void, A>> get200Model204NoModelDefaultError204Valid();
 
         @Headers({ "x-ms-logging-context: fixtures.http.MultipleResponses get200Model204NoModelDefaultError201Invalid" })
         @GET("http/payloads/200/A/204/none/default/Error/response/201/valid")
         @ExpectedResponses({200, 204})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<A> get200Model204NoModelDefaultError201Invalid();
+        Single<RestResponse<Void, A>> get200Model204NoModelDefaultError201Invalid();
 
         @Headers({ "x-ms-logging-context: fixtures.http.MultipleResponses get200Model204NoModelDefaultError202None" })
         @GET("http/payloads/200/A/204/none/default/Error/response/202/none")
         @ExpectedResponses({200, 204})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<A> get200Model204NoModelDefaultError202None();
+        Single<RestResponse<Void, A>> get200Model204NoModelDefaultError202None();
 
         @Headers({ "x-ms-logging-context: fixtures.http.MultipleResponses get200Model204NoModelDefaultError400Valid" })
         @GET("http/payloads/200/A/204/none/default/Error/response/400/valid")
         @ExpectedResponses({200, 204})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<A> get200Model204NoModelDefaultError400Valid();
+        Single<RestResponse<Void, A>> get200Model204NoModelDefaultError400Valid();
 
         @Headers({ "x-ms-logging-context: fixtures.http.MultipleResponses get200Model201ModelDefaultError200Valid" })
         @GET("http/payloads/200/A/201/B/default/Error/response/200/valid")
         @ExpectedResponses({200, 201})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<A> get200Model201ModelDefaultError200Valid();
+        Single<RestResponse<Void, A>> get200Model201ModelDefaultError200Valid();
 
         @Headers({ "x-ms-logging-context: fixtures.http.MultipleResponses get200Model201ModelDefaultError201Valid" })
         @GET("http/payloads/200/A/201/B/default/Error/response/201/valid")
         @ExpectedResponses({200, 201})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<A> get200Model201ModelDefaultError201Valid();
+        Single<RestResponse<Void, A>> get200Model201ModelDefaultError201Valid();
 
         @Headers({ "x-ms-logging-context: fixtures.http.MultipleResponses get200Model201ModelDefaultError400Valid" })
         @GET("http/payloads/200/A/201/B/default/Error/response/400/valid")
         @ExpectedResponses({200, 201})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<A> get200Model201ModelDefaultError400Valid();
+        Single<RestResponse<Void, A>> get200Model201ModelDefaultError400Valid();
 
         @Headers({ "x-ms-logging-context: fixtures.http.MultipleResponses get200ModelA201ModelC404ModelDDefaultError200Valid" })
         @GET("http/payloads/200/A/201/C/404/D/default/Error/response/200/valid")
         @ExpectedResponses({200, 201, 404})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Object> get200ModelA201ModelC404ModelDDefaultError200Valid();
+        Single<RestResponse<Void, Object>> get200ModelA201ModelC404ModelDDefaultError200Valid();
 
         @Headers({ "x-ms-logging-context: fixtures.http.MultipleResponses get200ModelA201ModelC404ModelDDefaultError201Valid" })
         @GET("http/payloads/200/A/201/C/404/D/default/Error/response/201/valid")
         @ExpectedResponses({200, 201, 404})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Object> get200ModelA201ModelC404ModelDDefaultError201Valid();
+        Single<RestResponse<Void, Object>> get200ModelA201ModelC404ModelDDefaultError201Valid();
 
         @Headers({ "x-ms-logging-context: fixtures.http.MultipleResponses get200ModelA201ModelC404ModelDDefaultError404Valid" })
         @GET("http/payloads/200/A/201/C/404/D/default/Error/response/404/valid")
         @ExpectedResponses({200, 201, 404})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Object> get200ModelA201ModelC404ModelDDefaultError404Valid();
+        Single<RestResponse<Void, Object>> get200ModelA201ModelC404ModelDDefaultError404Valid();
 
         @Headers({ "x-ms-logging-context: fixtures.http.MultipleResponses get200ModelA201ModelC404ModelDDefaultError400Valid" })
         @GET("http/payloads/200/A/201/C/404/D/default/Error/response/400/valid")
         @ExpectedResponses({200, 201, 404})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Object> get200ModelA201ModelC404ModelDDefaultError400Valid();
+        Single<RestResponse<Void, Object>> get200ModelA201ModelC404ModelDDefaultError400Valid();
 
         @Headers({ "x-ms-logging-context: fixtures.http.MultipleResponses get202None204NoneDefaultError202None" })
         @GET("http/payloads/202/none/204/none/default/Error/response/202/none")
         @ExpectedResponses({202, 204})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> get202None204NoneDefaultError202None();
+        Single<RestResponse<Void, Void>> get202None204NoneDefaultError202None();
 
         @Headers({ "x-ms-logging-context: fixtures.http.MultipleResponses get202None204NoneDefaultError204None" })
         @GET("http/payloads/202/none/204/none/default/Error/response/204/none")
         @ExpectedResponses({202, 204})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> get202None204NoneDefaultError204None();
+        Single<RestResponse<Void, Void>> get202None204NoneDefaultError204None();
 
         @Headers({ "x-ms-logging-context: fixtures.http.MultipleResponses get202None204NoneDefaultError400Valid" })
         @GET("http/payloads/202/none/204/none/default/Error/response/400/valid")
         @ExpectedResponses({202, 204})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> get202None204NoneDefaultError400Valid();
+        Single<RestResponse<Void, Void>> get202None204NoneDefaultError400Valid();
 
         @Headers({ "x-ms-logging-context: fixtures.http.MultipleResponses get202None204NoneDefaultNone202Invalid" })
         @GET("http/payloads/202/none/204/none/default/none/response/202/invalid")
         @ExpectedResponses({202, 204})
-        Single<Void> get202None204NoneDefaultNone202Invalid();
+        Single<RestResponse<Void, Void>> get202None204NoneDefaultNone202Invalid();
 
         @Headers({ "x-ms-logging-context: fixtures.http.MultipleResponses get202None204NoneDefaultNone204None" })
         @GET("http/payloads/202/none/204/none/default/none/response/204/none")
         @ExpectedResponses({202, 204})
-        Single<Void> get202None204NoneDefaultNone204None();
+        Single<RestResponse<Void, Void>> get202None204NoneDefaultNone204None();
 
         @Headers({ "x-ms-logging-context: fixtures.http.MultipleResponses get202None204NoneDefaultNone400None" })
         @GET("http/payloads/202/none/204/none/default/none/response/400/none")
         @ExpectedResponses({202, 204})
-        Single<Void> get202None204NoneDefaultNone400None();
+        Single<RestResponse<Void, Void>> get202None204NoneDefaultNone400None();
 
         @Headers({ "x-ms-logging-context: fixtures.http.MultipleResponses get202None204NoneDefaultNone400Invalid" })
         @GET("http/payloads/202/none/204/none/default/none/response/400/invalid")
         @ExpectedResponses({202, 204})
-        Single<Void> get202None204NoneDefaultNone400Invalid();
+        Single<RestResponse<Void, Void>> get202None204NoneDefaultNone400Invalid();
 
         @Headers({ "x-ms-logging-context: fixtures.http.MultipleResponses getDefaultModelA200Valid" })
         @GET("http/payloads/default/A/response/200/valid")
         @UnexpectedResponseExceptionType(MyException.class)
-        Single<A> getDefaultModelA200Valid();
+        Single<RestResponse<Void, A>> getDefaultModelA200Valid();
 
         @Headers({ "x-ms-logging-context: fixtures.http.MultipleResponses getDefaultModelA200None" })
         @GET("http/payloads/default/A/response/200/none")
         @UnexpectedResponseExceptionType(MyException.class)
-        Single<A> getDefaultModelA200None();
+        Single<RestResponse<Void, A>> getDefaultModelA200None();
 
         @Headers({ "x-ms-logging-context: fixtures.http.MultipleResponses getDefaultModelA400Valid" })
         @GET("http/payloads/default/A/response/400/valid")
         @UnexpectedResponseExceptionType(MyException.class)
-        Single<A> getDefaultModelA400Valid();
+        Single<RestResponse<Void, A>> getDefaultModelA400Valid();
 
         @Headers({ "x-ms-logging-context: fixtures.http.MultipleResponses getDefaultModelA400None" })
         @GET("http/payloads/default/A/response/400/none")
         @UnexpectedResponseExceptionType(MyException.class)
-        Single<A> getDefaultModelA400None();
+        Single<RestResponse<Void, A>> getDefaultModelA400None();
 
         @Headers({ "x-ms-logging-context: fixtures.http.MultipleResponses getDefaultNone200Invalid" })
         @GET("http/payloads/default/none/response/200/invalid")
-        Single<Void> getDefaultNone200Invalid();
+        Single<RestResponse<Void, Void>> getDefaultNone200Invalid();
 
         @Headers({ "x-ms-logging-context: fixtures.http.MultipleResponses getDefaultNone200None" })
         @GET("http/payloads/default/none/response/200/none")
-        Single<Void> getDefaultNone200None();
+        Single<RestResponse<Void, Void>> getDefaultNone200None();
 
         @Headers({ "x-ms-logging-context: fixtures.http.MultipleResponses getDefaultNone400Invalid" })
         @GET("http/payloads/default/none/response/400/invalid")
-        Single<Void> getDefaultNone400Invalid();
+        Single<RestResponse<Void, Void>> getDefaultNone400Invalid();
 
         @Headers({ "x-ms-logging-context: fixtures.http.MultipleResponses getDefaultNone400None" })
         @GET("http/payloads/default/none/response/400/none")
-        Single<Void> getDefaultNone400None();
+        Single<RestResponse<Void, Void>> getDefaultNone400None();
 
         @Headers({ "x-ms-logging-context: fixtures.http.MultipleResponses get200ModelA200None" })
         @GET("http/payloads/200/A/response/200/none")
         @ExpectedResponses({200})
-        Single<A> get200ModelA200None();
+        Single<RestResponse<Void, A>> get200ModelA200None();
 
         @Headers({ "x-ms-logging-context: fixtures.http.MultipleResponses get200ModelA200Valid" })
         @GET("http/payloads/200/A/response/200/valid")
         @ExpectedResponses({200})
-        Single<A> get200ModelA200Valid();
+        Single<RestResponse<Void, A>> get200ModelA200Valid();
 
         @Headers({ "x-ms-logging-context: fixtures.http.MultipleResponses get200ModelA200Invalid" })
         @GET("http/payloads/200/A/response/200/invalid")
         @ExpectedResponses({200})
-        Single<A> get200ModelA200Invalid();
+        Single<RestResponse<Void, A>> get200ModelA200Invalid();
 
         @Headers({ "x-ms-logging-context: fixtures.http.MultipleResponses get200ModelA400None" })
         @GET("http/payloads/200/A/response/400/none")
         @ExpectedResponses({200})
-        Single<A> get200ModelA400None();
+        Single<RestResponse<Void, A>> get200ModelA400None();
 
         @Headers({ "x-ms-logging-context: fixtures.http.MultipleResponses get200ModelA400Valid" })
         @GET("http/payloads/200/A/response/400/valid")
         @ExpectedResponses({200})
-        Single<A> get200ModelA400Valid();
+        Single<RestResponse<Void, A>> get200ModelA400Valid();
 
         @Headers({ "x-ms-logging-context: fixtures.http.MultipleResponses get200ModelA400Invalid" })
         @GET("http/payloads/200/A/response/400/invalid")
         @ExpectedResponses({200})
-        Single<A> get200ModelA400Invalid();
+        Single<RestResponse<Void, A>> get200ModelA400Invalid();
 
         @Headers({ "x-ms-logging-context: fixtures.http.MultipleResponses get200ModelA202Valid" })
         @GET("http/payloads/200/A/response/202/valid")
         @ExpectedResponses({200})
-        Single<A> get200ModelA202Valid();
+        Single<RestResponse<Void, A>> get200ModelA202Valid();
 
     }
 
@@ -261,7 +262,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<A> get200Model204NoModelDefaultError200ValidAsync(final ServiceCallback<A> serviceCallback) {
+    public ServiceFuture<A> get200Model204NoModelDefaultError200ValidAsync(ServiceCallback<A> serviceCallback) {
         return ServiceFuture.fromBody(get200Model204NoModelDefaultError200ValidAsync(), serviceCallback);
     }
 
@@ -269,11 +270,22 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * Send a 200 response with valid payload: {'statusCode': '200'}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the A object
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
      */
-    public Single<A> get200Model204NoModelDefaultError200ValidAsync() {
+    public Single<RestResponse<Void, A>> get200Model204NoModelDefaultError200ValidWithRestResponseAsync() {
         return service.get200Model204NoModelDefaultError200Valid();
     }
+
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
+     */
+    public Single<A> get200Model204NoModelDefaultError200ValidAsync() {
+        return get200Model204NoModelDefaultError200ValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, A>, A>() { public A call(RestResponse<Void, A> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -295,7 +307,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<A> get200Model204NoModelDefaultError204ValidAsync(final ServiceCallback<A> serviceCallback) {
+    public ServiceFuture<A> get200Model204NoModelDefaultError204ValidAsync(ServiceCallback<A> serviceCallback) {
         return ServiceFuture.fromBody(get200Model204NoModelDefaultError204ValidAsync(), serviceCallback);
     }
 
@@ -303,11 +315,22 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * Send a 204 response with no payload.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the A object
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
      */
-    public Single<A> get200Model204NoModelDefaultError204ValidAsync() {
+    public Single<RestResponse<Void, A>> get200Model204NoModelDefaultError204ValidWithRestResponseAsync() {
         return service.get200Model204NoModelDefaultError204Valid();
     }
+
+    /**
+     * Send a 204 response with no payload.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
+     */
+    public Single<A> get200Model204NoModelDefaultError204ValidAsync() {
+        return get200Model204NoModelDefaultError204ValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, A>, A>() { public A call(RestResponse<Void, A> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -329,7 +352,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<A> get200Model204NoModelDefaultError201InvalidAsync(final ServiceCallback<A> serviceCallback) {
+    public ServiceFuture<A> get200Model204NoModelDefaultError201InvalidAsync(ServiceCallback<A> serviceCallback) {
         return ServiceFuture.fromBody(get200Model204NoModelDefaultError201InvalidAsync(), serviceCallback);
     }
 
@@ -337,11 +360,22 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * Send a 201 response with valid payload: {'statusCode': '201'}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the A object
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
      */
-    public Single<A> get200Model204NoModelDefaultError201InvalidAsync() {
+    public Single<RestResponse<Void, A>> get200Model204NoModelDefaultError201InvalidWithRestResponseAsync() {
         return service.get200Model204NoModelDefaultError201Invalid();
     }
+
+    /**
+     * Send a 201 response with valid payload: {'statusCode': '201'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
+     */
+    public Single<A> get200Model204NoModelDefaultError201InvalidAsync() {
+        return get200Model204NoModelDefaultError201InvalidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, A>, A>() { public A call(RestResponse<Void, A> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -363,7 +397,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<A> get200Model204NoModelDefaultError202NoneAsync(final ServiceCallback<A> serviceCallback) {
+    public ServiceFuture<A> get200Model204NoModelDefaultError202NoneAsync(ServiceCallback<A> serviceCallback) {
         return ServiceFuture.fromBody(get200Model204NoModelDefaultError202NoneAsync(), serviceCallback);
     }
 
@@ -371,11 +405,22 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * Send a 202 response with no payload:.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the A object
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
      */
-    public Single<A> get200Model204NoModelDefaultError202NoneAsync() {
+    public Single<RestResponse<Void, A>> get200Model204NoModelDefaultError202NoneWithRestResponseAsync() {
         return service.get200Model204NoModelDefaultError202None();
     }
+
+    /**
+     * Send a 202 response with no payload:.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
+     */
+    public Single<A> get200Model204NoModelDefaultError202NoneAsync() {
+        return get200Model204NoModelDefaultError202NoneWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, A>, A>() { public A call(RestResponse<Void, A> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -397,7 +442,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<A> get200Model204NoModelDefaultError400ValidAsync(final ServiceCallback<A> serviceCallback) {
+    public ServiceFuture<A> get200Model204NoModelDefaultError400ValidAsync(ServiceCallback<A> serviceCallback) {
         return ServiceFuture.fromBody(get200Model204NoModelDefaultError400ValidAsync(), serviceCallback);
     }
 
@@ -405,11 +450,22 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * Send a 400 response with valid error payload: {'status': 400, 'message': 'client error'}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the A object
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
      */
-    public Single<A> get200Model204NoModelDefaultError400ValidAsync() {
+    public Single<RestResponse<Void, A>> get200Model204NoModelDefaultError400ValidWithRestResponseAsync() {
         return service.get200Model204NoModelDefaultError400Valid();
     }
+
+    /**
+     * Send a 400 response with valid error payload: {'status': 400, 'message': 'client error'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
+     */
+    public Single<A> get200Model204NoModelDefaultError400ValidAsync() {
+        return get200Model204NoModelDefaultError400ValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, A>, A>() { public A call(RestResponse<Void, A> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -431,7 +487,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<A> get200Model201ModelDefaultError200ValidAsync(final ServiceCallback<A> serviceCallback) {
+    public ServiceFuture<A> get200Model201ModelDefaultError200ValidAsync(ServiceCallback<A> serviceCallback) {
         return ServiceFuture.fromBody(get200Model201ModelDefaultError200ValidAsync(), serviceCallback);
     }
 
@@ -439,11 +495,22 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * Send a 200 response with valid payload: {'statusCode': '200'}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the A object
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
      */
-    public Single<A> get200Model201ModelDefaultError200ValidAsync() {
+    public Single<RestResponse<Void, A>> get200Model201ModelDefaultError200ValidWithRestResponseAsync() {
         return service.get200Model201ModelDefaultError200Valid();
     }
+
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
+     */
+    public Single<A> get200Model201ModelDefaultError200ValidAsync() {
+        return get200Model201ModelDefaultError200ValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, A>, A>() { public A call(RestResponse<Void, A> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -465,7 +532,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<A> get200Model201ModelDefaultError201ValidAsync(final ServiceCallback<A> serviceCallback) {
+    public ServiceFuture<A> get200Model201ModelDefaultError201ValidAsync(ServiceCallback<A> serviceCallback) {
         return ServiceFuture.fromBody(get200Model201ModelDefaultError201ValidAsync(), serviceCallback);
     }
 
@@ -473,11 +540,22 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * Send a 201 response with valid payload: {'statusCode': '201', 'textStatusCode': 'Created'}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the A object
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
      */
-    public Single<A> get200Model201ModelDefaultError201ValidAsync() {
+    public Single<RestResponse<Void, A>> get200Model201ModelDefaultError201ValidWithRestResponseAsync() {
         return service.get200Model201ModelDefaultError201Valid();
     }
+
+    /**
+     * Send a 201 response with valid payload: {'statusCode': '201', 'textStatusCode': 'Created'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
+     */
+    public Single<A> get200Model201ModelDefaultError201ValidAsync() {
+        return get200Model201ModelDefaultError201ValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, A>, A>() { public A call(RestResponse<Void, A> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -499,7 +577,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<A> get200Model201ModelDefaultError400ValidAsync(final ServiceCallback<A> serviceCallback) {
+    public ServiceFuture<A> get200Model201ModelDefaultError400ValidAsync(ServiceCallback<A> serviceCallback) {
         return ServiceFuture.fromBody(get200Model201ModelDefaultError400ValidAsync(), serviceCallback);
     }
 
@@ -507,11 +585,22 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the A object
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
      */
-    public Single<A> get200Model201ModelDefaultError400ValidAsync() {
+    public Single<RestResponse<Void, A>> get200Model201ModelDefaultError400ValidWithRestResponseAsync() {
         return service.get200Model201ModelDefaultError400Valid();
     }
+
+    /**
+     * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
+     */
+    public Single<A> get200Model201ModelDefaultError400ValidAsync() {
+        return get200Model201ModelDefaultError400ValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, A>, A>() { public A call(RestResponse<Void, A> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -533,7 +622,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Object> get200ModelA201ModelC404ModelDDefaultError200ValidAsync(final ServiceCallback<Object> serviceCallback) {
+    public ServiceFuture<Object> get200ModelA201ModelC404ModelDDefaultError200ValidAsync(ServiceCallback<Object> serviceCallback) {
         return ServiceFuture.fromBody(get200ModelA201ModelC404ModelDDefaultError200ValidAsync(), serviceCallback);
     }
 
@@ -541,11 +630,22 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * Send a 200 response with valid payload: {'statusCode': '200'}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Object object
+     * @return a {@link Single} emitting the RestResponse<Void, Object> object
      */
-    public Single<Object> get200ModelA201ModelC404ModelDDefaultError200ValidAsync() {
+    public Single<RestResponse<Void, Object>> get200ModelA201ModelC404ModelDDefaultError200ValidWithRestResponseAsync() {
         return service.get200ModelA201ModelC404ModelDDefaultError200Valid();
     }
+
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Object> object
+     */
+    public Single<Object> get200ModelA201ModelC404ModelDDefaultError200ValidAsync() {
+        return get200ModelA201ModelC404ModelDDefaultError200ValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Object>, Object>() { public Object call(RestResponse<Void, Object> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -567,7 +667,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Object> get200ModelA201ModelC404ModelDDefaultError201ValidAsync(final ServiceCallback<Object> serviceCallback) {
+    public ServiceFuture<Object> get200ModelA201ModelC404ModelDDefaultError201ValidAsync(ServiceCallback<Object> serviceCallback) {
         return ServiceFuture.fromBody(get200ModelA201ModelC404ModelDDefaultError201ValidAsync(), serviceCallback);
     }
 
@@ -575,11 +675,22 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * Send a 200 response with valid payload: {'httpCode': '201'}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Object object
+     * @return a {@link Single} emitting the RestResponse<Void, Object> object
      */
-    public Single<Object> get200ModelA201ModelC404ModelDDefaultError201ValidAsync() {
+    public Single<RestResponse<Void, Object>> get200ModelA201ModelC404ModelDDefaultError201ValidWithRestResponseAsync() {
         return service.get200ModelA201ModelC404ModelDDefaultError201Valid();
     }
+
+    /**
+     * Send a 200 response with valid payload: {'httpCode': '201'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Object> object
+     */
+    public Single<Object> get200ModelA201ModelC404ModelDDefaultError201ValidAsync() {
+        return get200ModelA201ModelC404ModelDDefaultError201ValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Object>, Object>() { public Object call(RestResponse<Void, Object> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -601,7 +712,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Object> get200ModelA201ModelC404ModelDDefaultError404ValidAsync(final ServiceCallback<Object> serviceCallback) {
+    public ServiceFuture<Object> get200ModelA201ModelC404ModelDDefaultError404ValidAsync(ServiceCallback<Object> serviceCallback) {
         return ServiceFuture.fromBody(get200ModelA201ModelC404ModelDDefaultError404ValidAsync(), serviceCallback);
     }
 
@@ -609,11 +720,22 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * Send a 200 response with valid payload: {'httpStatusCode': '404'}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Object object
+     * @return a {@link Single} emitting the RestResponse<Void, Object> object
      */
-    public Single<Object> get200ModelA201ModelC404ModelDDefaultError404ValidAsync() {
+    public Single<RestResponse<Void, Object>> get200ModelA201ModelC404ModelDDefaultError404ValidWithRestResponseAsync() {
         return service.get200ModelA201ModelC404ModelDDefaultError404Valid();
     }
+
+    /**
+     * Send a 200 response with valid payload: {'httpStatusCode': '404'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Object> object
+     */
+    public Single<Object> get200ModelA201ModelC404ModelDDefaultError404ValidAsync() {
+        return get200ModelA201ModelC404ModelDDefaultError404ValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Object>, Object>() { public Object call(RestResponse<Void, Object> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -635,7 +757,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Object> get200ModelA201ModelC404ModelDDefaultError400ValidAsync(final ServiceCallback<Object> serviceCallback) {
+    public ServiceFuture<Object> get200ModelA201ModelC404ModelDDefaultError400ValidAsync(ServiceCallback<Object> serviceCallback) {
         return ServiceFuture.fromBody(get200ModelA201ModelC404ModelDDefaultError400ValidAsync(), serviceCallback);
     }
 
@@ -643,11 +765,22 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Object object
+     * @return a {@link Single} emitting the RestResponse<Void, Object> object
      */
-    public Single<Object> get200ModelA201ModelC404ModelDDefaultError400ValidAsync() {
+    public Single<RestResponse<Void, Object>> get200ModelA201ModelC404ModelDDefaultError400ValidWithRestResponseAsync() {
         return service.get200ModelA201ModelC404ModelDDefaultError400Valid();
     }
+
+    /**
+     * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Object> object
+     */
+    public Single<Object> get200ModelA201ModelC404ModelDDefaultError400ValidAsync() {
+        return get200ModelA201ModelC404ModelDDefaultError400ValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Object>, Object>() { public Object call(RestResponse<Void, Object> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -656,6 +789,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void get202None204NoneDefaultError202None() {
         get202None204NoneDefaultError202NoneAsync().toBlocking().value();
@@ -668,7 +802,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> get202None204NoneDefaultError202NoneAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> get202None204NoneDefaultError202NoneAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(get202None204NoneDefaultError202NoneAsync(), serviceCallback);
     }
 
@@ -676,11 +810,22 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * Send a 202 response with no payload.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> get202None204NoneDefaultError202NoneAsync() {
+    public Single<RestResponse<Void, Void>> get202None204NoneDefaultError202NoneWithRestResponseAsync() {
         return service.get202None204NoneDefaultError202None();
     }
+
+    /**
+     * Send a 202 response with no payload.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> get202None204NoneDefaultError202NoneAsync() {
+        return get202None204NoneDefaultError202NoneWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -689,6 +834,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void get202None204NoneDefaultError204None() {
         get202None204NoneDefaultError204NoneAsync().toBlocking().value();
@@ -701,7 +847,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> get202None204NoneDefaultError204NoneAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> get202None204NoneDefaultError204NoneAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(get202None204NoneDefaultError204NoneAsync(), serviceCallback);
     }
 
@@ -709,11 +855,22 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * Send a 204 response with no payload.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> get202None204NoneDefaultError204NoneAsync() {
+    public Single<RestResponse<Void, Void>> get202None204NoneDefaultError204NoneWithRestResponseAsync() {
         return service.get202None204NoneDefaultError204None();
     }
+
+    /**
+     * Send a 204 response with no payload.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> get202None204NoneDefaultError204NoneAsync() {
+        return get202None204NoneDefaultError204NoneWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -722,6 +879,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void get202None204NoneDefaultError400Valid() {
         get202None204NoneDefaultError400ValidAsync().toBlocking().value();
@@ -734,7 +892,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> get202None204NoneDefaultError400ValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> get202None204NoneDefaultError400ValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(get202None204NoneDefaultError400ValidAsync(), serviceCallback);
     }
 
@@ -742,11 +900,22 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> get202None204NoneDefaultError400ValidAsync() {
+    public Single<RestResponse<Void, Void>> get202None204NoneDefaultError400ValidWithRestResponseAsync() {
         return service.get202None204NoneDefaultError400Valid();
     }
+
+    /**
+     * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> get202None204NoneDefaultError400ValidAsync() {
+        return get202None204NoneDefaultError400ValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -755,6 +924,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws RestException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void get202None204NoneDefaultNone202Invalid() {
         get202None204NoneDefaultNone202InvalidAsync().toBlocking().value();
@@ -767,7 +937,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> get202None204NoneDefaultNone202InvalidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> get202None204NoneDefaultNone202InvalidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(get202None204NoneDefaultNone202InvalidAsync(), serviceCallback);
     }
 
@@ -775,11 +945,22 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * Send a 202 response with an unexpected payload {'property': 'value'}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> get202None204NoneDefaultNone202InvalidAsync() {
+    public Single<RestResponse<Void, Void>> get202None204NoneDefaultNone202InvalidWithRestResponseAsync() {
         return service.get202None204NoneDefaultNone202Invalid();
     }
+
+    /**
+     * Send a 202 response with an unexpected payload {'property': 'value'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> get202None204NoneDefaultNone202InvalidAsync() {
+        return get202None204NoneDefaultNone202InvalidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -788,6 +969,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws RestException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void get202None204NoneDefaultNone204None() {
         get202None204NoneDefaultNone204NoneAsync().toBlocking().value();
@@ -800,7 +982,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> get202None204NoneDefaultNone204NoneAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> get202None204NoneDefaultNone204NoneAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(get202None204NoneDefaultNone204NoneAsync(), serviceCallback);
     }
 
@@ -808,11 +990,22 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * Send a 204 response with no payload.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> get202None204NoneDefaultNone204NoneAsync() {
+    public Single<RestResponse<Void, Void>> get202None204NoneDefaultNone204NoneWithRestResponseAsync() {
         return service.get202None204NoneDefaultNone204None();
     }
+
+    /**
+     * Send a 204 response with no payload.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> get202None204NoneDefaultNone204NoneAsync() {
+        return get202None204NoneDefaultNone204NoneWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -821,6 +1014,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws RestException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void get202None204NoneDefaultNone400None() {
         get202None204NoneDefaultNone400NoneAsync().toBlocking().value();
@@ -833,7 +1027,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> get202None204NoneDefaultNone400NoneAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> get202None204NoneDefaultNone400NoneAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(get202None204NoneDefaultNone400NoneAsync(), serviceCallback);
     }
 
@@ -841,11 +1035,22 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * Send a 400 response with no payload.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> get202None204NoneDefaultNone400NoneAsync() {
+    public Single<RestResponse<Void, Void>> get202None204NoneDefaultNone400NoneWithRestResponseAsync() {
         return service.get202None204NoneDefaultNone400None();
     }
+
+    /**
+     * Send a 400 response with no payload.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> get202None204NoneDefaultNone400NoneAsync() {
+        return get202None204NoneDefaultNone400NoneWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -854,6 +1059,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws RestException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void get202None204NoneDefaultNone400Invalid() {
         get202None204NoneDefaultNone400InvalidAsync().toBlocking().value();
@@ -866,7 +1072,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> get202None204NoneDefaultNone400InvalidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> get202None204NoneDefaultNone400InvalidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(get202None204NoneDefaultNone400InvalidAsync(), serviceCallback);
     }
 
@@ -874,11 +1080,22 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * Send a 400 response with an unexpected payload {'property': 'value'}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> get202None204NoneDefaultNone400InvalidAsync() {
+    public Single<RestResponse<Void, Void>> get202None204NoneDefaultNone400InvalidWithRestResponseAsync() {
         return service.get202None204NoneDefaultNone400Invalid();
     }
+
+    /**
+     * Send a 400 response with an unexpected payload {'property': 'value'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> get202None204NoneDefaultNone400InvalidAsync() {
+        return get202None204NoneDefaultNone400InvalidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -900,7 +1117,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<A> getDefaultModelA200ValidAsync(final ServiceCallback<A> serviceCallback) {
+    public ServiceFuture<A> getDefaultModelA200ValidAsync(ServiceCallback<A> serviceCallback) {
         return ServiceFuture.fromBody(getDefaultModelA200ValidAsync(), serviceCallback);
     }
 
@@ -908,11 +1125,22 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * Send a 200 response with valid payload: {'statusCode': '200'}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the A object
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
      */
-    public Single<A> getDefaultModelA200ValidAsync() {
+    public Single<RestResponse<Void, A>> getDefaultModelA200ValidWithRestResponseAsync() {
         return service.getDefaultModelA200Valid();
     }
+
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
+     */
+    public Single<A> getDefaultModelA200ValidAsync() {
+        return getDefaultModelA200ValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, A>, A>() { public A call(RestResponse<Void, A> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -934,7 +1162,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<A> getDefaultModelA200NoneAsync(final ServiceCallback<A> serviceCallback) {
+    public ServiceFuture<A> getDefaultModelA200NoneAsync(ServiceCallback<A> serviceCallback) {
         return ServiceFuture.fromBody(getDefaultModelA200NoneAsync(), serviceCallback);
     }
 
@@ -942,11 +1170,22 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * Send a 200 response with no payload.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the A object
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
      */
-    public Single<A> getDefaultModelA200NoneAsync() {
+    public Single<RestResponse<Void, A>> getDefaultModelA200NoneWithRestResponseAsync() {
         return service.getDefaultModelA200None();
     }
+
+    /**
+     * Send a 200 response with no payload.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
+     */
+    public Single<A> getDefaultModelA200NoneAsync() {
+        return getDefaultModelA200NoneWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, A>, A>() { public A call(RestResponse<Void, A> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -968,7 +1207,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<A> getDefaultModelA400ValidAsync(final ServiceCallback<A> serviceCallback) {
+    public ServiceFuture<A> getDefaultModelA400ValidAsync(ServiceCallback<A> serviceCallback) {
         return ServiceFuture.fromBody(getDefaultModelA400ValidAsync(), serviceCallback);
     }
 
@@ -976,11 +1215,22 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * Send a 400 response with valid payload: {'statusCode': '400'}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the A object
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
      */
-    public Single<A> getDefaultModelA400ValidAsync() {
+    public Single<RestResponse<Void, A>> getDefaultModelA400ValidWithRestResponseAsync() {
         return service.getDefaultModelA400Valid();
     }
+
+    /**
+     * Send a 400 response with valid payload: {'statusCode': '400'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
+     */
+    public Single<A> getDefaultModelA400ValidAsync() {
+        return getDefaultModelA400ValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, A>, A>() { public A call(RestResponse<Void, A> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1002,7 +1252,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<A> getDefaultModelA400NoneAsync(final ServiceCallback<A> serviceCallback) {
+    public ServiceFuture<A> getDefaultModelA400NoneAsync(ServiceCallback<A> serviceCallback) {
         return ServiceFuture.fromBody(getDefaultModelA400NoneAsync(), serviceCallback);
     }
 
@@ -1010,11 +1260,22 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * Send a 400 response with no payload.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the A object
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
      */
-    public Single<A> getDefaultModelA400NoneAsync() {
+    public Single<RestResponse<Void, A>> getDefaultModelA400NoneWithRestResponseAsync() {
         return service.getDefaultModelA400None();
     }
+
+    /**
+     * Send a 400 response with no payload.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
+     */
+    public Single<A> getDefaultModelA400NoneAsync() {
+        return getDefaultModelA400NoneWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, A>, A>() { public A call(RestResponse<Void, A> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1023,6 +1284,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws RestException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getDefaultNone200Invalid() {
         getDefaultNone200InvalidAsync().toBlocking().value();
@@ -1035,7 +1297,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getDefaultNone200InvalidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getDefaultNone200InvalidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getDefaultNone200InvalidAsync(), serviceCallback);
     }
 
@@ -1043,11 +1305,22 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * Send a 200 response with invalid payload: {'statusCode': '200'}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getDefaultNone200InvalidAsync() {
+    public Single<RestResponse<Void, Void>> getDefaultNone200InvalidWithRestResponseAsync() {
         return service.getDefaultNone200Invalid();
     }
+
+    /**
+     * Send a 200 response with invalid payload: {'statusCode': '200'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getDefaultNone200InvalidAsync() {
+        return getDefaultNone200InvalidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1056,6 +1329,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws RestException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getDefaultNone200None() {
         getDefaultNone200NoneAsync().toBlocking().value();
@@ -1068,7 +1342,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getDefaultNone200NoneAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getDefaultNone200NoneAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getDefaultNone200NoneAsync(), serviceCallback);
     }
 
@@ -1076,11 +1350,22 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * Send a 200 response with no payload.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getDefaultNone200NoneAsync() {
+    public Single<RestResponse<Void, Void>> getDefaultNone200NoneWithRestResponseAsync() {
         return service.getDefaultNone200None();
     }
+
+    /**
+     * Send a 200 response with no payload.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getDefaultNone200NoneAsync() {
+        return getDefaultNone200NoneWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1089,6 +1374,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws RestException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getDefaultNone400Invalid() {
         getDefaultNone400InvalidAsync().toBlocking().value();
@@ -1101,7 +1387,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getDefaultNone400InvalidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getDefaultNone400InvalidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getDefaultNone400InvalidAsync(), serviceCallback);
     }
 
@@ -1109,11 +1395,22 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * Send a 400 response with valid payload: {'statusCode': '400'}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getDefaultNone400InvalidAsync() {
+    public Single<RestResponse<Void, Void>> getDefaultNone400InvalidWithRestResponseAsync() {
         return service.getDefaultNone400Invalid();
     }
+
+    /**
+     * Send a 400 response with valid payload: {'statusCode': '400'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getDefaultNone400InvalidAsync() {
+        return getDefaultNone400InvalidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1122,6 +1419,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws RestException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getDefaultNone400None() {
         getDefaultNone400NoneAsync().toBlocking().value();
@@ -1134,7 +1432,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getDefaultNone400NoneAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getDefaultNone400NoneAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getDefaultNone400NoneAsync(), serviceCallback);
     }
 
@@ -1142,11 +1440,22 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * Send a 400 response with no payload.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getDefaultNone400NoneAsync() {
+    public Single<RestResponse<Void, Void>> getDefaultNone400NoneWithRestResponseAsync() {
         return service.getDefaultNone400None();
     }
+
+    /**
+     * Send a 400 response with no payload.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getDefaultNone400NoneAsync() {
+        return getDefaultNone400NoneWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1168,7 +1477,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<A> get200ModelA200NoneAsync(final ServiceCallback<A> serviceCallback) {
+    public ServiceFuture<A> get200ModelA200NoneAsync(ServiceCallback<A> serviceCallback) {
         return ServiceFuture.fromBody(get200ModelA200NoneAsync(), serviceCallback);
     }
 
@@ -1176,11 +1485,22 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * Send a 200 response with no payload, when a payload is expected - client should return a null object of thde type for model A.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the A object
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
      */
-    public Single<A> get200ModelA200NoneAsync() {
+    public Single<RestResponse<Void, A>> get200ModelA200NoneWithRestResponseAsync() {
         return service.get200ModelA200None();
     }
+
+    /**
+     * Send a 200 response with no payload, when a payload is expected - client should return a null object of thde type for model A.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
+     */
+    public Single<A> get200ModelA200NoneAsync() {
+        return get200ModelA200NoneWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, A>, A>() { public A call(RestResponse<Void, A> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1202,7 +1522,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<A> get200ModelA200ValidAsync(final ServiceCallback<A> serviceCallback) {
+    public ServiceFuture<A> get200ModelA200ValidAsync(ServiceCallback<A> serviceCallback) {
         return ServiceFuture.fromBody(get200ModelA200ValidAsync(), serviceCallback);
     }
 
@@ -1210,11 +1530,22 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * Send a 200 response with payload {'statusCode': '200'}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the A object
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
      */
-    public Single<A> get200ModelA200ValidAsync() {
+    public Single<RestResponse<Void, A>> get200ModelA200ValidWithRestResponseAsync() {
         return service.get200ModelA200Valid();
     }
+
+    /**
+     * Send a 200 response with payload {'statusCode': '200'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
+     */
+    public Single<A> get200ModelA200ValidAsync() {
+        return get200ModelA200ValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, A>, A>() { public A call(RestResponse<Void, A> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1236,7 +1567,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<A> get200ModelA200InvalidAsync(final ServiceCallback<A> serviceCallback) {
+    public ServiceFuture<A> get200ModelA200InvalidAsync(ServiceCallback<A> serviceCallback) {
         return ServiceFuture.fromBody(get200ModelA200InvalidAsync(), serviceCallback);
     }
 
@@ -1244,11 +1575,22 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * Send a 200 response with invalid payload {'statusCodeInvalid': '200'}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the A object
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
      */
-    public Single<A> get200ModelA200InvalidAsync() {
+    public Single<RestResponse<Void, A>> get200ModelA200InvalidWithRestResponseAsync() {
         return service.get200ModelA200Invalid();
     }
+
+    /**
+     * Send a 200 response with invalid payload {'statusCodeInvalid': '200'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
+     */
+    public Single<A> get200ModelA200InvalidAsync() {
+        return get200ModelA200InvalidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, A>, A>() { public A call(RestResponse<Void, A> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1270,7 +1612,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<A> get200ModelA400NoneAsync(final ServiceCallback<A> serviceCallback) {
+    public ServiceFuture<A> get200ModelA400NoneAsync(ServiceCallback<A> serviceCallback) {
         return ServiceFuture.fromBody(get200ModelA400NoneAsync(), serviceCallback);
     }
 
@@ -1278,11 +1620,22 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * Send a 400 response with no payload client should treat as an http error with no error model.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the A object
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
      */
-    public Single<A> get200ModelA400NoneAsync() {
+    public Single<RestResponse<Void, A>> get200ModelA400NoneWithRestResponseAsync() {
         return service.get200ModelA400None();
     }
+
+    /**
+     * Send a 400 response with no payload client should treat as an http error with no error model.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
+     */
+    public Single<A> get200ModelA400NoneAsync() {
+        return get200ModelA400NoneWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, A>, A>() { public A call(RestResponse<Void, A> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1304,7 +1657,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<A> get200ModelA400ValidAsync(final ServiceCallback<A> serviceCallback) {
+    public ServiceFuture<A> get200ModelA400ValidAsync(ServiceCallback<A> serviceCallback) {
         return ServiceFuture.fromBody(get200ModelA400ValidAsync(), serviceCallback);
     }
 
@@ -1312,11 +1665,22 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * Send a 200 response with payload {'statusCode': '400'}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the A object
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
      */
-    public Single<A> get200ModelA400ValidAsync() {
+    public Single<RestResponse<Void, A>> get200ModelA400ValidWithRestResponseAsync() {
         return service.get200ModelA400Valid();
     }
+
+    /**
+     * Send a 200 response with payload {'statusCode': '400'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
+     */
+    public Single<A> get200ModelA400ValidAsync() {
+        return get200ModelA400ValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, A>, A>() { public A call(RestResponse<Void, A> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1338,7 +1702,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<A> get200ModelA400InvalidAsync(final ServiceCallback<A> serviceCallback) {
+    public ServiceFuture<A> get200ModelA400InvalidAsync(ServiceCallback<A> serviceCallback) {
         return ServiceFuture.fromBody(get200ModelA400InvalidAsync(), serviceCallback);
     }
 
@@ -1346,11 +1710,22 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * Send a 200 response with invalid payload {'statusCodeInvalid': '400'}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the A object
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
      */
-    public Single<A> get200ModelA400InvalidAsync() {
+    public Single<RestResponse<Void, A>> get200ModelA400InvalidWithRestResponseAsync() {
         return service.get200ModelA400Invalid();
     }
+
+    /**
+     * Send a 200 response with invalid payload {'statusCodeInvalid': '400'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
+     */
+    public Single<A> get200ModelA400InvalidAsync() {
+        return get200ModelA400InvalidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, A>, A>() { public A call(RestResponse<Void, A> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1372,7 +1747,7 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<A> get200ModelA202ValidAsync(final ServiceCallback<A> serviceCallback) {
+    public ServiceFuture<A> get200ModelA202ValidAsync(ServiceCallback<A> serviceCallback) {
         return ServiceFuture.fromBody(get200ModelA202ValidAsync(), serviceCallback);
     }
 
@@ -1380,11 +1755,22 @@ public class MultipleResponsesImpl implements MultipleResponses {
      * Send a 202 response with payload {'statusCode': '202'}.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the A object
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
      */
-    public Single<A> get200ModelA202ValidAsync() {
+    public Single<RestResponse<Void, A>> get200ModelA202ValidWithRestResponseAsync() {
         return service.get200ModelA202Valid();
     }
+
+    /**
+     * Send a 202 response with payload {'statusCode': '202'}.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, A> object
+     */
+    public Single<A> get200ModelA202ValidAsync() {
+        return get200ModelA202ValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, A>, A>() { public A call(RestResponse<Void, A> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/modelflattening/AutoRestResourceFlatteningTestService.java
+++ b/test/vanilla/src/main/java/fixtures/modelflattening/AutoRestResourceFlatteningTestService.java
@@ -10,6 +10,7 @@
 
 package fixtures.modelflattening;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.modelflattening.models.ErrorException;
@@ -68,6 +69,14 @@ public interface AutoRestResourceFlatteningTestService {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putArrayAsync();
+
+    /**
+     * Put External Resource as an Array.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putArrayWithRestResponseAsync();
     /**
      * Put External Resource as an Array.
      *
@@ -96,6 +105,14 @@ public interface AutoRestResourceFlatteningTestService {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putArrayAsync(List<Resource> resourceArray);
+    /**
+     * Put External Resource as an Array.
+     *
+     * @param resourceArray External Resource as an Array to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putArrayWithRestResponseAsync(List<Resource> resourceArray);
 
 
     /**
@@ -124,6 +141,13 @@ public interface AutoRestResourceFlatteningTestService {
      * @return the observable to the List&lt;FlattenedProduct&gt; object
      */
     Single<List<FlattenedProduct>> getArrayAsync();
+    /**
+     * Get External Resource as an Array.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;FlattenedProduct&gt; object
+     */
+    Single<RestResponse<Void, List<FlattenedProduct>>> getArrayWithRestResponseAsync();
 
 
     /**
@@ -151,6 +175,14 @@ public interface AutoRestResourceFlatteningTestService {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putWrappedArrayAsync();
+
+    /**
+     * No need to have a route in Express server for this operation. Used to verify the type flattened is not removed if it's referenced in an array.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putWrappedArrayWithRestResponseAsync();
     /**
      * No need to have a route in Express server for this operation. Used to verify the type flattened is not removed if it's referenced in an array.
      *
@@ -179,6 +211,14 @@ public interface AutoRestResourceFlatteningTestService {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putWrappedArrayAsync(List<WrappedProduct> resourceArray);
+    /**
+     * No need to have a route in Express server for this operation. Used to verify the type flattened is not removed if it's referenced in an array.
+     *
+     * @param resourceArray External Resource as an Array to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putWrappedArrayWithRestResponseAsync(List<WrappedProduct> resourceArray);
 
 
     /**
@@ -207,6 +247,13 @@ public interface AutoRestResourceFlatteningTestService {
      * @return the observable to the List&lt;ProductWrapper&gt; object
      */
     Single<List<ProductWrapper>> getWrappedArrayAsync();
+    /**
+     * No need to have a route in Express server for this operation. Used to verify the type flattened is not removed if it's referenced in an array.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the List&lt;ProductWrapper&gt; object
+     */
+    Single<RestResponse<Void, List<ProductWrapper>>> getWrappedArrayWithRestResponseAsync();
 
 
     /**
@@ -234,6 +281,14 @@ public interface AutoRestResourceFlatteningTestService {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putDictionaryAsync();
+
+    /**
+     * Put External Resource as a Dictionary.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putDictionaryWithRestResponseAsync();
     /**
      * Put External Resource as a Dictionary.
      *
@@ -262,6 +317,14 @@ public interface AutoRestResourceFlatteningTestService {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putDictionaryAsync(Map<String, FlattenedProduct> resourceDictionary);
+    /**
+     * Put External Resource as a Dictionary.
+     *
+     * @param resourceDictionary External Resource as a Dictionary to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putDictionaryWithRestResponseAsync(Map<String, FlattenedProduct> resourceDictionary);
 
 
     /**
@@ -290,6 +353,13 @@ public interface AutoRestResourceFlatteningTestService {
      * @return the observable to the Map&lt;String, FlattenedProduct&gt; object
      */
     Single<Map<String, FlattenedProduct>> getDictionaryAsync();
+    /**
+     * Get External Resource as a Dictionary.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, FlattenedProduct&gt; object
+     */
+    Single<RestResponse<Void, Map<String, FlattenedProduct>>> getDictionaryWithRestResponseAsync();
 
 
     /**
@@ -317,6 +387,14 @@ public interface AutoRestResourceFlatteningTestService {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putResourceCollectionAsync();
+
+    /**
+     * Put External Resource as a ResourceCollection.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putResourceCollectionWithRestResponseAsync();
     /**
      * Put External Resource as a ResourceCollection.
      *
@@ -345,6 +423,14 @@ public interface AutoRestResourceFlatteningTestService {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putResourceCollectionAsync(ResourceCollection resourceComplexObject);
+    /**
+     * Put External Resource as a ResourceCollection.
+     *
+     * @param resourceComplexObject External Resource as a ResourceCollection to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putResourceCollectionWithRestResponseAsync(ResourceCollection resourceComplexObject);
 
 
     /**
@@ -373,6 +459,13 @@ public interface AutoRestResourceFlatteningTestService {
      * @return the observable to the ResourceCollection object
      */
     Single<ResourceCollection> getResourceCollectionAsync();
+    /**
+     * Get External Resource as a ResourceCollection.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the ResourceCollection object
+     */
+    Single<RestResponse<Void, ResourceCollection>> getResourceCollectionWithRestResponseAsync();
 
 
     /**
@@ -401,6 +494,14 @@ public interface AutoRestResourceFlatteningTestService {
      * @return the observable to the SimpleProduct object
      */
     Single<SimpleProduct> putSimpleProductAsync();
+
+    /**
+     * Put Simple Product with client flattening true on the model.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the SimpleProduct object
+     */
+    Single<RestResponse<Void, SimpleProduct>> putSimpleProductWithRestResponseAsync();
     /**
      * Put Simple Product with client flattening true on the model.
      *
@@ -430,6 +531,14 @@ public interface AutoRestResourceFlatteningTestService {
      * @return the observable to the SimpleProduct object
      */
     Single<SimpleProduct> putSimpleProductAsync(SimpleProduct simpleBodyProduct);
+    /**
+     * Put Simple Product with client flattening true on the model.
+     *
+     * @param simpleBodyProduct Simple body product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the SimpleProduct object
+     */
+    Single<RestResponse<Void, SimpleProduct>> putSimpleProductWithRestResponseAsync(SimpleProduct simpleBodyProduct);
 
 
     /**
@@ -464,6 +573,16 @@ public interface AutoRestResourceFlatteningTestService {
      * @return the observable to the SimpleProduct object
      */
     Single<SimpleProduct> postFlattenedSimpleProductAsync(String productId, String maxProductDisplayName);
+
+    /**
+     * Put Flattened Simple Product with client flattening true on the parameter.
+     *
+     * @param productId Unique identifier representing a specific product for a given latitude &amp; longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.
+     * @param maxProductDisplayName Display name of product.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the SimpleProduct object
+     */
+    Single<RestResponse<Void, SimpleProduct>> postFlattenedSimpleProductWithRestResponseAsync(String productId, String maxProductDisplayName);
     /**
      * Put Flattened Simple Product with client flattening true on the parameter.
      *
@@ -505,6 +624,18 @@ public interface AutoRestResourceFlatteningTestService {
      * @return the observable to the SimpleProduct object
      */
     Single<SimpleProduct> postFlattenedSimpleProductAsync(String productId, String maxProductDisplayName, String description, String genericValue, String odatavalue);
+    /**
+     * Put Flattened Simple Product with client flattening true on the parameter.
+     *
+     * @param productId Unique identifier representing a specific product for a given latitude &amp; longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.
+     * @param maxProductDisplayName Display name of product.
+     * @param description Description of product.
+     * @param genericValue Generic URL value.
+     * @param odatavalue URL value.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the SimpleProduct object
+     */
+    Single<RestResponse<Void, SimpleProduct>> postFlattenedSimpleProductWithRestResponseAsync(String productId, String maxProductDisplayName, String description, String genericValue, String odatavalue);
 
 
     /**
@@ -536,6 +667,14 @@ public interface AutoRestResourceFlatteningTestService {
      * @return the observable to the SimpleProduct object
      */
     Single<SimpleProduct> putSimpleProductWithGroupingAsync(FlattenParameterGroup flattenParameterGroup);
+    /**
+     * Put Simple Product with client flattening true on the model.
+     *
+     * @param flattenParameterGroup Additional parameters for the operation
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the SimpleProduct object
+     */
+    Single<RestResponse<Void, SimpleProduct>> putSimpleProductWithGroupingWithRestResponseAsync(FlattenParameterGroup flattenParameterGroup);
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/modelflattening/implementation/AutoRestResourceFlatteningTestServiceImpl.java
+++ b/test/vanilla/src/main/java/fixtures/modelflattening/implementation/AutoRestResourceFlatteningTestServiceImpl.java
@@ -12,6 +12,7 @@ package fixtures.modelflattening.implementation;
 
 import fixtures.modelflattening.AutoRestResourceFlatteningTestService;
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceClient;
 import com.microsoft.rest.RestClient;
 import rx.Single;
@@ -99,67 +100,67 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
         @PUT("model-flatten/array")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putArray(@BodyParam("application/json; charset=utf-8") List<Resource> resourceArray);
+        Single<RestResponse<Void, Void>> putArray(@BodyParam("application/json; charset=utf-8") List<Resource> resourceArray);
 
         @Headers({ "x-ms-logging-context: fixtures.modelflattening.AutoRestResourceFlatteningTestService getArray" })
         @GET("model-flatten/array")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<FlattenedProduct>> getArray();
+        Single<RestResponse<Void, List<FlattenedProduct>>> getArray();
 
         @Headers({ "x-ms-logging-context: fixtures.modelflattening.AutoRestResourceFlatteningTestService putWrappedArray" })
         @PUT("model-flatten/wrappedarray")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putWrappedArray(@BodyParam("application/json; charset=utf-8") List<WrappedProduct> resourceArray);
+        Single<RestResponse<Void, Void>> putWrappedArray(@BodyParam("application/json; charset=utf-8") List<WrappedProduct> resourceArray);
 
         @Headers({ "x-ms-logging-context: fixtures.modelflattening.AutoRestResourceFlatteningTestService getWrappedArray" })
         @GET("model-flatten/wrappedarray")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<List<ProductWrapper>> getWrappedArray();
+        Single<RestResponse<Void, List<ProductWrapper>>> getWrappedArray();
 
         @Headers({ "x-ms-logging-context: fixtures.modelflattening.AutoRestResourceFlatteningTestService putDictionary" })
         @PUT("model-flatten/dictionary")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putDictionary(@BodyParam("application/json; charset=utf-8") Map<String, FlattenedProduct> resourceDictionary);
+        Single<RestResponse<Void, Void>> putDictionary(@BodyParam("application/json; charset=utf-8") Map<String, FlattenedProduct> resourceDictionary);
 
         @Headers({ "x-ms-logging-context: fixtures.modelflattening.AutoRestResourceFlatteningTestService getDictionary" })
         @GET("model-flatten/dictionary")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, FlattenedProduct>> getDictionary();
+        Single<RestResponse<Void, Map<String, FlattenedProduct>>> getDictionary();
 
         @Headers({ "x-ms-logging-context: fixtures.modelflattening.AutoRestResourceFlatteningTestService putResourceCollection" })
         @PUT("model-flatten/resourcecollection")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putResourceCollection(@BodyParam("application/json; charset=utf-8") ResourceCollection resourceComplexObject);
+        Single<RestResponse<Void, Void>> putResourceCollection(@BodyParam("application/json; charset=utf-8") ResourceCollection resourceComplexObject);
 
         @Headers({ "x-ms-logging-context: fixtures.modelflattening.AutoRestResourceFlatteningTestService getResourceCollection" })
         @GET("model-flatten/resourcecollection")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<ResourceCollection> getResourceCollection();
+        Single<RestResponse<Void, ResourceCollection>> getResourceCollection();
 
         @Headers({ "x-ms-logging-context: fixtures.modelflattening.AutoRestResourceFlatteningTestService putSimpleProduct" })
         @PUT("model-flatten/customFlattening")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<SimpleProduct> putSimpleProduct(@BodyParam("application/json; charset=utf-8") SimpleProduct simpleBodyProduct);
+        Single<RestResponse<Void, SimpleProduct>> putSimpleProduct(@BodyParam("application/json; charset=utf-8") SimpleProduct simpleBodyProduct);
 
         @Headers({ "x-ms-logging-context: fixtures.modelflattening.AutoRestResourceFlatteningTestService postFlattenedSimpleProduct" })
         @POST("model-flatten/customFlattening")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<SimpleProduct> postFlattenedSimpleProduct(@BodyParam("application/json; charset=utf-8") SimpleProduct simpleBodyProduct);
+        Single<RestResponse<Void, SimpleProduct>> postFlattenedSimpleProduct(@BodyParam("application/json; charset=utf-8") SimpleProduct simpleBodyProduct);
 
         @Headers({ "x-ms-logging-context: fixtures.modelflattening.AutoRestResourceFlatteningTestService putSimpleProductWithGrouping" })
         @PUT("model-flatten/customFlattening/parametergrouping/{name}/")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<SimpleProduct> putSimpleProductWithGrouping(@PathParam("name") String name, @BodyParam("application/json; charset=utf-8") SimpleProduct simpleBodyProduct);
+        Single<RestResponse<Void, SimpleProduct>> putSimpleProductWithGrouping(@PathParam("name") String name, @BodyParam("application/json; charset=utf-8") SimpleProduct simpleBodyProduct);
 
     }
 
@@ -169,6 +170,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putArray() {
         putArrayAsync().toBlocking().value();
@@ -181,7 +183,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putArrayAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putArrayAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putArrayAsync(), serviceCallback);
     }
 
@@ -189,12 +191,24 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * Put External Resource as an Array.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putArrayAsync() {
+    public Single<RestResponse<Void, Void>> putArrayWithRestResponseAsync() {
         final List<Resource> resourceArray = null;
+        Validator.validate(resourceArray);
         return service.putArray(resourceArray);
     }
+
+    /**
+     * Put External Resource as an Array.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putArrayAsync() {
+        return putArrayWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Put External Resource as an Array.
@@ -203,6 +217,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putArray(List<Resource> resourceArray) {
         putArrayAsync(resourceArray).toBlocking().value();
@@ -216,7 +231,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putArrayAsync(List<Resource> resourceArray, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putArrayAsync(List<Resource> resourceArray, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putArrayAsync(resourceArray), serviceCallback);
     }
 
@@ -225,12 +240,24 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      *
      * @param resourceArray External Resource as an Array to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putArrayAsync(List<Resource> resourceArray) {
+    public Single<RestResponse<Void, Void>> putArrayWithRestResponseAsync(List<Resource> resourceArray) {
         Validator.validate(resourceArray);
         return service.putArray(resourceArray);
     }
+
+    /**
+     * Put External Resource as an Array.
+     *
+     * @param resourceArray External Resource as an Array to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putArrayAsync(List<Resource> resourceArray) {
+        return putArrayWithRestResponseAsync(resourceArray)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -252,7 +279,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<FlattenedProduct>> getArrayAsync(final ServiceCallback<List<FlattenedProduct>> serviceCallback) {
+    public ServiceFuture<List<FlattenedProduct>> getArrayAsync(ServiceCallback<List<FlattenedProduct>> serviceCallback) {
         return ServiceFuture.fromBody(getArrayAsync(), serviceCallback);
     }
 
@@ -260,11 +287,22 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * Get External Resource as an Array.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;FlattenedProduct&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<FlattenedProduct>> object
      */
-    public Single<List<FlattenedProduct>> getArrayAsync() {
+    public Single<RestResponse<Void, List<FlattenedProduct>>> getArrayWithRestResponseAsync() {
         return service.getArray();
     }
+
+    /**
+     * Get External Resource as an Array.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<FlattenedProduct>> object
+     */
+    public Single<List<FlattenedProduct>> getArrayAsync() {
+        return getArrayWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<FlattenedProduct>>, List<FlattenedProduct>>() { public List<FlattenedProduct> call(RestResponse<Void, List<FlattenedProduct>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -273,6 +311,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putWrappedArray() {
         putWrappedArrayAsync().toBlocking().value();
@@ -285,7 +324,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putWrappedArrayAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putWrappedArrayAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putWrappedArrayAsync(), serviceCallback);
     }
 
@@ -293,12 +332,24 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * No need to have a route in Express server for this operation. Used to verify the type flattened is not removed if it's referenced in an array.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putWrappedArrayAsync() {
+    public Single<RestResponse<Void, Void>> putWrappedArrayWithRestResponseAsync() {
         final List<WrappedProduct> resourceArray = null;
+        Validator.validate(resourceArray);
         return service.putWrappedArray(resourceArray);
     }
+
+    /**
+     * No need to have a route in Express server for this operation. Used to verify the type flattened is not removed if it's referenced in an array.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putWrappedArrayAsync() {
+        return putWrappedArrayWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * No need to have a route in Express server for this operation. Used to verify the type flattened is not removed if it's referenced in an array.
@@ -307,6 +358,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putWrappedArray(List<WrappedProduct> resourceArray) {
         putWrappedArrayAsync(resourceArray).toBlocking().value();
@@ -320,7 +372,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putWrappedArrayAsync(List<WrappedProduct> resourceArray, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putWrappedArrayAsync(List<WrappedProduct> resourceArray, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putWrappedArrayAsync(resourceArray), serviceCallback);
     }
 
@@ -329,12 +381,24 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      *
      * @param resourceArray External Resource as an Array to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putWrappedArrayAsync(List<WrappedProduct> resourceArray) {
+    public Single<RestResponse<Void, Void>> putWrappedArrayWithRestResponseAsync(List<WrappedProduct> resourceArray) {
         Validator.validate(resourceArray);
         return service.putWrappedArray(resourceArray);
     }
+
+    /**
+     * No need to have a route in Express server for this operation. Used to verify the type flattened is not removed if it's referenced in an array.
+     *
+     * @param resourceArray External Resource as an Array to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putWrappedArrayAsync(List<WrappedProduct> resourceArray) {
+        return putWrappedArrayWithRestResponseAsync(resourceArray)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -356,7 +420,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<List<ProductWrapper>> getWrappedArrayAsync(final ServiceCallback<List<ProductWrapper>> serviceCallback) {
+    public ServiceFuture<List<ProductWrapper>> getWrappedArrayAsync(ServiceCallback<List<ProductWrapper>> serviceCallback) {
         return ServiceFuture.fromBody(getWrappedArrayAsync(), serviceCallback);
     }
 
@@ -364,11 +428,22 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * No need to have a route in Express server for this operation. Used to verify the type flattened is not removed if it's referenced in an array.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the List&lt;ProductWrapper&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, List<ProductWrapper>> object
      */
-    public Single<List<ProductWrapper>> getWrappedArrayAsync() {
+    public Single<RestResponse<Void, List<ProductWrapper>>> getWrappedArrayWithRestResponseAsync() {
         return service.getWrappedArray();
     }
+
+    /**
+     * No need to have a route in Express server for this operation. Used to verify the type flattened is not removed if it's referenced in an array.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, List<ProductWrapper>> object
+     */
+    public Single<List<ProductWrapper>> getWrappedArrayAsync() {
+        return getWrappedArrayWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, List<ProductWrapper>>, List<ProductWrapper>>() { public List<ProductWrapper> call(RestResponse<Void, List<ProductWrapper>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -377,6 +452,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putDictionary() {
         putDictionaryAsync().toBlocking().value();
@@ -389,7 +465,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putDictionaryAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putDictionaryAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putDictionaryAsync(), serviceCallback);
     }
 
@@ -397,12 +473,24 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * Put External Resource as a Dictionary.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putDictionaryAsync() {
+    public Single<RestResponse<Void, Void>> putDictionaryWithRestResponseAsync() {
         final Map<String, FlattenedProduct> resourceDictionary = null;
+        Validator.validate(resourceDictionary);
         return service.putDictionary(resourceDictionary);
     }
+
+    /**
+     * Put External Resource as a Dictionary.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putDictionaryAsync() {
+        return putDictionaryWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Put External Resource as a Dictionary.
@@ -411,6 +499,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putDictionary(Map<String, FlattenedProduct> resourceDictionary) {
         putDictionaryAsync(resourceDictionary).toBlocking().value();
@@ -424,7 +513,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putDictionaryAsync(Map<String, FlattenedProduct> resourceDictionary, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putDictionaryAsync(Map<String, FlattenedProduct> resourceDictionary, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putDictionaryAsync(resourceDictionary), serviceCallback);
     }
 
@@ -433,12 +522,24 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      *
      * @param resourceDictionary External Resource as a Dictionary to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putDictionaryAsync(Map<String, FlattenedProduct> resourceDictionary) {
+    public Single<RestResponse<Void, Void>> putDictionaryWithRestResponseAsync(Map<String, FlattenedProduct> resourceDictionary) {
         Validator.validate(resourceDictionary);
         return service.putDictionary(resourceDictionary);
     }
+
+    /**
+     * Put External Resource as a Dictionary.
+     *
+     * @param resourceDictionary External Resource as a Dictionary to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putDictionaryAsync(Map<String, FlattenedProduct> resourceDictionary) {
+        return putDictionaryWithRestResponseAsync(resourceDictionary)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -460,7 +561,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, FlattenedProduct>> getDictionaryAsync(final ServiceCallback<Map<String, FlattenedProduct>> serviceCallback) {
+    public ServiceFuture<Map<String, FlattenedProduct>> getDictionaryAsync(ServiceCallback<Map<String, FlattenedProduct>> serviceCallback) {
         return ServiceFuture.fromBody(getDictionaryAsync(), serviceCallback);
     }
 
@@ -468,11 +569,22 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * Get External Resource as a Dictionary.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, FlattenedProduct&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, FlattenedProduct>> object
      */
-    public Single<Map<String, FlattenedProduct>> getDictionaryAsync() {
+    public Single<RestResponse<Void, Map<String, FlattenedProduct>>> getDictionaryWithRestResponseAsync() {
         return service.getDictionary();
     }
+
+    /**
+     * Get External Resource as a Dictionary.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, FlattenedProduct>> object
+     */
+    public Single<Map<String, FlattenedProduct>> getDictionaryAsync() {
+        return getDictionaryWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, FlattenedProduct>>, Map<String, FlattenedProduct>>() { public Map<String, FlattenedProduct> call(RestResponse<Void, Map<String, FlattenedProduct>> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -481,6 +593,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putResourceCollection() {
         putResourceCollectionAsync().toBlocking().value();
@@ -493,7 +606,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putResourceCollectionAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putResourceCollectionAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putResourceCollectionAsync(), serviceCallback);
     }
 
@@ -501,12 +614,24 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * Put External Resource as a ResourceCollection.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putResourceCollectionAsync() {
+    public Single<RestResponse<Void, Void>> putResourceCollectionWithRestResponseAsync() {
         final ResourceCollection resourceComplexObject = null;
+        Validator.validate(resourceComplexObject);
         return service.putResourceCollection(resourceComplexObject);
     }
+
+    /**
+     * Put External Resource as a ResourceCollection.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putResourceCollectionAsync() {
+        return putResourceCollectionWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Put External Resource as a ResourceCollection.
@@ -515,6 +640,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putResourceCollection(ResourceCollection resourceComplexObject) {
         putResourceCollectionAsync(resourceComplexObject).toBlocking().value();
@@ -528,7 +654,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putResourceCollectionAsync(ResourceCollection resourceComplexObject, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putResourceCollectionAsync(ResourceCollection resourceComplexObject, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putResourceCollectionAsync(resourceComplexObject), serviceCallback);
     }
 
@@ -537,12 +663,24 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      *
      * @param resourceComplexObject External Resource as a ResourceCollection to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putResourceCollectionAsync(ResourceCollection resourceComplexObject) {
+    public Single<RestResponse<Void, Void>> putResourceCollectionWithRestResponseAsync(ResourceCollection resourceComplexObject) {
         Validator.validate(resourceComplexObject);
         return service.putResourceCollection(resourceComplexObject);
     }
+
+    /**
+     * Put External Resource as a ResourceCollection.
+     *
+     * @param resourceComplexObject External Resource as a ResourceCollection to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putResourceCollectionAsync(ResourceCollection resourceComplexObject) {
+        return putResourceCollectionWithRestResponseAsync(resourceComplexObject)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -564,7 +702,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<ResourceCollection> getResourceCollectionAsync(final ServiceCallback<ResourceCollection> serviceCallback) {
+    public ServiceFuture<ResourceCollection> getResourceCollectionAsync(ServiceCallback<ResourceCollection> serviceCallback) {
         return ServiceFuture.fromBody(getResourceCollectionAsync(), serviceCallback);
     }
 
@@ -572,11 +710,22 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * Get External Resource as a ResourceCollection.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the ResourceCollection object
+     * @return a {@link Single} emitting the RestResponse<Void, ResourceCollection> object
      */
-    public Single<ResourceCollection> getResourceCollectionAsync() {
+    public Single<RestResponse<Void, ResourceCollection>> getResourceCollectionWithRestResponseAsync() {
         return service.getResourceCollection();
     }
+
+    /**
+     * Get External Resource as a ResourceCollection.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, ResourceCollection> object
+     */
+    public Single<ResourceCollection> getResourceCollectionAsync() {
+        return getResourceCollectionWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, ResourceCollection>, ResourceCollection>() { public ResourceCollection call(RestResponse<Void, ResourceCollection> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -598,7 +747,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<SimpleProduct> putSimpleProductAsync(final ServiceCallback<SimpleProduct> serviceCallback) {
+    public ServiceFuture<SimpleProduct> putSimpleProductAsync(ServiceCallback<SimpleProduct> serviceCallback) {
         return ServiceFuture.fromBody(putSimpleProductAsync(), serviceCallback);
     }
 
@@ -606,12 +755,24 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * Put Simple Product with client flattening true on the model.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the SimpleProduct object
+     * @return a {@link Single} emitting the RestResponse<Void, SimpleProduct> object
      */
-    public Single<SimpleProduct> putSimpleProductAsync() {
+    public Single<RestResponse<Void, SimpleProduct>> putSimpleProductWithRestResponseAsync() {
         final SimpleProduct simpleBodyProduct = null;
+        Validator.validate(simpleBodyProduct);
         return service.putSimpleProduct(simpleBodyProduct);
     }
+
+    /**
+     * Put Simple Product with client flattening true on the model.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, SimpleProduct> object
+     */
+    public Single<SimpleProduct> putSimpleProductAsync() {
+        return putSimpleProductWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, SimpleProduct>, SimpleProduct>() { public SimpleProduct call(RestResponse<Void, SimpleProduct> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Put Simple Product with client flattening true on the model.
@@ -634,7 +795,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<SimpleProduct> putSimpleProductAsync(SimpleProduct simpleBodyProduct, final ServiceCallback<SimpleProduct> serviceCallback) {
+    public ServiceFuture<SimpleProduct> putSimpleProductAsync(SimpleProduct simpleBodyProduct, ServiceCallback<SimpleProduct> serviceCallback) {
         return ServiceFuture.fromBody(putSimpleProductAsync(simpleBodyProduct), serviceCallback);
     }
 
@@ -643,12 +804,24 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      *
      * @param simpleBodyProduct Simple body product to put
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the SimpleProduct object
+     * @return a {@link Single} emitting the RestResponse<Void, SimpleProduct> object
      */
-    public Single<SimpleProduct> putSimpleProductAsync(SimpleProduct simpleBodyProduct) {
+    public Single<RestResponse<Void, SimpleProduct>> putSimpleProductWithRestResponseAsync(SimpleProduct simpleBodyProduct) {
         Validator.validate(simpleBodyProduct);
         return service.putSimpleProduct(simpleBodyProduct);
     }
+
+    /**
+     * Put Simple Product with client flattening true on the model.
+     *
+     * @param simpleBodyProduct Simple body product to put
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, SimpleProduct> object
+     */
+    public Single<SimpleProduct> putSimpleProductAsync(SimpleProduct simpleBodyProduct) {
+        return putSimpleProductWithRestResponseAsync(simpleBodyProduct)
+            .map(new Func1<RestResponse<Void, SimpleProduct>, SimpleProduct>() { public SimpleProduct call(RestResponse<Void, SimpleProduct> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -674,7 +847,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<SimpleProduct> postFlattenedSimpleProductAsync(String productId, String maxProductDisplayName, final ServiceCallback<SimpleProduct> serviceCallback) {
+    public ServiceFuture<SimpleProduct> postFlattenedSimpleProductAsync(String productId, String maxProductDisplayName, ServiceCallback<SimpleProduct> serviceCallback) {
         return ServiceFuture.fromBody(postFlattenedSimpleProductAsync(productId, maxProductDisplayName), serviceCallback);
     }
 
@@ -684,9 +857,9 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * @param productId Unique identifier representing a specific product for a given latitude &amp; longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.
      * @param maxProductDisplayName Display name of product.
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the SimpleProduct object
+     * @return a {@link Single} emitting the RestResponse<Void, SimpleProduct> object
      */
-    public Single<SimpleProduct> postFlattenedSimpleProductAsync(String productId, String maxProductDisplayName) {
+    public Single<RestResponse<Void, SimpleProduct>> postFlattenedSimpleProductWithRestResponseAsync(String productId, String maxProductDisplayName) {
         if (productId == null) {
             throw new IllegalArgumentException("Parameter productId is required and cannot be null.");
         }
@@ -696,14 +869,27 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
         final String description = null;
         final String genericValue = null;
         final String odatavalue = null;
-        SimpleProduct simpleBodyProduct = new SimpleProduct();
-        simpleBodyProduct.withProductId(productId);
-        simpleBodyProduct.withDescription(null);
-        simpleBodyProduct.withMaxProductDisplayName(maxProductDisplayName);
-        simpleBodyProduct.withGenericValue(null);
-        simpleBodyProduct.withOdatavalue(null);
+    SimpleProduct simpleBodyProduct = new SimpleProduct();
+    simpleBodyProduct.withProductId(productId);
+    simpleBodyProduct.withDescription(null);
+    simpleBodyProduct.withMaxProductDisplayName(maxProductDisplayName);
+    simpleBodyProduct.withGenericValue(null);
+    simpleBodyProduct.withOdatavalue(null);
         return service.postFlattenedSimpleProduct(simpleBodyProduct);
     }
+
+    /**
+     * Put Flattened Simple Product with client flattening true on the parameter.
+     *
+     * @param productId Unique identifier representing a specific product for a given latitude &amp; longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.
+     * @param maxProductDisplayName Display name of product.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, SimpleProduct> object
+     */
+    public Single<SimpleProduct> postFlattenedSimpleProductAsync(String productId, String maxProductDisplayName) {
+        return postFlattenedSimpleProductWithRestResponseAsync(productId, maxProductDisplayName)
+            .map(new Func1<RestResponse<Void, SimpleProduct>, SimpleProduct>() { public SimpleProduct call(RestResponse<Void, SimpleProduct> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Put Flattened Simple Product with client flattening true on the parameter.
@@ -734,7 +920,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<SimpleProduct> postFlattenedSimpleProductAsync(String productId, String maxProductDisplayName, String description, String genericValue, String odatavalue, final ServiceCallback<SimpleProduct> serviceCallback) {
+    public ServiceFuture<SimpleProduct> postFlattenedSimpleProductAsync(String productId, String maxProductDisplayName, String description, String genericValue, String odatavalue, ServiceCallback<SimpleProduct> serviceCallback) {
         return ServiceFuture.fromBody(postFlattenedSimpleProductAsync(productId, maxProductDisplayName, description, genericValue, odatavalue), serviceCallback);
     }
 
@@ -747,26 +933,42 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * @param genericValue Generic URL value.
      * @param odatavalue URL value.
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the SimpleProduct object
+     * @return a {@link Single} emitting the RestResponse<Void, SimpleProduct> object
      */
-    public Single<SimpleProduct> postFlattenedSimpleProductAsync(String productId, String maxProductDisplayName, String description, String genericValue, String odatavalue) {
+    public Single<RestResponse<Void, SimpleProduct>> postFlattenedSimpleProductWithRestResponseAsync(String productId, String maxProductDisplayName, String description, String genericValue, String odatavalue) {
         if (productId == null) {
             throw new IllegalArgumentException("Parameter productId is required and cannot be null.");
         }
         if (maxProductDisplayName == null) {
             throw new IllegalArgumentException("Parameter maxProductDisplayName is required and cannot be null.");
         }
-        SimpleProduct simpleBodyProduct = null;
-        if (description != null || genericValue != null || odatavalue != null) {
-            simpleBodyProduct = new SimpleProduct();
-            simpleBodyProduct.withProductId(productId);
-            simpleBodyProduct.withDescription(description);
-            simpleBodyProduct.withMaxProductDisplayName(maxProductDisplayName);
-            simpleBodyProduct.withGenericValue(genericValue);
-            simpleBodyProduct.withOdatavalue(odatavalue);
-        }
+    SimpleProduct simpleBodyProduct = null;
+    if (description != null || genericValue != null || odatavalue != null) {
+        simpleBodyProduct = new SimpleProduct();
+        simpleBodyProduct.withProductId(productId);
+        simpleBodyProduct.withDescription(description);
+        simpleBodyProduct.withMaxProductDisplayName(maxProductDisplayName);
+        simpleBodyProduct.withGenericValue(genericValue);
+        simpleBodyProduct.withOdatavalue(odatavalue);
+    }
         return service.postFlattenedSimpleProduct(simpleBodyProduct);
     }
+
+    /**
+     * Put Flattened Simple Product with client flattening true on the parameter.
+     *
+     * @param productId Unique identifier representing a specific product for a given latitude &amp; longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.
+     * @param maxProductDisplayName Display name of product.
+     * @param description Description of product.
+     * @param genericValue Generic URL value.
+     * @param odatavalue URL value.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, SimpleProduct> object
+     */
+    public Single<SimpleProduct> postFlattenedSimpleProductAsync(String productId, String maxProductDisplayName, String description, String genericValue, String odatavalue) {
+        return postFlattenedSimpleProductWithRestResponseAsync(productId, maxProductDisplayName, description, genericValue, odatavalue)
+            .map(new Func1<RestResponse<Void, SimpleProduct>, SimpleProduct>() { public SimpleProduct call(RestResponse<Void, SimpleProduct> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -790,7 +992,7 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<SimpleProduct> putSimpleProductWithGroupingAsync(FlattenParameterGroup flattenParameterGroup, final ServiceCallback<SimpleProduct> serviceCallback) {
+    public ServiceFuture<SimpleProduct> putSimpleProductWithGroupingAsync(FlattenParameterGroup flattenParameterGroup, ServiceCallback<SimpleProduct> serviceCallback) {
         return ServiceFuture.fromBody(putSimpleProductWithGroupingAsync(flattenParameterGroup), serviceCallback);
     }
 
@@ -799,30 +1001,42 @@ public class AutoRestResourceFlatteningTestServiceImpl extends ServiceClient imp
      *
      * @param flattenParameterGroup Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the SimpleProduct object
+     * @return a {@link Single} emitting the RestResponse<Void, SimpleProduct> object
      */
-    public Single<SimpleProduct> putSimpleProductWithGroupingAsync(FlattenParameterGroup flattenParameterGroup) {
+    public Single<RestResponse<Void, SimpleProduct>> putSimpleProductWithGroupingWithRestResponseAsync(FlattenParameterGroup flattenParameterGroup) {
         if (flattenParameterGroup == null) {
             throw new IllegalArgumentException("Parameter flattenParameterGroup is required and cannot be null.");
         }
         Validator.validate(flattenParameterGroup);
-        String name = flattenParameterGroup.name();
-        String productId = flattenParameterGroup.productId();
-        String description = flattenParameterGroup.description();
-        String maxProductDisplayName = flattenParameterGroup.maxProductDisplayName();
-        String genericValue = flattenParameterGroup.genericValue();
-        String odatavalue = flattenParameterGroup.odatavalue();
-        SimpleProduct simpleBodyProduct = null;
-        if (description != null || genericValue != null || odatavalue != null) {
-            simpleBodyProduct = new SimpleProduct();
-            simpleBodyProduct.withProductId(productId);
-            simpleBodyProduct.withDescription(description);
-            simpleBodyProduct.withMaxProductDisplayName(maxProductDisplayName);
-            simpleBodyProduct.withGenericValue(genericValue);
-            simpleBodyProduct.withOdatavalue(odatavalue);
-        }
+    String name = flattenParameterGroup.name();
+    String productId = flattenParameterGroup.productId();
+    String description = flattenParameterGroup.description();
+    String maxProductDisplayName = flattenParameterGroup.maxProductDisplayName();
+    String genericValue = flattenParameterGroup.genericValue();
+    String odatavalue = flattenParameterGroup.odatavalue();
+    SimpleProduct simpleBodyProduct = null;
+    if (description != null || genericValue != null || odatavalue != null) {
+        simpleBodyProduct = new SimpleProduct();
+        simpleBodyProduct.withProductId(productId);
+        simpleBodyProduct.withDescription(description);
+        simpleBodyProduct.withMaxProductDisplayName(maxProductDisplayName);
+        simpleBodyProduct.withGenericValue(genericValue);
+        simpleBodyProduct.withOdatavalue(odatavalue);
+    }
         return service.putSimpleProductWithGrouping(name, simpleBodyProduct);
     }
+
+    /**
+     * Put Simple Product with client flattening true on the model.
+     *
+     * @param flattenParameterGroup Additional parameters for the operation
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, SimpleProduct> object
+     */
+    public Single<SimpleProduct> putSimpleProductWithGroupingAsync(FlattenParameterGroup flattenParameterGroup) {
+        return putSimpleProductWithGroupingWithRestResponseAsync(flattenParameterGroup)
+            .map(new Func1<RestResponse<Void, SimpleProduct>, SimpleProduct>() { public SimpleProduct call(RestResponse<Void, SimpleProduct> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/parameterflattening/AvailabilitySets.java
+++ b/test/vanilla/src/main/java/fixtures/parameterflattening/AvailabilitySets.java
@@ -11,6 +11,7 @@
 package fixtures.parameterflattening;
 
 import com.microsoft.rest.RestException;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import java.io.IOException;
@@ -57,6 +58,16 @@ public interface AvailabilitySets {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> updateAsync(String resourceGroupName, String avset, Map<String, String> tags);
+    /**
+     * Updates the tags for an availability set.
+     *
+     * @param resourceGroupName The name of the resource group.
+     * @param avset The name of the storage availability set.
+     * @param tags A set of tags. A description about the set of tags.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> updateWithRestResponseAsync(String resourceGroupName, String avset, Map<String, String> tags);
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/parameterflattening/implementation/AutoRestParameterFlatteningImpl.java
+++ b/test/vanilla/src/main/java/fixtures/parameterflattening/implementation/AutoRestParameterFlatteningImpl.java
@@ -13,6 +13,7 @@ package fixtures.parameterflattening.implementation;
 import fixtures.parameterflattening.AutoRestParameterFlattening;
 import fixtures.parameterflattening.AvailabilitySets;
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceClient;
 import com.microsoft.rest.RestClient;
 import rx.Single;

--- a/test/vanilla/src/main/java/fixtures/parameterflattening/implementation/AvailabilitySetsImpl.java
+++ b/test/vanilla/src/main/java/fixtures/parameterflattening/implementation/AvailabilitySetsImpl.java
@@ -11,6 +11,7 @@
 package fixtures.parameterflattening.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.parameterflattening.AvailabilitySets;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.BodyParam;
@@ -61,7 +62,7 @@ public class AvailabilitySetsImpl implements AvailabilitySets {
         @Headers({ "x-ms-logging-context: fixtures.parameterflattening.AvailabilitySets update" })
         @PATCH("parameterFlattening/{resourceGroupName}/{availabilitySetName}")
         @ExpectedResponses({200})
-        Single<Void> update(@PathParam("resourceGroupName") String resourceGroupName, @PathParam("availabilitySetName") String avset, @BodyParam("application/json; charset=utf-8") AvailabilitySetUpdateParameters tags);
+        Single<RestResponse<Void, Void>> update(@PathParam("resourceGroupName") String resourceGroupName, @PathParam("availabilitySetName") String avset, @BodyParam("application/json; charset=utf-8") AvailabilitySetUpdateParameters tags);
 
     }
 
@@ -74,6 +75,7 @@ public class AvailabilitySetsImpl implements AvailabilitySets {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws RestException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void update(String resourceGroupName, String avset, Map<String, String> tags) {
         updateAsync(resourceGroupName, avset, tags).toBlocking().value();
@@ -89,7 +91,7 @@ public class AvailabilitySetsImpl implements AvailabilitySets {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> updateAsync(String resourceGroupName, String avset, Map<String, String> tags, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> updateAsync(String resourceGroupName, String avset, Map<String, String> tags, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(updateAsync(resourceGroupName, avset, tags), serviceCallback);
     }
 
@@ -100,9 +102,9 @@ public class AvailabilitySetsImpl implements AvailabilitySets {
      * @param avset The name of the storage availability set.
      * @param tags A set of tags. A description about the set of tags.
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> updateAsync(String resourceGroupName, String avset, Map<String, String> tags) {
+    public Single<RestResponse<Void, Void>> updateWithRestResponseAsync(String resourceGroupName, String avset, Map<String, String> tags) {
         if (resourceGroupName == null) {
             throw new IllegalArgumentException("Parameter resourceGroupName is required and cannot be null.");
         }
@@ -113,10 +115,24 @@ public class AvailabilitySetsImpl implements AvailabilitySets {
             throw new IllegalArgumentException("Parameter tags is required and cannot be null.");
         }
         Validator.validate(tags);
-        AvailabilitySetUpdateParameters tags1 = new AvailabilitySetUpdateParameters();
-        tags1.withTags(tags);
+    AvailabilitySetUpdateParameters tags1 = new AvailabilitySetUpdateParameters();
+    tags1.withTags(tags);
         return service.update(resourceGroupName, avset, tags1);
     }
+
+    /**
+     * Updates the tags for an availability set.
+     *
+     * @param resourceGroupName The name of the resource group.
+     * @param avset The name of the storage availability set.
+     * @param tags A set of tags. A description about the set of tags.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> updateAsync(String resourceGroupName, String avset, Map<String, String> tags) {
+        return updateWithRestResponseAsync(resourceGroupName, avset, tags)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/report/AutoRestReportService.java
+++ b/test/vanilla/src/main/java/fixtures/report/AutoRestReportService.java
@@ -10,6 +10,7 @@
 
 package fixtures.report;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.report.models.ErrorException;
@@ -61,6 +62,13 @@ public interface AutoRestReportService {
      * @return the observable to the Map&lt;String, Integer&gt; object
      */
     Single<Map<String, Integer>> getReportAsync();
+    /**
+     * Get test coverage report.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Map&lt;String, Integer&gt; object
+     */
+    Single<RestResponse<Void, Map<String, Integer>>> getReportWithRestResponseAsync();
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/report/implementation/AutoRestReportServiceImpl.java
+++ b/test/vanilla/src/main/java/fixtures/report/implementation/AutoRestReportServiceImpl.java
@@ -12,6 +12,7 @@ package fixtures.report.implementation;
 
 import fixtures.report.AutoRestReportService;
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceClient;
 import com.microsoft.rest.RestClient;
 import rx.Single;
@@ -86,7 +87,7 @@ public class AutoRestReportServiceImpl extends ServiceClient implements AutoRest
         @GET("report")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Map<String, Integer>> getReport();
+        Single<RestResponse<Void, Map<String, Integer>>> getReport();
 
     }
 
@@ -109,7 +110,7 @@ public class AutoRestReportServiceImpl extends ServiceClient implements AutoRest
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Map<String, Integer>> getReportAsync(final ServiceCallback<Map<String, Integer>> serviceCallback) {
+    public ServiceFuture<Map<String, Integer>> getReportAsync(ServiceCallback<Map<String, Integer>> serviceCallback) {
         return ServiceFuture.fromBody(getReportAsync(), serviceCallback);
     }
 
@@ -117,11 +118,22 @@ public class AutoRestReportServiceImpl extends ServiceClient implements AutoRest
      * Get test coverage report.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Map&lt;String, Integer&gt; object
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Integer>> object
      */
-    public Single<Map<String, Integer>> getReportAsync() {
+    public Single<RestResponse<Void, Map<String, Integer>>> getReportWithRestResponseAsync() {
         return service.getReport();
     }
+
+    /**
+     * Get test coverage report.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Map<String, Integer>> object
+     */
+    public Single<Map<String, Integer>> getReportAsync() {
+        return getReportWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Map<String, Integer>>, Map<String, Integer>>() { public Map<String, Integer> call(RestResponse<Void, Map<String, Integer>> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/requiredoptional/Explicits.java
+++ b/test/vanilla/src/main/java/fixtures/requiredoptional/Explicits.java
@@ -10,6 +10,7 @@
 
 package fixtures.requiredoptional;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.requiredoptional.models.ArrayOptionalWrapper;
@@ -62,6 +63,14 @@ public interface Explicits {
      * @return the observable to the Error object
      */
     Single<Error> postRequiredIntegerParameterAsync(int bodyParameter);
+    /**
+     * Test explicitly required integer. Please put null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter the int value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> postRequiredIntegerParameterWithRestResponseAsync(int bodyParameter);
 
 
     /**
@@ -89,6 +98,14 @@ public interface Explicits {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postOptionalIntegerParameterAsync();
+
+    /**
+     * Test explicitly optional integer. Please put null.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> postOptionalIntegerParameterWithRestResponseAsync();
     /**
      * Test explicitly optional integer. Please put null.
      *
@@ -117,6 +134,14 @@ public interface Explicits {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postOptionalIntegerParameterAsync(Integer bodyParameter);
+    /**
+     * Test explicitly optional integer. Please put null.
+     *
+     * @param bodyParameter the Integer value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> postOptionalIntegerParameterWithRestResponseAsync(Integer bodyParameter);
 
 
     /**
@@ -148,6 +173,14 @@ public interface Explicits {
      * @return the observable to the Error object
      */
     Single<Error> postRequiredIntegerPropertyAsync(IntWrapper bodyParameter);
+    /**
+     * Test explicitly required integer. Please put a valid int-wrapper with 'value' = null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter the IntWrapper value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> postRequiredIntegerPropertyWithRestResponseAsync(IntWrapper bodyParameter);
 
 
     /**
@@ -175,6 +208,14 @@ public interface Explicits {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postOptionalIntegerPropertyAsync();
+
+    /**
+     * Test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> postOptionalIntegerPropertyWithRestResponseAsync();
     /**
      * Test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
      *
@@ -203,6 +244,14 @@ public interface Explicits {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postOptionalIntegerPropertyAsync(IntOptionalWrapper bodyParameter);
+    /**
+     * Test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
+     *
+     * @param bodyParameter the IntOptionalWrapper value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> postOptionalIntegerPropertyWithRestResponseAsync(IntOptionalWrapper bodyParameter);
 
 
     /**
@@ -234,6 +283,14 @@ public interface Explicits {
      * @return the observable to the Error object
      */
     Single<Error> postRequiredIntegerHeaderAsync(int headerParameter);
+    /**
+     * Test explicitly required integer. Please put a header 'headerParameter' =&gt; null and the client library should throw before the request is sent.
+     *
+     * @param headerParameter the int value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> postRequiredIntegerHeaderWithRestResponseAsync(int headerParameter);
 
 
     /**
@@ -261,6 +318,14 @@ public interface Explicits {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postOptionalIntegerHeaderAsync();
+
+    /**
+     * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> postOptionalIntegerHeaderWithRestResponseAsync();
     /**
      * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
      *
@@ -289,6 +354,14 @@ public interface Explicits {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postOptionalIntegerHeaderAsync(Integer headerParameter);
+    /**
+     * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @param headerParameter the Integer value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> postOptionalIntegerHeaderWithRestResponseAsync(Integer headerParameter);
 
 
     /**
@@ -320,6 +393,14 @@ public interface Explicits {
      * @return the observable to the Error object
      */
     Single<Error> postRequiredStringParameterAsync(String bodyParameter);
+    /**
+     * Test explicitly required string. Please put null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter the String value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> postRequiredStringParameterWithRestResponseAsync(String bodyParameter);
 
 
     /**
@@ -347,6 +428,14 @@ public interface Explicits {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postOptionalStringParameterAsync();
+
+    /**
+     * Test explicitly optional string. Please put null.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> postOptionalStringParameterWithRestResponseAsync();
     /**
      * Test explicitly optional string. Please put null.
      *
@@ -375,6 +464,14 @@ public interface Explicits {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postOptionalStringParameterAsync(String bodyParameter);
+    /**
+     * Test explicitly optional string. Please put null.
+     *
+     * @param bodyParameter the String value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> postOptionalStringParameterWithRestResponseAsync(String bodyParameter);
 
 
     /**
@@ -406,6 +503,14 @@ public interface Explicits {
      * @return the observable to the Error object
      */
     Single<Error> postRequiredStringPropertyAsync(StringWrapper bodyParameter);
+    /**
+     * Test explicitly required string. Please put a valid string-wrapper with 'value' = null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter the StringWrapper value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> postRequiredStringPropertyWithRestResponseAsync(StringWrapper bodyParameter);
 
 
     /**
@@ -433,6 +538,14 @@ public interface Explicits {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postOptionalStringPropertyAsync();
+
+    /**
+     * Test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> postOptionalStringPropertyWithRestResponseAsync();
     /**
      * Test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
      *
@@ -461,6 +574,14 @@ public interface Explicits {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postOptionalStringPropertyAsync(StringOptionalWrapper bodyParameter);
+    /**
+     * Test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
+     *
+     * @param bodyParameter the StringOptionalWrapper value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> postOptionalStringPropertyWithRestResponseAsync(StringOptionalWrapper bodyParameter);
 
 
     /**
@@ -492,6 +613,14 @@ public interface Explicits {
      * @return the observable to the Error object
      */
     Single<Error> postRequiredStringHeaderAsync(String headerParameter);
+    /**
+     * Test explicitly required string. Please put a header 'headerParameter' =&gt; null and the client library should throw before the request is sent.
+     *
+     * @param headerParameter the String value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> postRequiredStringHeaderWithRestResponseAsync(String headerParameter);
 
 
     /**
@@ -519,6 +648,14 @@ public interface Explicits {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postOptionalStringHeaderAsync();
+
+    /**
+     * Test explicitly optional string. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> postOptionalStringHeaderWithRestResponseAsync();
     /**
      * Test explicitly optional string. Please put a header 'headerParameter' =&gt; null.
      *
@@ -547,6 +684,14 @@ public interface Explicits {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postOptionalStringHeaderAsync(String bodyParameter);
+    /**
+     * Test explicitly optional string. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @param bodyParameter the String value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> postOptionalStringHeaderWithRestResponseAsync(String bodyParameter);
 
 
     /**
@@ -578,6 +723,14 @@ public interface Explicits {
      * @return the observable to the Error object
      */
     Single<Error> postRequiredClassParameterAsync(Product bodyParameter);
+    /**
+     * Test explicitly required complex object. Please put null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter the Product value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> postRequiredClassParameterWithRestResponseAsync(Product bodyParameter);
 
 
     /**
@@ -605,6 +758,14 @@ public interface Explicits {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postOptionalClassParameterAsync();
+
+    /**
+     * Test explicitly optional complex object. Please put null.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> postOptionalClassParameterWithRestResponseAsync();
     /**
      * Test explicitly optional complex object. Please put null.
      *
@@ -633,6 +794,14 @@ public interface Explicits {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postOptionalClassParameterAsync(Product bodyParameter);
+    /**
+     * Test explicitly optional complex object. Please put null.
+     *
+     * @param bodyParameter the Product value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> postOptionalClassParameterWithRestResponseAsync(Product bodyParameter);
 
 
     /**
@@ -664,6 +833,14 @@ public interface Explicits {
      * @return the observable to the Error object
      */
     Single<Error> postRequiredClassPropertyAsync(ClassWrapper bodyParameter);
+    /**
+     * Test explicitly required complex object. Please put a valid class-wrapper with 'value' = null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter the ClassWrapper value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> postRequiredClassPropertyWithRestResponseAsync(ClassWrapper bodyParameter);
 
 
     /**
@@ -691,6 +868,14 @@ public interface Explicits {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postOptionalClassPropertyAsync();
+
+    /**
+     * Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> postOptionalClassPropertyWithRestResponseAsync();
     /**
      * Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
      *
@@ -719,6 +904,14 @@ public interface Explicits {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postOptionalClassPropertyAsync(ClassOptionalWrapper bodyParameter);
+    /**
+     * Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
+     *
+     * @param bodyParameter the ClassOptionalWrapper value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> postOptionalClassPropertyWithRestResponseAsync(ClassOptionalWrapper bodyParameter);
 
 
     /**
@@ -750,6 +943,14 @@ public interface Explicits {
      * @return the observable to the Error object
      */
     Single<Error> postRequiredArrayParameterAsync(List<String> bodyParameter);
+    /**
+     * Test explicitly required array. Please put null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter the List&lt;String&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> postRequiredArrayParameterWithRestResponseAsync(List<String> bodyParameter);
 
 
     /**
@@ -777,6 +978,14 @@ public interface Explicits {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postOptionalArrayParameterAsync();
+
+    /**
+     * Test explicitly optional array. Please put null.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> postOptionalArrayParameterWithRestResponseAsync();
     /**
      * Test explicitly optional array. Please put null.
      *
@@ -805,6 +1014,14 @@ public interface Explicits {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postOptionalArrayParameterAsync(List<String> bodyParameter);
+    /**
+     * Test explicitly optional array. Please put null.
+     *
+     * @param bodyParameter the List&lt;String&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> postOptionalArrayParameterWithRestResponseAsync(List<String> bodyParameter);
 
 
     /**
@@ -836,6 +1053,14 @@ public interface Explicits {
      * @return the observable to the Error object
      */
     Single<Error> postRequiredArrayPropertyAsync(ArrayWrapper bodyParameter);
+    /**
+     * Test explicitly required array. Please put a valid array-wrapper with 'value' = null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter the ArrayWrapper value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> postRequiredArrayPropertyWithRestResponseAsync(ArrayWrapper bodyParameter);
 
 
     /**
@@ -863,6 +1088,14 @@ public interface Explicits {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postOptionalArrayPropertyAsync();
+
+    /**
+     * Test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> postOptionalArrayPropertyWithRestResponseAsync();
     /**
      * Test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
      *
@@ -891,6 +1124,14 @@ public interface Explicits {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postOptionalArrayPropertyAsync(ArrayOptionalWrapper bodyParameter);
+    /**
+     * Test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
+     *
+     * @param bodyParameter the ArrayOptionalWrapper value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> postOptionalArrayPropertyWithRestResponseAsync(ArrayOptionalWrapper bodyParameter);
 
 
     /**
@@ -922,6 +1163,14 @@ public interface Explicits {
      * @return the observable to the Error object
      */
     Single<Error> postRequiredArrayHeaderAsync(List<String> headerParameter);
+    /**
+     * Test explicitly required array. Please put a header 'headerParameter' =&gt; null and the client library should throw before the request is sent.
+     *
+     * @param headerParameter the List&lt;String&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> postRequiredArrayHeaderWithRestResponseAsync(List<String> headerParameter);
 
 
     /**
@@ -949,6 +1198,14 @@ public interface Explicits {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postOptionalArrayHeaderAsync();
+
+    /**
+     * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> postOptionalArrayHeaderWithRestResponseAsync();
     /**
      * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
      *
@@ -977,6 +1234,14 @@ public interface Explicits {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> postOptionalArrayHeaderAsync(List<String> headerParameter);
+    /**
+     * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @param headerParameter the List&lt;String&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> postOptionalArrayHeaderWithRestResponseAsync(List<String> headerParameter);
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/requiredoptional/Implicits.java
+++ b/test/vanilla/src/main/java/fixtures/requiredoptional/Implicits.java
@@ -10,6 +10,7 @@
 
 package fixtures.requiredoptional;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.requiredoptional.models.Error;
@@ -52,6 +53,14 @@ public interface Implicits {
      * @return the observable to the Error object
      */
     Single<Error> getRequiredPathAsync(String pathParameter);
+    /**
+     * Test implicitly required path parameter.
+     *
+     * @param pathParameter the String value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> getRequiredPathWithRestResponseAsync(String pathParameter);
 
 
     /**
@@ -79,6 +88,14 @@ public interface Implicits {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putOptionalQueryAsync();
+
+    /**
+     * Test implicitly optional query parameter.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putOptionalQueryWithRestResponseAsync();
     /**
      * Test implicitly optional query parameter.
      *
@@ -107,6 +124,14 @@ public interface Implicits {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putOptionalQueryAsync(String queryParameter);
+    /**
+     * Test implicitly optional query parameter.
+     *
+     * @param queryParameter the String value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putOptionalQueryWithRestResponseAsync(String queryParameter);
 
 
     /**
@@ -134,6 +159,14 @@ public interface Implicits {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putOptionalHeaderAsync();
+
+    /**
+     * Test implicitly optional header parameter.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putOptionalHeaderWithRestResponseAsync();
     /**
      * Test implicitly optional header parameter.
      *
@@ -162,6 +195,14 @@ public interface Implicits {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putOptionalHeaderAsync(String queryParameter);
+    /**
+     * Test implicitly optional header parameter.
+     *
+     * @param queryParameter the String value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putOptionalHeaderWithRestResponseAsync(String queryParameter);
 
 
     /**
@@ -189,6 +230,14 @@ public interface Implicits {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putOptionalBodyAsync();
+
+    /**
+     * Test implicitly optional body parameter.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putOptionalBodyWithRestResponseAsync();
     /**
      * Test implicitly optional body parameter.
      *
@@ -217,6 +266,14 @@ public interface Implicits {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> putOptionalBodyAsync(String bodyParameter);
+    /**
+     * Test implicitly optional body parameter.
+     *
+     * @param bodyParameter the String value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> putOptionalBodyWithRestResponseAsync(String bodyParameter);
 
 
     /**
@@ -245,6 +302,13 @@ public interface Implicits {
      * @return the observable to the Error object
      */
     Single<Error> getRequiredGlobalPathAsync();
+    /**
+     * Test implicitly required path parameter.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> getRequiredGlobalPathWithRestResponseAsync();
 
 
     /**
@@ -273,6 +337,13 @@ public interface Implicits {
      * @return the observable to the Error object
      */
     Single<Error> getRequiredGlobalQueryAsync();
+    /**
+     * Test implicitly required query parameter.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> getRequiredGlobalQueryWithRestResponseAsync();
 
 
     /**
@@ -301,6 +372,13 @@ public interface Implicits {
      * @return the observable to the Error object
      */
     Single<Error> getOptionalGlobalQueryAsync();
+    /**
+     * Test implicitly optional query parameter.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Error object
+     */
+    Single<RestResponse<Void, Error>> getOptionalGlobalQueryWithRestResponseAsync();
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/requiredoptional/implementation/AutoRestRequiredOptionalTestServiceImpl.java
+++ b/test/vanilla/src/main/java/fixtures/requiredoptional/implementation/AutoRestRequiredOptionalTestServiceImpl.java
@@ -14,6 +14,7 @@ import fixtures.requiredoptional.AutoRestRequiredOptionalTestService;
 import fixtures.requiredoptional.Implicits;
 import fixtures.requiredoptional.Explicits;
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceClient;
 import com.microsoft.rest.RestClient;
 import rx.Single;

--- a/test/vanilla/src/main/java/fixtures/requiredoptional/implementation/ExplicitsImpl.java
+++ b/test/vanilla/src/main/java/fixtures/requiredoptional/implementation/ExplicitsImpl.java
@@ -11,6 +11,7 @@
 package fixtures.requiredoptional.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.requiredoptional.Explicits;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.BodyParam;
@@ -71,123 +72,123 @@ public class ExplicitsImpl implements Explicits {
         @Headers({ "x-ms-logging-context: fixtures.requiredoptional.Explicits postRequiredIntegerParameter" })
         @POST("reqopt/requied/integer/parameter")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> postRequiredIntegerParameter(@BodyParam("application/json; charset=utf-8") int bodyParameter);
+        Single<RestResponse<Void, Error>> postRequiredIntegerParameter(@BodyParam("application/json; charset=utf-8") int bodyParameter);
 
         @Headers({ "x-ms-logging-context: fixtures.requiredoptional.Explicits postOptionalIntegerParameter" })
         @POST("reqopt/optional/integer/parameter")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postOptionalIntegerParameter(@BodyParam("application/json; charset=utf-8") Integer bodyParameter);
+        Single<RestResponse<Void, Void>> postOptionalIntegerParameter(@BodyParam("application/json; charset=utf-8") Integer bodyParameter);
 
         @Headers({ "x-ms-logging-context: fixtures.requiredoptional.Explicits postRequiredIntegerProperty" })
         @POST("reqopt/requied/integer/property")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> postRequiredIntegerProperty(@BodyParam("application/json; charset=utf-8") IntWrapper bodyParameter);
+        Single<RestResponse<Void, Error>> postRequiredIntegerProperty(@BodyParam("application/json; charset=utf-8") IntWrapper bodyParameter);
 
         @Headers({ "x-ms-logging-context: fixtures.requiredoptional.Explicits postOptionalIntegerProperty" })
         @POST("reqopt/optional/integer/property")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postOptionalIntegerProperty(@BodyParam("application/json; charset=utf-8") IntOptionalWrapper bodyParameter);
+        Single<RestResponse<Void, Void>> postOptionalIntegerProperty(@BodyParam("application/json; charset=utf-8") IntOptionalWrapper bodyParameter);
 
         @Headers({ "x-ms-logging-context: fixtures.requiredoptional.Explicits postRequiredIntegerHeader" })
         @POST("reqopt/requied/integer/header")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> postRequiredIntegerHeader(@HeaderParam("headerParameter") int headerParameter);
+        Single<RestResponse<Void, Error>> postRequiredIntegerHeader(@HeaderParam("headerParameter") int headerParameter);
 
         @Headers({ "x-ms-logging-context: fixtures.requiredoptional.Explicits postOptionalIntegerHeader" })
         @POST("reqopt/optional/integer/header")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postOptionalIntegerHeader(@HeaderParam("headerParameter") Integer headerParameter);
+        Single<RestResponse<Void, Void>> postOptionalIntegerHeader(@HeaderParam("headerParameter") Integer headerParameter);
 
         @Headers({ "x-ms-logging-context: fixtures.requiredoptional.Explicits postRequiredStringParameter" })
         @POST("reqopt/requied/string/parameter")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> postRequiredStringParameter(@BodyParam("application/json; charset=utf-8") String bodyParameter);
+        Single<RestResponse<Void, Error>> postRequiredStringParameter(@BodyParam("application/json; charset=utf-8") String bodyParameter);
 
         @Headers({ "x-ms-logging-context: fixtures.requiredoptional.Explicits postOptionalStringParameter" })
         @POST("reqopt/optional/string/parameter")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postOptionalStringParameter(@BodyParam("application/json; charset=utf-8") String bodyParameter);
+        Single<RestResponse<Void, Void>> postOptionalStringParameter(@BodyParam("application/json; charset=utf-8") String bodyParameter);
 
         @Headers({ "x-ms-logging-context: fixtures.requiredoptional.Explicits postRequiredStringProperty" })
         @POST("reqopt/requied/string/property")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> postRequiredStringProperty(@BodyParam("application/json; charset=utf-8") StringWrapper bodyParameter);
+        Single<RestResponse<Void, Error>> postRequiredStringProperty(@BodyParam("application/json; charset=utf-8") StringWrapper bodyParameter);
 
         @Headers({ "x-ms-logging-context: fixtures.requiredoptional.Explicits postOptionalStringProperty" })
         @POST("reqopt/optional/string/property")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postOptionalStringProperty(@BodyParam("application/json; charset=utf-8") StringOptionalWrapper bodyParameter);
+        Single<RestResponse<Void, Void>> postOptionalStringProperty(@BodyParam("application/json; charset=utf-8") StringOptionalWrapper bodyParameter);
 
         @Headers({ "x-ms-logging-context: fixtures.requiredoptional.Explicits postRequiredStringHeader" })
         @POST("reqopt/requied/string/header")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> postRequiredStringHeader(@HeaderParam("headerParameter") String headerParameter);
+        Single<RestResponse<Void, Error>> postRequiredStringHeader(@HeaderParam("headerParameter") String headerParameter);
 
         @Headers({ "x-ms-logging-context: fixtures.requiredoptional.Explicits postOptionalStringHeader" })
         @POST("reqopt/optional/string/header")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postOptionalStringHeader(@HeaderParam("bodyParameter") String bodyParameter);
+        Single<RestResponse<Void, Void>> postOptionalStringHeader(@HeaderParam("bodyParameter") String bodyParameter);
 
         @Headers({ "x-ms-logging-context: fixtures.requiredoptional.Explicits postRequiredClassParameter" })
         @POST("reqopt/requied/class/parameter")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> postRequiredClassParameter(@BodyParam("application/json; charset=utf-8") Product bodyParameter);
+        Single<RestResponse<Void, Error>> postRequiredClassParameter(@BodyParam("application/json; charset=utf-8") Product bodyParameter);
 
         @Headers({ "x-ms-logging-context: fixtures.requiredoptional.Explicits postOptionalClassParameter" })
         @POST("reqopt/optional/class/parameter")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postOptionalClassParameter(@BodyParam("application/json; charset=utf-8") Product bodyParameter);
+        Single<RestResponse<Void, Void>> postOptionalClassParameter(@BodyParam("application/json; charset=utf-8") Product bodyParameter);
 
         @Headers({ "x-ms-logging-context: fixtures.requiredoptional.Explicits postRequiredClassProperty" })
         @POST("reqopt/requied/class/property")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> postRequiredClassProperty(@BodyParam("application/json; charset=utf-8") ClassWrapper bodyParameter);
+        Single<RestResponse<Void, Error>> postRequiredClassProperty(@BodyParam("application/json; charset=utf-8") ClassWrapper bodyParameter);
 
         @Headers({ "x-ms-logging-context: fixtures.requiredoptional.Explicits postOptionalClassProperty" })
         @POST("reqopt/optional/class/property")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postOptionalClassProperty(@BodyParam("application/json; charset=utf-8") ClassOptionalWrapper bodyParameter);
+        Single<RestResponse<Void, Void>> postOptionalClassProperty(@BodyParam("application/json; charset=utf-8") ClassOptionalWrapper bodyParameter);
 
         @Headers({ "x-ms-logging-context: fixtures.requiredoptional.Explicits postRequiredArrayParameter" })
         @POST("reqopt/requied/array/parameter")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> postRequiredArrayParameter(@BodyParam("application/json; charset=utf-8") List<String> bodyParameter);
+        Single<RestResponse<Void, Error>> postRequiredArrayParameter(@BodyParam("application/json; charset=utf-8") List<String> bodyParameter);
 
         @Headers({ "x-ms-logging-context: fixtures.requiredoptional.Explicits postOptionalArrayParameter" })
         @POST("reqopt/optional/array/parameter")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postOptionalArrayParameter(@BodyParam("application/json; charset=utf-8") List<String> bodyParameter);
+        Single<RestResponse<Void, Void>> postOptionalArrayParameter(@BodyParam("application/json; charset=utf-8") List<String> bodyParameter);
 
         @Headers({ "x-ms-logging-context: fixtures.requiredoptional.Explicits postRequiredArrayProperty" })
         @POST("reqopt/requied/array/property")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> postRequiredArrayProperty(@BodyParam("application/json; charset=utf-8") ArrayWrapper bodyParameter);
+        Single<RestResponse<Void, Error>> postRequiredArrayProperty(@BodyParam("application/json; charset=utf-8") ArrayWrapper bodyParameter);
 
         @Headers({ "x-ms-logging-context: fixtures.requiredoptional.Explicits postOptionalArrayProperty" })
         @POST("reqopt/optional/array/property")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postOptionalArrayProperty(@BodyParam("application/json; charset=utf-8") ArrayOptionalWrapper bodyParameter);
+        Single<RestResponse<Void, Void>> postOptionalArrayProperty(@BodyParam("application/json; charset=utf-8") ArrayOptionalWrapper bodyParameter);
 
         @Headers({ "x-ms-logging-context: fixtures.requiredoptional.Explicits postRequiredArrayHeader" })
         @POST("reqopt/requied/array/header")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> postRequiredArrayHeader(@HeaderParam("headerParameter") String headerParameter);
+        Single<RestResponse<Void, Error>> postRequiredArrayHeader(@HeaderParam("headerParameter") String headerParameter);
 
         @Headers({ "x-ms-logging-context: fixtures.requiredoptional.Explicits postOptionalArrayHeader" })
         @POST("reqopt/optional/array/header")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> postOptionalArrayHeader(@HeaderParam("headerParameter") String headerParameter);
+        Single<RestResponse<Void, Void>> postOptionalArrayHeader(@HeaderParam("headerParameter") String headerParameter);
 
     }
 
@@ -212,7 +213,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> postRequiredIntegerParameterAsync(int bodyParameter, final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> postRequiredIntegerParameterAsync(int bodyParameter, ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(postRequiredIntegerParameterAsync(bodyParameter), serviceCallback);
     }
 
@@ -221,11 +222,23 @@ public class ExplicitsImpl implements Explicits {
      *
      * @param bodyParameter the int value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> postRequiredIntegerParameterAsync(int bodyParameter) {
+    public Single<RestResponse<Void, Error>> postRequiredIntegerParameterWithRestResponseAsync(int bodyParameter) {
         return service.postRequiredIntegerParameter(bodyParameter);
     }
+
+    /**
+     * Test explicitly required integer. Please put null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter the int value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> postRequiredIntegerParameterAsync(int bodyParameter) {
+        return postRequiredIntegerParameterWithRestResponseAsync(bodyParameter)
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -234,6 +247,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postOptionalIntegerParameter() {
         postOptionalIntegerParameterAsync().toBlocking().value();
@@ -246,7 +260,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postOptionalIntegerParameterAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postOptionalIntegerParameterAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postOptionalIntegerParameterAsync(), serviceCallback);
     }
 
@@ -254,12 +268,23 @@ public class ExplicitsImpl implements Explicits {
      * Test explicitly optional integer. Please put null.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postOptionalIntegerParameterAsync() {
+    public Single<RestResponse<Void, Void>> postOptionalIntegerParameterWithRestResponseAsync() {
         final Integer bodyParameter = null;
         return service.postOptionalIntegerParameter(bodyParameter);
     }
+
+    /**
+     * Test explicitly optional integer. Please put null.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postOptionalIntegerParameterAsync() {
+        return postOptionalIntegerParameterWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Test explicitly optional integer. Please put null.
@@ -268,6 +293,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postOptionalIntegerParameter(Integer bodyParameter) {
         postOptionalIntegerParameterAsync(bodyParameter).toBlocking().value();
@@ -281,7 +307,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postOptionalIntegerParameterAsync(Integer bodyParameter, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postOptionalIntegerParameterAsync(Integer bodyParameter, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postOptionalIntegerParameterAsync(bodyParameter), serviceCallback);
     }
 
@@ -290,11 +316,23 @@ public class ExplicitsImpl implements Explicits {
      *
      * @param bodyParameter the Integer value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postOptionalIntegerParameterAsync(Integer bodyParameter) {
+    public Single<RestResponse<Void, Void>> postOptionalIntegerParameterWithRestResponseAsync(Integer bodyParameter) {
         return service.postOptionalIntegerParameter(bodyParameter);
     }
+
+    /**
+     * Test explicitly optional integer. Please put null.
+     *
+     * @param bodyParameter the Integer value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postOptionalIntegerParameterAsync(Integer bodyParameter) {
+        return postOptionalIntegerParameterWithRestResponseAsync(bodyParameter)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -318,7 +356,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> postRequiredIntegerPropertyAsync(IntWrapper bodyParameter, final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> postRequiredIntegerPropertyAsync(IntWrapper bodyParameter, ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(postRequiredIntegerPropertyAsync(bodyParameter), serviceCallback);
     }
 
@@ -327,15 +365,27 @@ public class ExplicitsImpl implements Explicits {
      *
      * @param bodyParameter the IntWrapper value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> postRequiredIntegerPropertyAsync(IntWrapper bodyParameter) {
+    public Single<RestResponse<Void, Error>> postRequiredIntegerPropertyWithRestResponseAsync(IntWrapper bodyParameter) {
         if (bodyParameter == null) {
             throw new IllegalArgumentException("Parameter bodyParameter is required and cannot be null.");
         }
         Validator.validate(bodyParameter);
         return service.postRequiredIntegerProperty(bodyParameter);
     }
+
+    /**
+     * Test explicitly required integer. Please put a valid int-wrapper with 'value' = null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter the IntWrapper value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> postRequiredIntegerPropertyAsync(IntWrapper bodyParameter) {
+        return postRequiredIntegerPropertyWithRestResponseAsync(bodyParameter)
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -344,6 +394,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postOptionalIntegerProperty() {
         postOptionalIntegerPropertyAsync().toBlocking().value();
@@ -356,7 +407,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postOptionalIntegerPropertyAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postOptionalIntegerPropertyAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postOptionalIntegerPropertyAsync(), serviceCallback);
     }
 
@@ -364,12 +415,24 @@ public class ExplicitsImpl implements Explicits {
      * Test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postOptionalIntegerPropertyAsync() {
+    public Single<RestResponse<Void, Void>> postOptionalIntegerPropertyWithRestResponseAsync() {
         final IntOptionalWrapper bodyParameter = null;
+        Validator.validate(bodyParameter);
         return service.postOptionalIntegerProperty(bodyParameter);
     }
+
+    /**
+     * Test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postOptionalIntegerPropertyAsync() {
+        return postOptionalIntegerPropertyWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
@@ -378,6 +441,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postOptionalIntegerProperty(IntOptionalWrapper bodyParameter) {
         postOptionalIntegerPropertyAsync(bodyParameter).toBlocking().value();
@@ -391,7 +455,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postOptionalIntegerPropertyAsync(IntOptionalWrapper bodyParameter, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postOptionalIntegerPropertyAsync(IntOptionalWrapper bodyParameter, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postOptionalIntegerPropertyAsync(bodyParameter), serviceCallback);
     }
 
@@ -400,12 +464,24 @@ public class ExplicitsImpl implements Explicits {
      *
      * @param bodyParameter the IntOptionalWrapper value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postOptionalIntegerPropertyAsync(IntOptionalWrapper bodyParameter) {
+    public Single<RestResponse<Void, Void>> postOptionalIntegerPropertyWithRestResponseAsync(IntOptionalWrapper bodyParameter) {
         Validator.validate(bodyParameter);
         return service.postOptionalIntegerProperty(bodyParameter);
     }
+
+    /**
+     * Test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
+     *
+     * @param bodyParameter the IntOptionalWrapper value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postOptionalIntegerPropertyAsync(IntOptionalWrapper bodyParameter) {
+        return postOptionalIntegerPropertyWithRestResponseAsync(bodyParameter)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -429,7 +505,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> postRequiredIntegerHeaderAsync(int headerParameter, final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> postRequiredIntegerHeaderAsync(int headerParameter, ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(postRequiredIntegerHeaderAsync(headerParameter), serviceCallback);
     }
 
@@ -438,11 +514,23 @@ public class ExplicitsImpl implements Explicits {
      *
      * @param headerParameter the int value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> postRequiredIntegerHeaderAsync(int headerParameter) {
+    public Single<RestResponse<Void, Error>> postRequiredIntegerHeaderWithRestResponseAsync(int headerParameter) {
         return service.postRequiredIntegerHeader(headerParameter);
     }
+
+    /**
+     * Test explicitly required integer. Please put a header 'headerParameter' =&gt; null and the client library should throw before the request is sent.
+     *
+     * @param headerParameter the int value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> postRequiredIntegerHeaderAsync(int headerParameter) {
+        return postRequiredIntegerHeaderWithRestResponseAsync(headerParameter)
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -451,6 +539,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postOptionalIntegerHeader() {
         postOptionalIntegerHeaderAsync().toBlocking().value();
@@ -463,7 +552,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postOptionalIntegerHeaderAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postOptionalIntegerHeaderAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postOptionalIntegerHeaderAsync(), serviceCallback);
     }
 
@@ -471,12 +560,23 @@ public class ExplicitsImpl implements Explicits {
      * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postOptionalIntegerHeaderAsync() {
+    public Single<RestResponse<Void, Void>> postOptionalIntegerHeaderWithRestResponseAsync() {
         final Integer headerParameter = null;
         return service.postOptionalIntegerHeader(headerParameter);
     }
+
+    /**
+     * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postOptionalIntegerHeaderAsync() {
+        return postOptionalIntegerHeaderWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
@@ -485,6 +585,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postOptionalIntegerHeader(Integer headerParameter) {
         postOptionalIntegerHeaderAsync(headerParameter).toBlocking().value();
@@ -498,7 +599,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postOptionalIntegerHeaderAsync(Integer headerParameter, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postOptionalIntegerHeaderAsync(Integer headerParameter, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postOptionalIntegerHeaderAsync(headerParameter), serviceCallback);
     }
 
@@ -507,11 +608,23 @@ public class ExplicitsImpl implements Explicits {
      *
      * @param headerParameter the Integer value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postOptionalIntegerHeaderAsync(Integer headerParameter) {
+    public Single<RestResponse<Void, Void>> postOptionalIntegerHeaderWithRestResponseAsync(Integer headerParameter) {
         return service.postOptionalIntegerHeader(headerParameter);
     }
+
+    /**
+     * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @param headerParameter the Integer value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postOptionalIntegerHeaderAsync(Integer headerParameter) {
+        return postOptionalIntegerHeaderWithRestResponseAsync(headerParameter)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -535,7 +648,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> postRequiredStringParameterAsync(String bodyParameter, final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> postRequiredStringParameterAsync(String bodyParameter, ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(postRequiredStringParameterAsync(bodyParameter), serviceCallback);
     }
 
@@ -544,14 +657,26 @@ public class ExplicitsImpl implements Explicits {
      *
      * @param bodyParameter the String value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> postRequiredStringParameterAsync(String bodyParameter) {
+    public Single<RestResponse<Void, Error>> postRequiredStringParameterWithRestResponseAsync(String bodyParameter) {
         if (bodyParameter == null) {
             throw new IllegalArgumentException("Parameter bodyParameter is required and cannot be null.");
         }
         return service.postRequiredStringParameter(bodyParameter);
     }
+
+    /**
+     * Test explicitly required string. Please put null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter the String value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> postRequiredStringParameterAsync(String bodyParameter) {
+        return postRequiredStringParameterWithRestResponseAsync(bodyParameter)
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -560,6 +685,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postOptionalStringParameter() {
         postOptionalStringParameterAsync().toBlocking().value();
@@ -572,7 +698,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postOptionalStringParameterAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postOptionalStringParameterAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postOptionalStringParameterAsync(), serviceCallback);
     }
 
@@ -580,12 +706,23 @@ public class ExplicitsImpl implements Explicits {
      * Test explicitly optional string. Please put null.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postOptionalStringParameterAsync() {
+    public Single<RestResponse<Void, Void>> postOptionalStringParameterWithRestResponseAsync() {
         final String bodyParameter = null;
         return service.postOptionalStringParameter(bodyParameter);
     }
+
+    /**
+     * Test explicitly optional string. Please put null.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postOptionalStringParameterAsync() {
+        return postOptionalStringParameterWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Test explicitly optional string. Please put null.
@@ -594,6 +731,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postOptionalStringParameter(String bodyParameter) {
         postOptionalStringParameterAsync(bodyParameter).toBlocking().value();
@@ -607,7 +745,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postOptionalStringParameterAsync(String bodyParameter, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postOptionalStringParameterAsync(String bodyParameter, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postOptionalStringParameterAsync(bodyParameter), serviceCallback);
     }
 
@@ -616,11 +754,23 @@ public class ExplicitsImpl implements Explicits {
      *
      * @param bodyParameter the String value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postOptionalStringParameterAsync(String bodyParameter) {
+    public Single<RestResponse<Void, Void>> postOptionalStringParameterWithRestResponseAsync(String bodyParameter) {
         return service.postOptionalStringParameter(bodyParameter);
     }
+
+    /**
+     * Test explicitly optional string. Please put null.
+     *
+     * @param bodyParameter the String value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postOptionalStringParameterAsync(String bodyParameter) {
+        return postOptionalStringParameterWithRestResponseAsync(bodyParameter)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -644,7 +794,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> postRequiredStringPropertyAsync(StringWrapper bodyParameter, final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> postRequiredStringPropertyAsync(StringWrapper bodyParameter, ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(postRequiredStringPropertyAsync(bodyParameter), serviceCallback);
     }
 
@@ -653,15 +803,27 @@ public class ExplicitsImpl implements Explicits {
      *
      * @param bodyParameter the StringWrapper value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> postRequiredStringPropertyAsync(StringWrapper bodyParameter) {
+    public Single<RestResponse<Void, Error>> postRequiredStringPropertyWithRestResponseAsync(StringWrapper bodyParameter) {
         if (bodyParameter == null) {
             throw new IllegalArgumentException("Parameter bodyParameter is required and cannot be null.");
         }
         Validator.validate(bodyParameter);
         return service.postRequiredStringProperty(bodyParameter);
     }
+
+    /**
+     * Test explicitly required string. Please put a valid string-wrapper with 'value' = null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter the StringWrapper value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> postRequiredStringPropertyAsync(StringWrapper bodyParameter) {
+        return postRequiredStringPropertyWithRestResponseAsync(bodyParameter)
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -670,6 +832,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postOptionalStringProperty() {
         postOptionalStringPropertyAsync().toBlocking().value();
@@ -682,7 +845,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postOptionalStringPropertyAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postOptionalStringPropertyAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postOptionalStringPropertyAsync(), serviceCallback);
     }
 
@@ -690,12 +853,24 @@ public class ExplicitsImpl implements Explicits {
      * Test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postOptionalStringPropertyAsync() {
+    public Single<RestResponse<Void, Void>> postOptionalStringPropertyWithRestResponseAsync() {
         final StringOptionalWrapper bodyParameter = null;
+        Validator.validate(bodyParameter);
         return service.postOptionalStringProperty(bodyParameter);
     }
+
+    /**
+     * Test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postOptionalStringPropertyAsync() {
+        return postOptionalStringPropertyWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
@@ -704,6 +879,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postOptionalStringProperty(StringOptionalWrapper bodyParameter) {
         postOptionalStringPropertyAsync(bodyParameter).toBlocking().value();
@@ -717,7 +893,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postOptionalStringPropertyAsync(StringOptionalWrapper bodyParameter, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postOptionalStringPropertyAsync(StringOptionalWrapper bodyParameter, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postOptionalStringPropertyAsync(bodyParameter), serviceCallback);
     }
 
@@ -726,12 +902,24 @@ public class ExplicitsImpl implements Explicits {
      *
      * @param bodyParameter the StringOptionalWrapper value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postOptionalStringPropertyAsync(StringOptionalWrapper bodyParameter) {
+    public Single<RestResponse<Void, Void>> postOptionalStringPropertyWithRestResponseAsync(StringOptionalWrapper bodyParameter) {
         Validator.validate(bodyParameter);
         return service.postOptionalStringProperty(bodyParameter);
     }
+
+    /**
+     * Test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
+     *
+     * @param bodyParameter the StringOptionalWrapper value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postOptionalStringPropertyAsync(StringOptionalWrapper bodyParameter) {
+        return postOptionalStringPropertyWithRestResponseAsync(bodyParameter)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -755,7 +943,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> postRequiredStringHeaderAsync(String headerParameter, final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> postRequiredStringHeaderAsync(String headerParameter, ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(postRequiredStringHeaderAsync(headerParameter), serviceCallback);
     }
 
@@ -764,14 +952,26 @@ public class ExplicitsImpl implements Explicits {
      *
      * @param headerParameter the String value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> postRequiredStringHeaderAsync(String headerParameter) {
+    public Single<RestResponse<Void, Error>> postRequiredStringHeaderWithRestResponseAsync(String headerParameter) {
         if (headerParameter == null) {
             throw new IllegalArgumentException("Parameter headerParameter is required and cannot be null.");
         }
         return service.postRequiredStringHeader(headerParameter);
     }
+
+    /**
+     * Test explicitly required string. Please put a header 'headerParameter' =&gt; null and the client library should throw before the request is sent.
+     *
+     * @param headerParameter the String value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> postRequiredStringHeaderAsync(String headerParameter) {
+        return postRequiredStringHeaderWithRestResponseAsync(headerParameter)
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -780,6 +980,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postOptionalStringHeader() {
         postOptionalStringHeaderAsync().toBlocking().value();
@@ -792,7 +993,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postOptionalStringHeaderAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postOptionalStringHeaderAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postOptionalStringHeaderAsync(), serviceCallback);
     }
 
@@ -800,12 +1001,23 @@ public class ExplicitsImpl implements Explicits {
      * Test explicitly optional string. Please put a header 'headerParameter' =&gt; null.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postOptionalStringHeaderAsync() {
+    public Single<RestResponse<Void, Void>> postOptionalStringHeaderWithRestResponseAsync() {
         final String bodyParameter = null;
         return service.postOptionalStringHeader(bodyParameter);
     }
+
+    /**
+     * Test explicitly optional string. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postOptionalStringHeaderAsync() {
+        return postOptionalStringHeaderWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Test explicitly optional string. Please put a header 'headerParameter' =&gt; null.
@@ -814,6 +1026,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postOptionalStringHeader(String bodyParameter) {
         postOptionalStringHeaderAsync(bodyParameter).toBlocking().value();
@@ -827,7 +1040,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postOptionalStringHeaderAsync(String bodyParameter, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postOptionalStringHeaderAsync(String bodyParameter, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postOptionalStringHeaderAsync(bodyParameter), serviceCallback);
     }
 
@@ -836,11 +1049,23 @@ public class ExplicitsImpl implements Explicits {
      *
      * @param bodyParameter the String value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postOptionalStringHeaderAsync(String bodyParameter) {
+    public Single<RestResponse<Void, Void>> postOptionalStringHeaderWithRestResponseAsync(String bodyParameter) {
         return service.postOptionalStringHeader(bodyParameter);
     }
+
+    /**
+     * Test explicitly optional string. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @param bodyParameter the String value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postOptionalStringHeaderAsync(String bodyParameter) {
+        return postOptionalStringHeaderWithRestResponseAsync(bodyParameter)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -864,7 +1089,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> postRequiredClassParameterAsync(Product bodyParameter, final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> postRequiredClassParameterAsync(Product bodyParameter, ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(postRequiredClassParameterAsync(bodyParameter), serviceCallback);
     }
 
@@ -873,15 +1098,27 @@ public class ExplicitsImpl implements Explicits {
      *
      * @param bodyParameter the Product value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> postRequiredClassParameterAsync(Product bodyParameter) {
+    public Single<RestResponse<Void, Error>> postRequiredClassParameterWithRestResponseAsync(Product bodyParameter) {
         if (bodyParameter == null) {
             throw new IllegalArgumentException("Parameter bodyParameter is required and cannot be null.");
         }
         Validator.validate(bodyParameter);
         return service.postRequiredClassParameter(bodyParameter);
     }
+
+    /**
+     * Test explicitly required complex object. Please put null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter the Product value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> postRequiredClassParameterAsync(Product bodyParameter) {
+        return postRequiredClassParameterWithRestResponseAsync(bodyParameter)
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -890,6 +1127,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postOptionalClassParameter() {
         postOptionalClassParameterAsync().toBlocking().value();
@@ -902,7 +1140,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postOptionalClassParameterAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postOptionalClassParameterAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postOptionalClassParameterAsync(), serviceCallback);
     }
 
@@ -910,12 +1148,24 @@ public class ExplicitsImpl implements Explicits {
      * Test explicitly optional complex object. Please put null.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postOptionalClassParameterAsync() {
+    public Single<RestResponse<Void, Void>> postOptionalClassParameterWithRestResponseAsync() {
         final Product bodyParameter = null;
+        Validator.validate(bodyParameter);
         return service.postOptionalClassParameter(bodyParameter);
     }
+
+    /**
+     * Test explicitly optional complex object. Please put null.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postOptionalClassParameterAsync() {
+        return postOptionalClassParameterWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Test explicitly optional complex object. Please put null.
@@ -924,6 +1174,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postOptionalClassParameter(Product bodyParameter) {
         postOptionalClassParameterAsync(bodyParameter).toBlocking().value();
@@ -937,7 +1188,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postOptionalClassParameterAsync(Product bodyParameter, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postOptionalClassParameterAsync(Product bodyParameter, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postOptionalClassParameterAsync(bodyParameter), serviceCallback);
     }
 
@@ -946,12 +1197,24 @@ public class ExplicitsImpl implements Explicits {
      *
      * @param bodyParameter the Product value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postOptionalClassParameterAsync(Product bodyParameter) {
+    public Single<RestResponse<Void, Void>> postOptionalClassParameterWithRestResponseAsync(Product bodyParameter) {
         Validator.validate(bodyParameter);
         return service.postOptionalClassParameter(bodyParameter);
     }
+
+    /**
+     * Test explicitly optional complex object. Please put null.
+     *
+     * @param bodyParameter the Product value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postOptionalClassParameterAsync(Product bodyParameter) {
+        return postOptionalClassParameterWithRestResponseAsync(bodyParameter)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -975,7 +1238,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> postRequiredClassPropertyAsync(ClassWrapper bodyParameter, final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> postRequiredClassPropertyAsync(ClassWrapper bodyParameter, ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(postRequiredClassPropertyAsync(bodyParameter), serviceCallback);
     }
 
@@ -984,15 +1247,27 @@ public class ExplicitsImpl implements Explicits {
      *
      * @param bodyParameter the ClassWrapper value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> postRequiredClassPropertyAsync(ClassWrapper bodyParameter) {
+    public Single<RestResponse<Void, Error>> postRequiredClassPropertyWithRestResponseAsync(ClassWrapper bodyParameter) {
         if (bodyParameter == null) {
             throw new IllegalArgumentException("Parameter bodyParameter is required and cannot be null.");
         }
         Validator.validate(bodyParameter);
         return service.postRequiredClassProperty(bodyParameter);
     }
+
+    /**
+     * Test explicitly required complex object. Please put a valid class-wrapper with 'value' = null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter the ClassWrapper value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> postRequiredClassPropertyAsync(ClassWrapper bodyParameter) {
+        return postRequiredClassPropertyWithRestResponseAsync(bodyParameter)
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1001,6 +1276,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postOptionalClassProperty() {
         postOptionalClassPropertyAsync().toBlocking().value();
@@ -1013,7 +1289,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postOptionalClassPropertyAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postOptionalClassPropertyAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postOptionalClassPropertyAsync(), serviceCallback);
     }
 
@@ -1021,12 +1297,24 @@ public class ExplicitsImpl implements Explicits {
      * Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postOptionalClassPropertyAsync() {
+    public Single<RestResponse<Void, Void>> postOptionalClassPropertyWithRestResponseAsync() {
         final ClassOptionalWrapper bodyParameter = null;
+        Validator.validate(bodyParameter);
         return service.postOptionalClassProperty(bodyParameter);
     }
+
+    /**
+     * Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postOptionalClassPropertyAsync() {
+        return postOptionalClassPropertyWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
@@ -1035,6 +1323,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postOptionalClassProperty(ClassOptionalWrapper bodyParameter) {
         postOptionalClassPropertyAsync(bodyParameter).toBlocking().value();
@@ -1048,7 +1337,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postOptionalClassPropertyAsync(ClassOptionalWrapper bodyParameter, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postOptionalClassPropertyAsync(ClassOptionalWrapper bodyParameter, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postOptionalClassPropertyAsync(bodyParameter), serviceCallback);
     }
 
@@ -1057,12 +1346,24 @@ public class ExplicitsImpl implements Explicits {
      *
      * @param bodyParameter the ClassOptionalWrapper value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postOptionalClassPropertyAsync(ClassOptionalWrapper bodyParameter) {
+    public Single<RestResponse<Void, Void>> postOptionalClassPropertyWithRestResponseAsync(ClassOptionalWrapper bodyParameter) {
         Validator.validate(bodyParameter);
         return service.postOptionalClassProperty(bodyParameter);
     }
+
+    /**
+     * Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
+     *
+     * @param bodyParameter the ClassOptionalWrapper value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postOptionalClassPropertyAsync(ClassOptionalWrapper bodyParameter) {
+        return postOptionalClassPropertyWithRestResponseAsync(bodyParameter)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1086,7 +1387,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> postRequiredArrayParameterAsync(List<String> bodyParameter, final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> postRequiredArrayParameterAsync(List<String> bodyParameter, ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(postRequiredArrayParameterAsync(bodyParameter), serviceCallback);
     }
 
@@ -1095,15 +1396,27 @@ public class ExplicitsImpl implements Explicits {
      *
      * @param bodyParameter the List&lt;String&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> postRequiredArrayParameterAsync(List<String> bodyParameter) {
+    public Single<RestResponse<Void, Error>> postRequiredArrayParameterWithRestResponseAsync(List<String> bodyParameter) {
         if (bodyParameter == null) {
             throw new IllegalArgumentException("Parameter bodyParameter is required and cannot be null.");
         }
         Validator.validate(bodyParameter);
         return service.postRequiredArrayParameter(bodyParameter);
     }
+
+    /**
+     * Test explicitly required array. Please put null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter the List&lt;String&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> postRequiredArrayParameterAsync(List<String> bodyParameter) {
+        return postRequiredArrayParameterWithRestResponseAsync(bodyParameter)
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1112,6 +1425,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postOptionalArrayParameter() {
         postOptionalArrayParameterAsync().toBlocking().value();
@@ -1124,7 +1438,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postOptionalArrayParameterAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postOptionalArrayParameterAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postOptionalArrayParameterAsync(), serviceCallback);
     }
 
@@ -1132,12 +1446,24 @@ public class ExplicitsImpl implements Explicits {
      * Test explicitly optional array. Please put null.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postOptionalArrayParameterAsync() {
+    public Single<RestResponse<Void, Void>> postOptionalArrayParameterWithRestResponseAsync() {
         final List<String> bodyParameter = null;
+        Validator.validate(bodyParameter);
         return service.postOptionalArrayParameter(bodyParameter);
     }
+
+    /**
+     * Test explicitly optional array. Please put null.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postOptionalArrayParameterAsync() {
+        return postOptionalArrayParameterWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Test explicitly optional array. Please put null.
@@ -1146,6 +1472,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postOptionalArrayParameter(List<String> bodyParameter) {
         postOptionalArrayParameterAsync(bodyParameter).toBlocking().value();
@@ -1159,7 +1486,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postOptionalArrayParameterAsync(List<String> bodyParameter, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postOptionalArrayParameterAsync(List<String> bodyParameter, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postOptionalArrayParameterAsync(bodyParameter), serviceCallback);
     }
 
@@ -1168,12 +1495,24 @@ public class ExplicitsImpl implements Explicits {
      *
      * @param bodyParameter the List&lt;String&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postOptionalArrayParameterAsync(List<String> bodyParameter) {
+    public Single<RestResponse<Void, Void>> postOptionalArrayParameterWithRestResponseAsync(List<String> bodyParameter) {
         Validator.validate(bodyParameter);
         return service.postOptionalArrayParameter(bodyParameter);
     }
+
+    /**
+     * Test explicitly optional array. Please put null.
+     *
+     * @param bodyParameter the List&lt;String&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postOptionalArrayParameterAsync(List<String> bodyParameter) {
+        return postOptionalArrayParameterWithRestResponseAsync(bodyParameter)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1197,7 +1536,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> postRequiredArrayPropertyAsync(ArrayWrapper bodyParameter, final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> postRequiredArrayPropertyAsync(ArrayWrapper bodyParameter, ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(postRequiredArrayPropertyAsync(bodyParameter), serviceCallback);
     }
 
@@ -1206,15 +1545,27 @@ public class ExplicitsImpl implements Explicits {
      *
      * @param bodyParameter the ArrayWrapper value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> postRequiredArrayPropertyAsync(ArrayWrapper bodyParameter) {
+    public Single<RestResponse<Void, Error>> postRequiredArrayPropertyWithRestResponseAsync(ArrayWrapper bodyParameter) {
         if (bodyParameter == null) {
             throw new IllegalArgumentException("Parameter bodyParameter is required and cannot be null.");
         }
         Validator.validate(bodyParameter);
         return service.postRequiredArrayProperty(bodyParameter);
     }
+
+    /**
+     * Test explicitly required array. Please put a valid array-wrapper with 'value' = null and the client library should throw before the request is sent.
+     *
+     * @param bodyParameter the ArrayWrapper value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> postRequiredArrayPropertyAsync(ArrayWrapper bodyParameter) {
+        return postRequiredArrayPropertyWithRestResponseAsync(bodyParameter)
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1223,6 +1574,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postOptionalArrayProperty() {
         postOptionalArrayPropertyAsync().toBlocking().value();
@@ -1235,7 +1587,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postOptionalArrayPropertyAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postOptionalArrayPropertyAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postOptionalArrayPropertyAsync(), serviceCallback);
     }
 
@@ -1243,12 +1595,24 @@ public class ExplicitsImpl implements Explicits {
      * Test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postOptionalArrayPropertyAsync() {
+    public Single<RestResponse<Void, Void>> postOptionalArrayPropertyWithRestResponseAsync() {
         final ArrayOptionalWrapper bodyParameter = null;
+        Validator.validate(bodyParameter);
         return service.postOptionalArrayProperty(bodyParameter);
     }
+
+    /**
+     * Test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postOptionalArrayPropertyAsync() {
+        return postOptionalArrayPropertyWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
@@ -1257,6 +1621,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postOptionalArrayProperty(ArrayOptionalWrapper bodyParameter) {
         postOptionalArrayPropertyAsync(bodyParameter).toBlocking().value();
@@ -1270,7 +1635,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postOptionalArrayPropertyAsync(ArrayOptionalWrapper bodyParameter, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postOptionalArrayPropertyAsync(ArrayOptionalWrapper bodyParameter, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postOptionalArrayPropertyAsync(bodyParameter), serviceCallback);
     }
 
@@ -1279,12 +1644,24 @@ public class ExplicitsImpl implements Explicits {
      *
      * @param bodyParameter the ArrayOptionalWrapper value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postOptionalArrayPropertyAsync(ArrayOptionalWrapper bodyParameter) {
+    public Single<RestResponse<Void, Void>> postOptionalArrayPropertyWithRestResponseAsync(ArrayOptionalWrapper bodyParameter) {
         Validator.validate(bodyParameter);
         return service.postOptionalArrayProperty(bodyParameter);
     }
+
+    /**
+     * Test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
+     *
+     * @param bodyParameter the ArrayOptionalWrapper value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postOptionalArrayPropertyAsync(ArrayOptionalWrapper bodyParameter) {
+        return postOptionalArrayPropertyWithRestResponseAsync(bodyParameter)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1308,7 +1685,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> postRequiredArrayHeaderAsync(List<String> headerParameter, final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> postRequiredArrayHeaderAsync(List<String> headerParameter, ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(postRequiredArrayHeaderAsync(headerParameter), serviceCallback);
     }
 
@@ -1317,16 +1694,28 @@ public class ExplicitsImpl implements Explicits {
      *
      * @param headerParameter the List&lt;String&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> postRequiredArrayHeaderAsync(List<String> headerParameter) {
+    public Single<RestResponse<Void, Error>> postRequiredArrayHeaderWithRestResponseAsync(List<String> headerParameter) {
         if (headerParameter == null) {
             throw new IllegalArgumentException("Parameter headerParameter is required and cannot be null.");
         }
         Validator.validate(headerParameter);
-        String headerParameterConverted = this.client.serializerAdapter().serializeList(headerParameter, CollectionFormat.CSV);
+    String headerParameterConverted = this.client.serializerAdapter().serializeList(headerParameter, CollectionFormat.CSV);
         return service.postRequiredArrayHeader(headerParameterConverted);
     }
+
+    /**
+     * Test explicitly required array. Please put a header 'headerParameter' =&gt; null and the client library should throw before the request is sent.
+     *
+     * @param headerParameter the List&lt;String&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> postRequiredArrayHeaderAsync(List<String> headerParameter) {
+        return postRequiredArrayHeaderWithRestResponseAsync(headerParameter)
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1335,6 +1724,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postOptionalArrayHeader() {
         postOptionalArrayHeaderAsync().toBlocking().value();
@@ -1347,7 +1737,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postOptionalArrayHeaderAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postOptionalArrayHeaderAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postOptionalArrayHeaderAsync(), serviceCallback);
     }
 
@@ -1355,13 +1745,25 @@ public class ExplicitsImpl implements Explicits {
      * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postOptionalArrayHeaderAsync() {
+    public Single<RestResponse<Void, Void>> postOptionalArrayHeaderWithRestResponseAsync() {
         final List<String> headerParameter = null;
-        String headerParameterConverted = this.client.serializerAdapter().serializeList(headerParameter, CollectionFormat.CSV);
+        Validator.validate(headerParameter);
+    String headerParameterConverted = this.client.serializerAdapter().serializeList(headerParameter, CollectionFormat.CSV);
         return service.postOptionalArrayHeader(headerParameterConverted);
     }
+
+    /**
+     * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postOptionalArrayHeaderAsync() {
+        return postOptionalArrayHeaderWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
@@ -1370,6 +1772,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void postOptionalArrayHeader(List<String> headerParameter) {
         postOptionalArrayHeaderAsync(headerParameter).toBlocking().value();
@@ -1383,7 +1786,7 @@ public class ExplicitsImpl implements Explicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> postOptionalArrayHeaderAsync(List<String> headerParameter, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> postOptionalArrayHeaderAsync(List<String> headerParameter, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(postOptionalArrayHeaderAsync(headerParameter), serviceCallback);
     }
 
@@ -1392,13 +1795,25 @@ public class ExplicitsImpl implements Explicits {
      *
      * @param headerParameter the List&lt;String&gt; value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> postOptionalArrayHeaderAsync(List<String> headerParameter) {
+    public Single<RestResponse<Void, Void>> postOptionalArrayHeaderWithRestResponseAsync(List<String> headerParameter) {
         Validator.validate(headerParameter);
-        String headerParameterConverted = this.client.serializerAdapter().serializeList(headerParameter, CollectionFormat.CSV);
+    String headerParameterConverted = this.client.serializerAdapter().serializeList(headerParameter, CollectionFormat.CSV);
         return service.postOptionalArrayHeader(headerParameterConverted);
     }
+
+    /**
+     * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
+     *
+     * @param headerParameter the List&lt;String&gt; value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> postOptionalArrayHeaderAsync(List<String> headerParameter) {
+        return postOptionalArrayHeaderWithRestResponseAsync(headerParameter)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/requiredoptional/implementation/ImplicitsImpl.java
+++ b/test/vanilla/src/main/java/fixtures/requiredoptional/implementation/ImplicitsImpl.java
@@ -11,6 +11,7 @@
 package fixtures.requiredoptional.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.requiredoptional.Implicits;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.BodyParam;
@@ -62,40 +63,40 @@ public class ImplicitsImpl implements Implicits {
         @Headers({ "x-ms-logging-context: fixtures.requiredoptional.Implicits getRequiredPath" })
         @GET("reqopt/implicit/required/path/{pathParameter}")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> getRequiredPath(@PathParam("pathParameter") String pathParameter);
+        Single<RestResponse<Void, Error>> getRequiredPath(@PathParam("pathParameter") String pathParameter);
 
         @Headers({ "x-ms-logging-context: fixtures.requiredoptional.Implicits putOptionalQuery" })
         @PUT("reqopt/implicit/optional/query")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putOptionalQuery(@QueryParam("queryParameter") String queryParameter);
+        Single<RestResponse<Void, Void>> putOptionalQuery(@QueryParam("queryParameter") String queryParameter);
 
         @Headers({ "x-ms-logging-context: fixtures.requiredoptional.Implicits putOptionalHeader" })
         @PUT("reqopt/implicit/optional/header")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putOptionalHeader(@HeaderParam("queryParameter") String queryParameter);
+        Single<RestResponse<Void, Void>> putOptionalHeader(@HeaderParam("queryParameter") String queryParameter);
 
         @Headers({ "x-ms-logging-context: fixtures.requiredoptional.Implicits putOptionalBody" })
         @PUT("reqopt/implicit/optional/body")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> putOptionalBody(@BodyParam("application/json; charset=utf-8") String bodyParameter);
+        Single<RestResponse<Void, Void>> putOptionalBody(@BodyParam("application/json; charset=utf-8") String bodyParameter);
 
         @Headers({ "x-ms-logging-context: fixtures.requiredoptional.Implicits getRequiredGlobalPath" })
         @GET("reqopt/global/required/path/{required-global-path}")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> getRequiredGlobalPath(@PathParam("required-global-path") String requiredGlobalPath);
+        Single<RestResponse<Void, Error>> getRequiredGlobalPath(@PathParam("required-global-path") String requiredGlobalPath);
 
         @Headers({ "x-ms-logging-context: fixtures.requiredoptional.Implicits getRequiredGlobalQuery" })
         @GET("reqopt/global/required/query")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> getRequiredGlobalQuery(@QueryParam("required-global-query") String requiredGlobalQuery);
+        Single<RestResponse<Void, Error>> getRequiredGlobalQuery(@QueryParam("required-global-query") String requiredGlobalQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.requiredoptional.Implicits getOptionalGlobalQuery" })
         @GET("reqopt/global/optional/query")
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Error> getOptionalGlobalQuery(@QueryParam("optional-global-query") Integer optionalGlobalQuery);
+        Single<RestResponse<Void, Error>> getOptionalGlobalQuery(@QueryParam("optional-global-query") Integer optionalGlobalQuery);
 
     }
 
@@ -120,7 +121,7 @@ public class ImplicitsImpl implements Implicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> getRequiredPathAsync(String pathParameter, final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> getRequiredPathAsync(String pathParameter, ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(getRequiredPathAsync(pathParameter), serviceCallback);
     }
 
@@ -129,14 +130,26 @@ public class ImplicitsImpl implements Implicits {
      *
      * @param pathParameter the String value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> getRequiredPathAsync(String pathParameter) {
+    public Single<RestResponse<Void, Error>> getRequiredPathWithRestResponseAsync(String pathParameter) {
         if (pathParameter == null) {
             throw new IllegalArgumentException("Parameter pathParameter is required and cannot be null.");
         }
         return service.getRequiredPath(pathParameter);
     }
+
+    /**
+     * Test implicitly required path parameter.
+     *
+     * @param pathParameter the String value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> getRequiredPathAsync(String pathParameter) {
+        return getRequiredPathWithRestResponseAsync(pathParameter)
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -145,6 +158,7 @@ public class ImplicitsImpl implements Implicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putOptionalQuery() {
         putOptionalQueryAsync().toBlocking().value();
@@ -157,7 +171,7 @@ public class ImplicitsImpl implements Implicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putOptionalQueryAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putOptionalQueryAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putOptionalQueryAsync(), serviceCallback);
     }
 
@@ -165,12 +179,23 @@ public class ImplicitsImpl implements Implicits {
      * Test implicitly optional query parameter.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putOptionalQueryAsync() {
+    public Single<RestResponse<Void, Void>> putOptionalQueryWithRestResponseAsync() {
         final String queryParameter = null;
         return service.putOptionalQuery(queryParameter);
     }
+
+    /**
+     * Test implicitly optional query parameter.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putOptionalQueryAsync() {
+        return putOptionalQueryWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Test implicitly optional query parameter.
@@ -179,6 +204,7 @@ public class ImplicitsImpl implements Implicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putOptionalQuery(String queryParameter) {
         putOptionalQueryAsync(queryParameter).toBlocking().value();
@@ -192,7 +218,7 @@ public class ImplicitsImpl implements Implicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putOptionalQueryAsync(String queryParameter, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putOptionalQueryAsync(String queryParameter, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putOptionalQueryAsync(queryParameter), serviceCallback);
     }
 
@@ -201,11 +227,23 @@ public class ImplicitsImpl implements Implicits {
      *
      * @param queryParameter the String value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putOptionalQueryAsync(String queryParameter) {
+    public Single<RestResponse<Void, Void>> putOptionalQueryWithRestResponseAsync(String queryParameter) {
         return service.putOptionalQuery(queryParameter);
     }
+
+    /**
+     * Test implicitly optional query parameter.
+     *
+     * @param queryParameter the String value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putOptionalQueryAsync(String queryParameter) {
+        return putOptionalQueryWithRestResponseAsync(queryParameter)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -214,6 +252,7 @@ public class ImplicitsImpl implements Implicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putOptionalHeader() {
         putOptionalHeaderAsync().toBlocking().value();
@@ -226,7 +265,7 @@ public class ImplicitsImpl implements Implicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putOptionalHeaderAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putOptionalHeaderAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putOptionalHeaderAsync(), serviceCallback);
     }
 
@@ -234,12 +273,23 @@ public class ImplicitsImpl implements Implicits {
      * Test implicitly optional header parameter.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putOptionalHeaderAsync() {
+    public Single<RestResponse<Void, Void>> putOptionalHeaderWithRestResponseAsync() {
         final String queryParameter = null;
         return service.putOptionalHeader(queryParameter);
     }
+
+    /**
+     * Test implicitly optional header parameter.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putOptionalHeaderAsync() {
+        return putOptionalHeaderWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Test implicitly optional header parameter.
@@ -248,6 +298,7 @@ public class ImplicitsImpl implements Implicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putOptionalHeader(String queryParameter) {
         putOptionalHeaderAsync(queryParameter).toBlocking().value();
@@ -261,7 +312,7 @@ public class ImplicitsImpl implements Implicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putOptionalHeaderAsync(String queryParameter, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putOptionalHeaderAsync(String queryParameter, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putOptionalHeaderAsync(queryParameter), serviceCallback);
     }
 
@@ -270,11 +321,23 @@ public class ImplicitsImpl implements Implicits {
      *
      * @param queryParameter the String value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putOptionalHeaderAsync(String queryParameter) {
+    public Single<RestResponse<Void, Void>> putOptionalHeaderWithRestResponseAsync(String queryParameter) {
         return service.putOptionalHeader(queryParameter);
     }
+
+    /**
+     * Test implicitly optional header parameter.
+     *
+     * @param queryParameter the String value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putOptionalHeaderAsync(String queryParameter) {
+        return putOptionalHeaderWithRestResponseAsync(queryParameter)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -283,6 +346,7 @@ public class ImplicitsImpl implements Implicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putOptionalBody() {
         putOptionalBodyAsync().toBlocking().value();
@@ -295,7 +359,7 @@ public class ImplicitsImpl implements Implicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putOptionalBodyAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putOptionalBodyAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putOptionalBodyAsync(), serviceCallback);
     }
 
@@ -303,12 +367,23 @@ public class ImplicitsImpl implements Implicits {
      * Test implicitly optional body parameter.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putOptionalBodyAsync() {
+    public Single<RestResponse<Void, Void>> putOptionalBodyWithRestResponseAsync() {
         final String bodyParameter = null;
         return service.putOptionalBody(bodyParameter);
     }
+
+    /**
+     * Test implicitly optional body parameter.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putOptionalBodyAsync() {
+        return putOptionalBodyWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Test implicitly optional body parameter.
@@ -317,6 +392,7 @@ public class ImplicitsImpl implements Implicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void putOptionalBody(String bodyParameter) {
         putOptionalBodyAsync(bodyParameter).toBlocking().value();
@@ -330,7 +406,7 @@ public class ImplicitsImpl implements Implicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> putOptionalBodyAsync(String bodyParameter, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> putOptionalBodyAsync(String bodyParameter, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(putOptionalBodyAsync(bodyParameter), serviceCallback);
     }
 
@@ -339,11 +415,23 @@ public class ImplicitsImpl implements Implicits {
      *
      * @param bodyParameter the String value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> putOptionalBodyAsync(String bodyParameter) {
+    public Single<RestResponse<Void, Void>> putOptionalBodyWithRestResponseAsync(String bodyParameter) {
         return service.putOptionalBody(bodyParameter);
     }
+
+    /**
+     * Test implicitly optional body parameter.
+     *
+     * @param bodyParameter the String value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> putOptionalBodyAsync(String bodyParameter) {
+        return putOptionalBodyWithRestResponseAsync(bodyParameter)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -365,7 +453,7 @@ public class ImplicitsImpl implements Implicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> getRequiredGlobalPathAsync(final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> getRequiredGlobalPathAsync(ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(getRequiredGlobalPathAsync(), serviceCallback);
     }
 
@@ -373,14 +461,25 @@ public class ImplicitsImpl implements Implicits {
      * Test implicitly required path parameter.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> getRequiredGlobalPathAsync() {
+    public Single<RestResponse<Void, Error>> getRequiredGlobalPathWithRestResponseAsync() {
         if (this.client.requiredGlobalPath() == null) {
             throw new IllegalArgumentException("Parameter this.client.requiredGlobalPath() is required and cannot be null.");
         }
         return service.getRequiredGlobalPath(this.client.requiredGlobalPath());
     }
+
+    /**
+     * Test implicitly required path parameter.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> getRequiredGlobalPathAsync() {
+        return getRequiredGlobalPathWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -402,7 +501,7 @@ public class ImplicitsImpl implements Implicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> getRequiredGlobalQueryAsync(final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> getRequiredGlobalQueryAsync(ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(getRequiredGlobalQueryAsync(), serviceCallback);
     }
 
@@ -410,14 +509,25 @@ public class ImplicitsImpl implements Implicits {
      * Test implicitly required query parameter.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> getRequiredGlobalQueryAsync() {
+    public Single<RestResponse<Void, Error>> getRequiredGlobalQueryWithRestResponseAsync() {
         if (this.client.requiredGlobalQuery() == null) {
             throw new IllegalArgumentException("Parameter this.client.requiredGlobalQuery() is required and cannot be null.");
         }
         return service.getRequiredGlobalQuery(this.client.requiredGlobalQuery());
     }
+
+    /**
+     * Test implicitly required query parameter.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> getRequiredGlobalQueryAsync() {
+        return getRequiredGlobalQueryWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -439,7 +549,7 @@ public class ImplicitsImpl implements Implicits {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Error> getOptionalGlobalQueryAsync(final ServiceCallback<Error> serviceCallback) {
+    public ServiceFuture<Error> getOptionalGlobalQueryAsync(ServiceCallback<Error> serviceCallback) {
         return ServiceFuture.fromBody(getOptionalGlobalQueryAsync(), serviceCallback);
     }
 
@@ -447,11 +557,22 @@ public class ImplicitsImpl implements Implicits {
      * Test implicitly optional query parameter.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Error object
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
      */
-    public Single<Error> getOptionalGlobalQueryAsync() {
+    public Single<RestResponse<Void, Error>> getOptionalGlobalQueryWithRestResponseAsync() {
         return service.getOptionalGlobalQuery(this.client.optionalGlobalQuery());
     }
+
+    /**
+     * Test implicitly optional query parameter.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Error> object
+     */
+    public Single<Error> getOptionalGlobalQueryAsync() {
+        return getOptionalGlobalQueryWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Error>, Error>() { public Error call(RestResponse<Void, Error> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/url/PathItems.java
+++ b/test/vanilla/src/main/java/fixtures/url/PathItems.java
@@ -10,6 +10,7 @@
 
 package fixtures.url;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.url.models.ErrorException;
@@ -53,6 +54,16 @@ public interface PathItems {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getAllWithValuesAsync(String localStringPath, String pathItemStringPath);
+
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> getAllWithValuesWithRestResponseAsync(String localStringPath, String pathItemStringPath);
     /**
      * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
      *
@@ -90,6 +101,17 @@ public interface PathItems {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getAllWithValuesAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery);
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @param localStringQuery should contain value 'localStringQuery'
+     * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> getAllWithValuesWithRestResponseAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery);
 
 
     /**
@@ -123,6 +145,16 @@ public interface PathItems {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getGlobalQueryNullAsync(String localStringPath, String pathItemStringPath);
+
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> getGlobalQueryNullWithRestResponseAsync(String localStringPath, String pathItemStringPath);
     /**
      * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
      *
@@ -160,6 +192,17 @@ public interface PathItems {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getGlobalQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery);
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @param localStringQuery should contain value 'localStringQuery'
+     * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> getGlobalQueryNullWithRestResponseAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery);
 
 
     /**
@@ -193,6 +236,16 @@ public interface PathItems {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getGlobalAndLocalQueryNullAsync(String localStringPath, String pathItemStringPath);
+
+    /**
+     * send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery=null.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> getGlobalAndLocalQueryNullWithRestResponseAsync(String localStringPath, String pathItemStringPath);
     /**
      * send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery=null.
      *
@@ -230,6 +283,17 @@ public interface PathItems {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getGlobalAndLocalQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery);
+    /**
+     * send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery=null.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @param localStringQuery should contain null value
+     * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> getGlobalAndLocalQueryNullWithRestResponseAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery);
 
 
     /**
@@ -263,6 +327,16 @@ public interface PathItems {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getLocalPathItemQueryNullAsync(String localStringPath, String pathItemStringPath);
+
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null, localStringQuery=null.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> getLocalPathItemQueryNullWithRestResponseAsync(String localStringPath, String pathItemStringPath);
     /**
      * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null, localStringQuery=null.
      *
@@ -300,6 +374,17 @@ public interface PathItems {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getLocalPathItemQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery);
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null, localStringQuery=null.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @param localStringQuery should contain value null
+     * @param pathItemStringQuery should contain value null
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> getLocalPathItemQueryNullWithRestResponseAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery);
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/url/Paths.java
+++ b/test/vanilla/src/main/java/fixtures/url/Paths.java
@@ -10,6 +10,7 @@
 
 package fixtures.url;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.url.models.ErrorException;
@@ -51,6 +52,13 @@ public interface Paths {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getBooleanTrueAsync();
+    /**
+     * Get true Boolean value on path.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> getBooleanTrueWithRestResponseAsync();
 
 
     /**
@@ -78,6 +86,13 @@ public interface Paths {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getBooleanFalseAsync();
+    /**
+     * Get false Boolean value on path.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> getBooleanFalseWithRestResponseAsync();
 
 
     /**
@@ -105,6 +120,13 @@ public interface Paths {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getIntOneMillionAsync();
+    /**
+     * Get '1000000' integer value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> getIntOneMillionWithRestResponseAsync();
 
 
     /**
@@ -132,6 +154,13 @@ public interface Paths {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getIntNegativeOneMillionAsync();
+    /**
+     * Get '-1000000' integer value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> getIntNegativeOneMillionWithRestResponseAsync();
 
 
     /**
@@ -159,6 +188,13 @@ public interface Paths {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getTenBillionAsync();
+    /**
+     * Get '10000000000' 64 bit integer value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> getTenBillionWithRestResponseAsync();
 
 
     /**
@@ -186,6 +222,13 @@ public interface Paths {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getNegativeTenBillionAsync();
+    /**
+     * Get '-10000000000' 64 bit integer value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> getNegativeTenBillionWithRestResponseAsync();
 
 
     /**
@@ -213,6 +256,13 @@ public interface Paths {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> floatScientificPositiveAsync();
+    /**
+     * Get '1.034E+20' numeric value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> floatScientificPositiveWithRestResponseAsync();
 
 
     /**
@@ -240,6 +290,13 @@ public interface Paths {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> floatScientificNegativeAsync();
+    /**
+     * Get '-1.034E-20' numeric value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> floatScientificNegativeWithRestResponseAsync();
 
 
     /**
@@ -267,6 +324,13 @@ public interface Paths {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> doubleDecimalPositiveAsync();
+    /**
+     * Get '9999999.999' numeric value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> doubleDecimalPositiveWithRestResponseAsync();
 
 
     /**
@@ -294,6 +358,13 @@ public interface Paths {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> doubleDecimalNegativeAsync();
+    /**
+     * Get '-9999999.999' numeric value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> doubleDecimalNegativeWithRestResponseAsync();
 
 
     /**
@@ -321,6 +392,13 @@ public interface Paths {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> stringUnicodeAsync();
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> stringUnicodeWithRestResponseAsync();
 
 
     /**
@@ -348,6 +426,13 @@ public interface Paths {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> stringUrlEncodedAsync();
+    /**
+     * Get 'begin!*'();:@ &amp;=+$,/?#[]end.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> stringUrlEncodedWithRestResponseAsync();
 
 
     /**
@@ -375,6 +460,13 @@ public interface Paths {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> stringEmptyAsync();
+    /**
+     * Get ''.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> stringEmptyWithRestResponseAsync();
 
 
     /**
@@ -405,6 +497,14 @@ public interface Paths {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> stringNullAsync(String stringPath);
+    /**
+     * Get null (should throw).
+     *
+     * @param stringPath null string value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> stringNullWithRestResponseAsync(String stringPath);
 
 
     /**
@@ -435,6 +535,14 @@ public interface Paths {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> enumValidAsync(UriColor enumPath);
+    /**
+     * Get using uri with 'green color' in path parameter.
+     *
+     * @param enumPath send the value green. Possible values include: 'red color', 'green color', 'blue color'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> enumValidWithRestResponseAsync(UriColor enumPath);
 
 
     /**
@@ -465,6 +573,14 @@ public interface Paths {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> enumNullAsync(UriColor enumPath);
+    /**
+     * Get null (should throw on the client before the request is sent on wire).
+     *
+     * @param enumPath send null should throw. Possible values include: 'red color', 'green color', 'blue color'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> enumNullWithRestResponseAsync(UriColor enumPath);
 
 
     /**
@@ -495,6 +611,14 @@ public interface Paths {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> byteMultiByteAsync(byte[] bytePath);
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
+     *
+     * @param bytePath '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> byteMultiByteWithRestResponseAsync(byte[] bytePath);
 
 
     /**
@@ -522,6 +646,13 @@ public interface Paths {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> byteEmptyAsync();
+    /**
+     * Get '' as byte array.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> byteEmptyWithRestResponseAsync();
 
 
     /**
@@ -552,6 +683,14 @@ public interface Paths {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> byteNullAsync(byte[] bytePath);
+    /**
+     * Get null as byte array (should throw).
+     *
+     * @param bytePath null as byte array (should throw)
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> byteNullWithRestResponseAsync(byte[] bytePath);
 
 
     /**
@@ -579,6 +718,13 @@ public interface Paths {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> dateValidAsync();
+    /**
+     * Get '2012-01-01' as date.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> dateValidWithRestResponseAsync();
 
 
     /**
@@ -609,6 +755,14 @@ public interface Paths {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> dateNullAsync(LocalDate datePath);
+    /**
+     * Get null as date - this should throw or be unusable on the client side, depending on date representation.
+     *
+     * @param datePath null as date (should throw)
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> dateNullWithRestResponseAsync(LocalDate datePath);
 
 
     /**
@@ -636,6 +790,13 @@ public interface Paths {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> dateTimeValidAsync();
+    /**
+     * Get '2012-01-01T01:01:01Z' as date-time.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> dateTimeValidWithRestResponseAsync();
 
 
     /**
@@ -666,6 +827,14 @@ public interface Paths {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> dateTimeNullAsync(DateTime dateTimePath);
+    /**
+     * Get null as date-time, should be disallowed or throw depending on representation of date-time.
+     *
+     * @param dateTimePath null as date-time
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> dateTimeNullWithRestResponseAsync(DateTime dateTimePath);
 
 
     /**
@@ -696,6 +865,14 @@ public interface Paths {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> base64UrlAsync(byte[] base64UrlPath);
+    /**
+     * Get 'lorem' encoded value as 'bG9yZW0' (base64url).
+     *
+     * @param base64UrlPath base64url encoded value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> base64UrlWithRestResponseAsync(byte[] base64UrlPath);
 
 
     /**
@@ -726,6 +903,14 @@ public interface Paths {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> arrayCsvInPathAsync(List<String> arrayPath);
+    /**
+     * Get an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
+     *
+     * @param arrayPath an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> arrayCsvInPathWithRestResponseAsync(List<String> arrayPath);
 
 
     /**
@@ -756,6 +941,14 @@ public interface Paths {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> unixTimeUrlAsync(DateTime unixTimeUrlPath);
+    /**
+     * Get the date 2016-04-13 encoded value as '1460505600' (Unix time).
+     *
+     * @param unixTimeUrlPath Unix time encoded value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> unixTimeUrlWithRestResponseAsync(DateTime unixTimeUrlPath);
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/url/Queries.java
+++ b/test/vanilla/src/main/java/fixtures/url/Queries.java
@@ -10,6 +10,7 @@
 
 package fixtures.url;
 
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.url.models.ErrorException;
@@ -51,6 +52,13 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getBooleanTrueAsync();
+    /**
+     * Get true Boolean value on path.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> getBooleanTrueWithRestResponseAsync();
 
 
     /**
@@ -78,6 +86,13 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getBooleanFalseAsync();
+    /**
+     * Get false Boolean value on path.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> getBooleanFalseWithRestResponseAsync();
 
 
     /**
@@ -105,6 +120,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getBooleanNullAsync();
+
+    /**
+     * Get null Boolean value on query (query string should be absent).
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> getBooleanNullWithRestResponseAsync();
     /**
      * Get null Boolean value on query (query string should be absent).
      *
@@ -133,6 +156,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getBooleanNullAsync(Boolean boolQuery);
+    /**
+     * Get null Boolean value on query (query string should be absent).
+     *
+     * @param boolQuery null boolean value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> getBooleanNullWithRestResponseAsync(Boolean boolQuery);
 
 
     /**
@@ -160,6 +191,13 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getIntOneMillionAsync();
+    /**
+     * Get '1000000' integer value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> getIntOneMillionWithRestResponseAsync();
 
 
     /**
@@ -187,6 +225,13 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getIntNegativeOneMillionAsync();
+    /**
+     * Get '-1000000' integer value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> getIntNegativeOneMillionWithRestResponseAsync();
 
 
     /**
@@ -214,6 +259,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getIntNullAsync();
+
+    /**
+     * Get null integer value (no query parameter).
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> getIntNullWithRestResponseAsync();
     /**
      * Get null integer value (no query parameter).
      *
@@ -242,6 +295,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getIntNullAsync(Integer intQuery);
+    /**
+     * Get null integer value (no query parameter).
+     *
+     * @param intQuery null integer value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> getIntNullWithRestResponseAsync(Integer intQuery);
 
 
     /**
@@ -269,6 +330,13 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getTenBillionAsync();
+    /**
+     * Get '10000000000' 64 bit integer value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> getTenBillionWithRestResponseAsync();
 
 
     /**
@@ -296,6 +364,13 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getNegativeTenBillionAsync();
+    /**
+     * Get '-10000000000' 64 bit integer value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> getNegativeTenBillionWithRestResponseAsync();
 
 
     /**
@@ -323,6 +398,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getLongNullAsync();
+
+    /**
+     * Get 'null 64 bit integer value (no query param in uri).
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> getLongNullWithRestResponseAsync();
     /**
      * Get 'null 64 bit integer value (no query param in uri).
      *
@@ -351,6 +434,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getLongNullAsync(Long longQuery);
+    /**
+     * Get 'null 64 bit integer value (no query param in uri).
+     *
+     * @param longQuery null 64 bit integer value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> getLongNullWithRestResponseAsync(Long longQuery);
 
 
     /**
@@ -378,6 +469,13 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> floatScientificPositiveAsync();
+    /**
+     * Get '1.034E+20' numeric value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> floatScientificPositiveWithRestResponseAsync();
 
 
     /**
@@ -405,6 +503,13 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> floatScientificNegativeAsync();
+    /**
+     * Get '-1.034E-20' numeric value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> floatScientificNegativeWithRestResponseAsync();
 
 
     /**
@@ -432,6 +537,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> floatNullAsync();
+
+    /**
+     * Get null numeric value (no query parameter).
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> floatNullWithRestResponseAsync();
     /**
      * Get null numeric value (no query parameter).
      *
@@ -460,6 +573,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> floatNullAsync(Double floatQuery);
+    /**
+     * Get null numeric value (no query parameter).
+     *
+     * @param floatQuery null numeric value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> floatNullWithRestResponseAsync(Double floatQuery);
 
 
     /**
@@ -487,6 +608,13 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> doubleDecimalPositiveAsync();
+    /**
+     * Get '9999999.999' numeric value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> doubleDecimalPositiveWithRestResponseAsync();
 
 
     /**
@@ -514,6 +642,13 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> doubleDecimalNegativeAsync();
+    /**
+     * Get '-9999999.999' numeric value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> doubleDecimalNegativeWithRestResponseAsync();
 
 
     /**
@@ -541,6 +676,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> doubleNullAsync();
+
+    /**
+     * Get null numeric value (no query parameter).
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> doubleNullWithRestResponseAsync();
     /**
      * Get null numeric value (no query parameter).
      *
@@ -569,6 +712,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> doubleNullAsync(Double doubleQuery);
+    /**
+     * Get null numeric value (no query parameter).
+     *
+     * @param doubleQuery null numeric value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> doubleNullWithRestResponseAsync(Double doubleQuery);
 
 
     /**
@@ -596,6 +747,13 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> stringUnicodeAsync();
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> stringUnicodeWithRestResponseAsync();
 
 
     /**
@@ -623,6 +781,13 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> stringUrlEncodedAsync();
+    /**
+     * Get 'begin!*'();:@ &amp;=+$,/?#[]end.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> stringUrlEncodedWithRestResponseAsync();
 
 
     /**
@@ -650,6 +815,13 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> stringEmptyAsync();
+    /**
+     * Get ''.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> stringEmptyWithRestResponseAsync();
 
 
     /**
@@ -677,6 +849,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> stringNullAsync();
+
+    /**
+     * Get null (no query parameter in url).
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> stringNullWithRestResponseAsync();
     /**
      * Get null (no query parameter in url).
      *
@@ -705,6 +885,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> stringNullAsync(String stringQuery);
+    /**
+     * Get null (no query parameter in url).
+     *
+     * @param stringQuery null string value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> stringNullWithRestResponseAsync(String stringQuery);
 
 
     /**
@@ -732,6 +920,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> enumValidAsync();
+
+    /**
+     * Get using uri with query parameter 'green color'.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> enumValidWithRestResponseAsync();
     /**
      * Get using uri with query parameter 'green color'.
      *
@@ -760,6 +956,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> enumValidAsync(UriColor enumQuery);
+    /**
+     * Get using uri with query parameter 'green color'.
+     *
+     * @param enumQuery 'green color' enum value. Possible values include: 'red color', 'green color', 'blue color'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> enumValidWithRestResponseAsync(UriColor enumQuery);
 
 
     /**
@@ -787,6 +991,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> enumNullAsync();
+
+    /**
+     * Get null (no query parameter in url).
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> enumNullWithRestResponseAsync();
     /**
      * Get null (no query parameter in url).
      *
@@ -815,6 +1027,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> enumNullAsync(UriColor enumQuery);
+    /**
+     * Get null (no query parameter in url).
+     *
+     * @param enumQuery null string value. Possible values include: 'red color', 'green color', 'blue color'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> enumNullWithRestResponseAsync(UriColor enumQuery);
 
 
     /**
@@ -842,6 +1062,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> byteMultiByteAsync();
+
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> byteMultiByteWithRestResponseAsync();
     /**
      * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
      *
@@ -870,6 +1098,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> byteMultiByteAsync(byte[] byteQuery);
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
+     *
+     * @param byteQuery '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> byteMultiByteWithRestResponseAsync(byte[] byteQuery);
 
 
     /**
@@ -897,6 +1133,13 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> byteEmptyAsync();
+    /**
+     * Get '' as byte array.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> byteEmptyWithRestResponseAsync();
 
 
     /**
@@ -924,6 +1167,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> byteNullAsync();
+
+    /**
+     * Get null as byte array (no query parameters in uri).
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> byteNullWithRestResponseAsync();
     /**
      * Get null as byte array (no query parameters in uri).
      *
@@ -952,6 +1203,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> byteNullAsync(byte[] byteQuery);
+    /**
+     * Get null as byte array (no query parameters in uri).
+     *
+     * @param byteQuery null as byte array (no query parameters in uri)
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> byteNullWithRestResponseAsync(byte[] byteQuery);
 
 
     /**
@@ -979,6 +1238,13 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> dateValidAsync();
+    /**
+     * Get '2012-01-01' as date.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> dateValidWithRestResponseAsync();
 
 
     /**
@@ -1006,6 +1272,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> dateNullAsync();
+
+    /**
+     * Get null as date - this should result in no query parameters in uri.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> dateNullWithRestResponseAsync();
     /**
      * Get null as date - this should result in no query parameters in uri.
      *
@@ -1034,6 +1308,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> dateNullAsync(LocalDate dateQuery);
+    /**
+     * Get null as date - this should result in no query parameters in uri.
+     *
+     * @param dateQuery null as date (no query parameters in uri)
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> dateNullWithRestResponseAsync(LocalDate dateQuery);
 
 
     /**
@@ -1061,6 +1343,13 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> dateTimeValidAsync();
+    /**
+     * Get '2012-01-01T01:01:01Z' as date-time.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> dateTimeValidWithRestResponseAsync();
 
 
     /**
@@ -1088,6 +1377,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> dateTimeNullAsync();
+
+    /**
+     * Get null as date-time, should result in no query parameters in uri.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> dateTimeNullWithRestResponseAsync();
     /**
      * Get null as date-time, should result in no query parameters in uri.
      *
@@ -1116,6 +1413,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> dateTimeNullAsync(DateTime dateTimeQuery);
+    /**
+     * Get null as date-time, should result in no query parameters in uri.
+     *
+     * @param dateTimeQuery null as date-time (no query parameters)
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> dateTimeNullWithRestResponseAsync(DateTime dateTimeQuery);
 
 
     /**
@@ -1143,6 +1448,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> arrayStringCsvValidAsync();
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> arrayStringCsvValidWithRestResponseAsync();
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
      *
@@ -1171,6 +1484,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> arrayStringCsvValidAsync(List<String> arrayQuery);
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
+     *
+     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> arrayStringCsvValidWithRestResponseAsync(List<String> arrayQuery);
 
 
     /**
@@ -1198,6 +1519,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> arrayStringCsvNullAsync();
+
+    /**
+     * Get a null array of string using the csv-array format.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> arrayStringCsvNullWithRestResponseAsync();
     /**
      * Get a null array of string using the csv-array format.
      *
@@ -1226,6 +1555,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> arrayStringCsvNullAsync(List<String> arrayQuery);
+    /**
+     * Get a null array of string using the csv-array format.
+     *
+     * @param arrayQuery a null array of string using the csv-array format
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> arrayStringCsvNullWithRestResponseAsync(List<String> arrayQuery);
 
 
     /**
@@ -1253,6 +1590,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> arrayStringCsvEmptyAsync();
+
+    /**
+     * Get an empty array [] of string using the csv-array format.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> arrayStringCsvEmptyWithRestResponseAsync();
     /**
      * Get an empty array [] of string using the csv-array format.
      *
@@ -1281,6 +1626,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> arrayStringCsvEmptyAsync(List<String> arrayQuery);
+    /**
+     * Get an empty array [] of string using the csv-array format.
+     *
+     * @param arrayQuery an empty array [] of string using the csv-array format
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> arrayStringCsvEmptyWithRestResponseAsync(List<String> arrayQuery);
 
 
     /**
@@ -1308,6 +1661,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> arrayStringSsvValidAsync();
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> arrayStringSsvValidWithRestResponseAsync();
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format.
      *
@@ -1336,6 +1697,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> arrayStringSsvValidAsync(List<String> arrayQuery);
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format.
+     *
+     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> arrayStringSsvValidWithRestResponseAsync(List<String> arrayQuery);
 
 
     /**
@@ -1363,6 +1732,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> arrayStringTsvValidAsync();
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> arrayStringTsvValidWithRestResponseAsync();
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format.
      *
@@ -1391,6 +1768,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> arrayStringTsvValidAsync(List<String> arrayQuery);
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format.
+     *
+     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> arrayStringTsvValidWithRestResponseAsync(List<String> arrayQuery);
 
 
     /**
@@ -1418,6 +1803,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> arrayStringPipesValidAsync();
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> arrayStringPipesValidWithRestResponseAsync();
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format.
      *
@@ -1446,6 +1839,14 @@ public interface Queries {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> arrayStringPipesValidAsync(List<String> arrayQuery);
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format.
+     *
+     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> arrayStringPipesValidWithRestResponseAsync(List<String> arrayQuery);
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/url/implementation/AutoRestUrlTestServiceImpl.java
+++ b/test/vanilla/src/main/java/fixtures/url/implementation/AutoRestUrlTestServiceImpl.java
@@ -15,6 +15,7 @@ import fixtures.url.Paths;
 import fixtures.url.Queries;
 import fixtures.url.PathItems;
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceClient;
 import com.microsoft.rest.RestClient;
 import rx.Single;

--- a/test/vanilla/src/main/java/fixtures/url/implementation/PathItemsImpl.java
+++ b/test/vanilla/src/main/java/fixtures/url/implementation/PathItemsImpl.java
@@ -11,6 +11,7 @@
 package fixtures.url.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.url.PathItems;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.ExpectedResponses;
@@ -59,25 +60,25 @@ public class PathItemsImpl implements PathItems {
         @GET("pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/pathItemStringQuery/localStringQuery")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getAllWithValues(@PathParam("localStringPath") String localStringPath, @PathParam("pathItemStringPath") String pathItemStringPath, @PathParam("globalStringPath") String globalStringPath, @QueryParam("localStringQuery") String localStringQuery, @QueryParam("pathItemStringQuery") String pathItemStringQuery, @QueryParam("globalStringQuery") String globalStringQuery);
+        Single<RestResponse<Void, Void>> getAllWithValues(@PathParam("localStringPath") String localStringPath, @PathParam("pathItemStringPath") String pathItemStringPath, @PathParam("globalStringPath") String globalStringPath, @QueryParam("localStringQuery") String localStringQuery, @QueryParam("pathItemStringQuery") String pathItemStringQuery, @QueryParam("globalStringQuery") String globalStringQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.PathItems getGlobalQueryNull" })
         @GET("pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/localStringQuery")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getGlobalQueryNull(@PathParam("localStringPath") String localStringPath, @PathParam("pathItemStringPath") String pathItemStringPath, @PathParam("globalStringPath") String globalStringPath, @QueryParam("localStringQuery") String localStringQuery, @QueryParam("pathItemStringQuery") String pathItemStringQuery, @QueryParam("globalStringQuery") String globalStringQuery);
+        Single<RestResponse<Void, Void>> getGlobalQueryNull(@PathParam("localStringPath") String localStringPath, @PathParam("pathItemStringPath") String pathItemStringPath, @PathParam("globalStringPath") String globalStringPath, @QueryParam("localStringQuery") String localStringQuery, @QueryParam("pathItemStringQuery") String pathItemStringQuery, @QueryParam("globalStringQuery") String globalStringQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.PathItems getGlobalAndLocalQueryNull" })
         @GET("pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getGlobalAndLocalQueryNull(@PathParam("localStringPath") String localStringPath, @PathParam("pathItemStringPath") String pathItemStringPath, @PathParam("globalStringPath") String globalStringPath, @QueryParam("localStringQuery") String localStringQuery, @QueryParam("pathItemStringQuery") String pathItemStringQuery, @QueryParam("globalStringQuery") String globalStringQuery);
+        Single<RestResponse<Void, Void>> getGlobalAndLocalQueryNull(@PathParam("localStringPath") String localStringPath, @PathParam("pathItemStringPath") String pathItemStringPath, @PathParam("globalStringPath") String globalStringPath, @QueryParam("localStringQuery") String localStringQuery, @QueryParam("pathItemStringQuery") String pathItemStringQuery, @QueryParam("globalStringQuery") String globalStringQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.PathItems getLocalPathItemQueryNull" })
         @GET("pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/null/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getLocalPathItemQueryNull(@PathParam("localStringPath") String localStringPath, @PathParam("pathItemStringPath") String pathItemStringPath, @PathParam("globalStringPath") String globalStringPath, @QueryParam("localStringQuery") String localStringQuery, @QueryParam("pathItemStringQuery") String pathItemStringQuery, @QueryParam("globalStringQuery") String globalStringQuery);
+        Single<RestResponse<Void, Void>> getLocalPathItemQueryNull(@PathParam("localStringPath") String localStringPath, @PathParam("pathItemStringPath") String pathItemStringPath, @PathParam("globalStringPath") String globalStringPath, @QueryParam("localStringQuery") String localStringQuery, @QueryParam("pathItemStringQuery") String pathItemStringQuery, @QueryParam("globalStringQuery") String globalStringQuery);
 
     }
 
@@ -89,6 +90,7 @@ public class PathItemsImpl implements PathItems {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getAllWithValues(String localStringPath, String pathItemStringPath) {
         getAllWithValuesAsync(localStringPath, pathItemStringPath).toBlocking().value();
@@ -103,7 +105,7 @@ public class PathItemsImpl implements PathItems {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getAllWithValuesAsync(String localStringPath, String pathItemStringPath, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getAllWithValuesAsync(String localStringPath, String pathItemStringPath, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getAllWithValuesAsync(localStringPath, pathItemStringPath), serviceCallback);
     }
 
@@ -113,9 +115,9 @@ public class PathItemsImpl implements PathItems {
      * @param localStringPath should contain value 'localStringPath'
      * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getAllWithValuesAsync(String localStringPath, String pathItemStringPath) {
+    public Single<RestResponse<Void, Void>> getAllWithValuesWithRestResponseAsync(String localStringPath, String pathItemStringPath) {
         if (localStringPath == null) {
             throw new IllegalArgumentException("Parameter localStringPath is required and cannot be null.");
         }
@@ -135,11 +137,25 @@ public class PathItemsImpl implements PathItems {
      *
      * @param localStringPath should contain value 'localStringPath'
      * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getAllWithValuesAsync(String localStringPath, String pathItemStringPath) {
+        return getAllWithValuesWithRestResponseAsync(localStringPath, pathItemStringPath)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
+
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
      * @param localStringQuery should contain value 'localStringQuery'
      * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getAllWithValues(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
         getAllWithValuesAsync(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery).toBlocking().value();
@@ -156,7 +172,7 @@ public class PathItemsImpl implements PathItems {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getAllWithValuesAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getAllWithValuesAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getAllWithValuesAsync(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery), serviceCallback);
     }
 
@@ -168,9 +184,9 @@ public class PathItemsImpl implements PathItems {
      * @param localStringQuery should contain value 'localStringQuery'
      * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getAllWithValuesAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
+    public Single<RestResponse<Void, Void>> getAllWithValuesWithRestResponseAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
         if (localStringPath == null) {
             throw new IllegalArgumentException("Parameter localStringPath is required and cannot be null.");
         }
@@ -183,6 +199,21 @@ public class PathItemsImpl implements PathItems {
         return service.getAllWithValues(localStringPath, pathItemStringPath, this.client.globalStringPath(), localStringQuery, pathItemStringQuery, this.client.globalStringQuery());
     }
 
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @param localStringQuery should contain value 'localStringQuery'
+     * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getAllWithValuesAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
+        return getAllWithValuesWithRestResponseAsync(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
+
 
     /**
      * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
@@ -192,6 +223,7 @@ public class PathItemsImpl implements PathItems {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getGlobalQueryNull(String localStringPath, String pathItemStringPath) {
         getGlobalQueryNullAsync(localStringPath, pathItemStringPath).toBlocking().value();
@@ -206,7 +238,7 @@ public class PathItemsImpl implements PathItems {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getGlobalQueryNullAsync(String localStringPath, String pathItemStringPath, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getGlobalQueryNullAsync(String localStringPath, String pathItemStringPath, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getGlobalQueryNullAsync(localStringPath, pathItemStringPath), serviceCallback);
     }
 
@@ -216,9 +248,9 @@ public class PathItemsImpl implements PathItems {
      * @param localStringPath should contain value 'localStringPath'
      * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getGlobalQueryNullAsync(String localStringPath, String pathItemStringPath) {
+    public Single<RestResponse<Void, Void>> getGlobalQueryNullWithRestResponseAsync(String localStringPath, String pathItemStringPath) {
         if (localStringPath == null) {
             throw new IllegalArgumentException("Parameter localStringPath is required and cannot be null.");
         }
@@ -238,11 +270,25 @@ public class PathItemsImpl implements PathItems {
      *
      * @param localStringPath should contain value 'localStringPath'
      * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getGlobalQueryNullAsync(String localStringPath, String pathItemStringPath) {
+        return getGlobalQueryNullWithRestResponseAsync(localStringPath, pathItemStringPath)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
+
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
      * @param localStringQuery should contain value 'localStringQuery'
      * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getGlobalQueryNull(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
         getGlobalQueryNullAsync(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery).toBlocking().value();
@@ -259,7 +305,7 @@ public class PathItemsImpl implements PathItems {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getGlobalQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getGlobalQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getGlobalQueryNullAsync(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery), serviceCallback);
     }
 
@@ -271,9 +317,9 @@ public class PathItemsImpl implements PathItems {
      * @param localStringQuery should contain value 'localStringQuery'
      * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getGlobalQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
+    public Single<RestResponse<Void, Void>> getGlobalQueryNullWithRestResponseAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
         if (localStringPath == null) {
             throw new IllegalArgumentException("Parameter localStringPath is required and cannot be null.");
         }
@@ -286,6 +332,21 @@ public class PathItemsImpl implements PathItems {
         return service.getGlobalQueryNull(localStringPath, pathItemStringPath, this.client.globalStringPath(), localStringQuery, pathItemStringQuery, this.client.globalStringQuery());
     }
 
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @param localStringQuery should contain value 'localStringQuery'
+     * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getGlobalQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
+        return getGlobalQueryNullWithRestResponseAsync(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
+
 
     /**
      * send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery=null.
@@ -295,6 +356,7 @@ public class PathItemsImpl implements PathItems {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getGlobalAndLocalQueryNull(String localStringPath, String pathItemStringPath) {
         getGlobalAndLocalQueryNullAsync(localStringPath, pathItemStringPath).toBlocking().value();
@@ -309,7 +371,7 @@ public class PathItemsImpl implements PathItems {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getGlobalAndLocalQueryNullAsync(String localStringPath, String pathItemStringPath, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getGlobalAndLocalQueryNullAsync(String localStringPath, String pathItemStringPath, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getGlobalAndLocalQueryNullAsync(localStringPath, pathItemStringPath), serviceCallback);
     }
 
@@ -319,9 +381,9 @@ public class PathItemsImpl implements PathItems {
      * @param localStringPath should contain value 'localStringPath'
      * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getGlobalAndLocalQueryNullAsync(String localStringPath, String pathItemStringPath) {
+    public Single<RestResponse<Void, Void>> getGlobalAndLocalQueryNullWithRestResponseAsync(String localStringPath, String pathItemStringPath) {
         if (localStringPath == null) {
             throw new IllegalArgumentException("Parameter localStringPath is required and cannot be null.");
         }
@@ -341,11 +403,25 @@ public class PathItemsImpl implements PathItems {
      *
      * @param localStringPath should contain value 'localStringPath'
      * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getGlobalAndLocalQueryNullAsync(String localStringPath, String pathItemStringPath) {
+        return getGlobalAndLocalQueryNullWithRestResponseAsync(localStringPath, pathItemStringPath)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
+
+    /**
+     * send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery=null.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
      * @param localStringQuery should contain null value
      * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getGlobalAndLocalQueryNull(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
         getGlobalAndLocalQueryNullAsync(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery).toBlocking().value();
@@ -362,7 +438,7 @@ public class PathItemsImpl implements PathItems {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getGlobalAndLocalQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getGlobalAndLocalQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getGlobalAndLocalQueryNullAsync(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery), serviceCallback);
     }
 
@@ -374,9 +450,9 @@ public class PathItemsImpl implements PathItems {
      * @param localStringQuery should contain null value
      * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getGlobalAndLocalQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
+    public Single<RestResponse<Void, Void>> getGlobalAndLocalQueryNullWithRestResponseAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
         if (localStringPath == null) {
             throw new IllegalArgumentException("Parameter localStringPath is required and cannot be null.");
         }
@@ -389,6 +465,21 @@ public class PathItemsImpl implements PathItems {
         return service.getGlobalAndLocalQueryNull(localStringPath, pathItemStringPath, this.client.globalStringPath(), localStringQuery, pathItemStringQuery, this.client.globalStringQuery());
     }
 
+    /**
+     * send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery=null.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @param localStringQuery should contain null value
+     * @param pathItemStringQuery A string value 'pathItemStringQuery' that appears as a query parameter
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getGlobalAndLocalQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
+        return getGlobalAndLocalQueryNullWithRestResponseAsync(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
+
 
     /**
      * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null, localStringQuery=null.
@@ -398,6 +489,7 @@ public class PathItemsImpl implements PathItems {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getLocalPathItemQueryNull(String localStringPath, String pathItemStringPath) {
         getLocalPathItemQueryNullAsync(localStringPath, pathItemStringPath).toBlocking().value();
@@ -412,7 +504,7 @@ public class PathItemsImpl implements PathItems {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getLocalPathItemQueryNullAsync(String localStringPath, String pathItemStringPath, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getLocalPathItemQueryNullAsync(String localStringPath, String pathItemStringPath, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getLocalPathItemQueryNullAsync(localStringPath, pathItemStringPath), serviceCallback);
     }
 
@@ -422,9 +514,9 @@ public class PathItemsImpl implements PathItems {
      * @param localStringPath should contain value 'localStringPath'
      * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getLocalPathItemQueryNullAsync(String localStringPath, String pathItemStringPath) {
+    public Single<RestResponse<Void, Void>> getLocalPathItemQueryNullWithRestResponseAsync(String localStringPath, String pathItemStringPath) {
         if (localStringPath == null) {
             throw new IllegalArgumentException("Parameter localStringPath is required and cannot be null.");
         }
@@ -444,11 +536,25 @@ public class PathItemsImpl implements PathItems {
      *
      * @param localStringPath should contain value 'localStringPath'
      * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getLocalPathItemQueryNullAsync(String localStringPath, String pathItemStringPath) {
+        return getLocalPathItemQueryNullWithRestResponseAsync(localStringPath, pathItemStringPath)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
+
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null, localStringQuery=null.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
      * @param localStringQuery should contain value null
      * @param pathItemStringQuery should contain value null
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getLocalPathItemQueryNull(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
         getLocalPathItemQueryNullAsync(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery).toBlocking().value();
@@ -465,7 +571,7 @@ public class PathItemsImpl implements PathItems {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getLocalPathItemQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getLocalPathItemQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getLocalPathItemQueryNullAsync(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery), serviceCallback);
     }
 
@@ -477,9 +583,9 @@ public class PathItemsImpl implements PathItems {
      * @param localStringQuery should contain value null
      * @param pathItemStringQuery should contain value null
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getLocalPathItemQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
+    public Single<RestResponse<Void, Void>> getLocalPathItemQueryNullWithRestResponseAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
         if (localStringPath == null) {
             throw new IllegalArgumentException("Parameter localStringPath is required and cannot be null.");
         }
@@ -491,6 +597,21 @@ public class PathItemsImpl implements PathItems {
         }
         return service.getLocalPathItemQueryNull(localStringPath, pathItemStringPath, this.client.globalStringPath(), localStringQuery, pathItemStringQuery, this.client.globalStringQuery());
     }
+
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null, localStringQuery=null.
+     *
+     * @param localStringPath should contain value 'localStringPath'
+     * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+     * @param localStringQuery should contain value null
+     * @param pathItemStringQuery should contain value null
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getLocalPathItemQueryNullAsync(String localStringPath, String pathItemStringPath, String localStringQuery, String pathItemStringQuery) {
+        return getLocalPathItemQueryNullWithRestResponseAsync(localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/url/implementation/PathsImpl.java
+++ b/test/vanilla/src/main/java/fixtures/url/implementation/PathsImpl.java
@@ -11,6 +11,7 @@
 package fixtures.url.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.url.Paths;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.ExpectedResponses;
@@ -67,157 +68,157 @@ public class PathsImpl implements Paths {
         @GET("paths/bool/true/{boolPath}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getBooleanTrue(@PathParam("boolPath") boolean boolPath);
+        Single<RestResponse<Void, Void>> getBooleanTrue(@PathParam("boolPath") boolean boolPath);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Paths getBooleanFalse" })
         @GET("paths/bool/false/{boolPath}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getBooleanFalse(@PathParam("boolPath") boolean boolPath);
+        Single<RestResponse<Void, Void>> getBooleanFalse(@PathParam("boolPath") boolean boolPath);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Paths getIntOneMillion" })
         @GET("paths/int/1000000/{intPath}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getIntOneMillion(@PathParam("intPath") int intPath);
+        Single<RestResponse<Void, Void>> getIntOneMillion(@PathParam("intPath") int intPath);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Paths getIntNegativeOneMillion" })
         @GET("paths/int/-1000000/{intPath}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getIntNegativeOneMillion(@PathParam("intPath") int intPath);
+        Single<RestResponse<Void, Void>> getIntNegativeOneMillion(@PathParam("intPath") int intPath);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Paths getTenBillion" })
         @GET("paths/long/10000000000/{longPath}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getTenBillion(@PathParam("longPath") long longPath);
+        Single<RestResponse<Void, Void>> getTenBillion(@PathParam("longPath") long longPath);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Paths getNegativeTenBillion" })
         @GET("paths/long/-10000000000/{longPath}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getNegativeTenBillion(@PathParam("longPath") long longPath);
+        Single<RestResponse<Void, Void>> getNegativeTenBillion(@PathParam("longPath") long longPath);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Paths floatScientificPositive" })
         @GET("paths/float/1.034E+20/{floatPath}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> floatScientificPositive(@PathParam("floatPath") double floatPath);
+        Single<RestResponse<Void, Void>> floatScientificPositive(@PathParam("floatPath") double floatPath);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Paths floatScientificNegative" })
         @GET("paths/float/-1.034E-20/{floatPath}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> floatScientificNegative(@PathParam("floatPath") double floatPath);
+        Single<RestResponse<Void, Void>> floatScientificNegative(@PathParam("floatPath") double floatPath);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Paths doubleDecimalPositive" })
         @GET("paths/double/9999999.999/{doublePath}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> doubleDecimalPositive(@PathParam("doublePath") double doublePath);
+        Single<RestResponse<Void, Void>> doubleDecimalPositive(@PathParam("doublePath") double doublePath);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Paths doubleDecimalNegative" })
         @GET("paths/double/-9999999.999/{doublePath}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> doubleDecimalNegative(@PathParam("doublePath") double doublePath);
+        Single<RestResponse<Void, Void>> doubleDecimalNegative(@PathParam("doublePath") double doublePath);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Paths stringUnicode" })
         @GET("paths/string/unicode/{stringPath}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> stringUnicode(@PathParam("stringPath") String stringPath);
+        Single<RestResponse<Void, Void>> stringUnicode(@PathParam("stringPath") String stringPath);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Paths stringUrlEncoded" })
         @GET("paths/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend/{stringPath}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> stringUrlEncoded(@PathParam("stringPath") String stringPath);
+        Single<RestResponse<Void, Void>> stringUrlEncoded(@PathParam("stringPath") String stringPath);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Paths stringEmpty" })
         @GET("paths/string/empty/{stringPath}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> stringEmpty(@PathParam("stringPath") String stringPath);
+        Single<RestResponse<Void, Void>> stringEmpty(@PathParam("stringPath") String stringPath);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Paths stringNull" })
         @GET("paths/string/null/{stringPath}")
         @ExpectedResponses({400})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> stringNull(@PathParam("stringPath") String stringPath);
+        Single<RestResponse<Void, Void>> stringNull(@PathParam("stringPath") String stringPath);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Paths enumValid" })
         @GET("paths/enum/green%20color/{enumPath}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> enumValid(@PathParam("enumPath") UriColor enumPath);
+        Single<RestResponse<Void, Void>> enumValid(@PathParam("enumPath") UriColor enumPath);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Paths enumNull" })
         @GET("paths/string/null/{enumPath}")
         @ExpectedResponses({400})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> enumNull(@PathParam("enumPath") UriColor enumPath);
+        Single<RestResponse<Void, Void>> enumNull(@PathParam("enumPath") UriColor enumPath);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Paths byteMultiByte" })
         @GET("paths/byte/multibyte/{bytePath}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> byteMultiByte(@PathParam("bytePath") String bytePath);
+        Single<RestResponse<Void, Void>> byteMultiByte(@PathParam("bytePath") String bytePath);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Paths byteEmpty" })
         @GET("paths/byte/empty/{bytePath}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> byteEmpty(@PathParam("bytePath") String bytePath);
+        Single<RestResponse<Void, Void>> byteEmpty(@PathParam("bytePath") String bytePath);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Paths byteNull" })
         @GET("paths/byte/null/{bytePath}")
         @ExpectedResponses({400})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> byteNull(@PathParam("bytePath") String bytePath);
+        Single<RestResponse<Void, Void>> byteNull(@PathParam("bytePath") String bytePath);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Paths dateValid" })
         @GET("paths/date/2012-01-01/{datePath}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> dateValid(@PathParam("datePath") LocalDate datePath);
+        Single<RestResponse<Void, Void>> dateValid(@PathParam("datePath") LocalDate datePath);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Paths dateNull" })
         @GET("paths/date/null/{datePath}")
         @ExpectedResponses({400})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> dateNull(@PathParam("datePath") LocalDate datePath);
+        Single<RestResponse<Void, Void>> dateNull(@PathParam("datePath") LocalDate datePath);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Paths dateTimeValid" })
         @GET("paths/datetime/2012-01-01T01%3A01%3A01Z/{dateTimePath}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> dateTimeValid(@PathParam("dateTimePath") DateTime dateTimePath);
+        Single<RestResponse<Void, Void>> dateTimeValid(@PathParam("dateTimePath") DateTime dateTimePath);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Paths dateTimeNull" })
         @GET("paths/datetime/null/{dateTimePath}")
         @ExpectedResponses({400})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> dateTimeNull(@PathParam("dateTimePath") DateTime dateTimePath);
+        Single<RestResponse<Void, Void>> dateTimeNull(@PathParam("dateTimePath") DateTime dateTimePath);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Paths base64Url" })
         @GET("paths/string/bG9yZW0/{base64UrlPath}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> base64Url(@PathParam("base64UrlPath") Base64Url base64UrlPath);
+        Single<RestResponse<Void, Void>> base64Url(@PathParam("base64UrlPath") Base64Url base64UrlPath);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Paths arrayCsvInPath" })
         @GET("paths/array/ArrayPath1%2cbegin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend%2c%2c/{arrayPath}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> arrayCsvInPath(@PathParam("arrayPath") String arrayPath);
+        Single<RestResponse<Void, Void>> arrayCsvInPath(@PathParam("arrayPath") String arrayPath);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Paths unixTimeUrl" })
         @GET("paths/int/1460505600/{unixTimeUrlPath}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> unixTimeUrl(@PathParam("unixTimeUrlPath") long unixTimeUrlPath);
+        Single<RestResponse<Void, Void>> unixTimeUrl(@PathParam("unixTimeUrlPath") long unixTimeUrlPath);
 
     }
 
@@ -227,6 +228,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getBooleanTrue() {
         getBooleanTrueAsync().toBlocking().value();
@@ -239,7 +241,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getBooleanTrueAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getBooleanTrueAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getBooleanTrueAsync(), serviceCallback);
     }
 
@@ -247,12 +249,23 @@ public class PathsImpl implements Paths {
      * Get true Boolean value on path.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getBooleanTrueAsync() {
+    public Single<RestResponse<Void, Void>> getBooleanTrueWithRestResponseAsync() {
         final boolean boolPath = true;
         return service.getBooleanTrue(boolPath);
     }
+
+    /**
+     * Get true Boolean value on path.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getBooleanTrueAsync() {
+        return getBooleanTrueWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -261,6 +274,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getBooleanFalse() {
         getBooleanFalseAsync().toBlocking().value();
@@ -273,7 +287,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getBooleanFalseAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getBooleanFalseAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getBooleanFalseAsync(), serviceCallback);
     }
 
@@ -281,12 +295,23 @@ public class PathsImpl implements Paths {
      * Get false Boolean value on path.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getBooleanFalseAsync() {
+    public Single<RestResponse<Void, Void>> getBooleanFalseWithRestResponseAsync() {
         final boolean boolPath = false;
         return service.getBooleanFalse(boolPath);
     }
+
+    /**
+     * Get false Boolean value on path.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getBooleanFalseAsync() {
+        return getBooleanFalseWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -295,6 +320,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getIntOneMillion() {
         getIntOneMillionAsync().toBlocking().value();
@@ -307,7 +333,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getIntOneMillionAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getIntOneMillionAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getIntOneMillionAsync(), serviceCallback);
     }
 
@@ -315,12 +341,23 @@ public class PathsImpl implements Paths {
      * Get '1000000' integer value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getIntOneMillionAsync() {
+    public Single<RestResponse<Void, Void>> getIntOneMillionWithRestResponseAsync() {
         final int intPath = 1000000;
         return service.getIntOneMillion(intPath);
     }
+
+    /**
+     * Get '1000000' integer value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getIntOneMillionAsync() {
+        return getIntOneMillionWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -329,6 +366,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getIntNegativeOneMillion() {
         getIntNegativeOneMillionAsync().toBlocking().value();
@@ -341,7 +379,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getIntNegativeOneMillionAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getIntNegativeOneMillionAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getIntNegativeOneMillionAsync(), serviceCallback);
     }
 
@@ -349,12 +387,23 @@ public class PathsImpl implements Paths {
      * Get '-1000000' integer value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getIntNegativeOneMillionAsync() {
+    public Single<RestResponse<Void, Void>> getIntNegativeOneMillionWithRestResponseAsync() {
         final int intPath = -1000000;
         return service.getIntNegativeOneMillion(intPath);
     }
+
+    /**
+     * Get '-1000000' integer value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getIntNegativeOneMillionAsync() {
+        return getIntNegativeOneMillionWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -363,6 +412,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getTenBillion() {
         getTenBillionAsync().toBlocking().value();
@@ -375,7 +425,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getTenBillionAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getTenBillionAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getTenBillionAsync(), serviceCallback);
     }
 
@@ -383,12 +433,23 @@ public class PathsImpl implements Paths {
      * Get '10000000000' 64 bit integer value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getTenBillionAsync() {
+    public Single<RestResponse<Void, Void>> getTenBillionWithRestResponseAsync() {
         final long longPath = 10000000000L;
         return service.getTenBillion(longPath);
     }
+
+    /**
+     * Get '10000000000' 64 bit integer value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getTenBillionAsync() {
+        return getTenBillionWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -397,6 +458,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getNegativeTenBillion() {
         getNegativeTenBillionAsync().toBlocking().value();
@@ -409,7 +471,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getNegativeTenBillionAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getNegativeTenBillionAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getNegativeTenBillionAsync(), serviceCallback);
     }
 
@@ -417,12 +479,23 @@ public class PathsImpl implements Paths {
      * Get '-10000000000' 64 bit integer value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getNegativeTenBillionAsync() {
+    public Single<RestResponse<Void, Void>> getNegativeTenBillionWithRestResponseAsync() {
         final long longPath = -10000000000L;
         return service.getNegativeTenBillion(longPath);
     }
+
+    /**
+     * Get '-10000000000' 64 bit integer value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getNegativeTenBillionAsync() {
+        return getNegativeTenBillionWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -431,6 +504,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void floatScientificPositive() {
         floatScientificPositiveAsync().toBlocking().value();
@@ -443,7 +517,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> floatScientificPositiveAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> floatScientificPositiveAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(floatScientificPositiveAsync(), serviceCallback);
     }
 
@@ -451,12 +525,23 @@ public class PathsImpl implements Paths {
      * Get '1.034E+20' numeric value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> floatScientificPositiveAsync() {
+    public Single<RestResponse<Void, Void>> floatScientificPositiveWithRestResponseAsync() {
         final double floatPath = 1.034E+20;
         return service.floatScientificPositive(floatPath);
     }
+
+    /**
+     * Get '1.034E+20' numeric value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> floatScientificPositiveAsync() {
+        return floatScientificPositiveWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -465,6 +550,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void floatScientificNegative() {
         floatScientificNegativeAsync().toBlocking().value();
@@ -477,7 +563,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> floatScientificNegativeAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> floatScientificNegativeAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(floatScientificNegativeAsync(), serviceCallback);
     }
 
@@ -485,12 +571,23 @@ public class PathsImpl implements Paths {
      * Get '-1.034E-20' numeric value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> floatScientificNegativeAsync() {
+    public Single<RestResponse<Void, Void>> floatScientificNegativeWithRestResponseAsync() {
         final double floatPath = -1.034E-20;
         return service.floatScientificNegative(floatPath);
     }
+
+    /**
+     * Get '-1.034E-20' numeric value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> floatScientificNegativeAsync() {
+        return floatScientificNegativeWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -499,6 +596,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void doubleDecimalPositive() {
         doubleDecimalPositiveAsync().toBlocking().value();
@@ -511,7 +609,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> doubleDecimalPositiveAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> doubleDecimalPositiveAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(doubleDecimalPositiveAsync(), serviceCallback);
     }
 
@@ -519,12 +617,23 @@ public class PathsImpl implements Paths {
      * Get '9999999.999' numeric value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> doubleDecimalPositiveAsync() {
+    public Single<RestResponse<Void, Void>> doubleDecimalPositiveWithRestResponseAsync() {
         final double doublePath = 9999999.999;
         return service.doubleDecimalPositive(doublePath);
     }
+
+    /**
+     * Get '9999999.999' numeric value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> doubleDecimalPositiveAsync() {
+        return doubleDecimalPositiveWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -533,6 +642,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void doubleDecimalNegative() {
         doubleDecimalNegativeAsync().toBlocking().value();
@@ -545,7 +655,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> doubleDecimalNegativeAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> doubleDecimalNegativeAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(doubleDecimalNegativeAsync(), serviceCallback);
     }
 
@@ -553,12 +663,23 @@ public class PathsImpl implements Paths {
      * Get '-9999999.999' numeric value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> doubleDecimalNegativeAsync() {
+    public Single<RestResponse<Void, Void>> doubleDecimalNegativeWithRestResponseAsync() {
         final double doublePath = -9999999.999;
         return service.doubleDecimalNegative(doublePath);
     }
+
+    /**
+     * Get '-9999999.999' numeric value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> doubleDecimalNegativeAsync() {
+        return doubleDecimalNegativeWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -567,6 +688,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void stringUnicode() {
         stringUnicodeAsync().toBlocking().value();
@@ -579,7 +701,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> stringUnicodeAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> stringUnicodeAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(stringUnicodeAsync(), serviceCallback);
     }
 
@@ -587,12 +709,23 @@ public class PathsImpl implements Paths {
      * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> stringUnicodeAsync() {
+    public Single<RestResponse<Void, Void>> stringUnicodeWithRestResponseAsync() {
         final String stringPath = "啊齄丂狛狜隣郎隣兀﨩";
         return service.stringUnicode(stringPath);
     }
+
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> stringUnicodeAsync() {
+        return stringUnicodeWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -601,6 +734,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void stringUrlEncoded() {
         stringUrlEncodedAsync().toBlocking().value();
@@ -613,7 +747,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> stringUrlEncodedAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> stringUrlEncodedAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(stringUrlEncodedAsync(), serviceCallback);
     }
 
@@ -621,12 +755,23 @@ public class PathsImpl implements Paths {
      * Get 'begin!*'();:@ &amp;=+$,/?#[]end.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> stringUrlEncodedAsync() {
+    public Single<RestResponse<Void, Void>> stringUrlEncodedWithRestResponseAsync() {
         final String stringPath = "begin!*'();:@ &=+$,/?#[]end";
         return service.stringUrlEncoded(stringPath);
     }
+
+    /**
+     * Get 'begin!*'();:@ &amp;=+$,/?#[]end.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> stringUrlEncodedAsync() {
+        return stringUrlEncodedWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -635,6 +780,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void stringEmpty() {
         stringEmptyAsync().toBlocking().value();
@@ -647,7 +793,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> stringEmptyAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> stringEmptyAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(stringEmptyAsync(), serviceCallback);
     }
 
@@ -655,12 +801,23 @@ public class PathsImpl implements Paths {
      * Get ''.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> stringEmptyAsync() {
+    public Single<RestResponse<Void, Void>> stringEmptyWithRestResponseAsync() {
         final String stringPath = "";
         return service.stringEmpty(stringPath);
     }
+
+    /**
+     * Get ''.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> stringEmptyAsync() {
+        return stringEmptyWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -670,6 +827,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void stringNull(String stringPath) {
         stringNullAsync(stringPath).toBlocking().value();
@@ -683,7 +841,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> stringNullAsync(String stringPath, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> stringNullAsync(String stringPath, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(stringNullAsync(stringPath), serviceCallback);
     }
 
@@ -692,14 +850,26 @@ public class PathsImpl implements Paths {
      *
      * @param stringPath null string value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> stringNullAsync(String stringPath) {
+    public Single<RestResponse<Void, Void>> stringNullWithRestResponseAsync(String stringPath) {
         if (stringPath == null) {
             throw new IllegalArgumentException("Parameter stringPath is required and cannot be null.");
         }
         return service.stringNull(stringPath);
     }
+
+    /**
+     * Get null (should throw).
+     *
+     * @param stringPath null string value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> stringNullAsync(String stringPath) {
+        return stringNullWithRestResponseAsync(stringPath)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -709,6 +879,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void enumValid(UriColor enumPath) {
         enumValidAsync(enumPath).toBlocking().value();
@@ -722,7 +893,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> enumValidAsync(UriColor enumPath, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> enumValidAsync(UriColor enumPath, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(enumValidAsync(enumPath), serviceCallback);
     }
 
@@ -731,14 +902,26 @@ public class PathsImpl implements Paths {
      *
      * @param enumPath send the value green. Possible values include: 'red color', 'green color', 'blue color'
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> enumValidAsync(UriColor enumPath) {
+    public Single<RestResponse<Void, Void>> enumValidWithRestResponseAsync(UriColor enumPath) {
         if (enumPath == null) {
             throw new IllegalArgumentException("Parameter enumPath is required and cannot be null.");
         }
         return service.enumValid(enumPath);
     }
+
+    /**
+     * Get using uri with 'green color' in path parameter.
+     *
+     * @param enumPath send the value green. Possible values include: 'red color', 'green color', 'blue color'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> enumValidAsync(UriColor enumPath) {
+        return enumValidWithRestResponseAsync(enumPath)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -748,6 +931,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void enumNull(UriColor enumPath) {
         enumNullAsync(enumPath).toBlocking().value();
@@ -761,7 +945,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> enumNullAsync(UriColor enumPath, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> enumNullAsync(UriColor enumPath, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(enumNullAsync(enumPath), serviceCallback);
     }
 
@@ -770,14 +954,26 @@ public class PathsImpl implements Paths {
      *
      * @param enumPath send null should throw. Possible values include: 'red color', 'green color', 'blue color'
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> enumNullAsync(UriColor enumPath) {
+    public Single<RestResponse<Void, Void>> enumNullWithRestResponseAsync(UriColor enumPath) {
         if (enumPath == null) {
             throw new IllegalArgumentException("Parameter enumPath is required and cannot be null.");
         }
         return service.enumNull(enumPath);
     }
+
+    /**
+     * Get null (should throw on the client before the request is sent on wire).
+     *
+     * @param enumPath send null should throw. Possible values include: 'red color', 'green color', 'blue color'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> enumNullAsync(UriColor enumPath) {
+        return enumNullWithRestResponseAsync(enumPath)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -787,6 +983,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void byteMultiByte(byte[] bytePath) {
         byteMultiByteAsync(bytePath).toBlocking().value();
@@ -800,7 +997,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> byteMultiByteAsync(byte[] bytePath, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> byteMultiByteAsync(byte[] bytePath, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(byteMultiByteAsync(bytePath), serviceCallback);
     }
 
@@ -809,15 +1006,27 @@ public class PathsImpl implements Paths {
      *
      * @param bytePath '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> byteMultiByteAsync(byte[] bytePath) {
+    public Single<RestResponse<Void, Void>> byteMultiByteWithRestResponseAsync(byte[] bytePath) {
         if (bytePath == null) {
             throw new IllegalArgumentException("Parameter bytePath is required and cannot be null.");
         }
-        String bytePathConverted = Base64.encodeBase64String(bytePath);
+    String bytePathConverted = Base64.encodeBase64String(bytePath);
         return service.byteMultiByte(bytePathConverted);
     }
+
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
+     *
+     * @param bytePath '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> byteMultiByteAsync(byte[] bytePath) {
+        return byteMultiByteWithRestResponseAsync(bytePath)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -826,6 +1035,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void byteEmpty() {
         byteEmptyAsync().toBlocking().value();
@@ -838,7 +1048,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> byteEmptyAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> byteEmptyAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(byteEmptyAsync(), serviceCallback);
     }
 
@@ -846,13 +1056,24 @@ public class PathsImpl implements Paths {
      * Get '' as byte array.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> byteEmptyAsync() {
+    public Single<RestResponse<Void, Void>> byteEmptyWithRestResponseAsync() {
         final byte[] bytePath = "".getBytes();
-        String bytePathConverted = Base64.encodeBase64String(bytePath);
+    String bytePathConverted = Base64.encodeBase64String(bytePath);
         return service.byteEmpty(bytePathConverted);
     }
+
+    /**
+     * Get '' as byte array.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> byteEmptyAsync() {
+        return byteEmptyWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -862,6 +1083,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void byteNull(byte[] bytePath) {
         byteNullAsync(bytePath).toBlocking().value();
@@ -875,7 +1097,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> byteNullAsync(byte[] bytePath, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> byteNullAsync(byte[] bytePath, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(byteNullAsync(bytePath), serviceCallback);
     }
 
@@ -884,15 +1106,27 @@ public class PathsImpl implements Paths {
      *
      * @param bytePath null as byte array (should throw)
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> byteNullAsync(byte[] bytePath) {
+    public Single<RestResponse<Void, Void>> byteNullWithRestResponseAsync(byte[] bytePath) {
         if (bytePath == null) {
             throw new IllegalArgumentException("Parameter bytePath is required and cannot be null.");
         }
-        String bytePathConverted = Base64.encodeBase64String(bytePath);
+    String bytePathConverted = Base64.encodeBase64String(bytePath);
         return service.byteNull(bytePathConverted);
     }
+
+    /**
+     * Get null as byte array (should throw).
+     *
+     * @param bytePath null as byte array (should throw)
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> byteNullAsync(byte[] bytePath) {
+        return byteNullWithRestResponseAsync(bytePath)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -901,6 +1135,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void dateValid() {
         dateValidAsync().toBlocking().value();
@@ -913,7 +1148,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> dateValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> dateValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(dateValidAsync(), serviceCallback);
     }
 
@@ -921,12 +1156,23 @@ public class PathsImpl implements Paths {
      * Get '2012-01-01' as date.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> dateValidAsync() {
+    public Single<RestResponse<Void, Void>> dateValidWithRestResponseAsync() {
         final LocalDate datePath = LocalDate.parse("2012-01-01");
         return service.dateValid(datePath);
     }
+
+    /**
+     * Get '2012-01-01' as date.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> dateValidAsync() {
+        return dateValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -936,6 +1182,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void dateNull(LocalDate datePath) {
         dateNullAsync(datePath).toBlocking().value();
@@ -949,7 +1196,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> dateNullAsync(LocalDate datePath, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> dateNullAsync(LocalDate datePath, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(dateNullAsync(datePath), serviceCallback);
     }
 
@@ -958,14 +1205,26 @@ public class PathsImpl implements Paths {
      *
      * @param datePath null as date (should throw)
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> dateNullAsync(LocalDate datePath) {
+    public Single<RestResponse<Void, Void>> dateNullWithRestResponseAsync(LocalDate datePath) {
         if (datePath == null) {
             throw new IllegalArgumentException("Parameter datePath is required and cannot be null.");
         }
         return service.dateNull(datePath);
     }
+
+    /**
+     * Get null as date - this should throw or be unusable on the client side, depending on date representation.
+     *
+     * @param datePath null as date (should throw)
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> dateNullAsync(LocalDate datePath) {
+        return dateNullWithRestResponseAsync(datePath)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -974,6 +1233,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void dateTimeValid() {
         dateTimeValidAsync().toBlocking().value();
@@ -986,7 +1246,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> dateTimeValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> dateTimeValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(dateTimeValidAsync(), serviceCallback);
     }
 
@@ -994,12 +1254,23 @@ public class PathsImpl implements Paths {
      * Get '2012-01-01T01:01:01Z' as date-time.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> dateTimeValidAsync() {
+    public Single<RestResponse<Void, Void>> dateTimeValidWithRestResponseAsync() {
         final DateTime dateTimePath = DateTime.parse("2012-01-01T01:01:01Z");
         return service.dateTimeValid(dateTimePath);
     }
+
+    /**
+     * Get '2012-01-01T01:01:01Z' as date-time.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> dateTimeValidAsync() {
+        return dateTimeValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1009,6 +1280,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void dateTimeNull(DateTime dateTimePath) {
         dateTimeNullAsync(dateTimePath).toBlocking().value();
@@ -1022,7 +1294,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> dateTimeNullAsync(DateTime dateTimePath, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> dateTimeNullAsync(DateTime dateTimePath, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(dateTimeNullAsync(dateTimePath), serviceCallback);
     }
 
@@ -1031,14 +1303,26 @@ public class PathsImpl implements Paths {
      *
      * @param dateTimePath null as date-time
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> dateTimeNullAsync(DateTime dateTimePath) {
+    public Single<RestResponse<Void, Void>> dateTimeNullWithRestResponseAsync(DateTime dateTimePath) {
         if (dateTimePath == null) {
             throw new IllegalArgumentException("Parameter dateTimePath is required and cannot be null.");
         }
         return service.dateTimeNull(dateTimePath);
     }
+
+    /**
+     * Get null as date-time, should be disallowed or throw depending on representation of date-time.
+     *
+     * @param dateTimePath null as date-time
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> dateTimeNullAsync(DateTime dateTimePath) {
+        return dateTimeNullWithRestResponseAsync(dateTimePath)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1048,6 +1332,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void base64Url(byte[] base64UrlPath) {
         base64UrlAsync(base64UrlPath).toBlocking().value();
@@ -1061,7 +1346,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> base64UrlAsync(byte[] base64UrlPath, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> base64UrlAsync(byte[] base64UrlPath, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(base64UrlAsync(base64UrlPath), serviceCallback);
     }
 
@@ -1070,15 +1355,27 @@ public class PathsImpl implements Paths {
      *
      * @param base64UrlPath base64url encoded value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> base64UrlAsync(byte[] base64UrlPath) {
+    public Single<RestResponse<Void, Void>> base64UrlWithRestResponseAsync(byte[] base64UrlPath) {
         if (base64UrlPath == null) {
             throw new IllegalArgumentException("Parameter base64UrlPath is required and cannot be null.");
         }
-        Base64Url base64UrlPathConverted = Base64Url.encode(base64UrlPath);
+    Base64Url base64UrlPathConverted = Base64Url.encode(base64UrlPath);
         return service.base64Url(base64UrlPathConverted);
     }
+
+    /**
+     * Get 'lorem' encoded value as 'bG9yZW0' (base64url).
+     *
+     * @param base64UrlPath base64url encoded value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> base64UrlAsync(byte[] base64UrlPath) {
+        return base64UrlWithRestResponseAsync(base64UrlPath)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1088,6 +1385,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void arrayCsvInPath(List<String> arrayPath) {
         arrayCsvInPathAsync(arrayPath).toBlocking().value();
@@ -1101,7 +1399,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> arrayCsvInPathAsync(List<String> arrayPath, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> arrayCsvInPathAsync(List<String> arrayPath, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(arrayCsvInPathAsync(arrayPath), serviceCallback);
     }
 
@@ -1110,16 +1408,28 @@ public class PathsImpl implements Paths {
      *
      * @param arrayPath an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> arrayCsvInPathAsync(List<String> arrayPath) {
+    public Single<RestResponse<Void, Void>> arrayCsvInPathWithRestResponseAsync(List<String> arrayPath) {
         if (arrayPath == null) {
             throw new IllegalArgumentException("Parameter arrayPath is required and cannot be null.");
         }
         Validator.validate(arrayPath);
-        String arrayPathConverted = this.client.serializerAdapter().serializeList(arrayPath, CollectionFormat.CSV);
+    String arrayPathConverted = this.client.serializerAdapter().serializeList(arrayPath, CollectionFormat.CSV);
         return service.arrayCsvInPath(arrayPathConverted);
     }
+
+    /**
+     * Get an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
+     *
+     * @param arrayPath an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> arrayCsvInPathAsync(List<String> arrayPath) {
+        return arrayCsvInPathWithRestResponseAsync(arrayPath)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1129,6 +1439,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void unixTimeUrl(DateTime unixTimeUrlPath) {
         unixTimeUrlAsync(unixTimeUrlPath).toBlocking().value();
@@ -1142,7 +1453,7 @@ public class PathsImpl implements Paths {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> unixTimeUrlAsync(DateTime unixTimeUrlPath, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> unixTimeUrlAsync(DateTime unixTimeUrlPath, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(unixTimeUrlAsync(unixTimeUrlPath), serviceCallback);
     }
 
@@ -1151,12 +1462,24 @@ public class PathsImpl implements Paths {
      *
      * @param unixTimeUrlPath Unix time encoded value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> unixTimeUrlAsync(DateTime unixTimeUrlPath) {
-        Long unixTimeUrlPathConverted = unixTimeUrlPath.toDateTime(DateTimeZone.UTC).getMillis() / 1000;
+    public Single<RestResponse<Void, Void>> unixTimeUrlWithRestResponseAsync(DateTime unixTimeUrlPath) {
+    Long unixTimeUrlPathConverted = unixTimeUrlPath.toDateTime(DateTimeZone.UTC).getMillis() / 1000;
         return service.unixTimeUrl(unixTimeUrlPathConverted);
     }
+
+    /**
+     * Get the date 2016-04-13 encoded value as '1460505600' (Unix time).
+     *
+     * @param unixTimeUrlPath Unix time encoded value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> unixTimeUrlAsync(DateTime unixTimeUrlPath) {
+        return unixTimeUrlWithRestResponseAsync(unixTimeUrlPath)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/url/implementation/QueriesImpl.java
+++ b/test/vanilla/src/main/java/fixtures/url/implementation/QueriesImpl.java
@@ -11,6 +11,7 @@
 package fixtures.url.implementation;
 
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import fixtures.url.Queries;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.ExpectedResponses;
@@ -65,205 +66,205 @@ public class QueriesImpl implements Queries {
         @GET("queries/bool/true")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getBooleanTrue(@QueryParam("boolQuery") boolean boolQuery);
+        Single<RestResponse<Void, Void>> getBooleanTrue(@QueryParam("boolQuery") boolean boolQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Queries getBooleanFalse" })
         @GET("queries/bool/false")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getBooleanFalse(@QueryParam("boolQuery") boolean boolQuery);
+        Single<RestResponse<Void, Void>> getBooleanFalse(@QueryParam("boolQuery") boolean boolQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Queries getBooleanNull" })
         @GET("queries/bool/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getBooleanNull(@QueryParam("boolQuery") Boolean boolQuery);
+        Single<RestResponse<Void, Void>> getBooleanNull(@QueryParam("boolQuery") Boolean boolQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Queries getIntOneMillion" })
         @GET("queries/int/1000000")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getIntOneMillion(@QueryParam("intQuery") int intQuery);
+        Single<RestResponse<Void, Void>> getIntOneMillion(@QueryParam("intQuery") int intQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Queries getIntNegativeOneMillion" })
         @GET("queries/int/-1000000")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getIntNegativeOneMillion(@QueryParam("intQuery") int intQuery);
+        Single<RestResponse<Void, Void>> getIntNegativeOneMillion(@QueryParam("intQuery") int intQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Queries getIntNull" })
         @GET("queries/int/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getIntNull(@QueryParam("intQuery") Integer intQuery);
+        Single<RestResponse<Void, Void>> getIntNull(@QueryParam("intQuery") Integer intQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Queries getTenBillion" })
         @GET("queries/long/10000000000")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getTenBillion(@QueryParam("longQuery") long longQuery);
+        Single<RestResponse<Void, Void>> getTenBillion(@QueryParam("longQuery") long longQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Queries getNegativeTenBillion" })
         @GET("queries/long/-10000000000")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getNegativeTenBillion(@QueryParam("longQuery") long longQuery);
+        Single<RestResponse<Void, Void>> getNegativeTenBillion(@QueryParam("longQuery") long longQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Queries getLongNull" })
         @GET("queries/long/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> getLongNull(@QueryParam("longQuery") Long longQuery);
+        Single<RestResponse<Void, Void>> getLongNull(@QueryParam("longQuery") Long longQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Queries floatScientificPositive" })
         @GET("queries/float/1.034E+20")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> floatScientificPositive(@QueryParam("floatQuery") double floatQuery);
+        Single<RestResponse<Void, Void>> floatScientificPositive(@QueryParam("floatQuery") double floatQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Queries floatScientificNegative" })
         @GET("queries/float/-1.034E-20")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> floatScientificNegative(@QueryParam("floatQuery") double floatQuery);
+        Single<RestResponse<Void, Void>> floatScientificNegative(@QueryParam("floatQuery") double floatQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Queries floatNull" })
         @GET("queries/float/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> floatNull(@QueryParam("floatQuery") Double floatQuery);
+        Single<RestResponse<Void, Void>> floatNull(@QueryParam("floatQuery") Double floatQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Queries doubleDecimalPositive" })
         @GET("queries/double/9999999.999")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> doubleDecimalPositive(@QueryParam("doubleQuery") double doubleQuery);
+        Single<RestResponse<Void, Void>> doubleDecimalPositive(@QueryParam("doubleQuery") double doubleQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Queries doubleDecimalNegative" })
         @GET("queries/double/-9999999.999")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> doubleDecimalNegative(@QueryParam("doubleQuery") double doubleQuery);
+        Single<RestResponse<Void, Void>> doubleDecimalNegative(@QueryParam("doubleQuery") double doubleQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Queries doubleNull" })
         @GET("queries/double/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> doubleNull(@QueryParam("doubleQuery") Double doubleQuery);
+        Single<RestResponse<Void, Void>> doubleNull(@QueryParam("doubleQuery") Double doubleQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Queries stringUnicode" })
         @GET("queries/string/unicode/")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> stringUnicode(@QueryParam("stringQuery") String stringQuery);
+        Single<RestResponse<Void, Void>> stringUnicode(@QueryParam("stringQuery") String stringQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Queries stringUrlEncoded" })
         @GET("queries/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> stringUrlEncoded(@QueryParam("stringQuery") String stringQuery);
+        Single<RestResponse<Void, Void>> stringUrlEncoded(@QueryParam("stringQuery") String stringQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Queries stringEmpty" })
         @GET("queries/string/empty")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> stringEmpty(@QueryParam("stringQuery") String stringQuery);
+        Single<RestResponse<Void, Void>> stringEmpty(@QueryParam("stringQuery") String stringQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Queries stringNull" })
         @GET("queries/string/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> stringNull(@QueryParam("stringQuery") String stringQuery);
+        Single<RestResponse<Void, Void>> stringNull(@QueryParam("stringQuery") String stringQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Queries enumValid" })
         @GET("queries/enum/green%20color")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> enumValid(@QueryParam("enumQuery") UriColor enumQuery);
+        Single<RestResponse<Void, Void>> enumValid(@QueryParam("enumQuery") UriColor enumQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Queries enumNull" })
         @GET("queries/enum/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> enumNull(@QueryParam("enumQuery") UriColor enumQuery);
+        Single<RestResponse<Void, Void>> enumNull(@QueryParam("enumQuery") UriColor enumQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Queries byteMultiByte" })
         @GET("queries/byte/multibyte")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> byteMultiByte(@QueryParam("byteQuery") String byteQuery);
+        Single<RestResponse<Void, Void>> byteMultiByte(@QueryParam("byteQuery") String byteQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Queries byteEmpty" })
         @GET("queries/byte/empty")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> byteEmpty(@QueryParam("byteQuery") String byteQuery);
+        Single<RestResponse<Void, Void>> byteEmpty(@QueryParam("byteQuery") String byteQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Queries byteNull" })
         @GET("queries/byte/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> byteNull(@QueryParam("byteQuery") String byteQuery);
+        Single<RestResponse<Void, Void>> byteNull(@QueryParam("byteQuery") String byteQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Queries dateValid" })
         @GET("queries/date/2012-01-01")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> dateValid(@QueryParam("dateQuery") LocalDate dateQuery);
+        Single<RestResponse<Void, Void>> dateValid(@QueryParam("dateQuery") LocalDate dateQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Queries dateNull" })
         @GET("queries/date/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> dateNull(@QueryParam("dateQuery") LocalDate dateQuery);
+        Single<RestResponse<Void, Void>> dateNull(@QueryParam("dateQuery") LocalDate dateQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Queries dateTimeValid" })
         @GET("queries/datetime/2012-01-01T01%3A01%3A01Z")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> dateTimeValid(@QueryParam("dateTimeQuery") DateTime dateTimeQuery);
+        Single<RestResponse<Void, Void>> dateTimeValid(@QueryParam("dateTimeQuery") DateTime dateTimeQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Queries dateTimeNull" })
         @GET("queries/datetime/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> dateTimeNull(@QueryParam("dateTimeQuery") DateTime dateTimeQuery);
+        Single<RestResponse<Void, Void>> dateTimeNull(@QueryParam("dateTimeQuery") DateTime dateTimeQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Queries arrayStringCsvValid" })
         @GET("queries/array/csv/string/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> arrayStringCsvValid(@QueryParam("arrayQuery") String arrayQuery);
+        Single<RestResponse<Void, Void>> arrayStringCsvValid(@QueryParam("arrayQuery") String arrayQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Queries arrayStringCsvNull" })
         @GET("queries/array/csv/string/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> arrayStringCsvNull(@QueryParam("arrayQuery") String arrayQuery);
+        Single<RestResponse<Void, Void>> arrayStringCsvNull(@QueryParam("arrayQuery") String arrayQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Queries arrayStringCsvEmpty" })
         @GET("queries/array/csv/string/empty")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> arrayStringCsvEmpty(@QueryParam("arrayQuery") String arrayQuery);
+        Single<RestResponse<Void, Void>> arrayStringCsvEmpty(@QueryParam("arrayQuery") String arrayQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Queries arrayStringSsvValid" })
         @GET("queries/array/ssv/string/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> arrayStringSsvValid(@QueryParam("arrayQuery") String arrayQuery);
+        Single<RestResponse<Void, Void>> arrayStringSsvValid(@QueryParam("arrayQuery") String arrayQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Queries arrayStringTsvValid" })
         @GET("queries/array/tsv/string/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> arrayStringTsvValid(@QueryParam("arrayQuery") String arrayQuery);
+        Single<RestResponse<Void, Void>> arrayStringTsvValid(@QueryParam("arrayQuery") String arrayQuery);
 
         @Headers({ "x-ms-logging-context: fixtures.url.Queries arrayStringPipesValid" })
         @GET("queries/array/pipes/string/valid")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Void> arrayStringPipesValid(@QueryParam("arrayQuery") String arrayQuery);
+        Single<RestResponse<Void, Void>> arrayStringPipesValid(@QueryParam("arrayQuery") String arrayQuery);
 
     }
 
@@ -273,6 +274,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getBooleanTrue() {
         getBooleanTrueAsync().toBlocking().value();
@@ -285,7 +287,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getBooleanTrueAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getBooleanTrueAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getBooleanTrueAsync(), serviceCallback);
     }
 
@@ -293,12 +295,23 @@ public class QueriesImpl implements Queries {
      * Get true Boolean value on path.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getBooleanTrueAsync() {
+    public Single<RestResponse<Void, Void>> getBooleanTrueWithRestResponseAsync() {
         final boolean boolQuery = true;
         return service.getBooleanTrue(boolQuery);
     }
+
+    /**
+     * Get true Boolean value on path.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getBooleanTrueAsync() {
+        return getBooleanTrueWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -307,6 +320,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getBooleanFalse() {
         getBooleanFalseAsync().toBlocking().value();
@@ -319,7 +333,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getBooleanFalseAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getBooleanFalseAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getBooleanFalseAsync(), serviceCallback);
     }
 
@@ -327,12 +341,23 @@ public class QueriesImpl implements Queries {
      * Get false Boolean value on path.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getBooleanFalseAsync() {
+    public Single<RestResponse<Void, Void>> getBooleanFalseWithRestResponseAsync() {
         final boolean boolQuery = false;
         return service.getBooleanFalse(boolQuery);
     }
+
+    /**
+     * Get false Boolean value on path.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getBooleanFalseAsync() {
+        return getBooleanFalseWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -341,6 +366,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getBooleanNull() {
         getBooleanNullAsync().toBlocking().value();
@@ -353,7 +379,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getBooleanNullAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getBooleanNullAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getBooleanNullAsync(), serviceCallback);
     }
 
@@ -361,12 +387,23 @@ public class QueriesImpl implements Queries {
      * Get null Boolean value on query (query string should be absent).
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getBooleanNullAsync() {
+    public Single<RestResponse<Void, Void>> getBooleanNullWithRestResponseAsync() {
         final Boolean boolQuery = null;
         return service.getBooleanNull(boolQuery);
     }
+
+    /**
+     * Get null Boolean value on query (query string should be absent).
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getBooleanNullAsync() {
+        return getBooleanNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Get null Boolean value on query (query string should be absent).
@@ -375,6 +412,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getBooleanNull(Boolean boolQuery) {
         getBooleanNullAsync(boolQuery).toBlocking().value();
@@ -388,7 +426,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getBooleanNullAsync(Boolean boolQuery, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getBooleanNullAsync(Boolean boolQuery, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getBooleanNullAsync(boolQuery), serviceCallback);
     }
 
@@ -397,11 +435,23 @@ public class QueriesImpl implements Queries {
      *
      * @param boolQuery null boolean value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getBooleanNullAsync(Boolean boolQuery) {
+    public Single<RestResponse<Void, Void>> getBooleanNullWithRestResponseAsync(Boolean boolQuery) {
         return service.getBooleanNull(boolQuery);
     }
+
+    /**
+     * Get null Boolean value on query (query string should be absent).
+     *
+     * @param boolQuery null boolean value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getBooleanNullAsync(Boolean boolQuery) {
+        return getBooleanNullWithRestResponseAsync(boolQuery)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -410,6 +460,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getIntOneMillion() {
         getIntOneMillionAsync().toBlocking().value();
@@ -422,7 +473,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getIntOneMillionAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getIntOneMillionAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getIntOneMillionAsync(), serviceCallback);
     }
 
@@ -430,12 +481,23 @@ public class QueriesImpl implements Queries {
      * Get '1000000' integer value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getIntOneMillionAsync() {
+    public Single<RestResponse<Void, Void>> getIntOneMillionWithRestResponseAsync() {
         final int intQuery = 1000000;
         return service.getIntOneMillion(intQuery);
     }
+
+    /**
+     * Get '1000000' integer value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getIntOneMillionAsync() {
+        return getIntOneMillionWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -444,6 +506,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getIntNegativeOneMillion() {
         getIntNegativeOneMillionAsync().toBlocking().value();
@@ -456,7 +519,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getIntNegativeOneMillionAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getIntNegativeOneMillionAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getIntNegativeOneMillionAsync(), serviceCallback);
     }
 
@@ -464,12 +527,23 @@ public class QueriesImpl implements Queries {
      * Get '-1000000' integer value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getIntNegativeOneMillionAsync() {
+    public Single<RestResponse<Void, Void>> getIntNegativeOneMillionWithRestResponseAsync() {
         final int intQuery = -1000000;
         return service.getIntNegativeOneMillion(intQuery);
     }
+
+    /**
+     * Get '-1000000' integer value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getIntNegativeOneMillionAsync() {
+        return getIntNegativeOneMillionWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -478,6 +552,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getIntNull() {
         getIntNullAsync().toBlocking().value();
@@ -490,7 +565,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getIntNullAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getIntNullAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getIntNullAsync(), serviceCallback);
     }
 
@@ -498,12 +573,23 @@ public class QueriesImpl implements Queries {
      * Get null integer value (no query parameter).
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getIntNullAsync() {
+    public Single<RestResponse<Void, Void>> getIntNullWithRestResponseAsync() {
         final Integer intQuery = null;
         return service.getIntNull(intQuery);
     }
+
+    /**
+     * Get null integer value (no query parameter).
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getIntNullAsync() {
+        return getIntNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Get null integer value (no query parameter).
@@ -512,6 +598,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getIntNull(Integer intQuery) {
         getIntNullAsync(intQuery).toBlocking().value();
@@ -525,7 +612,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getIntNullAsync(Integer intQuery, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getIntNullAsync(Integer intQuery, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getIntNullAsync(intQuery), serviceCallback);
     }
 
@@ -534,11 +621,23 @@ public class QueriesImpl implements Queries {
      *
      * @param intQuery null integer value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getIntNullAsync(Integer intQuery) {
+    public Single<RestResponse<Void, Void>> getIntNullWithRestResponseAsync(Integer intQuery) {
         return service.getIntNull(intQuery);
     }
+
+    /**
+     * Get null integer value (no query parameter).
+     *
+     * @param intQuery null integer value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getIntNullAsync(Integer intQuery) {
+        return getIntNullWithRestResponseAsync(intQuery)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -547,6 +646,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getTenBillion() {
         getTenBillionAsync().toBlocking().value();
@@ -559,7 +659,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getTenBillionAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getTenBillionAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getTenBillionAsync(), serviceCallback);
     }
 
@@ -567,12 +667,23 @@ public class QueriesImpl implements Queries {
      * Get '10000000000' 64 bit integer value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getTenBillionAsync() {
+    public Single<RestResponse<Void, Void>> getTenBillionWithRestResponseAsync() {
         final long longQuery = 10000000000L;
         return service.getTenBillion(longQuery);
     }
+
+    /**
+     * Get '10000000000' 64 bit integer value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getTenBillionAsync() {
+        return getTenBillionWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -581,6 +692,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getNegativeTenBillion() {
         getNegativeTenBillionAsync().toBlocking().value();
@@ -593,7 +705,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getNegativeTenBillionAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getNegativeTenBillionAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getNegativeTenBillionAsync(), serviceCallback);
     }
 
@@ -601,12 +713,23 @@ public class QueriesImpl implements Queries {
      * Get '-10000000000' 64 bit integer value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getNegativeTenBillionAsync() {
+    public Single<RestResponse<Void, Void>> getNegativeTenBillionWithRestResponseAsync() {
         final long longQuery = -10000000000L;
         return service.getNegativeTenBillion(longQuery);
     }
+
+    /**
+     * Get '-10000000000' 64 bit integer value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getNegativeTenBillionAsync() {
+        return getNegativeTenBillionWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -615,6 +738,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getLongNull() {
         getLongNullAsync().toBlocking().value();
@@ -627,7 +751,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getLongNullAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getLongNullAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getLongNullAsync(), serviceCallback);
     }
 
@@ -635,12 +759,23 @@ public class QueriesImpl implements Queries {
      * Get 'null 64 bit integer value (no query param in uri).
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getLongNullAsync() {
+    public Single<RestResponse<Void, Void>> getLongNullWithRestResponseAsync() {
         final Long longQuery = null;
         return service.getLongNull(longQuery);
     }
+
+    /**
+     * Get 'null 64 bit integer value (no query param in uri).
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getLongNullAsync() {
+        return getLongNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Get 'null 64 bit integer value (no query param in uri).
@@ -649,6 +784,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getLongNull(Long longQuery) {
         getLongNullAsync(longQuery).toBlocking().value();
@@ -662,7 +798,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getLongNullAsync(Long longQuery, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getLongNullAsync(Long longQuery, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getLongNullAsync(longQuery), serviceCallback);
     }
 
@@ -671,11 +807,23 @@ public class QueriesImpl implements Queries {
      *
      * @param longQuery null 64 bit integer value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getLongNullAsync(Long longQuery) {
+    public Single<RestResponse<Void, Void>> getLongNullWithRestResponseAsync(Long longQuery) {
         return service.getLongNull(longQuery);
     }
+
+    /**
+     * Get 'null 64 bit integer value (no query param in uri).
+     *
+     * @param longQuery null 64 bit integer value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getLongNullAsync(Long longQuery) {
+        return getLongNullWithRestResponseAsync(longQuery)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -684,6 +832,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void floatScientificPositive() {
         floatScientificPositiveAsync().toBlocking().value();
@@ -696,7 +845,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> floatScientificPositiveAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> floatScientificPositiveAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(floatScientificPositiveAsync(), serviceCallback);
     }
 
@@ -704,12 +853,23 @@ public class QueriesImpl implements Queries {
      * Get '1.034E+20' numeric value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> floatScientificPositiveAsync() {
+    public Single<RestResponse<Void, Void>> floatScientificPositiveWithRestResponseAsync() {
         final double floatQuery = 1.034E+20;
         return service.floatScientificPositive(floatQuery);
     }
+
+    /**
+     * Get '1.034E+20' numeric value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> floatScientificPositiveAsync() {
+        return floatScientificPositiveWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -718,6 +878,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void floatScientificNegative() {
         floatScientificNegativeAsync().toBlocking().value();
@@ -730,7 +891,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> floatScientificNegativeAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> floatScientificNegativeAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(floatScientificNegativeAsync(), serviceCallback);
     }
 
@@ -738,12 +899,23 @@ public class QueriesImpl implements Queries {
      * Get '-1.034E-20' numeric value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> floatScientificNegativeAsync() {
+    public Single<RestResponse<Void, Void>> floatScientificNegativeWithRestResponseAsync() {
         final double floatQuery = -1.034E-20;
         return service.floatScientificNegative(floatQuery);
     }
+
+    /**
+     * Get '-1.034E-20' numeric value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> floatScientificNegativeAsync() {
+        return floatScientificNegativeWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -752,6 +924,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void floatNull() {
         floatNullAsync().toBlocking().value();
@@ -764,7 +937,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> floatNullAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> floatNullAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(floatNullAsync(), serviceCallback);
     }
 
@@ -772,12 +945,23 @@ public class QueriesImpl implements Queries {
      * Get null numeric value (no query parameter).
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> floatNullAsync() {
+    public Single<RestResponse<Void, Void>> floatNullWithRestResponseAsync() {
         final Double floatQuery = null;
         return service.floatNull(floatQuery);
     }
+
+    /**
+     * Get null numeric value (no query parameter).
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> floatNullAsync() {
+        return floatNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Get null numeric value (no query parameter).
@@ -786,6 +970,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void floatNull(Double floatQuery) {
         floatNullAsync(floatQuery).toBlocking().value();
@@ -799,7 +984,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> floatNullAsync(Double floatQuery, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> floatNullAsync(Double floatQuery, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(floatNullAsync(floatQuery), serviceCallback);
     }
 
@@ -808,11 +993,23 @@ public class QueriesImpl implements Queries {
      *
      * @param floatQuery null numeric value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> floatNullAsync(Double floatQuery) {
+    public Single<RestResponse<Void, Void>> floatNullWithRestResponseAsync(Double floatQuery) {
         return service.floatNull(floatQuery);
     }
+
+    /**
+     * Get null numeric value (no query parameter).
+     *
+     * @param floatQuery null numeric value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> floatNullAsync(Double floatQuery) {
+        return floatNullWithRestResponseAsync(floatQuery)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -821,6 +1018,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void doubleDecimalPositive() {
         doubleDecimalPositiveAsync().toBlocking().value();
@@ -833,7 +1031,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> doubleDecimalPositiveAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> doubleDecimalPositiveAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(doubleDecimalPositiveAsync(), serviceCallback);
     }
 
@@ -841,12 +1039,23 @@ public class QueriesImpl implements Queries {
      * Get '9999999.999' numeric value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> doubleDecimalPositiveAsync() {
+    public Single<RestResponse<Void, Void>> doubleDecimalPositiveWithRestResponseAsync() {
         final double doubleQuery = 9999999.999;
         return service.doubleDecimalPositive(doubleQuery);
     }
+
+    /**
+     * Get '9999999.999' numeric value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> doubleDecimalPositiveAsync() {
+        return doubleDecimalPositiveWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -855,6 +1064,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void doubleDecimalNegative() {
         doubleDecimalNegativeAsync().toBlocking().value();
@@ -867,7 +1077,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> doubleDecimalNegativeAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> doubleDecimalNegativeAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(doubleDecimalNegativeAsync(), serviceCallback);
     }
 
@@ -875,12 +1085,23 @@ public class QueriesImpl implements Queries {
      * Get '-9999999.999' numeric value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> doubleDecimalNegativeAsync() {
+    public Single<RestResponse<Void, Void>> doubleDecimalNegativeWithRestResponseAsync() {
         final double doubleQuery = -9999999.999;
         return service.doubleDecimalNegative(doubleQuery);
     }
+
+    /**
+     * Get '-9999999.999' numeric value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> doubleDecimalNegativeAsync() {
+        return doubleDecimalNegativeWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -889,6 +1110,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void doubleNull() {
         doubleNullAsync().toBlocking().value();
@@ -901,7 +1123,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> doubleNullAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> doubleNullAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(doubleNullAsync(), serviceCallback);
     }
 
@@ -909,12 +1131,23 @@ public class QueriesImpl implements Queries {
      * Get null numeric value (no query parameter).
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> doubleNullAsync() {
+    public Single<RestResponse<Void, Void>> doubleNullWithRestResponseAsync() {
         final Double doubleQuery = null;
         return service.doubleNull(doubleQuery);
     }
+
+    /**
+     * Get null numeric value (no query parameter).
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> doubleNullAsync() {
+        return doubleNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Get null numeric value (no query parameter).
@@ -923,6 +1156,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void doubleNull(Double doubleQuery) {
         doubleNullAsync(doubleQuery).toBlocking().value();
@@ -936,7 +1170,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> doubleNullAsync(Double doubleQuery, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> doubleNullAsync(Double doubleQuery, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(doubleNullAsync(doubleQuery), serviceCallback);
     }
 
@@ -945,11 +1179,23 @@ public class QueriesImpl implements Queries {
      *
      * @param doubleQuery null numeric value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> doubleNullAsync(Double doubleQuery) {
+    public Single<RestResponse<Void, Void>> doubleNullWithRestResponseAsync(Double doubleQuery) {
         return service.doubleNull(doubleQuery);
     }
+
+    /**
+     * Get null numeric value (no query parameter).
+     *
+     * @param doubleQuery null numeric value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> doubleNullAsync(Double doubleQuery) {
+        return doubleNullWithRestResponseAsync(doubleQuery)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -958,6 +1204,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void stringUnicode() {
         stringUnicodeAsync().toBlocking().value();
@@ -970,7 +1217,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> stringUnicodeAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> stringUnicodeAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(stringUnicodeAsync(), serviceCallback);
     }
 
@@ -978,12 +1225,23 @@ public class QueriesImpl implements Queries {
      * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> stringUnicodeAsync() {
+    public Single<RestResponse<Void, Void>> stringUnicodeWithRestResponseAsync() {
         final String stringQuery = "啊齄丂狛狜隣郎隣兀﨩";
         return service.stringUnicode(stringQuery);
     }
+
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> stringUnicodeAsync() {
+        return stringUnicodeWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -992,6 +1250,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void stringUrlEncoded() {
         stringUrlEncodedAsync().toBlocking().value();
@@ -1004,7 +1263,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> stringUrlEncodedAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> stringUrlEncodedAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(stringUrlEncodedAsync(), serviceCallback);
     }
 
@@ -1012,12 +1271,23 @@ public class QueriesImpl implements Queries {
      * Get 'begin!*'();:@ &amp;=+$,/?#[]end.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> stringUrlEncodedAsync() {
+    public Single<RestResponse<Void, Void>> stringUrlEncodedWithRestResponseAsync() {
         final String stringQuery = "begin!*'();:@ &=+$,/?#[]end";
         return service.stringUrlEncoded(stringQuery);
     }
+
+    /**
+     * Get 'begin!*'();:@ &amp;=+$,/?#[]end.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> stringUrlEncodedAsync() {
+        return stringUrlEncodedWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1026,6 +1296,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void stringEmpty() {
         stringEmptyAsync().toBlocking().value();
@@ -1038,7 +1309,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> stringEmptyAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> stringEmptyAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(stringEmptyAsync(), serviceCallback);
     }
 
@@ -1046,12 +1317,23 @@ public class QueriesImpl implements Queries {
      * Get ''.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> stringEmptyAsync() {
+    public Single<RestResponse<Void, Void>> stringEmptyWithRestResponseAsync() {
         final String stringQuery = "";
         return service.stringEmpty(stringQuery);
     }
+
+    /**
+     * Get ''.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> stringEmptyAsync() {
+        return stringEmptyWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1060,6 +1342,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void stringNull() {
         stringNullAsync().toBlocking().value();
@@ -1072,7 +1355,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> stringNullAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> stringNullAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(stringNullAsync(), serviceCallback);
     }
 
@@ -1080,12 +1363,23 @@ public class QueriesImpl implements Queries {
      * Get null (no query parameter in url).
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> stringNullAsync() {
+    public Single<RestResponse<Void, Void>> stringNullWithRestResponseAsync() {
         final String stringQuery = null;
         return service.stringNull(stringQuery);
     }
+
+    /**
+     * Get null (no query parameter in url).
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> stringNullAsync() {
+        return stringNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Get null (no query parameter in url).
@@ -1094,6 +1388,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void stringNull(String stringQuery) {
         stringNullAsync(stringQuery).toBlocking().value();
@@ -1107,7 +1402,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> stringNullAsync(String stringQuery, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> stringNullAsync(String stringQuery, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(stringNullAsync(stringQuery), serviceCallback);
     }
 
@@ -1116,11 +1411,23 @@ public class QueriesImpl implements Queries {
      *
      * @param stringQuery null string value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> stringNullAsync(String stringQuery) {
+    public Single<RestResponse<Void, Void>> stringNullWithRestResponseAsync(String stringQuery) {
         return service.stringNull(stringQuery);
     }
+
+    /**
+     * Get null (no query parameter in url).
+     *
+     * @param stringQuery null string value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> stringNullAsync(String stringQuery) {
+        return stringNullWithRestResponseAsync(stringQuery)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1129,6 +1436,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void enumValid() {
         enumValidAsync().toBlocking().value();
@@ -1141,7 +1449,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> enumValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> enumValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(enumValidAsync(), serviceCallback);
     }
 
@@ -1149,12 +1457,23 @@ public class QueriesImpl implements Queries {
      * Get using uri with query parameter 'green color'.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> enumValidAsync() {
+    public Single<RestResponse<Void, Void>> enumValidWithRestResponseAsync() {
         final UriColor enumQuery = null;
         return service.enumValid(enumQuery);
     }
+
+    /**
+     * Get using uri with query parameter 'green color'.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> enumValidAsync() {
+        return enumValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Get using uri with query parameter 'green color'.
@@ -1163,6 +1482,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void enumValid(UriColor enumQuery) {
         enumValidAsync(enumQuery).toBlocking().value();
@@ -1176,7 +1496,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> enumValidAsync(UriColor enumQuery, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> enumValidAsync(UriColor enumQuery, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(enumValidAsync(enumQuery), serviceCallback);
     }
 
@@ -1185,11 +1505,23 @@ public class QueriesImpl implements Queries {
      *
      * @param enumQuery 'green color' enum value. Possible values include: 'red color', 'green color', 'blue color'
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> enumValidAsync(UriColor enumQuery) {
+    public Single<RestResponse<Void, Void>> enumValidWithRestResponseAsync(UriColor enumQuery) {
         return service.enumValid(enumQuery);
     }
+
+    /**
+     * Get using uri with query parameter 'green color'.
+     *
+     * @param enumQuery 'green color' enum value. Possible values include: 'red color', 'green color', 'blue color'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> enumValidAsync(UriColor enumQuery) {
+        return enumValidWithRestResponseAsync(enumQuery)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1198,6 +1530,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void enumNull() {
         enumNullAsync().toBlocking().value();
@@ -1210,7 +1543,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> enumNullAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> enumNullAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(enumNullAsync(), serviceCallback);
     }
 
@@ -1218,12 +1551,23 @@ public class QueriesImpl implements Queries {
      * Get null (no query parameter in url).
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> enumNullAsync() {
+    public Single<RestResponse<Void, Void>> enumNullWithRestResponseAsync() {
         final UriColor enumQuery = null;
         return service.enumNull(enumQuery);
     }
+
+    /**
+     * Get null (no query parameter in url).
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> enumNullAsync() {
+        return enumNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Get null (no query parameter in url).
@@ -1232,6 +1576,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void enumNull(UriColor enumQuery) {
         enumNullAsync(enumQuery).toBlocking().value();
@@ -1245,7 +1590,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> enumNullAsync(UriColor enumQuery, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> enumNullAsync(UriColor enumQuery, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(enumNullAsync(enumQuery), serviceCallback);
     }
 
@@ -1254,11 +1599,23 @@ public class QueriesImpl implements Queries {
      *
      * @param enumQuery null string value. Possible values include: 'red color', 'green color', 'blue color'
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> enumNullAsync(UriColor enumQuery) {
+    public Single<RestResponse<Void, Void>> enumNullWithRestResponseAsync(UriColor enumQuery) {
         return service.enumNull(enumQuery);
     }
+
+    /**
+     * Get null (no query parameter in url).
+     *
+     * @param enumQuery null string value. Possible values include: 'red color', 'green color', 'blue color'
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> enumNullAsync(UriColor enumQuery) {
+        return enumNullWithRestResponseAsync(enumQuery)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1267,6 +1624,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void byteMultiByte() {
         byteMultiByteAsync().toBlocking().value();
@@ -1279,7 +1637,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> byteMultiByteAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> byteMultiByteAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(byteMultiByteAsync(), serviceCallback);
     }
 
@@ -1287,13 +1645,24 @@ public class QueriesImpl implements Queries {
      * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> byteMultiByteAsync() {
+    public Single<RestResponse<Void, Void>> byteMultiByteWithRestResponseAsync() {
         final byte[] byteQuery = new byte[0];
-        String byteQueryConverted = Base64.encodeBase64String(byteQuery);
+    String byteQueryConverted = Base64.encodeBase64String(byteQuery);
         return service.byteMultiByte(byteQueryConverted);
     }
+
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> byteMultiByteAsync() {
+        return byteMultiByteWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
@@ -1302,6 +1671,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void byteMultiByte(byte[] byteQuery) {
         byteMultiByteAsync(byteQuery).toBlocking().value();
@@ -1315,7 +1685,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> byteMultiByteAsync(byte[] byteQuery, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> byteMultiByteAsync(byte[] byteQuery, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(byteMultiByteAsync(byteQuery), serviceCallback);
     }
 
@@ -1324,12 +1694,24 @@ public class QueriesImpl implements Queries {
      *
      * @param byteQuery '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> byteMultiByteAsync(byte[] byteQuery) {
-        String byteQueryConverted = Base64.encodeBase64String(byteQuery);
+    public Single<RestResponse<Void, Void>> byteMultiByteWithRestResponseAsync(byte[] byteQuery) {
+    String byteQueryConverted = Base64.encodeBase64String(byteQuery);
         return service.byteMultiByte(byteQueryConverted);
     }
+
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
+     *
+     * @param byteQuery '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> byteMultiByteAsync(byte[] byteQuery) {
+        return byteMultiByteWithRestResponseAsync(byteQuery)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1338,6 +1720,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void byteEmpty() {
         byteEmptyAsync().toBlocking().value();
@@ -1350,7 +1733,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> byteEmptyAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> byteEmptyAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(byteEmptyAsync(), serviceCallback);
     }
 
@@ -1358,13 +1741,24 @@ public class QueriesImpl implements Queries {
      * Get '' as byte array.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> byteEmptyAsync() {
+    public Single<RestResponse<Void, Void>> byteEmptyWithRestResponseAsync() {
         final byte[] byteQuery = "".getBytes();
-        String byteQueryConverted = Base64.encodeBase64String(byteQuery);
+    String byteQueryConverted = Base64.encodeBase64String(byteQuery);
         return service.byteEmpty(byteQueryConverted);
     }
+
+    /**
+     * Get '' as byte array.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> byteEmptyAsync() {
+        return byteEmptyWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1373,6 +1767,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void byteNull() {
         byteNullAsync().toBlocking().value();
@@ -1385,7 +1780,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> byteNullAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> byteNullAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(byteNullAsync(), serviceCallback);
     }
 
@@ -1393,13 +1788,24 @@ public class QueriesImpl implements Queries {
      * Get null as byte array (no query parameters in uri).
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> byteNullAsync() {
+    public Single<RestResponse<Void, Void>> byteNullWithRestResponseAsync() {
         final byte[] byteQuery = new byte[0];
-        String byteQueryConverted = Base64.encodeBase64String(byteQuery);
+    String byteQueryConverted = Base64.encodeBase64String(byteQuery);
         return service.byteNull(byteQueryConverted);
     }
+
+    /**
+     * Get null as byte array (no query parameters in uri).
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> byteNullAsync() {
+        return byteNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Get null as byte array (no query parameters in uri).
@@ -1408,6 +1814,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void byteNull(byte[] byteQuery) {
         byteNullAsync(byteQuery).toBlocking().value();
@@ -1421,7 +1828,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> byteNullAsync(byte[] byteQuery, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> byteNullAsync(byte[] byteQuery, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(byteNullAsync(byteQuery), serviceCallback);
     }
 
@@ -1430,12 +1837,24 @@ public class QueriesImpl implements Queries {
      *
      * @param byteQuery null as byte array (no query parameters in uri)
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> byteNullAsync(byte[] byteQuery) {
-        String byteQueryConverted = Base64.encodeBase64String(byteQuery);
+    public Single<RestResponse<Void, Void>> byteNullWithRestResponseAsync(byte[] byteQuery) {
+    String byteQueryConverted = Base64.encodeBase64String(byteQuery);
         return service.byteNull(byteQueryConverted);
     }
+
+    /**
+     * Get null as byte array (no query parameters in uri).
+     *
+     * @param byteQuery null as byte array (no query parameters in uri)
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> byteNullAsync(byte[] byteQuery) {
+        return byteNullWithRestResponseAsync(byteQuery)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1444,6 +1863,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void dateValid() {
         dateValidAsync().toBlocking().value();
@@ -1456,7 +1876,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> dateValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> dateValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(dateValidAsync(), serviceCallback);
     }
 
@@ -1464,12 +1884,23 @@ public class QueriesImpl implements Queries {
      * Get '2012-01-01' as date.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> dateValidAsync() {
+    public Single<RestResponse<Void, Void>> dateValidWithRestResponseAsync() {
         final LocalDate dateQuery = LocalDate.parse("2012-01-01");
         return service.dateValid(dateQuery);
     }
+
+    /**
+     * Get '2012-01-01' as date.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> dateValidAsync() {
+        return dateValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1478,6 +1909,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void dateNull() {
         dateNullAsync().toBlocking().value();
@@ -1490,7 +1922,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> dateNullAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> dateNullAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(dateNullAsync(), serviceCallback);
     }
 
@@ -1498,12 +1930,23 @@ public class QueriesImpl implements Queries {
      * Get null as date - this should result in no query parameters in uri.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> dateNullAsync() {
+    public Single<RestResponse<Void, Void>> dateNullWithRestResponseAsync() {
         final LocalDate dateQuery = null;
         return service.dateNull(dateQuery);
     }
+
+    /**
+     * Get null as date - this should result in no query parameters in uri.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> dateNullAsync() {
+        return dateNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Get null as date - this should result in no query parameters in uri.
@@ -1512,6 +1955,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void dateNull(LocalDate dateQuery) {
         dateNullAsync(dateQuery).toBlocking().value();
@@ -1525,7 +1969,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> dateNullAsync(LocalDate dateQuery, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> dateNullAsync(LocalDate dateQuery, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(dateNullAsync(dateQuery), serviceCallback);
     }
 
@@ -1534,11 +1978,23 @@ public class QueriesImpl implements Queries {
      *
      * @param dateQuery null as date (no query parameters in uri)
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> dateNullAsync(LocalDate dateQuery) {
+    public Single<RestResponse<Void, Void>> dateNullWithRestResponseAsync(LocalDate dateQuery) {
         return service.dateNull(dateQuery);
     }
+
+    /**
+     * Get null as date - this should result in no query parameters in uri.
+     *
+     * @param dateQuery null as date (no query parameters in uri)
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> dateNullAsync(LocalDate dateQuery) {
+        return dateNullWithRestResponseAsync(dateQuery)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1547,6 +2003,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void dateTimeValid() {
         dateTimeValidAsync().toBlocking().value();
@@ -1559,7 +2016,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> dateTimeValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> dateTimeValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(dateTimeValidAsync(), serviceCallback);
     }
 
@@ -1567,12 +2024,23 @@ public class QueriesImpl implements Queries {
      * Get '2012-01-01T01:01:01Z' as date-time.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> dateTimeValidAsync() {
+    public Single<RestResponse<Void, Void>> dateTimeValidWithRestResponseAsync() {
         final DateTime dateTimeQuery = DateTime.parse("2012-01-01T01:01:01Z");
         return service.dateTimeValid(dateTimeQuery);
     }
+
+    /**
+     * Get '2012-01-01T01:01:01Z' as date-time.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> dateTimeValidAsync() {
+        return dateTimeValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1581,6 +2049,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void dateTimeNull() {
         dateTimeNullAsync().toBlocking().value();
@@ -1593,7 +2062,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> dateTimeNullAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> dateTimeNullAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(dateTimeNullAsync(), serviceCallback);
     }
 
@@ -1601,12 +2070,23 @@ public class QueriesImpl implements Queries {
      * Get null as date-time, should result in no query parameters in uri.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> dateTimeNullAsync() {
+    public Single<RestResponse<Void, Void>> dateTimeNullWithRestResponseAsync() {
         final DateTime dateTimeQuery = null;
         return service.dateTimeNull(dateTimeQuery);
     }
+
+    /**
+     * Get null as date-time, should result in no query parameters in uri.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> dateTimeNullAsync() {
+        return dateTimeNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Get null as date-time, should result in no query parameters in uri.
@@ -1615,6 +2095,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void dateTimeNull(DateTime dateTimeQuery) {
         dateTimeNullAsync(dateTimeQuery).toBlocking().value();
@@ -1628,7 +2109,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> dateTimeNullAsync(DateTime dateTimeQuery, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> dateTimeNullAsync(DateTime dateTimeQuery, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(dateTimeNullAsync(dateTimeQuery), serviceCallback);
     }
 
@@ -1637,11 +2118,23 @@ public class QueriesImpl implements Queries {
      *
      * @param dateTimeQuery null as date-time (no query parameters)
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> dateTimeNullAsync(DateTime dateTimeQuery) {
+    public Single<RestResponse<Void, Void>> dateTimeNullWithRestResponseAsync(DateTime dateTimeQuery) {
         return service.dateTimeNull(dateTimeQuery);
     }
+
+    /**
+     * Get null as date-time, should result in no query parameters in uri.
+     *
+     * @param dateTimeQuery null as date-time (no query parameters)
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> dateTimeNullAsync(DateTime dateTimeQuery) {
+        return dateTimeNullWithRestResponseAsync(dateTimeQuery)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1650,6 +2143,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void arrayStringCsvValid() {
         arrayStringCsvValidAsync().toBlocking().value();
@@ -1662,7 +2156,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> arrayStringCsvValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> arrayStringCsvValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(arrayStringCsvValidAsync(), serviceCallback);
     }
 
@@ -1670,13 +2164,25 @@ public class QueriesImpl implements Queries {
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> arrayStringCsvValidAsync() {
+    public Single<RestResponse<Void, Void>> arrayStringCsvValidWithRestResponseAsync() {
         final List<String> arrayQuery = null;
-        String arrayQueryConverted = this.client.serializerAdapter().serializeList(arrayQuery, CollectionFormat.CSV);
+        Validator.validate(arrayQuery);
+    String arrayQueryConverted = this.client.serializerAdapter().serializeList(arrayQuery, CollectionFormat.CSV);
         return service.arrayStringCsvValid(arrayQueryConverted);
     }
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> arrayStringCsvValidAsync() {
+        return arrayStringCsvValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
@@ -1685,6 +2191,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void arrayStringCsvValid(List<String> arrayQuery) {
         arrayStringCsvValidAsync(arrayQuery).toBlocking().value();
@@ -1698,7 +2205,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> arrayStringCsvValidAsync(List<String> arrayQuery, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> arrayStringCsvValidAsync(List<String> arrayQuery, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(arrayStringCsvValidAsync(arrayQuery), serviceCallback);
     }
 
@@ -1707,13 +2214,25 @@ public class QueriesImpl implements Queries {
      *
      * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> arrayStringCsvValidAsync(List<String> arrayQuery) {
+    public Single<RestResponse<Void, Void>> arrayStringCsvValidWithRestResponseAsync(List<String> arrayQuery) {
         Validator.validate(arrayQuery);
-        String arrayQueryConverted = this.client.serializerAdapter().serializeList(arrayQuery, CollectionFormat.CSV);
+    String arrayQueryConverted = this.client.serializerAdapter().serializeList(arrayQuery, CollectionFormat.CSV);
         return service.arrayStringCsvValid(arrayQueryConverted);
     }
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
+     *
+     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> arrayStringCsvValidAsync(List<String> arrayQuery) {
+        return arrayStringCsvValidWithRestResponseAsync(arrayQuery)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1722,6 +2241,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void arrayStringCsvNull() {
         arrayStringCsvNullAsync().toBlocking().value();
@@ -1734,7 +2254,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> arrayStringCsvNullAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> arrayStringCsvNullAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(arrayStringCsvNullAsync(), serviceCallback);
     }
 
@@ -1742,13 +2262,25 @@ public class QueriesImpl implements Queries {
      * Get a null array of string using the csv-array format.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> arrayStringCsvNullAsync() {
+    public Single<RestResponse<Void, Void>> arrayStringCsvNullWithRestResponseAsync() {
         final List<String> arrayQuery = null;
-        String arrayQueryConverted = this.client.serializerAdapter().serializeList(arrayQuery, CollectionFormat.CSV);
+        Validator.validate(arrayQuery);
+    String arrayQueryConverted = this.client.serializerAdapter().serializeList(arrayQuery, CollectionFormat.CSV);
         return service.arrayStringCsvNull(arrayQueryConverted);
     }
+
+    /**
+     * Get a null array of string using the csv-array format.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> arrayStringCsvNullAsync() {
+        return arrayStringCsvNullWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Get a null array of string using the csv-array format.
@@ -1757,6 +2289,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void arrayStringCsvNull(List<String> arrayQuery) {
         arrayStringCsvNullAsync(arrayQuery).toBlocking().value();
@@ -1770,7 +2303,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> arrayStringCsvNullAsync(List<String> arrayQuery, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> arrayStringCsvNullAsync(List<String> arrayQuery, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(arrayStringCsvNullAsync(arrayQuery), serviceCallback);
     }
 
@@ -1779,13 +2312,25 @@ public class QueriesImpl implements Queries {
      *
      * @param arrayQuery a null array of string using the csv-array format
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> arrayStringCsvNullAsync(List<String> arrayQuery) {
+    public Single<RestResponse<Void, Void>> arrayStringCsvNullWithRestResponseAsync(List<String> arrayQuery) {
         Validator.validate(arrayQuery);
-        String arrayQueryConverted = this.client.serializerAdapter().serializeList(arrayQuery, CollectionFormat.CSV);
+    String arrayQueryConverted = this.client.serializerAdapter().serializeList(arrayQuery, CollectionFormat.CSV);
         return service.arrayStringCsvNull(arrayQueryConverted);
     }
+
+    /**
+     * Get a null array of string using the csv-array format.
+     *
+     * @param arrayQuery a null array of string using the csv-array format
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> arrayStringCsvNullAsync(List<String> arrayQuery) {
+        return arrayStringCsvNullWithRestResponseAsync(arrayQuery)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1794,6 +2339,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void arrayStringCsvEmpty() {
         arrayStringCsvEmptyAsync().toBlocking().value();
@@ -1806,7 +2352,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> arrayStringCsvEmptyAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> arrayStringCsvEmptyAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(arrayStringCsvEmptyAsync(), serviceCallback);
     }
 
@@ -1814,13 +2360,25 @@ public class QueriesImpl implements Queries {
      * Get an empty array [] of string using the csv-array format.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> arrayStringCsvEmptyAsync() {
+    public Single<RestResponse<Void, Void>> arrayStringCsvEmptyWithRestResponseAsync() {
         final List<String> arrayQuery = null;
-        String arrayQueryConverted = this.client.serializerAdapter().serializeList(arrayQuery, CollectionFormat.CSV);
+        Validator.validate(arrayQuery);
+    String arrayQueryConverted = this.client.serializerAdapter().serializeList(arrayQuery, CollectionFormat.CSV);
         return service.arrayStringCsvEmpty(arrayQueryConverted);
     }
+
+    /**
+     * Get an empty array [] of string using the csv-array format.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> arrayStringCsvEmptyAsync() {
+        return arrayStringCsvEmptyWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Get an empty array [] of string using the csv-array format.
@@ -1829,6 +2387,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void arrayStringCsvEmpty(List<String> arrayQuery) {
         arrayStringCsvEmptyAsync(arrayQuery).toBlocking().value();
@@ -1842,7 +2401,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> arrayStringCsvEmptyAsync(List<String> arrayQuery, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> arrayStringCsvEmptyAsync(List<String> arrayQuery, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(arrayStringCsvEmptyAsync(arrayQuery), serviceCallback);
     }
 
@@ -1851,13 +2410,25 @@ public class QueriesImpl implements Queries {
      *
      * @param arrayQuery an empty array [] of string using the csv-array format
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> arrayStringCsvEmptyAsync(List<String> arrayQuery) {
+    public Single<RestResponse<Void, Void>> arrayStringCsvEmptyWithRestResponseAsync(List<String> arrayQuery) {
         Validator.validate(arrayQuery);
-        String arrayQueryConverted = this.client.serializerAdapter().serializeList(arrayQuery, CollectionFormat.CSV);
+    String arrayQueryConverted = this.client.serializerAdapter().serializeList(arrayQuery, CollectionFormat.CSV);
         return service.arrayStringCsvEmpty(arrayQueryConverted);
     }
+
+    /**
+     * Get an empty array [] of string using the csv-array format.
+     *
+     * @param arrayQuery an empty array [] of string using the csv-array format
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> arrayStringCsvEmptyAsync(List<String> arrayQuery) {
+        return arrayStringCsvEmptyWithRestResponseAsync(arrayQuery)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1866,6 +2437,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void arrayStringSsvValid() {
         arrayStringSsvValidAsync().toBlocking().value();
@@ -1878,7 +2450,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> arrayStringSsvValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> arrayStringSsvValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(arrayStringSsvValidAsync(), serviceCallback);
     }
 
@@ -1886,13 +2458,25 @@ public class QueriesImpl implements Queries {
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> arrayStringSsvValidAsync() {
+    public Single<RestResponse<Void, Void>> arrayStringSsvValidWithRestResponseAsync() {
         final List<String> arrayQuery = null;
-        String arrayQueryConverted = this.client.serializerAdapter().serializeList(arrayQuery, CollectionFormat.SSV);
+        Validator.validate(arrayQuery);
+    String arrayQueryConverted = this.client.serializerAdapter().serializeList(arrayQuery, CollectionFormat.SSV);
         return service.arrayStringSsvValid(arrayQueryConverted);
     }
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> arrayStringSsvValidAsync() {
+        return arrayStringSsvValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format.
@@ -1901,6 +2485,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void arrayStringSsvValid(List<String> arrayQuery) {
         arrayStringSsvValidAsync(arrayQuery).toBlocking().value();
@@ -1914,7 +2499,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> arrayStringSsvValidAsync(List<String> arrayQuery, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> arrayStringSsvValidAsync(List<String> arrayQuery, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(arrayStringSsvValidAsync(arrayQuery), serviceCallback);
     }
 
@@ -1923,13 +2508,25 @@ public class QueriesImpl implements Queries {
      *
      * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> arrayStringSsvValidAsync(List<String> arrayQuery) {
+    public Single<RestResponse<Void, Void>> arrayStringSsvValidWithRestResponseAsync(List<String> arrayQuery) {
         Validator.validate(arrayQuery);
-        String arrayQueryConverted = this.client.serializerAdapter().serializeList(arrayQuery, CollectionFormat.SSV);
+    String arrayQueryConverted = this.client.serializerAdapter().serializeList(arrayQuery, CollectionFormat.SSV);
         return service.arrayStringSsvValid(arrayQueryConverted);
     }
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format.
+     *
+     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> arrayStringSsvValidAsync(List<String> arrayQuery) {
+        return arrayStringSsvValidWithRestResponseAsync(arrayQuery)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -1938,6 +2535,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void arrayStringTsvValid() {
         arrayStringTsvValidAsync().toBlocking().value();
@@ -1950,7 +2548,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> arrayStringTsvValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> arrayStringTsvValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(arrayStringTsvValidAsync(), serviceCallback);
     }
 
@@ -1958,13 +2556,25 @@ public class QueriesImpl implements Queries {
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> arrayStringTsvValidAsync() {
+    public Single<RestResponse<Void, Void>> arrayStringTsvValidWithRestResponseAsync() {
         final List<String> arrayQuery = null;
-        String arrayQueryConverted = this.client.serializerAdapter().serializeList(arrayQuery, CollectionFormat.TSV);
+        Validator.validate(arrayQuery);
+    String arrayQueryConverted = this.client.serializerAdapter().serializeList(arrayQuery, CollectionFormat.TSV);
         return service.arrayStringTsvValid(arrayQueryConverted);
     }
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> arrayStringTsvValidAsync() {
+        return arrayStringTsvValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format.
@@ -1973,6 +2583,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void arrayStringTsvValid(List<String> arrayQuery) {
         arrayStringTsvValidAsync(arrayQuery).toBlocking().value();
@@ -1986,7 +2597,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> arrayStringTsvValidAsync(List<String> arrayQuery, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> arrayStringTsvValidAsync(List<String> arrayQuery, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(arrayStringTsvValidAsync(arrayQuery), serviceCallback);
     }
 
@@ -1995,13 +2606,25 @@ public class QueriesImpl implements Queries {
      *
      * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> arrayStringTsvValidAsync(List<String> arrayQuery) {
+    public Single<RestResponse<Void, Void>> arrayStringTsvValidWithRestResponseAsync(List<String> arrayQuery) {
         Validator.validate(arrayQuery);
-        String arrayQueryConverted = this.client.serializerAdapter().serializeList(arrayQuery, CollectionFormat.TSV);
+    String arrayQueryConverted = this.client.serializerAdapter().serializeList(arrayQuery, CollectionFormat.TSV);
         return service.arrayStringTsvValid(arrayQueryConverted);
     }
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format.
+     *
+     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> arrayStringTsvValidAsync(List<String> arrayQuery) {
+        return arrayStringTsvValidWithRestResponseAsync(arrayQuery)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -2010,6 +2633,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void arrayStringPipesValid() {
         arrayStringPipesValidAsync().toBlocking().value();
@@ -2022,7 +2646,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> arrayStringPipesValidAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> arrayStringPipesValidAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(arrayStringPipesValidAsync(), serviceCallback);
     }
 
@@ -2030,13 +2654,25 @@ public class QueriesImpl implements Queries {
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format.
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Void} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> arrayStringPipesValidAsync() {
+    public Single<RestResponse<Void, Void>> arrayStringPipesValidWithRestResponseAsync() {
         final List<String> arrayQuery = null;
-        String arrayQueryConverted = this.client.serializerAdapter().serializeList(arrayQuery, CollectionFormat.PIPES);
+        Validator.validate(arrayQuery);
+    String arrayQueryConverted = this.client.serializerAdapter().serializeList(arrayQuery, CollectionFormat.PIPES);
         return service.arrayStringPipesValid(arrayQueryConverted);
     }
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format.
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> arrayStringPipesValidAsync() {
+        return arrayStringPipesValidWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format.
@@ -2045,6 +2681,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws ErrorException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void arrayStringPipesValid(List<String> arrayQuery) {
         arrayStringPipesValidAsync(arrayQuery).toBlocking().value();
@@ -2058,7 +2695,7 @@ public class QueriesImpl implements Queries {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> arrayStringPipesValidAsync(List<String> arrayQuery, final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> arrayStringPipesValidAsync(List<String> arrayQuery, ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(arrayStringPipesValidAsync(arrayQuery), serviceCallback);
     }
 
@@ -2067,13 +2704,25 @@ public class QueriesImpl implements Queries {
      *
      * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> arrayStringPipesValidAsync(List<String> arrayQuery) {
+    public Single<RestResponse<Void, Void>> arrayStringPipesValidWithRestResponseAsync(List<String> arrayQuery) {
         Validator.validate(arrayQuery);
-        String arrayQueryConverted = this.client.serializerAdapter().serializeList(arrayQuery, CollectionFormat.PIPES);
+    String arrayQueryConverted = this.client.serializerAdapter().serializeList(arrayQuery, CollectionFormat.PIPES);
         return service.arrayStringPipesValid(arrayQueryConverted);
     }
+
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format.
+     *
+     * @param arrayQuery an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> arrayStringPipesValidAsync(List<String> arrayQuery) {
+        return arrayStringPipesValidWithRestResponseAsync(arrayQuery)
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/validation/AutoRestValidationTest.java
+++ b/test/vanilla/src/main/java/fixtures/validation/AutoRestValidationTest.java
@@ -11,6 +11,7 @@
 package fixtures.validation;
 
 import com.microsoft.rest.RestException;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceCallback;
 import com.microsoft.rest.ServiceFuture;
 import fixtures.validation.models.ErrorException;
@@ -98,6 +99,15 @@ public interface AutoRestValidationTest {
      * @return the observable to the Product object
      */
     Single<Product> validationOfMethodParametersAsync(String resourceGroupName, int id);
+    /**
+     * Validates input parameters on the method. See swagger for details.
+     *
+     * @param resourceGroupName Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
+     * @param id Required int multiple of 10 from 100 to 1000.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    Single<RestResponse<Void, Product>> validationOfMethodParametersWithRestResponseAsync(String resourceGroupName, int id);
 
 
     /**
@@ -132,6 +142,16 @@ public interface AutoRestValidationTest {
      * @return the observable to the Product object
      */
     Single<Product> validationOfBodyAsync(String resourceGroupName, int id);
+
+    /**
+     * Validates body parameters on the method. See swagger for details.
+     *
+     * @param resourceGroupName Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
+     * @param id Required int multiple of 10 from 100 to 1000.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    Single<RestResponse<Void, Product>> validationOfBodyWithRestResponseAsync(String resourceGroupName, int id);
     /**
      * Validates body parameters on the method. See swagger for details.
      *
@@ -167,6 +187,16 @@ public interface AutoRestValidationTest {
      * @return the observable to the Product object
      */
     Single<Product> validationOfBodyAsync(String resourceGroupName, int id, Product body);
+    /**
+     * Validates body parameters on the method. See swagger for details.
+     *
+     * @param resourceGroupName Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
+     * @param id Required int multiple of 10 from 100 to 1000.
+     * @param body the Product value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    Single<RestResponse<Void, Product>> validationOfBodyWithRestResponseAsync(String resourceGroupName, int id, Product body);
 
 
     /**
@@ -191,6 +221,12 @@ public interface AutoRestValidationTest {
      * @return the {@link Single<Void>} object if successful.
      */
     Single<Void> getWithConstantInPathAsync();
+    /**
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the {@link Single<Void>} object if successful.
+     */
+    Single<RestResponse<Void, Void>> getWithConstantInPathWithRestResponseAsync();
 
 
     /**
@@ -216,6 +252,13 @@ public interface AutoRestValidationTest {
      * @return the observable to the Product object
      */
     Single<Product> postWithConstantInBodyAsync();
+
+    /**
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    Single<RestResponse<Void, Product>> postWithConstantInBodyWithRestResponseAsync();
     /**
      *
      * @param body the Product value
@@ -242,6 +285,13 @@ public interface AutoRestValidationTest {
      * @return the observable to the Product object
      */
     Single<Product> postWithConstantInBodyAsync(Product body);
+    /**
+     *
+     * @param body the Product value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return the observable to the Product object
+     */
+    Single<RestResponse<Void, Product>> postWithConstantInBodyWithRestResponseAsync(Product body);
 
 
 }

--- a/test/vanilla/src/main/java/fixtures/validation/implementation/AutoRestValidationTestImpl.java
+++ b/test/vanilla/src/main/java/fixtures/validation/implementation/AutoRestValidationTestImpl.java
@@ -12,6 +12,7 @@ package fixtures.validation.implementation;
 
 import fixtures.validation.AutoRestValidationTest;
 import com.microsoft.rest.RestProxy;
+import com.microsoft.rest.RestResponse;
 import com.microsoft.rest.ServiceClient;
 import com.microsoft.rest.RestClient;
 import rx.Single;
@@ -139,23 +140,23 @@ public class AutoRestValidationTestImpl extends ServiceClient implements AutoRes
         @GET("fakepath/{subscriptionId}/{resourceGroupName}/{id}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Product> validationOfMethodParameters(@PathParam("subscriptionId") String subscriptionId, @PathParam("resourceGroupName") String resourceGroupName, @PathParam("id") int id, @QueryParam("apiVersion") String apiVersion);
+        Single<RestResponse<Void, Product>> validationOfMethodParameters(@PathParam("subscriptionId") String subscriptionId, @PathParam("resourceGroupName") String resourceGroupName, @PathParam("id") int id, @QueryParam("apiVersion") String apiVersion);
 
         @Headers({ "x-ms-logging-context: fixtures.validation.AutoRestValidationTest validationOfBody" })
         @PUT("fakepath/{subscriptionId}/{resourceGroupName}/{id}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Single<Product> validationOfBody(@PathParam("subscriptionId") String subscriptionId, @PathParam("resourceGroupName") String resourceGroupName, @PathParam("id") int id, @BodyParam("application/json; charset=utf-8") Product body, @QueryParam("apiVersion") String apiVersion);
+        Single<RestResponse<Void, Product>> validationOfBody(@PathParam("subscriptionId") String subscriptionId, @PathParam("resourceGroupName") String resourceGroupName, @PathParam("id") int id, @BodyParam("application/json; charset=utf-8") Product body, @QueryParam("apiVersion") String apiVersion);
 
         @Headers({ "x-ms-logging-context: fixtures.validation.AutoRestValidationTest getWithConstantInPath" })
         @GET("validation/constantsInPath/{constantParam}/value")
         @ExpectedResponses({200})
-        Single<Void> getWithConstantInPath(@PathParam("constantParam") String constantParam);
+        Single<RestResponse<Void, Void>> getWithConstantInPath(@PathParam("constantParam") String constantParam);
 
         @Headers({ "x-ms-logging-context: fixtures.validation.AutoRestValidationTest postWithConstantInBody" })
         @POST("validation/constantsInPath/{constantParam}/value")
         @ExpectedResponses({200})
-        Single<Product> postWithConstantInBody(@PathParam("constantParam") String constantParam, @BodyParam("application/json; charset=utf-8") Product body);
+        Single<RestResponse<Void, Product>> postWithConstantInBody(@PathParam("constantParam") String constantParam, @BodyParam("application/json; charset=utf-8") Product body);
 
     }
 
@@ -182,7 +183,7 @@ public class AutoRestValidationTestImpl extends ServiceClient implements AutoRes
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> validationOfMethodParametersAsync(String resourceGroupName, int id, final ServiceCallback<Product> serviceCallback) {
+    public ServiceFuture<Product> validationOfMethodParametersAsync(String resourceGroupName, int id, ServiceCallback<Product> serviceCallback) {
         return ServiceFuture.fromBody(validationOfMethodParametersAsync(resourceGroupName, id), serviceCallback);
     }
 
@@ -192,9 +193,9 @@ public class AutoRestValidationTestImpl extends ServiceClient implements AutoRes
      * @param resourceGroupName Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
      * @param id Required int multiple of 10 from 100 to 1000.
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
      */
-    public Single<Product> validationOfMethodParametersAsync(String resourceGroupName, int id) {
+    public Single<RestResponse<Void, Product>> validationOfMethodParametersWithRestResponseAsync(String resourceGroupName, int id) {
         if (this.subscriptionId() == null) {
             throw new IllegalArgumentException("Parameter this.subscriptionId() is required and cannot be null.");
         }
@@ -206,6 +207,19 @@ public class AutoRestValidationTestImpl extends ServiceClient implements AutoRes
         }
         return service.validationOfMethodParameters(this.subscriptionId(), resourceGroupName, id, this.apiVersion());
     }
+
+    /**
+     * Validates input parameters on the method. See swagger for details.
+     *
+     * @param resourceGroupName Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
+     * @param id Required int multiple of 10 from 100 to 1000.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
+     */
+    public Single<Product> validationOfMethodParametersAsync(String resourceGroupName, int id) {
+        return validationOfMethodParametersWithRestResponseAsync(resourceGroupName, id)
+            .map(new Func1<RestResponse<Void, Product>, Product>() { public Product call(RestResponse<Void, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -231,7 +245,7 @@ public class AutoRestValidationTestImpl extends ServiceClient implements AutoRes
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> validationOfBodyAsync(String resourceGroupName, int id, final ServiceCallback<Product> serviceCallback) {
+    public ServiceFuture<Product> validationOfBodyAsync(String resourceGroupName, int id, ServiceCallback<Product> serviceCallback) {
         return ServiceFuture.fromBody(validationOfBodyAsync(resourceGroupName, id), serviceCallback);
     }
 
@@ -241,9 +255,9 @@ public class AutoRestValidationTestImpl extends ServiceClient implements AutoRes
      * @param resourceGroupName Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
      * @param id Required int multiple of 10 from 100 to 1000.
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
      */
-    public Single<Product> validationOfBodyAsync(String resourceGroupName, int id) {
+    public Single<RestResponse<Void, Product>> validationOfBodyWithRestResponseAsync(String resourceGroupName, int id) {
         if (this.subscriptionId() == null) {
             throw new IllegalArgumentException("Parameter this.subscriptionId() is required and cannot be null.");
         }
@@ -254,8 +268,22 @@ public class AutoRestValidationTestImpl extends ServiceClient implements AutoRes
             throw new IllegalArgumentException("Parameter this.apiVersion() is required and cannot be null.");
         }
         final Product body = null;
+        Validator.validate(body);
         return service.validationOfBody(this.subscriptionId(), resourceGroupName, id, body, this.apiVersion());
     }
+
+    /**
+     * Validates body parameters on the method. See swagger for details.
+     *
+     * @param resourceGroupName Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
+     * @param id Required int multiple of 10 from 100 to 1000.
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
+     */
+    public Single<Product> validationOfBodyAsync(String resourceGroupName, int id) {
+        return validationOfBodyWithRestResponseAsync(resourceGroupName, id)
+            .map(new Func1<RestResponse<Void, Product>, Product>() { public Product call(RestResponse<Void, Product> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      * Validates body parameters on the method. See swagger for details.
@@ -282,7 +310,7 @@ public class AutoRestValidationTestImpl extends ServiceClient implements AutoRes
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> validationOfBodyAsync(String resourceGroupName, int id, Product body, final ServiceCallback<Product> serviceCallback) {
+    public ServiceFuture<Product> validationOfBodyAsync(String resourceGroupName, int id, Product body, ServiceCallback<Product> serviceCallback) {
         return ServiceFuture.fromBody(validationOfBodyAsync(resourceGroupName, id, body), serviceCallback);
     }
 
@@ -293,9 +321,9 @@ public class AutoRestValidationTestImpl extends ServiceClient implements AutoRes
      * @param id Required int multiple of 10 from 100 to 1000.
      * @param body the Product value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
      */
-    public Single<Product> validationOfBodyAsync(String resourceGroupName, int id, Product body) {
+    public Single<RestResponse<Void, Product>> validationOfBodyWithRestResponseAsync(String resourceGroupName, int id, Product body) {
         if (this.subscriptionId() == null) {
             throw new IllegalArgumentException("Parameter this.subscriptionId() is required and cannot be null.");
         }
@@ -309,12 +337,27 @@ public class AutoRestValidationTestImpl extends ServiceClient implements AutoRes
         return service.validationOfBody(this.subscriptionId(), resourceGroupName, id, body, this.apiVersion());
     }
 
+    /**
+     * Validates body parameters on the method. See swagger for details.
+     *
+     * @param resourceGroupName Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
+     * @param id Required int multiple of 10 from 100 to 1000.
+     * @param body the Product value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
+     */
+    public Single<Product> validationOfBodyAsync(String resourceGroupName, int id, Product body) {
+        return validationOfBodyWithRestResponseAsync(resourceGroupName, id, body)
+            .map(new Func1<RestResponse<Void, Product>, Product>() { public Product call(RestResponse<Void, Product> restResponse) { return restResponse.body(); } });
+        }
+
 
     /**
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @throws RestException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the void object if successful.
      */
     public void getWithConstantInPath() {
         getWithConstantInPathAsync().toBlocking().value();
@@ -326,19 +369,29 @@ public class AutoRestValidationTestImpl extends ServiceClient implements AutoRes
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Void> getWithConstantInPathAsync(final ServiceCallback<Void> serviceCallback) {
+    public ServiceFuture<Void> getWithConstantInPathAsync(ServiceCallback<Void> serviceCallback) {
         return ServiceFuture.fromBody(getWithConstantInPathAsync(), serviceCallback);
     }
 
     /**
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link Single<Void>} object if successful.
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
      */
-    public Single<Void> getWithConstantInPathAsync() {
+    public Single<RestResponse<Void, Void>> getWithConstantInPathWithRestResponseAsync() {
         final String constantParam = "constant";
         return service.getWithConstantInPath(constantParam);
     }
+
+    /**
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Void> object
+     */
+    public Single<Void> getWithConstantInPathAsync() {
+        return getWithConstantInPathWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Void>, Void>() { public Void call(RestResponse<Void, Void> restResponse) { return restResponse.body(); } });
+        }
 
 
     /**
@@ -358,20 +411,31 @@ public class AutoRestValidationTestImpl extends ServiceClient implements AutoRes
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> postWithConstantInBodyAsync(final ServiceCallback<Product> serviceCallback) {
+    public ServiceFuture<Product> postWithConstantInBodyAsync(ServiceCallback<Product> serviceCallback) {
         return ServiceFuture.fromBody(postWithConstantInBodyAsync(), serviceCallback);
     }
 
     /**
      *
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
      */
-    public Single<Product> postWithConstantInBodyAsync() {
+    public Single<RestResponse<Void, Product>> postWithConstantInBodyWithRestResponseAsync() {
         final String constantParam = "constant";
         final Product body = null;
+        Validator.validate(body);
         return service.postWithConstantInBody(constantParam, body);
     }
+
+    /**
+     *
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
+     */
+    public Single<Product> postWithConstantInBodyAsync() {
+        return postWithConstantInBodyWithRestResponseAsync()
+            .map(new Func1<RestResponse<Void, Product>, Product>() { public Product call(RestResponse<Void, Product> restResponse) { return restResponse.body(); } });
+        }
 
     /**
      *
@@ -392,7 +456,7 @@ public class AutoRestValidationTestImpl extends ServiceClient implements AutoRes
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceFuture} object
      */
-    public ServiceFuture<Product> postWithConstantInBodyAsync(Product body, final ServiceCallback<Product> serviceCallback) {
+    public ServiceFuture<Product> postWithConstantInBodyAsync(Product body, ServiceCallback<Product> serviceCallback) {
         return ServiceFuture.fromBody(postWithConstantInBodyAsync(body), serviceCallback);
     }
 
@@ -400,13 +464,24 @@ public class AutoRestValidationTestImpl extends ServiceClient implements AutoRes
      *
      * @param body the Product value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the observable to the Product object
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
      */
-    public Single<Product> postWithConstantInBodyAsync(Product body) {
-        Validator.validate(body);
+    public Single<RestResponse<Void, Product>> postWithConstantInBodyWithRestResponseAsync(Product body) {
         final String constantParam = "constant";
+        Validator.validate(body);
         return service.postWithConstantInBody(constantParam, body);
     }
+
+    /**
+     *
+     * @param body the Product value
+     * @throws IllegalArgumentException thrown if parameters fail the validation
+     * @return a {@link Single} emitting the RestResponse<Void, Product> object
+     */
+    public Single<Product> postWithConstantInBodyAsync(Product body) {
+        return postWithConstantInBodyWithRestResponseAsync(body)
+            .map(new Func1<RestResponse<Void, Product>, Product>() { public Product call(RestResponse<Void, Product> restResponse) { return restResponse.body(); } });
+        }
 
 
 }

--- a/test/vanilla/src/test/java/fixtures/header/HeaderOperationsTests.java
+++ b/test/vanilla/src/test/java/fixtures/header/HeaderOperationsTests.java
@@ -1,5 +1,6 @@
 package fixtures.header;
 
+import com.microsoft.rest.RestResponse;
 import org.apache.commons.codec.binary.Base64;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -11,6 +12,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.nio.charset.Charset;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -34,7 +36,6 @@ import rx.functions.Action1;
 
 import static org.junit.Assert.fail;
 
-@Ignore("RestProxy doesn't currently support reading response headers")
 public class HeaderOperationsTests {
     private static AutoRestSwaggerBATHeaderService client;
     private CountDownLatch lock;
@@ -44,606 +45,603 @@ public class HeaderOperationsTests {
         client = new AutoRestSwaggerBATHeaderServiceImpl("http://localhost:3000");
     }
 
-//    @Test
-//    public void paramExistingKey() throws Exception {
-//        client.headers().paramExistingKey("overwrite");
-//    }
-//
-//    @Test
-//    public void responseExistingKey() throws Exception {
-//        // Headers not supported by RestProxy
-//        Assert.fail();
-//
-//        lock = new CountDownLatch(1);
-//        client.headers().responseExistingKeyAsync()
-//            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseExistingKeyHeaders>>() {
-//                @Override
-//                public void call(ServiceResponseWithHeaders<Void, HeaderResponseExistingKeyHeaders> response) {
-//                    Headers headers = response.response().headers();
-//                    if (headers.get("User-Agent") != null) {
-//                        Assert.assertEquals("overwrite", headers.get("User-Agent"));
-//                        lock.countDown();
-//                    }
-//                }
-//            }, new Action1<Throwable>() {
-//                @Override
-//                public void call(Throwable throwable) {
-//                    fail();
-//                }
-//            });
-//        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
-//    }
-//
-//    @Test
-//    public void paramProtectedKey() throws Exception {
-//        try {
-//            client.headers().paramProtectedKey("text/html");
-//        } catch (RuntimeException ex) {
-//            // OkHttp can actually overwrite header "Content-Type"
-//        }
-//    }
-//
-//    @Test
-//    public void responseProtectedKey() throws Exception {
-//        lock = new CountDownLatch(1);
-//        client.headers().responseProtectedKeyWithServiceResponseAsync()
-//            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseProtectedKeyHeaders>>() {
-//                @Override
-//                public void call(ServiceResponseWithHeaders<Void, HeaderResponseProtectedKeyHeaders> response) {
-//                    Headers headers = response.response().headers();
-//                    if (headers.get("Content-Type") != null) {
-//                        Assert.assertTrue(headers.get("Content-Type").contains("text/html"));
-//                        lock.countDown();
-//                    }
-//                }
-//            }, new Action1<Throwable>() {
-//                @Override
-//                public void call(Throwable throwable) {
-//                    fail();
-//                }
-//            });
-//        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
-//    }
-//
-//    @Test
-//    public void paramInteger() throws Exception {
-//        client.headers().paramInteger("positive", 1);
-//        client.headers().paramInteger("negative", -2);
-//    }
-//
-//    @Test
-//    public void responseInteger() throws Exception {
-//        lock = new CountDownLatch(1);
-//        client.headers().responseIntegerWithServiceResponseAsync("positive")
-//            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseIntegerHeaders>>() {
-//                @Override
-//                public void call(ServiceResponseWithHeaders<Void, HeaderResponseIntegerHeaders> response) {
-//                    Headers headers = response.response().headers();
-//                    if (headers.get("value") != null) {
-//                        Assert.assertEquals("1", headers.get("value"));
-//                        lock.countDown();
-//                    }
-//                }
-//            }, new Action1<Throwable>() {
-//                @Override
-//                public void call(Throwable throwable) {
-//                    fail();
-//                }
-//            });
-//        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
-//        lock = new CountDownLatch(1);
-//        client.headers().responseIntegerWithServiceResponseAsync("negative")
-//            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseIntegerHeaders>>() {
-//                @Override
-//                public void call(ServiceResponseWithHeaders<Void, HeaderResponseIntegerHeaders> response) {
-//                    Headers headers = response.response().headers();
-//                    if (headers.get("value") != null) {
-//                        Assert.assertEquals("-2", headers.get("value"));
-//                        lock.countDown();
-//                    }
-//                }
-//            }, new Action1<Throwable>() {
-//                @Override
-//                public void call(Throwable throwable) {
-//                    fail();
-//                }
-//            });
-//        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
-//    }
-//
-//    @Test
-//    public void paramLong() throws Exception {
-//        client.headers().paramLong("positive", 105);
-//        client.headers().paramLong("negative", -2);
-//    }
-//
-//    @Test
-//    public void responseLong() throws Exception {
-//        lock = new CountDownLatch(1);
-//        client.headers().responseLongWithServiceResponseAsync("positive")
-//            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseLongHeaders>>() {
-//                @Override
-//                public void call(ServiceResponseWithHeaders<Void, HeaderResponseLongHeaders> response) {
-//                    Headers headers = response.response().headers();
-//                    if (headers.get("value") != null) {
-//                        Assert.assertEquals("105", headers.get("value"));
-//                        lock.countDown();
-//                    }
-//                }
-//            }, new Action1<Throwable>() {
-//                @Override
-//                public void call(Throwable throwable) {
-//                    fail();
-//                }
-//            });
-//        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
-//        lock = new CountDownLatch(1);
-//        client.headers().responseLongWithServiceResponseAsync("negative")
-//            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseLongHeaders>>() {
-//                @Override
-//                public void call(ServiceResponseWithHeaders<Void, HeaderResponseLongHeaders> response) {
-//                    Headers headers = response.response().headers();
-//                    if (headers.get("value") != null) {
-//                        Assert.assertEquals("-2", headers.get("value"));
-//                        lock.countDown();
-//                    }
-//                }
-//            }, new Action1<Throwable>() {
-//                @Override
-//                public void call(Throwable throwable) {
-//                    fail();
-//                }
-//            });
-//        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
-//    }
-//
-//    @Test
-//    public void paramFloat() throws Exception {
-//        client.headers().paramFloat("positive", 0.07);
-//        client.headers().paramFloat("negative", -3.0);
-//    }
-//
-//    @Test
-//    public void responseFloat() throws Exception {
-//        lock = new CountDownLatch(1);
-//        client.headers().responseFloatWithServiceResponseAsync("positive")
-//            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseFloatHeaders>>() {
-//                @Override
-//                public void call(ServiceResponseWithHeaders<Void, HeaderResponseFloatHeaders> response) {
-//                    Headers headers = response.response().headers();
-//                    if (headers.get("value") != null) {
-//                        Assert.assertEquals("0.07", headers.get("value"));
-//                        lock.countDown();
-//                    }
-//                }
-//            }, new Action1<Throwable>() {
-//                @Override
-//                public void call(Throwable throwable) {
-//                    fail();
-//                }
-//            });
-//        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
-//        lock = new CountDownLatch(1);
-//        client.headers().responseFloatWithServiceResponseAsync("negative")
-//            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseFloatHeaders>>() {
-//                @Override
-//                public void call(ServiceResponseWithHeaders<Void, HeaderResponseFloatHeaders> response) {
-//                    Headers headers = response.response().headers();
-//                    if (headers.get("value") != null) {
-//                        Assert.assertEquals("-3", headers.get("value"));
-//                        lock.countDown();
-//                    }
-//                }
-//            }, new Action1<Throwable>() {
-//                @Override
-//                public void call(Throwable throwable) {
-//                    fail();
-//                }
-//            });
-//        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
-//    }
-//
-//    @Test
-//    public void paramDouble() throws Exception {
-//        client.headers().paramDouble("positive", 7e120);
-//        client.headers().paramDouble("negative", -3.0);
-//    }
-//
-//    @Test
-//    public void responseDouble() throws Exception {
-//        lock = new CountDownLatch(1);
-//        client.headers().responseDoubleWithServiceResponseAsync("positive")
-//            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseDoubleHeaders>>() {
-//                @Override
-//                public void call(ServiceResponseWithHeaders<Void, HeaderResponseDoubleHeaders> response) {
-//                    Headers headers = response.response().headers();
-//                    if (headers.get("value") != null) {
-//                        Assert.assertEquals("7e+120", headers.get("value"));
-//                        lock.countDown();
-//                    }
-//                }
-//            }, new Action1<Throwable>() {
-//                @Override
-//                public void call(Throwable throwable) {
-//                    fail();
-//                }
-//            });
-//        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
-//        lock = new CountDownLatch(1);
-//        client.headers().responseDoubleWithServiceResponseAsync("negative")
-//            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseDoubleHeaders>>() {
-//                @Override
-//                public void call(ServiceResponseWithHeaders<Void, HeaderResponseDoubleHeaders> response) {
-//                    Headers headers = response.response().headers();
-//                    if (headers.get("value") != null) {
-//                        Assert.assertEquals("-3", headers.get("value"));
-//                        lock.countDown();
-//                    }
-//                }
-//            }, new Action1<Throwable>() {
-//                @Override
-//                public void call(Throwable throwable) {
-//                    fail();
-//                }
-//            });
-//        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
-//    }
-//
-//    @Test
-//    public void paramBool() throws Exception {
-//        client.headers().paramBool("true", true);
-//        client.headers().paramBool("false", false);
-//    }
-//
-//    @Test
-//    public void responseBool() throws Exception {
-//        lock = new CountDownLatch(1);
-//        client.headers().responseBoolWithServiceResponseAsync("true")
-//            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseBoolHeaders>>() {
-//                @Override
-//                public void call(ServiceResponseWithHeaders<Void, HeaderResponseBoolHeaders> response) {
-//                    Headers headers = response.response().headers();
-//                    if (headers.get("value") != null) {
-//                        Assert.assertEquals("true", headers.get("value"));
-//                        lock.countDown();
-//                    }
-//                }
-//            }, new Action1<Throwable>() {
-//                @Override
-//                public void call(Throwable throwable) {
-//                    fail();
-//                }
-//            });
-//        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
-//        lock = new CountDownLatch(1);
-//        client.headers().responseBoolWithServiceResponseAsync("false")
-//            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseBoolHeaders>>() {
-//                @Override
-//                public void call(ServiceResponseWithHeaders<Void, HeaderResponseBoolHeaders> response) {
-//                    Headers headers = response.response().headers();
-//                    if (headers.get("value") != null) {
-//                        Assert.assertEquals("false", headers.get("value"));
-//                        lock.countDown();
-//                    }
-//                }
-//            }, new Action1<Throwable>() {
-//                @Override
-//                public void call(Throwable throwable) {
-//                    fail();
-//                }
-//            });
-//        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
-//    }
-//
-//    @Test
-//    public void paramString() throws Exception {
-//        client.headers().paramString("valid", "The quick brown fox jumps over the lazy dog");
-//        client.headers().paramString("null", null);
-//        client.headers().paramString("empty", "");
-//    }
-//
-//    @Test
-//    public void responseString() throws Exception {
-//        lock = new CountDownLatch(1);
-//        client.headers().responseStringWithServiceResponseAsync("valid")
-//            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseStringHeaders>>() {
-//                @Override
-//                public void call(ServiceResponseWithHeaders<Void, HeaderResponseStringHeaders> response) {
-//                    Headers headers = response.response().headers();
-//                    if (headers.get("value") != null) {
-//                        Assert.assertEquals("The quick brown fox jumps over the lazy dog", headers.get("value"));
-//                        lock.countDown();
-//                    }
-//                }
-//            }, new Action1<Throwable>() {
-//                @Override
-//                public void call(Throwable throwable) {
-//                    fail();
-//                }
-//            });
-//        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
-//        lock = new CountDownLatch(1);
-//        client.headers().responseStringWithServiceResponseAsync("null")
-//            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseStringHeaders>>() {
-//                @Override
-//                public void call(ServiceResponseWithHeaders<Void, HeaderResponseStringHeaders> response) {
-//                    Headers headers = response.response().headers();
-//                    if (headers.get("value") != null) {
-//                        Assert.assertEquals("null", headers.get("value"));
-//                        lock.countDown();
-//                    }
-//                }
-//            }, new Action1<Throwable>() {
-//                @Override
-//                public void call(Throwable throwable) {
-//                    fail();
-//                }
-//            });
-//        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
-//        lock = new CountDownLatch(1);
-//        client.headers().responseStringWithServiceResponseAsync("empty")
-//            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseStringHeaders>>() {
-//                @Override
-//                public void call(ServiceResponseWithHeaders<Void, HeaderResponseStringHeaders> response) {
-//                    Headers headers = response.response().headers();
-//                    if (headers.get("value") != null) {
-//                        Assert.assertEquals("", headers.get("value"));
-//                        lock.countDown();
-//                    }
-//                }
-//            }, new Action1<Throwable>() {
-//                @Override
-//                public void call(Throwable throwable) {
-//                    fail();
-//                }
-//            });
-//        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
-//    }
-//
-//    @Test
-//    public void paramDate() throws Exception {
-//        client.headers().paramDate("valid", new LocalDate(2010, 1, 1));
-//        client.headers().paramDate("min", new LocalDate(1, 1, 1));
-//    }
-//
-//    @Test
-//    public void responseDate() throws Exception {
-//        lock = new CountDownLatch(1);
-//        client.headers().responseDateWithServiceResponseAsync("valid")
-//            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseDateHeaders>>() {
-//                @Override
-//                public void call(ServiceResponseWithHeaders<Void, HeaderResponseDateHeaders> response) {
-//                    Headers headers = response.response().headers();
-//                    if (headers.get("value") != null) {
-//                        Assert.assertEquals("2010-01-01", headers.get("value"));
-//                        lock.countDown();
-//                    }
-//                }
-//            }, new Action1<Throwable>() {
-//                @Override
-//                public void call(Throwable throwable) {
-//                    fail();
-//                }
-//            });
-//        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
-//        lock = new CountDownLatch(1);
-//        client.headers().responseDateWithServiceResponseAsync("min")
-//            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseDateHeaders>>() {
-//                @Override
-//                public void call(ServiceResponseWithHeaders<Void, HeaderResponseDateHeaders> response) {
-//                    Headers headers = response.response().headers();
-//                    if (headers.get("value") != null) {
-//                        Assert.assertEquals("0001-01-01", headers.get("value"));
-//                        lock.countDown();
-//                    }
-//                }
-//            }, new Action1<Throwable>() {
-//                @Override
-//                public void call(Throwable throwable) {
-//                    fail();
-//                }
-//            });
-//        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
-//    }
-//
-//    @Test
-//    public void paramDuration() throws Exception {
-//        client.headers().paramDuration("valid", new Period(0, 0, 0, 123, 22, 14, 12, 11));
-//    }
-//
-//    @Test
-//    public void responseDuration() throws Exception {
-//        lock = new CountDownLatch(1);
-//        client.headers().responseDurationWithServiceResponseAsync("valid")
-//            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseDurationHeaders>>() {
-//                @Override
-//                public void call(ServiceResponseWithHeaders<Void, HeaderResponseDurationHeaders> response) {
-//                    Headers headers = response.response().headers();
-//                    if (headers.get("value") != null) {
-//                        Assert.assertEquals("P123DT22H14M12.011S", headers.get("value"));
-//                        lock.countDown();
-//                    }
-//                }
-//            }, new Action1<Throwable>() {
-//                @Override
-//                public void call(Throwable throwable) {
-//                    fail();
-//                }
-//            });
-//        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
-//    }
-//
-//    @Test
-//    public void paramDatetimeRfc1123() throws Exception {
-//        client.headers().paramDatetimeRfc1123("valid", new DateTime(2010, 1, 1, 12, 34, 56, DateTimeZone.UTC));
-//        client.headers().paramDatetimeRfc1123("min", new DateTime(1, 1, 1, 0, 0, 0, DateTimeZone.UTC));
-//    }
-//
-//    @Test
-//    public void responseDatetimeRfc1123() throws Exception {
-//        lock = new CountDownLatch(1);
-//        client.headers().responseDatetimeRfc1123WithServiceResponseAsync("valid")
-//            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseDatetimeRfc1123Headers>>() {
-//                @Override
-//                public void call(ServiceResponseWithHeaders<Void, HeaderResponseDatetimeRfc1123Headers> response) {
-//                    Headers headers = response.response().headers();
-//                    if (headers.get("value") != null) {
-//                        Assert.assertEquals("Fri, 01 Jan 2010 12:34:56 GMT", headers.get("value"));
-//                        lock.countDown();
-//                    }
-//                }
-//            }, new Action1<Throwable>() {
-//                @Override
-//                public void call(Throwable throwable) {
-//                    fail();
-//                }
-//            });
-//        Assert.assertTrue(lock.await(100000, TimeUnit.MILLISECONDS));
-//        lock = new CountDownLatch(1);
-//        client.headers().responseDatetimeRfc1123WithServiceResponseAsync("min")
-//            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseDatetimeRfc1123Headers>>() {
-//                @Override
-//                public void call(ServiceResponseWithHeaders<Void, HeaderResponseDatetimeRfc1123Headers> response) {
-//                    Headers headers = response.response().headers();
-//                    if (headers.get("value") != null) {
-//                        Assert.assertEquals("Mon, 01 Jan 0001 00:00:00 GMT", headers.get("value"));
-//                        lock.countDown();
-//
-//                    }
-//                }
-//            }, new Action1<Throwable>() {
-//                @Override
-//                public void call(Throwable throwable) {
-//                    fail();
-//                }
-//            });
-//        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
-//    }
-//
-//    @Test
-//    public void paramDatetime() throws Exception {
-//        client.headers().paramDatetime("valid", new DateTime(2010, 1, 1, 12, 34, 56, DateTimeZone.UTC));
-//        client.headers().paramDatetime("min", new DateTime(1, 1, 1, 0, 0, 0, DateTimeZone.UTC));
-//    }
-//
-//    @Test
-//    public void responseDatetime() throws Exception {
-//        lock = new CountDownLatch(1);
-//        client.headers().responseDatetimeWithServiceResponseAsync("valid")
-//            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseDatetimeHeaders>>() {
-//                @Override
-//                public void call(ServiceResponseWithHeaders<Void, HeaderResponseDatetimeHeaders> response) {
-//                    Headers headers = response.response().headers();
-//                    if (headers.get("value") != null) {
-//                        Assert.assertEquals("2010-01-01T12:34:56Z", headers.get("value"));
-//                        lock.countDown();
-//                    }
-//                }
-//            }, new Action1<Throwable>() {
-//                @Override
-//                public void call(Throwable throwable) {
-//                    fail();
-//                }
-//            });
-//        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
-//        lock = new CountDownLatch(1);
-//        client.headers().responseDatetimeWithServiceResponseAsync("min")
-//            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseDatetimeHeaders>>() {
-//                @Override
-//                public void call(ServiceResponseWithHeaders<Void, HeaderResponseDatetimeHeaders> response) {
-//                    Headers headers = response.response().headers();
-//                    if (headers.get("value") != null) {
-//                        Assert.assertEquals("0001-01-01T00:00:00Z", headers.get("value"));
-//                        lock.countDown();
-//                    }
-//                }
-//            }, new Action1<Throwable>() {
-//                @Override
-//                public void call(Throwable throwable) {
-//                    fail();
-//                }
-//            });
-//        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
-//    }
-//
-//    @Test
-//    public void paramByte() throws Exception {
-//        client.headers().paramByte("valid", "啊齄丂狛狜隣郎隣兀﨩".getBytes(Charset.forName("UTF-8")));
-//    }
-//
-//    @Test
-//    public void responseByte() throws Exception {
-//        lock = new CountDownLatch(1);
-//        client.headers().responseByteWithServiceResponseAsync("valid")
-//            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseByteHeaders>>() {
-//                @Override
-//                public void call(ServiceResponseWithHeaders<Void, HeaderResponseByteHeaders> response) {
-//                    Headers headers = response.response().headers();
-//                    if (headers.get("value") != null) {
-//                        byte[] value = Base64.decodeBase64(headers.get("value"));
-//                        String actual = new String(value, Charset.forName("UTF-8"));
-//                        Assert.assertEquals("啊齄丂狛狜隣郎隣兀﨩", actual);
-//                        lock.countDown();
-//                    }
-//                }
-//            }, new Action1<Throwable>() {
-//                @Override
-//                public void call(Throwable throwable) {
-//                    fail();
-//                }
-//            });
-//        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
-//    }
-//
-//    @Test
-//    public void paramEnum() throws Exception {
-//        client.headers().paramEnum("valid", GreyscaleColors.GREY);
-//        client.headers().paramEnum("null", null);
-//    }
-//
-//    @Test
-//    public void responseEnum() throws Exception {
-//        lock = new CountDownLatch(1);
-//        client.headers().responseEnumWithServiceResponseAsync("valid")
-//            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseEnumHeaders>>() {
-//                @Override
-//                public void call(ServiceResponseWithHeaders<Void, HeaderResponseEnumHeaders> response) {
-//                    Headers headers = response.response().headers();
-//                    if (headers.get("value") != null) {
-//                        Assert.assertEquals("GREY", headers.get("value"));
-//                        lock.countDown();
-//                    }
-//                }
-//            }, new Action1<Throwable>() {
-//                @Override
-//                public void call(Throwable throwable) {
-//                    fail();
-//                }
-//            });
-//        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
-//        lock = new CountDownLatch(1);
-//        client.headers().responseEnumWithServiceResponseAsync("null")
-//            .subscribe(new Action1<ServiceResponseWithHeaders<Void, HeaderResponseEnumHeaders>>() {
-//                @Override
-//                public void call(ServiceResponseWithHeaders<Void, HeaderResponseEnumHeaders> response) {
-//                    Headers headers = response.response().headers();
-//                    if (headers.get("value") != null) {
-//                        Assert.assertEquals("", headers.get("value"));
-//                        lock.countDown();
-//                    }
-//                }
-//            }, new Action1<Throwable>() {
-//                @Override
-//                public void call(Throwable throwable) {
-//                    fail();
-//                }
-//            });
-//        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
-//    }
-//
-//    @Test
-//    @Ignore("Custom header not supported yet")
-//    public void customRequestId() throws Exception {
-//        client.headers().customRequestId();
-//    }
+    @Test
+    public void paramExistingKey() throws Exception {
+        client.headers().paramExistingKey("overwrite");
+    }
+
+    @Test
+    public void responseExistingKey() throws Exception {
+        lock = new CountDownLatch(1);
+        client.headers().responseExistingKeyWithRestResponseAsync()
+            .subscribe(new Action1<RestResponse<HeaderResponseExistingKeyHeaders, Void>>() {
+                @Override
+                public void call(RestResponse<HeaderResponseExistingKeyHeaders, Void> response) {
+                    Map<String, String> headers = response.rawHeaders();
+                    if (headers.get("User-Agent") != null) {
+                        Assert.assertEquals("overwrite", headers.get("User-Agent"));
+                        lock.countDown();
+                    }
+                }
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
+        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void paramProtectedKey() throws Exception {
+        try {
+            client.headers().paramProtectedKey("text/html");
+        } catch (RuntimeException ex) {
+            // OkHttp can actually overwrite header "Content-Type"
+        }
+    }
+
+    @Test
+    public void responseProtectedKey() throws Exception {
+        lock = new CountDownLatch(1);
+        client.headers().responseProtectedKeyWithRestResponseAsync()
+            .subscribe(new Action1<RestResponse<HeaderResponseProtectedKeyHeaders, Void>>() {
+                @Override
+                public void call(RestResponse<HeaderResponseProtectedKeyHeaders, Void> response) {
+                    Map<String, String> headers = response.rawHeaders();
+                    if (headers.get("Content-Type") != null) {
+                        Assert.assertTrue(headers.get("Content-Type").contains("text/html"));
+                        lock.countDown();
+                    }
+                }
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
+        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void paramInteger() throws Exception {
+        client.headers().paramInteger("positive", 1);
+        client.headers().paramInteger("negative", -2);
+    }
+
+    @Test
+    public void responseInteger() throws Exception {
+        lock = new CountDownLatch(1);
+        client.headers().responseIntegerWithRestResponseAsync("positive")
+            .subscribe(new Action1<RestResponse<HeaderResponseIntegerHeaders, Void>>() {
+                @Override
+                public void call(RestResponse<HeaderResponseIntegerHeaders, Void> response) {
+                    Map<String, String> headers = response.rawHeaders();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("1", headers.get("value"));
+                        lock.countDown();
+                    }
+                }
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
+        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+        lock = new CountDownLatch(1);
+        client.headers().responseIntegerWithRestResponseAsync("negative")
+            .subscribe(new Action1<RestResponse<HeaderResponseIntegerHeaders, Void>>() {
+                @Override
+                public void call(RestResponse<HeaderResponseIntegerHeaders, Void> response) {
+                    Map<String, String> headers = response.rawHeaders();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("-2", headers.get("value"));
+                        lock.countDown();
+                    }
+                }
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
+        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void paramLong() throws Exception {
+        client.headers().paramLong("positive", 105);
+        client.headers().paramLong("negative", -2);
+    }
+
+    @Test
+    public void responseLong() throws Exception {
+        lock = new CountDownLatch(1);
+        client.headers().responseLongWithRestResponseAsync("positive")
+            .subscribe(new Action1<RestResponse<HeaderResponseLongHeaders, Void>>() {
+                @Override
+                public void call(RestResponse<HeaderResponseLongHeaders, Void> response) {
+                    Map<String, String> headers = response.rawHeaders();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("105", headers.get("value"));
+                        lock.countDown();
+                    }
+                }
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
+        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+        lock = new CountDownLatch(1);
+        client.headers().responseLongWithRestResponseAsync("negative")
+            .subscribe(new Action1<RestResponse<HeaderResponseLongHeaders, Void>>() {
+                @Override
+                public void call(RestResponse<HeaderResponseLongHeaders, Void> response) {
+                    Map<String, String> headers = response.rawHeaders();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("-2", headers.get("value"));
+                        lock.countDown();
+                    }
+                }
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
+        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void paramFloat() throws Exception {
+        client.headers().paramFloat("positive", 0.07);
+        client.headers().paramFloat("negative", -3.0);
+    }
+
+    @Test
+    public void responseFloat() throws Exception {
+        lock = new CountDownLatch(1);
+        client.headers().responseFloatWithRestResponseAsync("positive")
+            .subscribe(new Action1<RestResponse<HeaderResponseFloatHeaders, Void>>() {
+                @Override
+                public void call(RestResponse<HeaderResponseFloatHeaders, Void> response) {
+                    Map<String, String> headers = response.rawHeaders();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("0.07", headers.get("value"));
+                        lock.countDown();
+                    }
+                }
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
+        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+        lock = new CountDownLatch(1);
+        client.headers().responseFloatWithRestResponseAsync("negative")
+            .subscribe(new Action1<RestResponse<HeaderResponseFloatHeaders, Void>>() {
+                @Override
+                public void call(RestResponse<HeaderResponseFloatHeaders, Void> response) {
+                    Map<String, String> headers = response.rawHeaders();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("-3", headers.get("value"));
+                        lock.countDown();
+                    }
+                }
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
+        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void paramDouble() throws Exception {
+        client.headers().paramDouble("positive", 7e120);
+        client.headers().paramDouble("negative", -3.0);
+    }
+
+    @Test
+    public void responseDouble() throws Exception {
+        lock = new CountDownLatch(1);
+        client.headers().responseDoubleWithRestResponseAsync("positive")
+            .subscribe(new Action1<RestResponse<HeaderResponseDoubleHeaders, Void>>() {
+                @Override
+                public void call(RestResponse<HeaderResponseDoubleHeaders, Void> response) {
+                    Map<String, String> headers = response.rawHeaders();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("7e+120", headers.get("value"));
+                        lock.countDown();
+                    }
+                }
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
+        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+        lock = new CountDownLatch(1);
+        client.headers().responseDoubleWithRestResponseAsync("negative")
+            .subscribe(new Action1<RestResponse<HeaderResponseDoubleHeaders, Void>>() {
+                @Override
+                public void call(RestResponse<HeaderResponseDoubleHeaders, Void> response) {
+                    Map<String, String> headers = response.rawHeaders();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("-3", headers.get("value"));
+                        lock.countDown();
+                    }
+                }
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
+        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void paramBool() throws Exception {
+        client.headers().paramBool("true", true);
+        client.headers().paramBool("false", false);
+    }
+
+    @Test
+    public void responseBool() throws Exception {
+        lock = new CountDownLatch(1);
+        client.headers().responseBoolWithRestResponseAsync("true")
+            .subscribe(new Action1<RestResponse<HeaderResponseBoolHeaders, Void>>() {
+                @Override
+                public void call(RestResponse<HeaderResponseBoolHeaders, Void> response) {
+                    Map<String, String> headers = response.rawHeaders();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("true", headers.get("value"));
+                        lock.countDown();
+                    }
+                }
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
+        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+        lock = new CountDownLatch(1);
+        client.headers().responseBoolWithRestResponseAsync("false")
+            .subscribe(new Action1<RestResponse<HeaderResponseBoolHeaders, Void>>() {
+                @Override
+                public void call(RestResponse<HeaderResponseBoolHeaders, Void> response) {
+                    Map<String, String> headers = response.rawHeaders();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("false", headers.get("value"));
+                        lock.countDown();
+                    }
+                }
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
+        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void paramString() throws Exception {
+        client.headers().paramString("valid", "The quick brown fox jumps over the lazy dog");
+        client.headers().paramString("null", null);
+        client.headers().paramString("empty", "");
+    }
+
+    @Test
+    public void responseString() throws Exception {
+        lock = new CountDownLatch(1);
+        client.headers().responseStringWithRestResponseAsync("valid")
+            .subscribe(new Action1<RestResponse<HeaderResponseStringHeaders, Void>>() {
+                @Override
+                public void call(RestResponse<HeaderResponseStringHeaders, Void> response) {
+                    Map<String, String> headers = response.rawHeaders();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("The quick brown fox jumps over the lazy dog", headers.get("value"));
+                        lock.countDown();
+                    }
+                }
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
+        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+        lock = new CountDownLatch(1);
+        client.headers().responseStringWithRestResponseAsync("null")
+            .subscribe(new Action1<RestResponse<HeaderResponseStringHeaders, Void>>() {
+                @Override
+                public void call(RestResponse<HeaderResponseStringHeaders, Void> response) {
+                    Map<String, String> headers = response.rawHeaders();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("null", headers.get("value"));
+                        lock.countDown();
+                    }
+                }
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
+        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+        lock = new CountDownLatch(1);
+        client.headers().responseStringWithRestResponseAsync("empty")
+            .subscribe(new Action1<RestResponse<HeaderResponseStringHeaders, Void>>() {
+                @Override
+                public void call(RestResponse<HeaderResponseStringHeaders, Void> response) {
+                    Map<String, String> headers = response.rawHeaders();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("", headers.get("value"));
+                        lock.countDown();
+                    }
+                }
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
+        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void paramDate() throws Exception {
+        client.headers().paramDate("valid", new LocalDate(2010, 1, 1));
+        client.headers().paramDate("min", new LocalDate(1, 1, 1));
+    }
+
+    @Test
+    public void responseDate() throws Exception {
+        lock = new CountDownLatch(1);
+        client.headers().responseDateWithRestResponseAsync("valid")
+            .subscribe(new Action1<RestResponse<HeaderResponseDateHeaders, Void>>() {
+                @Override
+                public void call(RestResponse<HeaderResponseDateHeaders, Void> response) {
+                    Map<String, String> headers = response.rawHeaders();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("2010-01-01", headers.get("value"));
+                        lock.countDown();
+                    }
+                }
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
+        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+        lock = new CountDownLatch(1);
+        client.headers().responseDateWithRestResponseAsync("min")
+            .subscribe(new Action1<RestResponse<HeaderResponseDateHeaders, Void>>() {
+                @Override
+                public void call(RestResponse<HeaderResponseDateHeaders, Void> response) {
+                    Map<String, String> headers = response.rawHeaders();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("0001-01-01", headers.get("value"));
+                        lock.countDown();
+                    }
+                }
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
+        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void paramDuration() throws Exception {
+        client.headers().paramDuration("valid", new Period(0, 0, 0, 123, 22, 14, 12, 11));
+    }
+
+    @Test
+    public void responseDuration() throws Exception {
+        lock = new CountDownLatch(1);
+        client.headers().responseDurationWithRestResponseAsync("valid")
+            .subscribe(new Action1<RestResponse<HeaderResponseDurationHeaders, Void>>() {
+                @Override
+                public void call(RestResponse<HeaderResponseDurationHeaders, Void> response) {
+                    Map<String, String> headers = response.rawHeaders();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("P123DT22H14M12.011S", headers.get("value"));
+                        lock.countDown();
+                    }
+                }
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
+        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void paramDatetimeRfc1123() throws Exception {
+        client.headers().paramDatetimeRfc1123("valid", new DateTime(2010, 1, 1, 12, 34, 56, DateTimeZone.UTC));
+        client.headers().paramDatetimeRfc1123("min", new DateTime(1, 1, 1, 0, 0, 0, DateTimeZone.UTC));
+    }
+
+    @Test
+    public void responseDatetimeRfc1123() throws Exception {
+        lock = new CountDownLatch(1);
+        client.headers().responseDatetimeRfc1123WithRestResponseAsync("valid")
+            .subscribe(new Action1<RestResponse<HeaderResponseDatetimeRfc1123Headers, Void>>() {
+                @Override
+                public void call(RestResponse<HeaderResponseDatetimeRfc1123Headers, Void> response) {
+                    Map<String, String> headers = response.rawHeaders();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("Fri, 01 Jan 2010 12:34:56 GMT", headers.get("value"));
+                        lock.countDown();
+                    }
+                }
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
+        Assert.assertTrue(lock.await(100000, TimeUnit.MILLISECONDS));
+        lock = new CountDownLatch(1);
+        client.headers().responseDatetimeRfc1123WithRestResponseAsync("min")
+            .subscribe(new Action1<RestResponse<HeaderResponseDatetimeRfc1123Headers, Void>>() {
+                @Override
+                public void call(RestResponse<HeaderResponseDatetimeRfc1123Headers, Void> response) {
+                    Map<String, String> headers = response.rawHeaders();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("Mon, 01 Jan 0001 00:00:00 GMT", headers.get("value"));
+                        lock.countDown();
+
+                    }
+                }
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
+        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void paramDatetime() throws Exception {
+        client.headers().paramDatetime("valid", new DateTime(2010, 1, 1, 12, 34, 56, DateTimeZone.UTC));
+        client.headers().paramDatetime("min", new DateTime(1, 1, 1, 0, 0, 0, DateTimeZone.UTC));
+    }
+
+    @Test
+    public void responseDatetime() throws Exception {
+        lock = new CountDownLatch(1);
+        client.headers().responseDatetimeWithRestResponseAsync("valid")
+            .subscribe(new Action1<RestResponse<HeaderResponseDatetimeHeaders, Void>>() {
+                @Override
+                public void call(RestResponse<HeaderResponseDatetimeHeaders, Void> response) {
+                    Map<String, String> headers = response.rawHeaders();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("2010-01-01T12:34:56Z", headers.get("value"));
+                        lock.countDown();
+                    }
+                }
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
+        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+        lock = new CountDownLatch(1);
+        client.headers().responseDatetimeWithRestResponseAsync("min")
+            .subscribe(new Action1<RestResponse<HeaderResponseDatetimeHeaders, Void>>() {
+                @Override
+                public void call(RestResponse<HeaderResponseDatetimeHeaders, Void> response) {
+                    Map<String, String> headers = response.rawHeaders();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("0001-01-01T00:00:00Z", headers.get("value"));
+                        lock.countDown();
+                    }
+                }
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
+        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void paramByte() throws Exception {
+        client.headers().paramByte("valid", "啊齄丂狛狜隣郎隣兀﨩".getBytes(Charset.forName("UTF-8")));
+    }
+
+    @Test
+    public void responseByte() throws Exception {
+        lock = new CountDownLatch(1);
+        client.headers().responseByteWithRestResponseAsync("valid")
+            .subscribe(new Action1<RestResponse<HeaderResponseByteHeaders, Void>>() {
+                @Override
+                public void call(RestResponse<HeaderResponseByteHeaders, Void> response) {
+                    Map<String, String> headers = response.rawHeaders();
+                    if (headers.get("value") != null) {
+                        byte[] value = Base64.decodeBase64(headers.get("value"));
+                        String actual = new String(value, Charset.forName("UTF-8"));
+                        Assert.assertEquals("啊齄丂狛狜隣郎隣兀﨩", actual);
+                        lock.countDown();
+                    }
+                }
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
+        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void paramEnum() throws Exception {
+        client.headers().paramEnum("valid", GreyscaleColors.GREY);
+        client.headers().paramEnum("null", null);
+    }
+
+    @Test
+    public void responseEnum() throws Exception {
+        lock = new CountDownLatch(1);
+        client.headers().responseEnumWithRestResponseAsync("valid")
+            .subscribe(new Action1<RestResponse<HeaderResponseEnumHeaders, Void>>() {
+                @Override
+                public void call(RestResponse<HeaderResponseEnumHeaders, Void> response) {
+                    Map<String, String> headers = response.rawHeaders();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("GREY", headers.get("value"));
+                        lock.countDown();
+                    }
+                }
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
+        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+        lock = new CountDownLatch(1);
+        client.headers().responseEnumWithRestResponseAsync("null")
+            .subscribe(new Action1<RestResponse<HeaderResponseEnumHeaders, Void>>() {
+                @Override
+                public void call(RestResponse<HeaderResponseEnumHeaders, Void> response) {
+                    Map<String, String> headers = response.rawHeaders();
+                    if (headers.get("value") != null) {
+                        Assert.assertEquals("", headers.get("value"));
+                        lock.countDown();
+                    }
+                }
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    fail();
+                }
+            });
+        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    @Ignore("Custom header not supported yet")
+    public void customRequestId() throws Exception {
+        client.headers().customRequestId();
+    }
 }

--- a/test/vanilla/src/test/java/fixtures/header/HeaderOperationsTests.java
+++ b/test/vanilla/src/test/java/fixtures/header/HeaderOperationsTests.java
@@ -1,6 +1,12 @@
 package fixtures.header;
 
+import com.microsoft.rest.RestClient;
+import com.microsoft.rest.RestClient.Builder;
 import com.microsoft.rest.RestResponse;
+import com.microsoft.rest.http.HttpHeaders;
+import com.microsoft.rest.policy.AddHeadersPolicy;
+import com.microsoft.rest.policy.RequestPolicy;
+import com.microsoft.rest.serializer.JacksonAdapter;
 import org.apache.commons.codec.binary.Base64;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -42,7 +48,18 @@ public class HeaderOperationsTests {
 
     @BeforeClass
     public static void setup() {
-        client = new AutoRestSwaggerBATHeaderServiceImpl("http://localhost:3000");
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("x-ms-client-request-id", "9C4D50EE-2D56-4CD3-8152-34347DC9F2B0");
+        RequestPolicy.Factory addHeadersFactory = new AddHeadersPolicy.Factory(headers);
+
+        RestClient restClient = new RestClient.Builder()
+                .withUserAgent("")
+                .withBaseUrl("http://localhost:3000")
+                .withSerializerAdapter(new JacksonAdapter())
+                .addCustomPolicy(addHeadersFactory)
+                .build();
+
+        client = new AutoRestSwaggerBATHeaderServiceImpl(restClient);
     }
 
     @Test
@@ -640,7 +657,6 @@ public class HeaderOperationsTests {
     }
 
     @Test
-    @Ignore("Custom header not supported yet")
     public void customRequestId() throws Exception {
         client.headers().customRequestId();
     }

--- a/test/vanilla/src/test/java/fixtures/http/HttpRetryTests.java
+++ b/test/vanilla/src/test/java/fixtures/http/HttpRetryTests.java
@@ -1,16 +1,16 @@
 package fixtures.http;
 
+import com.microsoft.rest.RestResponse;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import fixtures.http.implementation.AutoRestHttpInfrastructureTestServiceImpl;
+import rx.functions.Action1;
 
-@Ignore("TODO: reimplement")
 public class HttpRetryTests {
     private static AutoRestHttpInfrastructureTestService client;
     private CountDownLatch lock = new CountDownLatch(1);
@@ -20,107 +20,107 @@ public class HttpRetryTests {
         client = new AutoRestHttpInfrastructureTestServiceImpl("http://localhost:3000");
     }
 
-//    @Test
-//    public void head408() throws Exception {
-//        client.httpRetrys().head408WithServiceResponseAsync()
-//            .subscribe(new Action1<ServiceResponse<Void>>() {
-//                @Override
-//                public void call(ServiceResponse<Void> response) {
-//                    Assert.assertEquals(200, response.headResponse().code());
-//                    lock.countDown();
-//                }
-//            });
-//        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
-//    }
-//
-//    @Test
-//    public void put500() throws Exception {
-//        client.httpRetrys().put500WithServiceResponseAsync(true)
-//            .subscribe(new Action1<ServiceResponse<Void>>() {
-//                @Override
-//                public void call(ServiceResponse<Void> response) {
-//                    Assert.assertEquals(200, response.response().code());
-//                    lock.countDown();
-//                }
-//            });
-//        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
-//    }
-//
-//    @Test
-//    public void patch500() throws Exception {
-//        client.httpRetrys().patch500WithServiceResponseAsync(true)
-//            .subscribe(new Action1<ServiceResponse<Void>>() {
-//                @Override
-//                public void call(ServiceResponse<Void> response) {
-//                    Assert.assertEquals(200, response.response().code());
-//                    lock.countDown();
-//                }
-//            });
-//        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
-//    }
-//
-//    @Test
-//    public void get502() throws Exception {
-//        client.httpRetrys().get502WithServiceResponseAsync()
-//            .subscribe(new Action1<ServiceResponse<Void>>() {
-//                @Override
-//                public void call(ServiceResponse<Void> response) {
-//                    Assert.assertEquals(200, response.response().code());
-//                    lock.countDown();
-//                }
-//            });
-//        Assert.assertTrue(lock.await(50000, TimeUnit.MILLISECONDS));
-//    }
-//
-//    @Test
-//    public void post503() throws Exception {
-//        client.httpRetrys().post503WithServiceResponseAsync(true)
-//            .subscribe(new Action1<ServiceResponse<Void>>() {
-//                @Override
-//                public void call(ServiceResponse<Void> response) {
-//                    Assert.assertEquals(200, response.response().code());
-//                    lock.countDown();
-//                }
-//            });
-//        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
-//    }
-//
-//    @Test
-//    public void delete503() throws Exception {
-//        client.httpRetrys().delete503WithServiceResponseAsync(true)
-//            .subscribe(new Action1<ServiceResponse<Void>>() {
-//                @Override
-//                public void call(ServiceResponse<Void> response) {
-//                    Assert.assertEquals(200, response.response().code());
-//                    lock.countDown();
-//                }
-//            });
-//        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
-//    }
-//
-//    @Test
-//    public void put504() throws Exception {
-//        client.httpRetrys().put504WithServiceResponseAsync(true)
-//            .subscribe(new Action1<ServiceResponse<Void>>() {
-//                @Override
-//                public void call(ServiceResponse<Void> response) {
-//                    Assert.assertEquals(200, response.response().code());
-//                    lock.countDown();
-//                }
-//            });
-//        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
-//    }
-//
-//    @Test
-//    public void patch504() throws Exception {
-//        client.httpRetrys().patch504WithServiceResponseAsync(true)
-//            .subscribe(new Action1<ServiceResponse<Void>>() {
-//                @Override
-//                public void call(ServiceResponse<Void> response) {
-//                    Assert.assertEquals(200, response.response().code());
-//                    lock.countDown();
-//                }
-//            });
-//        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
-//    }
+    @Test
+    public void head408() throws Exception {
+        client.httpRetrys().head408WithRestResponseAsync()
+            .subscribe(new Action1<RestResponse<Void, Void>>() {
+                @Override
+                public void call(RestResponse<Void, Void> response) {
+                    Assert.assertEquals(200, response.statusCode());
+                    lock.countDown();
+                }
+            });
+        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void put500() throws Exception {
+        client.httpRetrys().put500WithRestResponseAsync(true)
+            .subscribe(new Action1<RestResponse<Void, Void>>() {
+                @Override
+                public void call(RestResponse<Void, Void> response) {
+                    Assert.assertEquals(200, response.statusCode());
+                    lock.countDown();
+                }
+            });
+        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void patch500() throws Exception {
+        client.httpRetrys().patch500WithRestResponseAsync(true)
+            .subscribe(new Action1<RestResponse<Void, Void>>() {
+                @Override
+                public void call(RestResponse<Void, Void> response) {
+                    Assert.assertEquals(200, response.statusCode());
+                    lock.countDown();
+                }
+            });
+        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void get502() throws Exception {
+        client.httpRetrys().get502WithRestResponseAsync()
+            .subscribe(new Action1<RestResponse<Void, Void>>() {
+                @Override
+                public void call(RestResponse<Void, Void> response) {
+                    Assert.assertEquals(200, response.statusCode());
+                    lock.countDown();
+                }
+            });
+        Assert.assertTrue(lock.await(50000, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void post503() throws Exception {
+        client.httpRetrys().post503WithRestResponseAsync(true)
+            .subscribe(new Action1<RestResponse<Void, Void>>() {
+                @Override
+                public void call(RestResponse<Void, Void> response) {
+                    Assert.assertEquals(200, response.statusCode());
+                    lock.countDown();
+                }
+            });
+        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void delete503() throws Exception {
+        client.httpRetrys().delete503WithRestResponseAsync(true)
+            .subscribe(new Action1<RestResponse<Void, Void>>() {
+                @Override
+                public void call(RestResponse<Void, Void> response) {
+                    Assert.assertEquals(200, response.statusCode());
+                    lock.countDown();
+                }
+            });
+        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void put504() throws Exception {
+        client.httpRetrys().put504WithRestResponseAsync(true)
+            .subscribe(new Action1<RestResponse<Void, Void>>() {
+                @Override
+                public void call(RestResponse<Void, Void> response) {
+                    Assert.assertEquals(200, response.statusCode());
+                    lock.countDown();
+                }
+            });
+        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void patch504() throws Exception {
+        client.httpRetrys().patch504WithRestResponseAsync(true)
+            .subscribe(new Action1<RestResponse<Void, Void>>() {
+                @Override
+                public void call(RestResponse<Void, Void> response) {
+                    Assert.assertEquals(200, response.statusCode());
+                    lock.countDown();
+                }
+            });
+        Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
+    }
 }


### PR DESCRIPTION
In addition to adding the extra overloads to return RestResponse, this PR begins a refactor that should minimize the copy and pasting needed to maintain the Javadoc generation. See MethodJv.cs and let me know what you think. I didn't push it all the way across the InterfaceTemplates, Retrofit templates, etc. just yet because I wanted to see how this would go over. Especially don't want to deal with paging and LRO specific templates until we have new overloads or something where it's a reasonable opportunity to refactor them.

I have been considering pushing it out a little further even to have a `class JavaClass` and `class JavaMethod` which would be much simpler than real ASTs but would simply allow us to capture the differences between the overloads in a more maintainable way.