### PR TITLE
Fix XML serialization for composite types containing multiple lists

### DIFF
--- a/src/JavaClass.cs
+++ b/src/JavaClass.cs
@@ -48,6 +48,13 @@ namespace AutoRest.Java
             addNewLine = true;
         }
 
+        public void PrivateConstructor(string constructorSignature, Action<JavaBlock> constructor)
+        {
+            AddExpectedNewLine();
+            contents.Block($"private {constructorSignature}", constructor);
+            addNewLine = true;
+        }
+
         public void PublicConstructor(string constructorSignature, Action<JavaBlock> constructor)
         {
             AddExpectedNewLine();

--- a/src/JavaCodeGenerator.cs
+++ b/src/JavaCodeGenerator.cs
@@ -2607,9 +2607,11 @@ namespace AutoRest.Java
             }
             javaFile.Class(classVisibility, classModifiers, classNameWithBaseType, (classBlock) =>
             {
+                string propertyXmlWrapperClassName(ServiceModelProperty property) => property.XmlName + "Wrapper";
+
                 foreach (ServiceModelProperty property in model.Properties)
                 {
-                    string xmlWrapperClassName = property.XmlName + "Wrapper";
+                    string xmlWrapperClassName = propertyXmlWrapperClassName(property);
                     if (settings.ShouldGenerateXmlSerialization && property.ModelTypeIsSequence)
                     {
                         classBlock.PrivateStaticFinalClass(xmlWrapperClassName, innerClass =>
@@ -2797,7 +2799,7 @@ namespace AutoRest.Java
                             {
                                 if (settings.ShouldGenerateXmlSerialization && property.ModelTypeIsSequence)
                                 {
-                                    methodBlock.Line($"this.{property.Name} = new {property.XmlName}Wrapper({property.Name});");
+                                    methodBlock.Line($"this.{property.Name} = new {propertyXmlWrapperClassName(property)}({property.Name});");
                                 }
                                 else
                                 {


### PR DESCRIPTION
Fixes https://github.com/Azure/autorest-clientruntime-for-java/issues/365
This is a workaround for a Jackson XML limitation: https://github.com/FasterXML/jackson-dataformat-xml/issues/192

Also fixes a few miscellaneous issues:
 - XmlSequenceWrapper had wrong localName annotation argument for constructor parameter
 - Flowable<byte[]> was used as the Stream type when getting a default value for an optional body parameter

Here's an example XML class before this generator change:
```java
/**
 * The AppleBarrel model.
 */
@JacksonXmlRootElement(localName = "AppleBarrel")
public class AppleBarrel {
    /**
     * The goodApples property.
     */
    @JacksonXmlElementWrapper(localName = "GoodApples")
    private List<Apple> goodApples;

    /**
     * The badApples property.
     */
    @JacksonXmlElementWrapper(localName = "BadApples")
    private List<Apple> badApples;

    /**
     * Get the goodApples value.
     *
     * @return the goodApples value.
     */
    public List<Apple> goodApples() {
        return this.goodApples;
    }

    /**
     * Set the goodApples value.
     *
     * @param goodApples the goodApples value to set.
     * @return the AppleBarrel object itself.
     */
    public AppleBarrel withGoodApples(List<Apple> goodApples) {
        this.goodApples = goodApples;
        return this;
    }

    /**
     * Get the badApples value.
     *
     * @return the badApples value.
     */
    public List<Apple> badApples() {
        return this.badApples;
    }

    /**
     * Set the badApples value.
     *
     * @param badApples the badApples value to set.
     * @return the AppleBarrel object itself.
     */
    public AppleBarrel withBadApples(List<Apple> badApples) {
        this.badApples = badApples;
        return this;
    }
}
```

After the generator change:
```java
/**
 * The AppleBarrel model.
 */
@JacksonXmlRootElement(localName = "AppleBarrel")
public final class AppleBarrel {
    private static final class GoodApplesWrapper {
        @JacksonXmlProperty(localName = "Apple")
        private final List<Apple> items;

        @JsonCreator
        private GoodApplesWrapper(@JacksonXmlProperty(localName = "Apple") List<Apple> items) {
            this.items = items;
        }
    }

    /**
     * The goodApples property.
     */
    @JacksonXmlProperty(localName = "GoodApples")
    private GoodApplesWrapper goodApples;

    private static final class BadApplesWrapper {
        @JacksonXmlProperty(localName = "Apple")
        private final List<Apple> items;

        @JsonCreator
        private BadApplesWrapper(@JacksonXmlProperty(localName = "Apple") List<Apple> items) {
            this.items = items;
        }
    }

    /**
     * The badApples property.
     */
    @JacksonXmlProperty(localName = "BadApples")
    private BadApplesWrapper badApples;

    /**
     * Get the goodApples value.
     *
     * @return the goodApples value.
     */
    public List<Apple> goodApples() {
        return this.goodApples.items;
    }

    /**
     * Set the goodApples value.
     *
     * @param goodApples the goodApples value to set.
     * @return the AppleBarrel object itself.
     */
    public AppleBarrel withGoodApples(List<Apple> goodApples) {
        this.goodApples = new GoodApplesWrapper(goodApples);
        return this;
    }

    /**
     * Get the badApples value.
     *
     * @return the badApples value.
     */
    public List<Apple> badApples() {
        return this.badApples.items;
    }

    /**
     * Set the badApples value.
     *
     * @param badApples the badApples value to set.
     * @return the AppleBarrel object itself.
     */
    public AppleBarrel withBadApples(List<Apple> badApples) {
        this.badApples = new BadApplesWrapper(badApples);
        return this;
    }
}
```
