### PR TITLE
Only use XML wrappers for body parameters

### DIFF
--- a/src/vanilla/DanModel/DanCodeGenerator.cs
+++ b/src/vanilla/DanModel/DanCodeGenerator.cs
@@ -4152,7 +4152,7 @@ namespace AutoRest.Java.DanModel
                     string declarativeName = parameter.ClientProperty != null ? (string)parameter.ClientProperty.Name : ParameterGetName(parameter);
 
                     IModelType parameterModelType = ParameterGetModelType(parameter);
-                    bool shouldUseXmlListWrapper = shouldGenerateXmlSerialization && (parameterModelType is SequenceType);
+                    bool shouldUseXmlListWrapper = shouldGenerateXmlSerialization && parameter.Location == ParameterLocation.Body && (parameterModelType is SequenceType);
                     if (shouldUseXmlListWrapper)
                     {
                         declarationBuilder.Append(parameterModelType.XmlName + "Wrapper");
@@ -4217,7 +4217,7 @@ namespace AutoRest.Java.DanModel
                     string declarativeName = parameter.ClientProperty != null ? (string)parameter.ClientProperty.Name : ParameterGetName(parameter);
 
                     IModelType parameterModelType = ParameterGetModelType(parameter);
-                    bool shouldUseXmlListWrapper = shouldGenerateXmlSerialization && (parameterModelType is SequenceType);
+                    bool shouldUseXmlListWrapper = shouldGenerateXmlSerialization && parameter.Location == ParameterLocation.Body && parameterModelType is SequenceType;
                     if (shouldUseXmlListWrapper)
                     {
                         declarationBuilder.Append(parameterModelType.XmlName + "Wrapper");


### PR DESCRIPTION
An XML list wrapper type allows the name of the root element to be specified when the root object being serialized is a list. The only situation that we serialize to XML in RestProxy is for a body parameter with an XML content type.