### PR TITLE
Some more cleanup

### DIFF
--- a/src/Model/ArrayType.cs
+++ b/src/Model/ArrayType.cs
@@ -1,20 +1,24 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 
 namespace AutoRest.Java.Model
 {
     public class ArrayType : IType
     {
-        public static readonly ArrayType ByteArray = new ArrayType(PrimitiveType.Byte);
+        public static readonly ArrayType ByteArray = new ArrayType(PrimitiveType.Byte, (string defaultValueExpression) => $"\"{defaultValueExpression}\".getBytes()");
 
-        private ArrayType(IType elementType)
+        private ArrayType(IType elementType, Func<string,string> defaultValueExpressionConverter)
         {
             ElementType = elementType;
+            DefaultValueExpressionConverter = defaultValueExpressionConverter;
         }
 
         public IType ElementType { get; }
+
+        private Func<string, string> DefaultValueExpressionConverter { get; }
 
         public override string ToString()
         {
@@ -34,6 +38,16 @@ namespace AutoRest.Java.Model
         public void AddImportsTo(ISet<string> imports, bool includeImplementationImports)
         {
             ElementType.AddImportsTo(imports, includeImplementationImports);
+        }
+
+        public string DefaultValueExpression(string sourceExpression)
+        {
+            string result = sourceExpression;
+            if (result != null && DefaultValueExpressionConverter != null)
+            {
+                result = DefaultValueExpressionConverter(sourceExpression);
+            }
+            return result;
         }
     }
 }

--- a/src/Model/ClassType.cs
+++ b/src/Model/ClassType.cs
@@ -1,54 +1,57 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using AutoRest.Core;
+using System;
 using System.Collections.Generic;
 
 namespace AutoRest.Java.Model
 {
     public class ClassType : IType
     {
-        public static readonly ClassType Void = new ClassType("java.lang", "Void", null, null, false);
-        public static readonly ClassType Boolean = new ClassType("java.lang", "Boolean", null, null, false);
-        public static readonly ClassType Byte = new ClassType("java.lang", "Byte", null, null, false);
-        public static readonly ClassType Integer = new ClassType("java.lang", "Integer", null, null, false);
-        public static readonly ClassType Long = new ClassType("java.lang", "Long", null, null, false);
-        public static readonly ClassType Double = new ClassType("java.lang", "Double", null, null, false);
-        public static readonly ClassType String = new ClassType("java.lang", "String", null, null, false);
-        public static readonly ClassType Base64Url = new ClassType("com.microsoft.rest.v2", "Base64Url", null, null, false);
-        public static readonly ClassType LocalDate = new ClassType("org.joda.time", "LocalDate", null, null, false);
-        public static readonly ClassType DateTime = new ClassType("org.joda.time", "DateTime", null, null, false);
-        public static readonly ClassType DateTimeRfc1123 = new ClassType("com.microsoft.rest.v2", "DateTimeRfc1123", null, null, false);
-        public static readonly ClassType BigDecimal = new ClassType("java.math", "BigDecimal", null, null, false);
-        public static readonly ClassType Period = new ClassType("org.joda.time", "Period", null, null, false);
-        public static readonly ClassType UUID = new ClassType("java.util", "UUID", null, null, false);
-        public static readonly ClassType Object = new ClassType("java.lang", "Object", null, null, false);
-        public static readonly ClassType ServiceClientCredentials = new ClassType("com.microsoft.rest.v2.credentials", "ServiceClientCredentials", null, null, false);
-        public static readonly ClassType AzureTokenCredentials = new ClassType("com.microsoft.azure.v2.credentials", "AzureTokenCredentials", null, null, false);
-        public static readonly ClassType CloudException = new ClassType("com.microsoft.azure.v2", "CloudException", null, null, false);
-        public static readonly ClassType RestException = new ClassType("com.microsoft.azure.v2", "RestException", null, null, false);
-        public static readonly ClassType UnixTime = new ClassType("com.microsoft.rest.v2", "UnixTime", null, null, false);
-        public static readonly ClassType UnixTimeDateTime = new ClassType("org.joda.time", "DateTime", new[] { "org.joda.time.DateTimeZone" }, null, false);
-        public static readonly ClassType UnixTimeLong = new ClassType("java.lang", "Long", null, null, false);
-        public static readonly ClassType AzureEnvironment = new ClassType("com.microsoft.azure.v2", "AzureEnvironment", null, null, false);
-        public static readonly ClassType HttpPipeline = new ClassType("com.microsoft.rest.v2.http", "HttpPipeline", null, null, false);
-        public static readonly ClassType Completable = new ClassType("io.reactivex", "Completable", null, null, false);
-        public static readonly ClassType AzureProxy = new ClassType("com.microsoft.azure.v2", "AzureProxy", null, null, false);
-        public static readonly ClassType RestProxy = new ClassType("com.microsoft.rest.v2", "RestProxy", null, null, false);
-        public static readonly ClassType Validator = new ClassType("com.microsoft.rest.v2", "Validator", null, null, false);
-        public static readonly ClassType Function = new ClassType("io.reactivex.functions", "Function", null, null, false);
-        public static readonly ClassType ByteBuffer = new ClassType("java.nio", "ByteBuffer", null, null, false);
-        public static readonly ClassType Resource = new ClassType("com.microsoft.azure.v2", "Resource", null, null, false);
-        public static readonly ClassType SubResource = new ClassType("com.microsoft.azure.v2", "SubResource", null, null, false);
-        public static readonly ClassType URL = new ClassType("java.net", "URL", null, null, false);
-        public static readonly ClassType NonNull = new ClassType("io.reactivex.annotations", "NonNull", null, null, false);
-        
-        public ClassType(string package, string name, IEnumerable<string> implementationImports, IDictionary<string,string> extensions, bool isInnerModelType)
+        public static readonly ClassType Void = new ClassType("java.lang", "Void");
+        public static readonly ClassType Boolean = new ClassType("java.lang", "Boolean", defaultValueExpressionConverter: (string defaultValueExpression) => defaultValueExpression.ToLowerInvariant());
+        public static readonly ClassType Byte = new ClassType("java.lang", "Byte");
+        public static readonly ClassType Integer = new ClassType("java.lang", "Integer");
+        public static readonly ClassType Long = new ClassType("java.lang", "Long", defaultValueExpressionConverter: (string defaultValueExpression) => defaultValueExpression + 'L');
+        public static readonly ClassType Double = new ClassType("java.lang", "Double", defaultValueExpressionConverter: (string defaultValueExpression) => double.Parse(defaultValueExpression).ToString());
+        public static readonly ClassType String = new ClassType("java.lang", "String", defaultValueExpressionConverter: (string defaultValueExpression) => CodeNamer.Instance.QuoteValue(defaultValueExpression));
+        public static readonly ClassType Base64Url = new ClassType("com.microsoft.rest.v2", "Base64Url");
+        public static readonly ClassType LocalDate = new ClassType("org.joda.time", "LocalDate", defaultValueExpressionConverter: (string defaultValueExpression) => $"LocalDate.parse(\"{defaultValueExpression}\")");
+        public static readonly ClassType DateTime = new ClassType("org.joda.time", "DateTime", defaultValueExpressionConverter: (string defaultValueExpression) => $"DateTime.parse(\"{defaultValueExpression}\")");
+        public static readonly ClassType DateTimeRfc1123 = new ClassType("com.microsoft.rest.v2", "DateTimeRfc1123", defaultValueExpressionConverter: (string defaultValueExpression) => $"DateTime.parse(\"{defaultValueExpression}\")");
+        public static readonly ClassType BigDecimal = new ClassType("java.math", "BigDecimal");
+        public static readonly ClassType Period = new ClassType("org.joda.time", "Period", defaultValueExpressionConverter: (string defaultValueExpression) => $"Period.parse(\"{defaultValueExpression}\")");
+        public static readonly ClassType UUID = new ClassType("java.util", "UUID");
+        public static readonly ClassType Object = new ClassType("java.lang", "Object");
+        public static readonly ClassType ServiceClientCredentials = new ClassType("com.microsoft.rest.v2.credentials", "ServiceClientCredentials");
+        public static readonly ClassType AzureTokenCredentials = new ClassType("com.microsoft.azure.v2.credentials", "AzureTokenCredentials");
+        public static readonly ClassType CloudException = new ClassType("com.microsoft.azure.v2", "CloudException");
+        public static readonly ClassType RestException = new ClassType("com.microsoft.azure.v2", "RestException");
+        public static readonly ClassType UnixTime = new ClassType("com.microsoft.rest.v2", "UnixTime");
+        public static readonly ClassType UnixTimeDateTime = new ClassType("org.joda.time", "DateTime", new[] { "org.joda.time.DateTimeZone" });
+        public static readonly ClassType UnixTimeLong = new ClassType("java.lang", "Long");
+        public static readonly ClassType AzureEnvironment = new ClassType("com.microsoft.azure.v2", "AzureEnvironment");
+        public static readonly ClassType HttpPipeline = new ClassType("com.microsoft.rest.v2.http", "HttpPipeline");
+        public static readonly ClassType Completable = new ClassType("io.reactivex", "Completable");
+        public static readonly ClassType AzureProxy = new ClassType("com.microsoft.azure.v2", "AzureProxy");
+        public static readonly ClassType RestProxy = new ClassType("com.microsoft.rest.v2", "RestProxy");
+        public static readonly ClassType Validator = new ClassType("com.microsoft.rest.v2", "Validator");
+        public static readonly ClassType Function = new ClassType("io.reactivex.functions", "Function");
+        public static readonly ClassType ByteBuffer = new ClassType("java.nio", "ByteBuffer");
+        public static readonly ClassType Resource = new ClassType("com.microsoft.azure.v2", "Resource");
+        public static readonly ClassType SubResource = new ClassType("com.microsoft.azure.v2", "SubResource");
+        public static readonly ClassType URL = new ClassType("java.net", "URL");
+        public static readonly ClassType NonNull = new ClassType("io.reactivex.annotations", "NonNull");
+
+        public ClassType(string package, string name, IEnumerable<string> implementationImports = null, IDictionary<string,string> extensions = null, bool isInnerModelType = false, Func<string,string> defaultValueExpressionConverter = null)
         {
             Package = package;
             Name = name;
             ImplementationImports = implementationImports;
             Extensions = extensions;
             IsInnerModelType = isInnerModelType;
+            DefaultValueExpressionConverter = defaultValueExpressionConverter;
         }
 
         public string Package { get; }
@@ -65,6 +68,8 @@ namespace AutoRest.Java.Model
         }
 
         public bool IsInnerModelType { get; }
+
+        private Func<string,string> DefaultValueExpressionConverter { get; }
 
         public override string ToString()
         {
@@ -97,6 +102,23 @@ namespace AutoRest.Java.Model
                     imports.Add(implementationImport);
                 }
             }
+        }
+
+        public string DefaultValueExpression(string sourceExpression)
+        {
+            string result = sourceExpression;
+            if (result != null)
+            {
+                if (DefaultValueExpressionConverter != null)
+                {
+                    result = DefaultValueExpressionConverter(sourceExpression);
+                }
+                else
+                {
+                    result = $"new {ToString()}()";
+                }
+            }
+            return result;
         }
     }
 }

