### PR TITLE
Fix XML case #64 and use ListWrapper annotation #65

### DIFF
--- a/src/vanilla/ClientModelExtensions.cs
+++ b/src/vanilla/ClientModelExtensions.cs
@@ -39,14 +39,14 @@ namespace AutoRest.Java
             return builder.ToString();
         }
 
-        public static string GetJsonProperty(this Property property)
+        public static string GetSerializeAnnotationArgs(this Property property, bool shouldUseXmlSerialization)
         {
             if (property == null)
             {
                 return null;
             }
 
-            string name = string.IsNullOrEmpty(property.XmlName) ? property.SerializedName : property.XmlName;
+            string name = shouldUseXmlSerialization ? property.XmlName : property.SerializedName;
             List<string> settings = new List<string>();
             settings.Add(string.Format(CultureInfo.InvariantCulture, "value = \"{0}\"", name));
             if (property.IsRequired)

--- a/src/vanilla/ClientModelExtensions.cs
+++ b/src/vanilla/ClientModelExtensions.cs
@@ -46,8 +46,9 @@ namespace AutoRest.Java
                 return null;
             }
 
+            string name = string.IsNullOrEmpty(property.XmlName) ? property.SerializedName : property.XmlName;
             List<string> settings = new List<string>();
-            settings.Add(string.Format(CultureInfo.InvariantCulture, "value = \"{0}\"", property.SerializedName));
+            settings.Add(string.Format(CultureInfo.InvariantCulture, "value = \"{0}\"", name));
             if (property.IsRequired)
             {
                 settings.Add("required = true");

--- a/src/vanilla/DanModel/DanCodeGenerator.cs
+++ b/src/vanilla/DanModel/DanCodeGenerator.cs
@@ -2813,7 +2813,7 @@ namespace AutoRest.Java.DanModel
                         imports.AddRange(GetImports(property, settings));
                     }
 
-                    if (compositeTypeProperties.Any(p => !p.GetJsonProperty().IsNullOrEmpty()))
+                    if (compositeTypeProperties.Any(p => !p.GetSerializeAnnotationArgs(shouldGenerateXmlSerialization).IsNullOrEmpty()))
                     {
                         imports.Add("com.fasterxml.jackson.annotation.JsonProperty");
                     }
@@ -2947,22 +2947,22 @@ namespace AutoRest.Java.DanModel
                         }
 
                         string annotation = null;
-                        string jsonSetting = property.GetJsonProperty();
-                        if (!string.IsNullOrEmpty(jsonSetting))
+                        string annotationArgs = property.GetSerializeAnnotationArgs(shouldGenerateXmlSerialization);
+                        if (!string.IsNullOrEmpty(annotationArgs))
                         {
                             if (property.XmlIsAttribute)
                             {
-                                string localName = string.IsNullOrEmpty(property.XmlName) ? property.SerializedName.ToString() : property.XmlName;
+                                string localName = shouldGenerateXmlSerialization ? property.XmlName : property.SerializedName.ToString();
                                 annotation = $"JacksonXmlProperty(localName = \"{localName}\", isAttribute = true)";
                             }
                             else if (shouldGenerateXmlSerialization && property.ModelType is SequenceType)
                             {
-                                string localName = string.IsNullOrEmpty(property.XmlName) ? property.SerializedName.ToString() : property.XmlName;
+                                string localName = shouldGenerateXmlSerialization ? property.XmlName : property.SerializedName.ToString();
                                 annotation = $"JacksonXmlElementWrapper(localName = \"{localName}\")";
                             }
                             else
                             {
-                                annotation = $"JsonProperty({jsonSetting})";
+                                annotation = $"JsonProperty({annotationArgs})";
                             }
                         }
 


### PR DESCRIPTION
Addresses #64 and #65.

It sounds when we're doing XML serialization we should get the serialized name from `Property.XmlName`. If we're doing JSON serialization we should just use `Property.SerializedName`.

I'm passing around the `shouldGenerateXmlSerialization` flag because I assume it is still expensive-- it can wind up doing a seek on the entire list of methods in the service looking for XML-related attributes, IIRC.