### PR TITLE
Reenable Mbcs tests

### DIFF
--- a/test/vanilla/src/test/java/fixtures/bodystring/StringOperationsTests.java
+++ b/test/vanilla/src/test/java/fixtures/bodystring/StringOperationsTests.java
@@ -60,10 +60,7 @@ public class StringOperationsTests {
         assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
-    // FIXME
-
     @Test
-    @Ignore("FIXME: This test fails on the Windows command line, but passes on Mac and Linux command line. Passes in IntelliJ on all platforms.")
     public void getMbcs() throws Exception {
         String result = client.strings().getMbcs();
         String expected = "啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑ\uE7C7ɡ〇〾⿻⺁\uE843䜣\uE864€";
@@ -71,7 +68,6 @@ public class StringOperationsTests {
     }
 
     @Test
-    @Ignore("FIXME: This test fails on the Windows command line, but passes on Mac and Linux command line. Passes in IntelliJ on all platforms.")
     public void putMbcs() throws Exception {
         String content = "啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑ\uE7C7ɡ〇〾⿻⺁\uE843䜣\uE864€";
         client.strings().putMbcs(content);


### PR DESCRIPTION
At some point we disabled these tests because they failed on the Windows command line. I figured out the root cause so I'm re-enabling them now.