--- a/src/Model/EnumType.cs
+++ b/src/Model/EnumType.cs
@@ -60,6 +60,11 @@ namespace AutoRest.Java.Model
             return this == type;
         }
 
+        public string DefaultValueExpression(string sourceExpression)
+        {
+            return sourceExpression;
+        }
+
         public override string ToString()
         {
             return Name;

--- a/src/Model/GenericType.cs
+++ b/src/Model/GenericType.cs
@@ -90,5 +90,10 @@ namespace AutoRest.Java.Model
                 typeArgument.AddImportsTo(imports, includeImplementationImports);
             }
         }
+
+        public string DefaultValueExpression(string sourceExpression)
+        {
+            return sourceExpression;
+        }
     }
 }

--- a/src/Model/IType.cs
+++ b/src/Model/IType.cs
@@ -29,5 +29,12 @@ namespace AutoRest.Java.Model
         /// <param name="imports">The set of imports to add to.</param>
         /// <param name="includeImplementationImports">Whether or not to include imports that are only necessary for method implementations.</param>
         void AddImportsTo(ISet<string> imports, bool includeImplementationImports);
+
+        /// <summary>
+        /// Convert the provided default value expression to this type's default value expression.
+        /// </summary>
+        /// <param name="sourceExpression">The source expression to convert to this type's default value expression.</param>
+        /// <returns>This type's default value expression.</returns>
+        string DefaultValueExpression(string sourceExpression);
     }
 }

