### PR TITLE
 Use XmlElementName in XML lists

### DIFF
--- a/src/Model/ServiceProperty.cs
+++ b/src/Model/ServiceProperty.cs
@@ -18,6 +18,7 @@ namespace AutoRest.Java.Model
         /// <param name="xmlName">This property's name when serialized to XML.</param>
         /// <param name="serializedName">This property's name when it is serialized.</param>
         /// <param name="isXmlWrapper">Whether or not this property is a container.</param>
+        /// <param name="xmlListElementName">The name of each list element tag within an XML list property.</param>
         /// <param name="wireTypeName">The name of this property's type when it is sent through the network (across the wire).</param>
         /// <param name="isConstant">Whether or not this property has a constant value.</param>
         /// <param name="modelTypeIsSequence">Whether or not this property's model type is a sequence type.</param>
@@ -25,7 +26,7 @@ namespace AutoRest.Java.Model
         /// <param name="clientTypeName">The name of this property's type when it is exposed via the client library.</param>
         /// <param name="defaultValue">The default value expression of this property.</param>
         /// <param name="isReadOnly">Whether or not this property's value can be changed by the client library.</param>
-        public ServiceProperty(string name, string description, string annotationArguments, bool isXmlAttribute, string xmlName, string serializedName, bool isXmlWrapper, string wireTypeName, bool isConstant, bool modelTypeIsSequence, bool modelTypeIsComposite, string clientTypeName, string defaultValue, bool isReadOnly)
+        public ServiceProperty(string name, string description, string annotationArguments, bool isXmlAttribute, string xmlName, string serializedName, bool isXmlWrapper, string xmlListElementName, string wireTypeName, bool isConstant, bool modelTypeIsSequence, bool modelTypeIsComposite, string clientTypeName, string defaultValue, bool isReadOnly)
         {
             Name = name;
             Description = description;
@@ -34,6 +35,7 @@ namespace AutoRest.Java.Model
             XmlName = xmlName;
             SerializedName = serializedName;
             IsXmlWrapper = isXmlWrapper;
+            XmlListElementName = xmlListElementName;
             WireTypeName = wireTypeName;
             IsConstant = isConstant;
             ModelTypeIsSequence = modelTypeIsSequence;
@@ -77,6 +79,11 @@ namespace AutoRest.Java.Model
         /// Get whether or not this property is a container.
         /// </summary>
         public bool IsXmlWrapper { get; }
+
+        /// <summary>
+        /// The name of each list element tag within an XML list property.
+        /// </summary>
+        public string XmlListElementName { get; }
 
         /// <summary>
         /// Get the name of this property's type when it is sent through the network (across the wire).

--- a/test/azure/src/main/java/fixtures/azureparametergrouping/ParameterGroupings.java
+++ b/test/azure/src/main/java/fixtures/azureparametergrouping/ParameterGroupings.java
@@ -21,7 +21,6 @@ import fixtures.azureparametergrouping.models.ParameterGroupingPostRequiredParam
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azure/src/main/java/fixtures/azureparametergrouping/implementation/ParameterGroupingsImpl.java
+++ b/test/azure/src/main/java/fixtures/azureparametergrouping/implementation/ParameterGroupingsImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.azureparametergrouping.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -19,13 +18,11 @@ import com.microsoft.rest.v2.Validator;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PathParam;
 import com.microsoft.rest.v2.annotations.POST;
 import com.microsoft.rest.v2.annotations.QueryParam;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.azureparametergrouping.ParameterGroupings;
 import fixtures.azureparametergrouping.models.ErrorException;
 import fixtures.azureparametergrouping.models.FirstParameterGroup;
@@ -36,7 +33,6 @@ import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azure/src/main/java/fixtures/azurereport/AutoRestReportServiceForAzure.java
+++ b/test/azure/src/main/java/fixtures/azurereport/AutoRestReportServiceForAzure.java
@@ -17,7 +17,6 @@ import fixtures.azurereport.models.ErrorException;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 import java.util.Map;
 
 /**

--- a/test/azure/src/main/java/fixtures/azurereport/implementation/AutoRestReportServiceForAzureImpl.java
+++ b/test/azure/src/main/java/fixtures/azurereport/implementation/AutoRestReportServiceForAzureImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.azurereport.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureEnvironment;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.azure.v2.AzureServiceClient;
@@ -20,12 +19,10 @@ import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.QueryParam;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
 import com.microsoft.rest.v2.credentials.ServiceClientCredentials;
-import com.microsoft.rest.v2.http.HttpClient;
 import com.microsoft.rest.v2.http.HttpPipeline;
 import fixtures.azurereport.AutoRestReportServiceForAzure;
 import fixtures.azurereport.models.ErrorException;
@@ -33,7 +30,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 import java.util.Map;
 
 /**

--- a/test/azure/src/main/java/fixtures/azureresource/AutoRestResourceFlatteningTestService.java
+++ b/test/azure/src/main/java/fixtures/azureresource/AutoRestResourceFlatteningTestService.java
@@ -21,7 +21,6 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 

--- a/test/azure/src/main/java/fixtures/azureresource/implementation/AutoRestResourceFlatteningTestServiceImpl.java
+++ b/test/azure/src/main/java/fixtures/azureresource/implementation/AutoRestResourceFlatteningTestServiceImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.azureresource.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureEnvironment;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.azure.v2.AzureServiceClient;
@@ -23,12 +22,10 @@ import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
 import com.microsoft.rest.v2.credentials.ServiceClientCredentials;
-import com.microsoft.rest.v2.http.HttpClient;
 import com.microsoft.rest.v2.http.HttpPipeline;
 import fixtures.azureresource.AutoRestResourceFlatteningTestService;
 import fixtures.azureresource.models.ErrorException;
@@ -39,7 +36,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 

--- a/test/azure/src/main/java/fixtures/azurespecials/ApiVersionDefaults.java
+++ b/test/azure/src/main/java/fixtures/azurespecials/ApiVersionDefaults.java
@@ -17,7 +17,6 @@ import fixtures.azurespecials.models.ErrorException;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azure/src/main/java/fixtures/azurespecials/ApiVersionLocals.java
+++ b/test/azure/src/main/java/fixtures/azurespecials/ApiVersionLocals.java
@@ -17,7 +17,6 @@ import fixtures.azurespecials.models.ErrorException;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azure/src/main/java/fixtures/azurespecials/Headers.java
+++ b/test/azure/src/main/java/fixtures/azurespecials/Headers.java
@@ -22,7 +22,6 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azure/src/main/java/fixtures/azurespecials/Odatas.java
+++ b/test/azure/src/main/java/fixtures/azurespecials/Odatas.java
@@ -17,7 +17,6 @@ import fixtures.azurespecials.models.ErrorException;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azure/src/main/java/fixtures/azurespecials/SkipUrlEncodings.java
+++ b/test/azure/src/main/java/fixtures/azurespecials/SkipUrlEncodings.java
@@ -17,7 +17,6 @@ import fixtures.azurespecials.models.ErrorException;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azure/src/main/java/fixtures/azurespecials/SubscriptionInCredentials.java
+++ b/test/azure/src/main/java/fixtures/azurespecials/SubscriptionInCredentials.java
@@ -17,7 +17,6 @@ import fixtures.azurespecials.models.ErrorException;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azure/src/main/java/fixtures/azurespecials/SubscriptionInMethods.java
+++ b/test/azure/src/main/java/fixtures/azurespecials/SubscriptionInMethods.java
@@ -17,7 +17,6 @@ import fixtures.azurespecials.models.ErrorException;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azure/src/main/java/fixtures/azurespecials/XMsClientRequestIds.java
+++ b/test/azure/src/main/java/fixtures/azurespecials/XMsClientRequestIds.java
@@ -18,7 +18,6 @@ import fixtures.azurespecials.models.ErrorException;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azure/src/main/java/fixtures/azurespecials/implementation/ApiVersionDefaultsImpl.java
+++ b/test/azure/src/main/java/fixtures/azurespecials/implementation/ApiVersionDefaultsImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.azurespecials.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -18,18 +17,15 @@ import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.QueryParam;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.azurespecials.ApiVersionDefaults;
 import fixtures.azurespecials.models.ErrorException;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azure/src/main/java/fixtures/azurespecials/implementation/ApiVersionLocalsImpl.java
+++ b/test/azure/src/main/java/fixtures/azurespecials/implementation/ApiVersionLocalsImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.azurespecials.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -18,18 +17,15 @@ import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.QueryParam;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.azurespecials.ApiVersionLocals;
 import fixtures.azurespecials.models.ErrorException;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azure/src/main/java/fixtures/azurespecials/implementation/HeadersImpl.java
+++ b/test/azure/src/main/java/fixtures/azurespecials/implementation/HeadersImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.azurespecials.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -19,11 +18,10 @@ import com.microsoft.rest.v2.Validator;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.HEAD;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.POST;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
+import fixtures.azurespecials.Headers;
 import fixtures.azurespecials.models.ErrorException;
 import fixtures.azurespecials.models.HeaderCustomNamedRequestIdHeaders;
 import fixtures.azurespecials.models.HeaderCustomNamedRequestIdHeadHeaders;
@@ -34,13 +32,12 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in
  * Headers.
  */
-public class HeadersImpl implements fixtures.azurespecials.Headers {
+public class HeadersImpl implements Headers {
     /**
      * The proxy service used to perform REST calls.
      */

--- a/test/azure/src/main/java/fixtures/azurespecials/implementation/OdatasImpl.java
+++ b/test/azure/src/main/java/fixtures/azurespecials/implementation/OdatasImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.azurespecials.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -18,18 +17,15 @@ import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.QueryParam;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.azurespecials.Odatas;
 import fixtures.azurespecials.models.ErrorException;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azure/src/main/java/fixtures/azurespecials/implementation/SkipUrlEncodingsImpl.java
+++ b/test/azure/src/main/java/fixtures/azurespecials/implementation/SkipUrlEncodingsImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.azurespecials.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -18,19 +17,16 @@ import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PathParam;
 import com.microsoft.rest.v2.annotations.QueryParam;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.azurespecials.SkipUrlEncodings;
 import fixtures.azurespecials.models.ErrorException;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azure/src/main/java/fixtures/azurespecials/implementation/SubscriptionInCredentialsImpl.java
+++ b/test/azure/src/main/java/fixtures/azurespecials/implementation/SubscriptionInCredentialsImpl.java
@@ -10,27 +10,23 @@
 
 package fixtures.azurespecials.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
 import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PathParam;
 import com.microsoft.rest.v2.annotations.POST;
 import com.microsoft.rest.v2.annotations.QueryParam;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.azurespecials.SubscriptionInCredentials;
 import fixtures.azurespecials.models.ErrorException;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azure/src/main/java/fixtures/azurespecials/implementation/SubscriptionInMethodsImpl.java
+++ b/test/azure/src/main/java/fixtures/azurespecials/implementation/SubscriptionInMethodsImpl.java
@@ -10,26 +10,22 @@
 
 package fixtures.azurespecials.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
 import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PathParam;
 import com.microsoft.rest.v2.annotations.POST;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.azurespecials.SubscriptionInMethods;
 import fixtures.azurespecials.models.ErrorException;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azure/src/main/java/fixtures/azurespecials/implementation/XMsClientRequestIdsImpl.java
+++ b/test/azure/src/main/java/fixtures/azurespecials/implementation/XMsClientRequestIdsImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.azurespecials.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.azure.v2.CloudException;
 import com.microsoft.rest.v2.RestResponse;
@@ -19,17 +18,14 @@ import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.azurespecials.XMsClientRequestIds;
 import fixtures.azurespecials.models.ErrorException;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azure/src/main/java/fixtures/custombaseuri/Paths.java
+++ b/test/azure/src/main/java/fixtures/custombaseuri/Paths.java
@@ -17,7 +17,6 @@ import fixtures.custombaseuri.models.ErrorException;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azure/src/main/java/fixtures/custombaseuri/implementation/PathsImpl.java
+++ b/test/azure/src/main/java/fixtures/custombaseuri/implementation/PathsImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.custombaseuri.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -18,19 +17,16 @@ import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.HostParam;
 import com.microsoft.rest.v2.annotations.PathParam;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.custombaseuri.Paths;
 import fixtures.custombaseuri.models.ErrorException;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azure/src/main/java/fixtures/head/HttpSuccess.java
+++ b/test/azure/src/main/java/fixtures/head/HttpSuccess.java
@@ -17,7 +17,6 @@ import com.microsoft.rest.v2.ServiceFuture;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azure/src/main/java/fixtures/head/implementation/HttpSuccessImpl.java
+++ b/test/azure/src/main/java/fixtures/head/implementation/HttpSuccessImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.head.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.azure.v2.CloudException;
 import com.microsoft.rest.v2.RestResponse;
@@ -19,16 +18,13 @@ import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.HEAD;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.head.HttpSuccess;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azure/src/main/java/fixtures/headexceptions/HeadExceptions.java
+++ b/test/azure/src/main/java/fixtures/headexceptions/HeadExceptions.java
@@ -17,7 +17,6 @@ import com.microsoft.rest.v2.ServiceFuture;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azure/src/main/java/fixtures/headexceptions/implementation/HeadExceptionsImpl.java
+++ b/test/azure/src/main/java/fixtures/headexceptions/implementation/HeadExceptionsImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.headexceptions.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.azure.v2.CloudException;
 import com.microsoft.rest.v2.RestResponse;
@@ -19,16 +18,13 @@ import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.HEAD;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.headexceptions.HeadExceptions;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azure/src/main/java/fixtures/lro/LRORetrys.java
+++ b/test/azure/src/main/java/fixtures/lro/LRORetrys.java
@@ -26,7 +26,6 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azure/src/main/java/fixtures/lro/LROSADs.java
+++ b/test/azure/src/main/java/fixtures/lro/LROSADs.java
@@ -40,7 +40,6 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azure/src/main/java/fixtures/lro/LROs.java
+++ b/test/azure/src/main/java/fixtures/lro/LROs.java
@@ -45,7 +45,6 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azure/src/main/java/fixtures/lro/LROsCustomHeaders.java
+++ b/test/azure/src/main/java/fixtures/lro/LROsCustomHeaders.java
@@ -23,7 +23,6 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azure/src/main/java/fixtures/lro/implementation/LRORetrysImpl.java
+++ b/test/azure/src/main/java/fixtures/lro/implementation/LRORetrysImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.lro.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.azure.v2.CloudException;
 import com.microsoft.azure.v2.OperationStatus;
@@ -23,12 +22,10 @@ import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.DELETE;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.POST;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.lro.LRORetrys;
 import fixtures.lro.models.LRORetrysDelete202Retry200Headers;
 import fixtures.lro.models.LRORetrysDeleteAsyncRelativeRetrySucceededHeaders;
@@ -42,7 +39,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azure/src/main/java/fixtures/lro/implementation/LROSADsImpl.java
+++ b/test/azure/src/main/java/fixtures/lro/implementation/LROSADsImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.lro.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.azure.v2.CloudException;
 import com.microsoft.azure.v2.OperationStatus;
@@ -23,12 +22,10 @@ import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.DELETE;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.POST;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.lro.LROSADs;
 import fixtures.lro.models.LROSADsDelete202NonRetry400Headers;
 import fixtures.lro.models.LROSADsDelete202RetryInvalidHeaderHeaders;
@@ -56,7 +53,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azure/src/main/java/fixtures/lro/implementation/LROsCustomHeadersImpl.java
+++ b/test/azure/src/main/java/fixtures/lro/implementation/LROsCustomHeadersImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.lro.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.azure.v2.CloudException;
 import com.microsoft.azure.v2.OperationStatus;
@@ -22,12 +21,10 @@ import com.microsoft.rest.v2.Validator;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.POST;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.lro.LROsCustomHeaders;
 import fixtures.lro.models.LROsCustomHeaderPost202Retry200Headers;
 import fixtures.lro.models.LROsCustomHeaderPostAsyncRetrySucceededHeaders;
@@ -38,7 +35,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azure/src/main/java/fixtures/lro/implementation/LROsImpl.java
+++ b/test/azure/src/main/java/fixtures/lro/implementation/LROsImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.lro.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.azure.v2.CloudException;
 import com.microsoft.azure.v2.OperationStatus;
@@ -23,12 +22,10 @@ import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.DELETE;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.POST;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.lro.LROs;
 import fixtures.lro.models.LROsDelete202NoRetry204Headers;
 import fixtures.lro.models.LROsDelete202Retry200Headers;
@@ -61,7 +58,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azure/src/main/java/fixtures/paging/Pagings.java
+++ b/test/azure/src/main/java/fixtures/paging/Pagings.java
@@ -25,7 +25,6 @@ import fixtures.paging.models.Product;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 import java.util.List;
 
 /**

--- a/test/azure/src/main/java/fixtures/paging/implementation/PagingsImpl.java
+++ b/test/azure/src/main/java/fixtures/paging/implementation/PagingsImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.paging.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.azure.v2.CloudException;
 import com.microsoft.azure.v2.ListOperationCallback;
@@ -22,12 +21,10 @@ import com.microsoft.rest.v2.Validator;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PathParam;
 import com.microsoft.rest.v2.annotations.QueryParam;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.paging.Pagings;
 import fixtures.paging.models.CustomParameterGroup;
 import fixtures.paging.models.PageImpl;
@@ -41,7 +38,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 import java.util.List;
 
 /**

--- a/test/azure/src/main/java/fixtures/subscriptionidapiversion/Groups.java
+++ b/test/azure/src/main/java/fixtures/subscriptionidapiversion/Groups.java
@@ -18,7 +18,6 @@ import fixtures.subscriptionidapiversion.models.SampleResourceGroup;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azure/src/main/java/fixtures/subscriptionidapiversion/implementation/GroupsImpl.java
+++ b/test/azure/src/main/java/fixtures/subscriptionidapiversion/implementation/GroupsImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.subscriptionidapiversion.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -18,12 +17,10 @@ import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PathParam;
 import com.microsoft.rest.v2.annotations.QueryParam;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.subscriptionidapiversion.Groups;
 import fixtures.subscriptionidapiversion.models.ErrorException;
 import fixtures.subscriptionidapiversion.models.SampleResourceGroup;
@@ -31,7 +28,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azurefluent/src/main/java/fixtures/azureparametergrouping/implementation/ParameterGroupingsInner.java
+++ b/test/azurefluent/src/main/java/fixtures/azureparametergrouping/implementation/ParameterGroupingsInner.java
@@ -10,7 +10,6 @@
 
 package fixtures.azureparametergrouping.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -19,19 +18,16 @@ import com.microsoft.rest.v2.Validator;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PathParam;
 import com.microsoft.rest.v2.annotations.POST;
 import com.microsoft.rest.v2.annotations.QueryParam;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.azureparametergrouping.ErrorException;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azurefluent/src/main/java/fixtures/azurereport/implementation/AutoRestReportServiceForAzureImpl.java
+++ b/test/azurefluent/src/main/java/fixtures/azurereport/implementation/AutoRestReportServiceForAzureImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.azurereport.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureEnvironment;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.azure.v2.AzureServiceClient;
@@ -20,19 +19,16 @@ import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.QueryParam;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
 import com.microsoft.rest.v2.credentials.ServiceClientCredentials;
-import com.microsoft.rest.v2.http.HttpClient;
 import com.microsoft.rest.v2.http.HttpPipeline;
 import fixtures.azurereport.ErrorException;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 import java.util.Map;
 
 /**

--- a/test/azurefluent/src/main/java/fixtures/azureresource/implementation/AutoRestResourceFlatteningTestServiceImpl.java
+++ b/test/azurefluent/src/main/java/fixtures/azureresource/implementation/AutoRestResourceFlatteningTestServiceImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.azureresource.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureEnvironment;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.azure.v2.AzureServiceClient;
@@ -23,12 +22,10 @@ import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
 import com.microsoft.rest.v2.credentials.ServiceClientCredentials;
-import com.microsoft.rest.v2.http.HttpClient;
 import com.microsoft.rest.v2.http.HttpPipeline;
 import fixtures.azureresource.ErrorException;
 import io.reactivex.Completable;
@@ -36,7 +33,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 

--- a/test/azurefluent/src/main/java/fixtures/azurespecials/implementation/ApiVersionDefaultsInner.java
+++ b/test/azurefluent/src/main/java/fixtures/azurespecials/implementation/ApiVersionDefaultsInner.java
@@ -10,7 +10,6 @@
 
 package fixtures.azurespecials.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -18,17 +17,14 @@ import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.QueryParam;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.azurespecials.ErrorException;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azurefluent/src/main/java/fixtures/azurespecials/implementation/ApiVersionLocalsInner.java
+++ b/test/azurefluent/src/main/java/fixtures/azurespecials/implementation/ApiVersionLocalsInner.java
@@ -10,7 +10,6 @@
 
 package fixtures.azurespecials.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -18,17 +17,14 @@ import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.QueryParam;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.azurespecials.ErrorException;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azurefluent/src/main/java/fixtures/azurespecials/implementation/HeadersInner.java
+++ b/test/azurefluent/src/main/java/fixtures/azurespecials/implementation/HeadersInner.java
@@ -10,7 +10,6 @@
 
 package fixtures.azurespecials.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -19,18 +18,15 @@ import com.microsoft.rest.v2.Validator;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.HEAD;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.POST;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.azurespecials.ErrorException;
 import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azurefluent/src/main/java/fixtures/azurespecials/implementation/OdatasInner.java
+++ b/test/azurefluent/src/main/java/fixtures/azurespecials/implementation/OdatasInner.java
@@ -10,7 +10,6 @@
 
 package fixtures.azurespecials.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -18,17 +17,14 @@ import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.QueryParam;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.azurespecials.ErrorException;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azurefluent/src/main/java/fixtures/azurespecials/implementation/SkipUrlEncodingsInner.java
+++ b/test/azurefluent/src/main/java/fixtures/azurespecials/implementation/SkipUrlEncodingsInner.java
@@ -10,7 +10,6 @@
 
 package fixtures.azurespecials.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -18,18 +17,15 @@ import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PathParam;
 import com.microsoft.rest.v2.annotations.QueryParam;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.azurespecials.ErrorException;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azurefluent/src/main/java/fixtures/azurespecials/implementation/SubscriptionInCredentialsInner.java
+++ b/test/azurefluent/src/main/java/fixtures/azurespecials/implementation/SubscriptionInCredentialsInner.java
@@ -10,26 +10,22 @@
 
 package fixtures.azurespecials.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
 import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PathParam;
 import com.microsoft.rest.v2.annotations.POST;
 import com.microsoft.rest.v2.annotations.QueryParam;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.azurespecials.ErrorException;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azurefluent/src/main/java/fixtures/azurespecials/implementation/SubscriptionInMethodsInner.java
+++ b/test/azurefluent/src/main/java/fixtures/azurespecials/implementation/SubscriptionInMethodsInner.java
@@ -10,25 +10,21 @@
 
 package fixtures.azurespecials.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
 import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PathParam;
 import com.microsoft.rest.v2.annotations.POST;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.azurespecials.ErrorException;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azurefluent/src/main/java/fixtures/azurespecials/implementation/XMsClientRequestIdsInner.java
+++ b/test/azurefluent/src/main/java/fixtures/azurespecials/implementation/XMsClientRequestIdsInner.java
@@ -10,7 +10,6 @@
 
 package fixtures.azurespecials.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.azure.v2.CloudException;
 import com.microsoft.rest.v2.RestResponse;
@@ -19,16 +18,13 @@ import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.azurespecials.ErrorException;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azurefluent/src/main/java/fixtures/custombaseuri/implementation/PathsInner.java
+++ b/test/azurefluent/src/main/java/fixtures/custombaseuri/implementation/PathsInner.java
@@ -10,7 +10,6 @@
 
 package fixtures.custombaseuri.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -18,18 +17,15 @@ import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.HostParam;
 import com.microsoft.rest.v2.annotations.PathParam;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.custombaseuri.ErrorException;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azurefluent/src/main/java/fixtures/head/implementation/HttpSuccessInner.java
+++ b/test/azurefluent/src/main/java/fixtures/head/implementation/HttpSuccessInner.java
@@ -10,7 +10,6 @@
 
 package fixtures.head.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.azure.v2.CloudException;
 import com.microsoft.rest.v2.RestResponse;
@@ -19,15 +18,12 @@ import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.HEAD;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azurefluent/src/main/java/fixtures/headexceptions/implementation/HeadExceptionsInner.java
+++ b/test/azurefluent/src/main/java/fixtures/headexceptions/implementation/HeadExceptionsInner.java
@@ -10,7 +10,6 @@
 
 package fixtures.headexceptions.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.azure.v2.CloudException;
 import com.microsoft.rest.v2.RestResponse;
@@ -19,15 +18,12 @@ import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.HEAD;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azurefluent/src/main/java/fixtures/lro/implementation/LRORetrysInner.java
+++ b/test/azurefluent/src/main/java/fixtures/lro/implementation/LRORetrysInner.java
@@ -10,7 +10,6 @@
 
 package fixtures.lro.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.azure.v2.CloudException;
 import com.microsoft.azure.v2.OperationStatus;
@@ -23,18 +22,15 @@ import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.DELETE;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.POST;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azurefluent/src/main/java/fixtures/lro/implementation/LROSADsInner.java
+++ b/test/azurefluent/src/main/java/fixtures/lro/implementation/LROSADsInner.java
@@ -10,7 +10,6 @@
 
 package fixtures.lro.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.azure.v2.CloudException;
 import com.microsoft.azure.v2.OperationStatus;
@@ -23,18 +22,15 @@ import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.DELETE;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.POST;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azurefluent/src/main/java/fixtures/lro/implementation/LROsCustomHeadersInner.java
+++ b/test/azurefluent/src/main/java/fixtures/lro/implementation/LROsCustomHeadersInner.java
@@ -10,7 +10,6 @@
 
 package fixtures.lro.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.azure.v2.CloudException;
 import com.microsoft.azure.v2.OperationStatus;
@@ -22,18 +21,15 @@ import com.microsoft.rest.v2.Validator;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.POST;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azurefluent/src/main/java/fixtures/lro/implementation/LROsInner.java
+++ b/test/azurefluent/src/main/java/fixtures/lro/implementation/LROsInner.java
@@ -10,7 +10,6 @@
 
 package fixtures.lro.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.azure.v2.CloudException;
 import com.microsoft.azure.v2.OperationStatus;
@@ -23,18 +22,15 @@ import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.DELETE;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.POST;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/azurefluent/src/main/java/fixtures/paging/implementation/PagingsInner.java
+++ b/test/azurefluent/src/main/java/fixtures/paging/implementation/PagingsInner.java
@@ -10,7 +10,6 @@
 
 package fixtures.paging.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.azure.v2.CloudException;
 import com.microsoft.azure.v2.ListOperationCallback;
@@ -22,17 +21,14 @@ import com.microsoft.rest.v2.Validator;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PathParam;
 import com.microsoft.rest.v2.annotations.QueryParam;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 import java.util.List;
 
 /**

--- a/test/azurefluent/src/main/java/fixtures/subscriptionidapiversion/implementation/GroupsInner.java
+++ b/test/azurefluent/src/main/java/fixtures/subscriptionidapiversion/implementation/GroupsInner.java
@@ -10,7 +10,6 @@
 
 package fixtures.subscriptionidapiversion.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -18,18 +17,15 @@ import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PathParam;
 import com.microsoft.rest.v2.annotations.QueryParam;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.subscriptionidapiversion.ErrorException;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/bodyarray/Arrays.java
+++ b/test/vanilla/src/main/java/fixtures/bodyarray/Arrays.java
@@ -19,7 +19,6 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;

--- a/test/vanilla/src/main/java/fixtures/bodyarray/implementation/ArraysImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodyarray/implementation/ArraysImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.bodyarray.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.Base64Url;
 import com.microsoft.rest.v2.DateTimeRfc1123;
 import com.microsoft.rest.v2.RestProxy;
@@ -21,12 +20,10 @@ import com.microsoft.rest.v2.Validator;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.ReturnValueWireType;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.bodyarray.Arrays;
 import fixtures.bodyarray.models.ErrorException;
 import fixtures.bodyarray.models.Product;
@@ -35,7 +32,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/test/vanilla/src/main/java/fixtures/bodyboolean/Bools.java
+++ b/test/vanilla/src/main/java/fixtures/bodyboolean/Bools.java
@@ -18,7 +18,6 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/bodyboolean/implementation/BoolsImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodyboolean/implementation/BoolsImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.bodyboolean.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -18,11 +17,9 @@ import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.bodyboolean.Bools;
 import fixtures.bodyboolean.models.ErrorException;
 import io.reactivex.Completable;
@@ -30,7 +27,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/bodybyte/Bytes.java
+++ b/test/vanilla/src/main/java/fixtures/bodybyte/Bytes.java
@@ -18,7 +18,6 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/bodybyte/implementation/BytesImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodybyte/implementation/BytesImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.bodybyte.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -18,11 +17,9 @@ import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.bodybyte.Bytes;
 import fixtures.bodybyte.models.ErrorException;
 import io.reactivex.Completable;
@@ -30,7 +27,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/Arrays.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/Arrays.java
@@ -19,7 +19,6 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/Basics.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/Basics.java
@@ -19,7 +19,6 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/Dictionarys.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/Dictionarys.java
@@ -19,7 +19,6 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/Inheritances.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/Inheritances.java
@@ -19,7 +19,6 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/Polymorphicrecursives.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/Polymorphicrecursives.java
@@ -19,7 +19,6 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/Polymorphisms.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/Polymorphisms.java
@@ -20,7 +20,6 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/Primitives.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/Primitives.java
@@ -29,7 +29,6 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/Readonlypropertys.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/Readonlypropertys.java
@@ -19,7 +19,6 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/ArraysImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/ArraysImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.bodycomplex.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -19,11 +18,9 @@ import com.microsoft.rest.v2.Validator;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.bodycomplex.Arrays;
 import fixtures.bodycomplex.models.ArrayWrapper;
 import fixtures.bodycomplex.models.ErrorException;
@@ -32,7 +29,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/BasicsImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/BasicsImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.bodycomplex.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -19,12 +18,10 @@ import com.microsoft.rest.v2.Validator;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.QueryParam;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.bodycomplex.Basics;
 import fixtures.bodycomplex.models.Basic;
 import fixtures.bodycomplex.models.ErrorException;
@@ -33,7 +30,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/DictionarysImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/DictionarysImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.bodycomplex.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -19,11 +18,9 @@ import com.microsoft.rest.v2.Validator;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.bodycomplex.Dictionarys;
 import fixtures.bodycomplex.models.DictionaryWrapper;
 import fixtures.bodycomplex.models.ErrorException;
@@ -32,7 +29,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/InheritancesImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/InheritancesImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.bodycomplex.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -19,11 +18,9 @@ import com.microsoft.rest.v2.Validator;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.bodycomplex.Inheritances;
 import fixtures.bodycomplex.models.ErrorException;
 import fixtures.bodycomplex.models.Siamese;
@@ -32,7 +29,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/PolymorphicrecursivesImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/PolymorphicrecursivesImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.bodycomplex.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -19,11 +18,9 @@ import com.microsoft.rest.v2.Validator;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.bodycomplex.Polymorphicrecursives;
 import fixtures.bodycomplex.models.ErrorException;
 import fixtures.bodycomplex.models.Fish;
@@ -32,7 +29,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/PolymorphismsImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/PolymorphismsImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.bodycomplex.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -19,11 +18,9 @@ import com.microsoft.rest.v2.Validator;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.bodycomplex.Polymorphisms;
 import fixtures.bodycomplex.models.ErrorException;
 import fixtures.bodycomplex.models.Fish;
@@ -33,7 +30,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/PrimitivesImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/PrimitivesImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.bodycomplex.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -19,11 +18,9 @@ import com.microsoft.rest.v2.Validator;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.bodycomplex.Primitives;
 import fixtures.bodycomplex.models.BooleanWrapper;
 import fixtures.bodycomplex.models.ByteWrapper;
@@ -42,7 +39,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/ReadonlypropertysImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodycomplex/implementation/ReadonlypropertysImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.bodycomplex.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -19,11 +18,9 @@ import com.microsoft.rest.v2.Validator;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.bodycomplex.Readonlypropertys;
 import fixtures.bodycomplex.models.ErrorException;
 import fixtures.bodycomplex.models.ReadonlyObj;
@@ -32,7 +29,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/bodydate/Dates.java
+++ b/test/vanilla/src/main/java/fixtures/bodydate/Dates.java
@@ -18,7 +18,6 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 import org.joda.time.LocalDate;
 
 /**

--- a/test/vanilla/src/main/java/fixtures/bodydate/implementation/DatesImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodydate/implementation/DatesImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.bodydate.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -18,11 +17,9 @@ import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.bodydate.Dates;
 import fixtures.bodydate.models.ErrorException;
 import io.reactivex.Completable;
@@ -30,7 +27,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 import org.joda.time.LocalDate;
 
 /**

--- a/test/vanilla/src/main/java/fixtures/bodydatetime/Datetimes.java
+++ b/test/vanilla/src/main/java/fixtures/bodydatetime/Datetimes.java
@@ -18,7 +18,6 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 import org.joda.time.DateTime;
 
 /**

--- a/test/vanilla/src/main/java/fixtures/bodydatetime/implementation/DatetimesImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodydatetime/implementation/DatetimesImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.bodydatetime.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -18,11 +17,9 @@ import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.bodydatetime.Datetimes;
 import fixtures.bodydatetime.models.ErrorException;
 import io.reactivex.Completable;
@@ -30,7 +27,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 import org.joda.time.DateTime;
 
 /**

--- a/test/vanilla/src/main/java/fixtures/bodydatetimerfc1123/Datetimerfc1123s.java
+++ b/test/vanilla/src/main/java/fixtures/bodydatetimerfc1123/Datetimerfc1123s.java
@@ -18,7 +18,6 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 import org.joda.time.DateTime;
 
 /**

--- a/test/vanilla/src/main/java/fixtures/bodydatetimerfc1123/implementation/Datetimerfc1123sImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodydatetimerfc1123/implementation/Datetimerfc1123sImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.bodydatetimerfc1123.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.DateTimeRfc1123;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
@@ -19,12 +18,10 @@ import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.ReturnValueWireType;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.bodydatetimerfc1123.Datetimerfc1123s;
 import fixtures.bodydatetimerfc1123.models.ErrorException;
 import io.reactivex.Completable;
@@ -32,7 +29,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 import org.joda.time.DateTime;
 
 /**

--- a/test/vanilla/src/main/java/fixtures/bodydictionary/Dictionarys.java
+++ b/test/vanilla/src/main/java/fixtures/bodydictionary/Dictionarys.java
@@ -19,7 +19,6 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import org.joda.time.DateTime;

--- a/test/vanilla/src/main/java/fixtures/bodydictionary/implementation/DictionarysImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodydictionary/implementation/DictionarysImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.bodydictionary.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.Base64Url;
 import com.microsoft.rest.v2.DateTimeRfc1123;
 import com.microsoft.rest.v2.RestProxy;
@@ -21,12 +20,10 @@ import com.microsoft.rest.v2.Validator;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.ReturnValueWireType;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.bodydictionary.Dictionarys;
 import fixtures.bodydictionary.models.ErrorException;
 import fixtures.bodydictionary.models.Widget;
@@ -35,7 +32,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/test/vanilla/src/main/java/fixtures/bodyduration/Durations.java
+++ b/test/vanilla/src/main/java/fixtures/bodyduration/Durations.java
@@ -18,7 +18,6 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 import org.joda.time.Period;
 
 /**

--- a/test/vanilla/src/main/java/fixtures/bodyduration/implementation/DurationsImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodyduration/implementation/DurationsImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.bodyduration.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -18,11 +17,9 @@ import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.bodyduration.Durations;
 import fixtures.bodyduration.models.ErrorException;
 import io.reactivex.Completable;
@@ -30,7 +27,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 import org.joda.time.Period;
 
 /**

--- a/test/vanilla/src/main/java/fixtures/bodyfile/Files.java
+++ b/test/vanilla/src/main/java/fixtures/bodyfile/Files.java
@@ -18,7 +18,6 @@ import io.reactivex.Flowable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/bodyfile/implementation/FilesImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodyfile/implementation/FilesImpl.java
@@ -10,17 +10,14 @@
 
 package fixtures.bodyfile.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
 import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.bodyfile.Files;
 import fixtures.bodyfile.models.ErrorException;
 import io.reactivex.Flowable;
@@ -28,7 +25,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/bodyformdata/Formdatas.java
+++ b/test/vanilla/src/main/java/fixtures/bodyformdata/Formdatas.java
@@ -18,7 +18,6 @@ import io.reactivex.Flowable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/bodyformdata/implementation/FormdatasImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodyformdata/implementation/FormdatasImpl.java
@@ -10,19 +10,16 @@
 
 package fixtures.bodyformdata.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
 import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.POST;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.bodyformdata.Formdatas;
 import fixtures.bodyformdata.models.ErrorException;
 import io.reactivex.Flowable;
@@ -30,7 +27,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/bodyinteger/Ints.java
+++ b/test/vanilla/src/main/java/fixtures/bodyinteger/Ints.java
@@ -18,7 +18,6 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 import org.joda.time.DateTime;
 
 /**

--- a/test/vanilla/src/main/java/fixtures/bodyinteger/implementation/IntsImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodyinteger/implementation/IntsImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.bodyinteger.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -19,12 +18,10 @@ import com.microsoft.rest.v2.UnixTime;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.ReturnValueWireType;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.bodyinteger.Ints;
 import fixtures.bodyinteger.models.ErrorException;
 import io.reactivex.Completable;
@@ -32,7 +29,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 

--- a/test/vanilla/src/main/java/fixtures/bodynumber/Numbers.java
+++ b/test/vanilla/src/main/java/fixtures/bodynumber/Numbers.java
@@ -18,7 +18,6 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 import java.math.BigDecimal;
 
 /**

--- a/test/vanilla/src/main/java/fixtures/bodynumber/implementation/NumbersImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodynumber/implementation/NumbersImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.bodynumber.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -18,11 +17,9 @@ import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.bodynumber.Numbers;
 import fixtures.bodynumber.models.ErrorException;
 import io.reactivex.Completable;
@@ -30,7 +27,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 import java.math.BigDecimal;
 
 /**

--- a/test/vanilla/src/main/java/fixtures/bodystring/Enums.java
+++ b/test/vanilla/src/main/java/fixtures/bodystring/Enums.java
@@ -20,7 +20,6 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/bodystring/Strings.java
+++ b/test/vanilla/src/main/java/fixtures/bodystring/Strings.java
@@ -18,7 +18,6 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/bodystring/implementation/EnumsImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodystring/implementation/EnumsImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.bodystring.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -19,11 +18,9 @@ import com.microsoft.rest.v2.Validator;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.bodystring.Enums;
 import fixtures.bodystring.models.Colors;
 import fixtures.bodystring.models.ErrorException;
@@ -33,7 +30,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/bodystring/implementation/StringsImpl.java
+++ b/test/vanilla/src/main/java/fixtures/bodystring/implementation/StringsImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.bodystring.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.Base64Url;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
@@ -19,12 +18,10 @@ import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.ReturnValueWireType;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.bodystring.Strings;
 import fixtures.bodystring.models.ErrorException;
 import io.reactivex.Completable;
@@ -32,7 +29,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/custombaseuri/Paths.java
+++ b/test/vanilla/src/main/java/fixtures/custombaseuri/Paths.java
@@ -17,7 +17,6 @@ import fixtures.custombaseuri.models.ErrorException;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/custombaseuri/implementation/PathsImpl.java
+++ b/test/vanilla/src/main/java/fixtures/custombaseuri/implementation/PathsImpl.java
@@ -10,26 +10,22 @@
 
 package fixtures.custombaseuri.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
 import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.HostParam;
 import com.microsoft.rest.v2.annotations.PathParam;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.custombaseuri.Paths;
 import fixtures.custombaseuri.models.ErrorException;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/custombaseurimoreoptions/Paths.java
+++ b/test/vanilla/src/main/java/fixtures/custombaseurimoreoptions/Paths.java
@@ -17,7 +17,6 @@ import fixtures.custombaseurimoreoptions.models.ErrorException;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/custombaseurimoreoptions/implementation/PathsImpl.java
+++ b/test/vanilla/src/main/java/fixtures/custombaseurimoreoptions/implementation/PathsImpl.java
@@ -10,27 +10,23 @@
 
 package fixtures.custombaseurimoreoptions.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
 import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.HostParam;
 import com.microsoft.rest.v2.annotations.PathParam;
 import com.microsoft.rest.v2.annotations.QueryParam;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.custombaseurimoreoptions.Paths;
 import fixtures.custombaseurimoreoptions.models.ErrorException;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/header/Headers.java
+++ b/test/vanilla/src/main/java/fixtures/header/Headers.java
@@ -32,7 +32,6 @@ import fixtures.header.models.HeaderResponseStringHeaders;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.joda.time.Period;

--- a/test/vanilla/src/main/java/fixtures/header/implementation/HeadersImpl.java
+++ b/test/vanilla/src/main/java/fixtures/header/implementation/HeadersImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.header.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.DateTimeRfc1123;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
@@ -18,11 +17,10 @@ import com.microsoft.rest.v2.ServiceCallback;
 import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.POST;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
+import fixtures.header.Headers;
 import fixtures.header.models.ErrorException;
 import fixtures.header.models.GreyscaleColors;
 import fixtures.header.models.HeaderResponseBoolHeaders;
@@ -43,7 +41,6 @@ import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 import org.apache.commons.codec.binary.Base64;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
@@ -53,7 +50,7 @@ import org.joda.time.Period;
  * An instance of this class provides access to all the operations defined in
  * Headers.
  */
-public class HeadersImpl implements fixtures.header.Headers {
+public class HeadersImpl implements Headers {
     /**
      * The proxy service used to perform REST calls.
      */

--- a/test/vanilla/src/main/java/fixtures/http/HttpClientFailures.java
+++ b/test/vanilla/src/main/java/fixtures/http/HttpClientFailures.java
@@ -18,7 +18,6 @@ import fixtures.http.models.ErrorException;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/http/HttpFailures.java
+++ b/test/vanilla/src/main/java/fixtures/http/HttpFailures.java
@@ -18,7 +18,6 @@ import fixtures.http.models.ErrorException;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/http/HttpRedirects.java
+++ b/test/vanilla/src/main/java/fixtures/http/HttpRedirects.java
@@ -33,7 +33,6 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 import java.util.List;
 
 /**

--- a/test/vanilla/src/main/java/fixtures/http/HttpRetrys.java
+++ b/test/vanilla/src/main/java/fixtures/http/HttpRetrys.java
@@ -17,7 +17,6 @@ import fixtures.http.models.ErrorException;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/http/HttpServerFailures.java
+++ b/test/vanilla/src/main/java/fixtures/http/HttpServerFailures.java
@@ -18,7 +18,6 @@ import fixtures.http.models.ErrorException;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/http/HttpSuccess.java
+++ b/test/vanilla/src/main/java/fixtures/http/HttpSuccess.java
@@ -18,7 +18,6 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/http/MultipleResponses.java
+++ b/test/vanilla/src/main/java/fixtures/http/MultipleResponses.java
@@ -21,7 +21,6 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/http/implementation/HttpClientFailuresImpl.java
+++ b/test/vanilla/src/main/java/fixtures/http/implementation/HttpClientFailuresImpl.java
@@ -19,13 +19,11 @@ import com.microsoft.rest.v2.annotations.DELETE;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
 import com.microsoft.rest.v2.annotations.HEAD;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PATCH;
 import com.microsoft.rest.v2.annotations.POST;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.http.HttpClientFailures;
 import fixtures.http.models.Error;
 import fixtures.http.models.ErrorException;
@@ -33,7 +31,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/http/implementation/HttpFailuresImpl.java
+++ b/test/vanilla/src/main/java/fixtures/http/implementation/HttpFailuresImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.http.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.RestException;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
@@ -18,17 +17,14 @@ import com.microsoft.rest.v2.ServiceCallback;
 import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.http.HttpFailures;
 import fixtures.http.models.ErrorException;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/http/implementation/HttpRedirectsImpl.java
+++ b/test/vanilla/src/main/java/fixtures/http/implementation/HttpRedirectsImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.http.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -20,13 +19,11 @@ import com.microsoft.rest.v2.annotations.DELETE;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
 import com.microsoft.rest.v2.annotations.HEAD;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PATCH;
 import com.microsoft.rest.v2.annotations.POST;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.http.HttpRedirects;
 import fixtures.http.models.ErrorException;
 import fixtures.http.models.HttpRedirectsDelete307Headers;
@@ -49,7 +46,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 import java.util.List;
 
 /**

--- a/test/vanilla/src/main/java/fixtures/http/implementation/HttpRetrysImpl.java
+++ b/test/vanilla/src/main/java/fixtures/http/implementation/HttpRetrysImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.http.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -20,20 +19,17 @@ import com.microsoft.rest.v2.annotations.DELETE;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
 import com.microsoft.rest.v2.annotations.HEAD;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PATCH;
 import com.microsoft.rest.v2.annotations.POST;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.http.HttpRetrys;
 import fixtures.http.models.ErrorException;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/http/implementation/HttpServerFailuresImpl.java
+++ b/test/vanilla/src/main/java/fixtures/http/implementation/HttpServerFailuresImpl.java
@@ -19,11 +19,9 @@ import com.microsoft.rest.v2.annotations.DELETE;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
 import com.microsoft.rest.v2.annotations.HEAD;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.POST;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.http.HttpServerFailures;
 import fixtures.http.models.Error;
 import fixtures.http.models.ErrorException;
@@ -31,7 +29,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/http/implementation/HttpSuccessImpl.java
+++ b/test/vanilla/src/main/java/fixtures/http/implementation/HttpSuccessImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.http.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -20,13 +19,11 @@ import com.microsoft.rest.v2.annotations.DELETE;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
 import com.microsoft.rest.v2.annotations.HEAD;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PATCH;
 import com.microsoft.rest.v2.annotations.POST;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.http.HttpSuccess;
 import fixtures.http.models.ErrorException;
 import io.reactivex.Completable;
@@ -34,7 +31,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/http/implementation/MultipleResponsesImpl.java
+++ b/test/vanilla/src/main/java/fixtures/http/implementation/MultipleResponsesImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.http.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.RestException;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
@@ -18,10 +17,8 @@ import com.microsoft.rest.v2.ServiceCallback;
 import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.http.MultipleResponses;
 import fixtures.http.models.A;
 import fixtures.http.models.AException;
@@ -34,7 +31,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/modelflattening/AutoRestResourceFlatteningTestService.java
+++ b/test/vanilla/src/main/java/fixtures/modelflattening/AutoRestResourceFlatteningTestService.java
@@ -25,7 +25,6 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 

--- a/test/vanilla/src/main/java/fixtures/modelflattening/implementation/AutoRestResourceFlatteningTestServiceImpl.java
+++ b/test/vanilla/src/main/java/fixtures/modelflattening/implementation/AutoRestResourceFlatteningTestServiceImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.modelflattening.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -20,13 +19,11 @@ import com.microsoft.rest.v2.Validator;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PathParam;
 import com.microsoft.rest.v2.annotations.POST;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import com.microsoft.rest.v2.http.HttpPipeline;
 import fixtures.modelflattening.AutoRestResourceFlatteningTestService;
 import fixtures.modelflattening.models.ErrorException;
@@ -42,7 +39,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 

--- a/test/vanilla/src/main/java/fixtures/parameterflattening/AvailabilitySets.java
+++ b/test/vanilla/src/main/java/fixtures/parameterflattening/AvailabilitySets.java
@@ -17,7 +17,6 @@ import com.microsoft.rest.v2.ServiceFuture;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 import java.util.Map;
 
 /**

--- a/test/vanilla/src/main/java/fixtures/parameterflattening/implementation/AvailabilitySetsImpl.java
+++ b/test/vanilla/src/main/java/fixtures/parameterflattening/implementation/AvailabilitySetsImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.parameterflattening.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.RestException;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
@@ -19,18 +18,15 @@ import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.Validator;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PATCH;
 import com.microsoft.rest.v2.annotations.PathParam;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.parameterflattening.AvailabilitySets;
 import fixtures.parameterflattening.models.AvailabilitySetUpdateParameters;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 import java.util.Map;
 
 /**

--- a/test/vanilla/src/main/java/fixtures/report/AutoRestReportService.java
+++ b/test/vanilla/src/main/java/fixtures/report/AutoRestReportService.java
@@ -17,7 +17,6 @@ import fixtures.report.models.ErrorException;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 import java.util.Map;
 
 /**

--- a/test/vanilla/src/main/java/fixtures/report/implementation/AutoRestReportServiceImpl.java
+++ b/test/vanilla/src/main/java/fixtures/report/implementation/AutoRestReportServiceImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.report.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -18,11 +17,9 @@ import com.microsoft.rest.v2.ServiceClient;
 import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.QueryParam;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import com.microsoft.rest.v2.http.HttpPipeline;
 import fixtures.report.AutoRestReportService;
 import fixtures.report.models.ErrorException;
@@ -30,7 +27,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 import java.util.Map;
 
 /**

--- a/test/vanilla/src/main/java/fixtures/requiredoptional/Explicits.java
+++ b/test/vanilla/src/main/java/fixtures/requiredoptional/Explicits.java
@@ -28,7 +28,6 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 import java.util.List;
 
 /**

--- a/test/vanilla/src/main/java/fixtures/requiredoptional/Implicits.java
+++ b/test/vanilla/src/main/java/fixtures/requiredoptional/Implicits.java
@@ -19,7 +19,6 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/requiredoptional/implementation/ExplicitsImpl.java
+++ b/test/vanilla/src/main/java/fixtures/requiredoptional/implementation/ExplicitsImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.requiredoptional.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.CollectionFormat;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
@@ -20,11 +19,9 @@ import com.microsoft.rest.v2.Validator;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.POST;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.requiredoptional.Explicits;
 import fixtures.requiredoptional.models.ArrayOptionalWrapper;
 import fixtures.requiredoptional.models.ArrayWrapper;
@@ -42,7 +39,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 import java.util.List;
 
 /**

--- a/test/vanilla/src/main/java/fixtures/requiredoptional/implementation/ImplicitsImpl.java
+++ b/test/vanilla/src/main/java/fixtures/requiredoptional/implementation/ImplicitsImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.requiredoptional.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
@@ -19,13 +18,11 @@ import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
 import com.microsoft.rest.v2.annotations.HeaderParam;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PathParam;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.QueryParam;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.requiredoptional.Implicits;
 import fixtures.requiredoptional.models.Error;
 import fixtures.requiredoptional.models.ErrorException;
@@ -34,7 +31,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/url/PathItems.java
+++ b/test/vanilla/src/main/java/fixtures/url/PathItems.java
@@ -17,7 +17,6 @@ import fixtures.url.models.ErrorException;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/url/Paths.java
+++ b/test/vanilla/src/main/java/fixtures/url/Paths.java
@@ -18,7 +18,6 @@ import fixtures.url.models.UriColor;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 import java.util.List;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;

--- a/test/vanilla/src/main/java/fixtures/url/Queries.java
+++ b/test/vanilla/src/main/java/fixtures/url/Queries.java
@@ -18,7 +18,6 @@ import fixtures.url.models.UriColor;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 import java.util.List;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;

--- a/test/vanilla/src/main/java/fixtures/url/implementation/PathItemsImpl.java
+++ b/test/vanilla/src/main/java/fixtures/url/implementation/PathItemsImpl.java
@@ -10,26 +10,22 @@
 
 package fixtures.url.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
 import com.microsoft.rest.v2.ServiceCallback;
 import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PathParam;
 import com.microsoft.rest.v2.annotations.QueryParam;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.url.PathItems;
 import fixtures.url.models.ErrorException;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/test/vanilla/src/main/java/fixtures/url/implementation/PathsImpl.java
+++ b/test/vanilla/src/main/java/fixtures/url/implementation/PathsImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.url.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.Base64Url;
 import com.microsoft.rest.v2.CollectionFormat;
 import com.microsoft.rest.v2.RestProxy;
@@ -20,11 +19,9 @@ import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.Validator;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PathParam;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.url.Paths;
 import fixtures.url.models.ErrorException;
 import fixtures.url.models.UriColor;
@@ -32,7 +29,6 @@ import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 import java.util.List;
 import org.apache.commons.codec.binary.Base64;
 import org.joda.time.DateTime;

--- a/test/vanilla/src/main/java/fixtures/url/implementation/QueriesImpl.java
+++ b/test/vanilla/src/main/java/fixtures/url/implementation/QueriesImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.url.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.CollectionFormat;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
@@ -19,11 +18,9 @@ import com.microsoft.rest.v2.ServiceFuture;
 import com.microsoft.rest.v2.Validator;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.QueryParam;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import fixtures.url.Queries;
 import fixtures.url.models.ErrorException;
 import fixtures.url.models.UriColor;
@@ -31,7 +28,6 @@ import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 import java.util.List;
 import org.apache.commons.codec.binary.Base64;
 import org.joda.time.DateTime;

--- a/test/vanilla/src/main/java/fixtures/validation/AutoRestValidationTest.java
+++ b/test/vanilla/src/main/java/fixtures/validation/AutoRestValidationTest.java
@@ -20,7 +20,6 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
 
 /**
  * The interface for AutoRestValidationTest class.

--- a/test/vanilla/src/main/java/fixtures/validation/implementation/AutoRestValidationTestImpl.java
+++ b/test/vanilla/src/main/java/fixtures/validation/implementation/AutoRestValidationTestImpl.java
@@ -10,7 +10,6 @@
 
 package fixtures.validation.implementation;
 
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.RestException;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.RestResponse;
@@ -21,14 +20,12 @@ import com.microsoft.rest.v2.Validator;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
-import com.microsoft.rest.v2.annotations.Headers;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PathParam;
 import com.microsoft.rest.v2.annotations.POST;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.QueryParam;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.http.HttpClient;
 import com.microsoft.rest.v2.http.HttpPipeline;
 import fixtures.validation.AutoRestValidationTest;
 import fixtures.validation.models.ErrorException;
@@ -38,7 +35,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import java.io.IOException;
 
 /**
  * Initializes a new instance of the AutoRestValidationTest type.


### PR DESCRIPTION
This fixes another bug with XML serialization. Also took the opportunity to remove some .Import statements which are never used as part of our eventual goal to produce only import statements that are actually used in the generated files.