### PR TITLE
Check for Content-Length instead of Content-Type

### DIFF
--- a/src/JavaCodeGenerator.cs
+++ b/src/JavaCodeGenerator.cs
@@ -1072,7 +1072,7 @@ namespace AutoRest.Java
             int streamBodyParameterIndex = autoRestMethodParameters.FindIndex(p => p.Location == AutoRestParameterLocation.Body && p.ModelType is AutoRestPrimaryType mt && mt.KnownPrimaryType == AutoRestKnownPrimaryType.Stream);
             if (streamBodyParameterIndex != -1 &&
                 !autoRestMethodParameters.Any(p =>
-                    p.Location == AutoRestParameterLocation.Header && p.SerializedName.EqualsIgnoreCase("Content-Type")))
+                    p.Location == AutoRestParameterLocation.Header && p.SerializedName.EqualsIgnoreCase("Content-Length")))
             {
                 AutoRestParameter contentLengthParameter = DependencyInjection.New<AutoRestParameter>();
                 contentLengthParameter.Method = autoRestMethod;


### PR DESCRIPTION
The plan here was to only add a Content-Length parameter when the Swagger didn't already have one specified. But we searched for the wrong parameter name.

This really should have a test-- so may delay merging until I can add a simple test Swagger, or append to an existing Swagger to exercise it.