--- a/src/Model/PrimitiveType.cs
+++ b/src/Model/PrimitiveType.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 
 namespace AutoRest.Java.Model
@@ -11,11 +12,11 @@ namespace AutoRest.Java.Model
     public class PrimitiveType : IType
     {
         public static readonly PrimitiveType Void = new PrimitiveType("void", ClassType.Void);
-        public static readonly PrimitiveType Boolean = new PrimitiveType("boolean", ClassType.Boolean);
+        public static readonly PrimitiveType Boolean = new PrimitiveType("boolean", ClassType.Boolean, (string defaultValueExpression) => defaultValueExpression.ToLowerInvariant());
         public static readonly PrimitiveType Byte = new PrimitiveType("byte", ClassType.Byte);
         public static readonly PrimitiveType Int = new PrimitiveType("int", ClassType.Integer);
-        public static readonly PrimitiveType Long = new PrimitiveType("long", ClassType.Long);
-        public static readonly PrimitiveType Double = new PrimitiveType("double", ClassType.Double);
+        public static readonly PrimitiveType Long = new PrimitiveType("long", ClassType.Long, (string defaultValueExpression) => defaultValueExpression + 'L');
+        public static readonly PrimitiveType Double = new PrimitiveType("double", ClassType.Double, (string defaultValueExpression) => double.Parse(defaultValueExpression).ToString());
 
         public static readonly PrimitiveType UnixTimeLong = new PrimitiveType("long", ClassType.UnixTimeLong);
 
@@ -23,10 +24,11 @@ namespace AutoRest.Java.Model
         /// Create a new PrimitiveType from the provided properties.
         /// </summary>
         /// <param name="name">The name of this type.</param>
-        private PrimitiveType(string name, ClassType nullableType)
+        private PrimitiveType(string name, ClassType nullableType, Func<string,string> defaultValueExpressionConverter = null)
         {
             Name = name;
             NullableType = nullableType;
+            DefaultValueExpressionConverter = defaultValueExpressionConverter;
         }
 
         /// <summary>
@@ -51,6 +53,18 @@ namespace AutoRest.Java.Model
         public bool Contains(IType type)
         {
             return this == type;
+        }
+
+        private Func<string,string> DefaultValueExpressionConverter { get; }
+
+        public string DefaultValueExpression(string sourceExpression)
+        {
+            string result = sourceExpression;
+            if (result != null && DefaultValueExpressionConverter != null)
+            {
+                result = DefaultValueExpressionConverter(sourceExpression);
+            }
+            return result;
         }
 
         public override string ToString()

--- a/src/Model/XmlSequenceWrapper.cs
+++ b/src/Model/XmlSequenceWrapper.cs
@@ -1,19 +1,18 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-
 using System.Collections.Generic;
 
 namespace AutoRest.Java.Model
 {
     public class XmlSequenceWrapper
     {
-        private readonly string sequenceType;
+        private readonly ListType sequenceType;
         private readonly string xmlElementName;
         private readonly string wrapperClassName;
         private readonly ISet<string> imports;
 
-        public XmlSequenceWrapper(string sequenceType, string xmlElementName, ISet<string> imports)
+        public XmlSequenceWrapper(ListType sequenceType, string xmlElementName, ISet<string> imports)
         {
             this.sequenceType = sequenceType;
             this.xmlElementName = xmlElementName;
@@ -21,7 +20,7 @@ namespace AutoRest.Java.Model
             this.imports = imports;
         }
 
-        public string SequenceType => sequenceType;
+        public ListType SequenceType => sequenceType;
 
         public string XmlElementName => xmlElementName;
 


### PR DESCRIPTION
This cleanup fixes a problem where Model properties weren't getting the correct types if the `string-dates` flag was specified.
There's also just some other cleanup in here too.