### PR TITLE
Support for LROOptions extension handling, correctly import InnerSupp…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,12 +75,12 @@
       <dependency>
         <groupId>com.microsoft.rest</groupId>
         <artifactId>client-runtime</artifactId>
-        <version>1.3.3-SNAPSHOT</version>
+        <version>1.5.3</version>
       </dependency>
       <dependency>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-client-runtime</artifactId>
-        <version>1.3.3-SNAPSHOT</version>
+        <version>1.5.3</version>
       </dependency>
       <dependency>
         <groupId>commons-codec</groupId>

--- a/src/azure/Model/MethodGroupJva.cs
+++ b/src/azure/Model/MethodGroupJva.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Linq;
 using AutoRest.Core.Model;
 using AutoRest.Core.Utilities;
 using AutoRest.Java.Model;
+using Newtonsoft.Json;
 
 namespace AutoRest.Java.Azure.Model
 {
@@ -17,6 +19,24 @@ namespace AutoRest.Java.Azure.Model
         }
         public MethodGroupJva(string name) : base(name)
         {
+        }
+
+        [JsonIgnore]
+        public override IEnumerable<string> ImplImports
+        {
+            get
+            {
+                var imports = new List<string>();
+                imports.AddRange(base.ImplImports);
+                bool hasLroOptions = this.Methods.OfType<MethodJva>().Any(m => m.HasLroOptions);
+                if (hasLroOptions)
+                {
+                    imports.Add("com.microsoft.azure.LongRunningFinalState");
+                    imports.Add("com.microsoft.azure.LongRunningOperationOptions");
+                }
+                return imports;
+            }
+
         }
     }
 }

--- a/src/azure/Model/MethodJva.cs
+++ b/src/azure/Model/MethodJva.cs
@@ -318,6 +318,43 @@ namespace AutoRest.Java.Azure.Model
         }
 
         [JsonIgnore]
+        public string PollingLroOptionsArgs
+        {
+            get
+            {
+                if (this.HasLroOptions)
+                {
+                    switch(LongRunningFinalState)
+                    {
+                        case FinalStateVia.AzureAsyncOperation:
+                            return "new LongRunningOperationOptions().withFinalStateVia(LongRunningFinalState.AZURE_ASYNC_OPERATION), ";
+                        case FinalStateVia.Location:
+                            return "new LongRunningOperationOptions().withFinalStateVia(LongRunningFinalState.LOCATION), ";
+                        case FinalStateVia.OriginalUri:
+                            return "new LongRunningOperationOptions().withFinalStateVia(LongRunningFinalState.ORIGINAL_URI), ";
+                        case FinalStateVia.None:
+                        case FinalStateVia.Default:
+                        default:
+                            return string.Empty;
+                    }
+                }
+                return string.Empty;
+            }
+        }
+
+        [JsonIgnore]
+        public bool HasLroOptions
+        {
+            get
+            {
+                return IsLongRunningOperation
+                    && LongRunningFinalState != FinalStateVia.None
+                    && LongRunningFinalState != FinalStateVia.Default
+                    && HttpMethod == HttpMethod.Post;   // lro options extenion is only enabled for POST at the moment
+            }
+        }
+
+        [JsonIgnore]
         public string PollingResourceTypeArgs
         {
             get

--- a/src/azure/Templates/AzureMethodTemplate.cshtml
+++ b/src/azure/Templates/AzureMethodTemplate.cshtml
@@ -139,7 +139,7 @@ public Observable<@Model.ReturnTypeJva.ClientResponseTypeString> @(Model.Name)Wi
     @Model.BuildInputMappings(true)
     @Model.RequiredParameterConversion
     Observable<Response<@Model.CallType>> observable = service.@(Model.Name)(@Model.MethodRequiredParameterApiInvocation);
-    return client.getAzureClient().@(Model.PollingMethod)Async(observable, @Model.PollingResourceTypeArgs);
+    return client.getAzureClient().@(Model.PollingMethod)Async(observable, @(Model.PollingLroOptionsArgs)@(Model.PollingResourceTypeArgs));
 }
 </text>
 }
@@ -263,7 +263,7 @@ public Observable<@Model.ReturnTypeJva.ClientResponseTypeString> @(Model.Name)Wi
     @Model.BuildInputMappings()
     @Model.ParameterConversion
     Observable<Response<@Model.CallType>> observable = service.@(Model.Name)(@Model.MethodParameterApiInvocation);
-    return client.getAzureClient().@(Model.PollingMethod)Async(observable, @Model.PollingResourceTypeArgs);
+    return client.getAzureClient().@(Model.PollingMethod)Async(observable, @(Model.PollingLroOptionsArgs)@(Model.PollingResourceTypeArgs));
 }
 </text>
 }

--- a/src/azure/Templates/AzurePomTemplate.cshtml
+++ b/src/azure/Templates/AzurePomTemplate.cshtml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-client-runtime</artifactId>
-            <version>1.3.0</version>
+            <version>1.5.3</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-client-authentication</artifactId>
-            <version>1.3.0</version>
+            <version>1.5.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/azurefluent/Model/MethodGroupJvaf.cs
+++ b/src/azurefluent/Model/MethodGroupJvaf.cs
@@ -79,7 +79,22 @@ namespace AutoRest.Java.Azure.Fluent.Model
                         imports.Add(i);
                     }
                 }
+
+                bool hasLroOptions = this.Methods.OfType<MethodJvaf>().Any(m => m.HasLroOptions);
+                if (hasLroOptions)
+                {
+                    imports.Add("com.microsoft.azure.LongRunningFinalState");
+                    imports.Add("com.microsoft.azure.LongRunningOperationOptions");
+                }
                 return imports;
+            }
+        }
+
+        private bool IsMultiApi
+        {
+            get
+            {
+                return ((CodeModelJvaf)CodeModel).IsMultiApi;
             }
         }
 
@@ -94,9 +109,9 @@ namespace AutoRest.Java.Azure.Fluent.Model
             {
                 return;
             }
-
-            const string packageName = "com.microsoft.azure.arm.collection";
-
+            //
+            string packageName = IsMultiApi ? "com.microsoft.azure.arm.collection" : "com.microsoft.azure.management.resources.fluentcore.collection";
+            //
             Method getMethod = FindGetMethod(this.Methods);
             if (getMethod != null)
             {

--- a/test/azure/src/main/java/fixtures/lro/implementation/LROsImpl.java
+++ b/test/azure/src/main/java/fixtures/lro/implementation/LROsImpl.java
@@ -6377,7 +6377,7 @@ public class LROsImpl implements LROs {
      */
     public Observable<ServiceResponse<Product>> postDoubleHeadersFinalLocationGetWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.postDoubleHeadersFinalLocationGet(this.client.acceptLanguage(), this.client.userAgent());
-        return client.getAzureClient().getPostOrDeleteResultAsync(observable, new TypeToken<Product>() { }.getType());
+        return client.getAzureClient().getPostOrDeleteResultAsync(observable, new LongRunningOperationOptions().withFinalStateVia(LongRunningFinalState.LOCATION), new TypeToken<Product>() { }.getType());
     }
 
     /**
@@ -6492,7 +6492,7 @@ public class LROsImpl implements LROs {
      */
     public Observable<ServiceResponse<Product>> postDoubleHeadersFinalAzureHeaderGetWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.postDoubleHeadersFinalAzureHeaderGet(this.client.acceptLanguage(), this.client.userAgent());
-        return client.getAzureClient().getPostOrDeleteResultAsync(observable, new TypeToken<Product>() { }.getType());
+        return client.getAzureClient().getPostOrDeleteResultAsync(observable, new LongRunningOperationOptions().withFinalStateVia(LongRunningFinalState.AZURE_ASYNC_OPERATION), new TypeToken<Product>() { }.getType());
     }
 
     /**

--- a/test/azure/src/main/java/fixtures/lro/implementation/LROsImpl.java
+++ b/test/azure/src/main/java/fixtures/lro/implementation/LROsImpl.java
@@ -56,6 +56,8 @@ import retrofit2.http.PUT;
 import retrofit2.Response;
 import rx.functions.Func1;
 import rx.Observable;
+import com.microsoft.azure.LongRunningFinalState;
+import com.microsoft.azure.LongRunningOperationOptions;
 
 /**
  * An instance of this class provides access to all the operations defined

--- a/test/azurefluent/src/main/java/fixtures/lro/implementation/LROsInner.java
+++ b/test/azurefluent/src/main/java/fixtures/lro/implementation/LROsInner.java
@@ -54,6 +54,8 @@ import rx.functions.Func1;
 import rx.Observable;
 import com.microsoft.azure.LongRunningFinalState;
 import com.microsoft.azure.LongRunningOperationOptions;
+import com.microsoft.azure.LongRunningFinalState;
+import com.microsoft.azure.LongRunningOperationOptions;
 
 /**
  * An instance of this class provides access to all the operations defined

--- a/test/azurefluent/src/main/java/fixtures/lro/implementation/LROsInner.java
+++ b/test/azurefluent/src/main/java/fixtures/lro/implementation/LROsInner.java
@@ -52,6 +52,8 @@ import retrofit2.http.PUT;
 import retrofit2.Response;
 import rx.functions.Func1;
 import rx.Observable;
+import com.microsoft.azure.LongRunningFinalState;
+import com.microsoft.azure.LongRunningOperationOptions;
 
 /**
  * An instance of this class provides access to all the operations defined
@@ -6373,7 +6375,7 @@ public class LROsInner {
      */
     public Observable<ServiceResponse<ProductInner>> postDoubleHeadersFinalLocationGetWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.postDoubleHeadersFinalLocationGet(this.client.acceptLanguage(), this.client.userAgent());
-        return client.getAzureClient().getPostOrDeleteResultAsync(observable, new TypeToken<ProductInner>() { }.getType());
+        return client.getAzureClient().getPostOrDeleteResultAsync(observable, new LongRunningOperationOptions().withFinalStateVia(LongRunningFinalState.LOCATION), new TypeToken<ProductInner>() { }.getType());
     }
 
     /**
@@ -6488,7 +6490,7 @@ public class LROsInner {
      */
     public Observable<ServiceResponse<ProductInner>> postDoubleHeadersFinalAzureHeaderGetWithServiceResponseAsync() {
         Observable<Response<ResponseBody>> observable = service.postDoubleHeadersFinalAzureHeaderGet(this.client.acceptLanguage(), this.client.userAgent());
-        return client.getAzureClient().getPostOrDeleteResultAsync(observable, new TypeToken<ProductInner>() { }.getType());
+        return client.getAzureClient().getPostOrDeleteResultAsync(observable, new LongRunningOperationOptions().withFinalStateVia(LongRunningFinalState.AZURE_ASYNC_OPERATION), new TypeToken<ProductInner>() { }.getType());
     }
 
     /**


### PR DESCRIPTION
…ort* based on multi-apiversion vs non-muti-apiversion (#258)

* Support for LROOptions extension handling, correctly import InnterSupport* based on multi-apiversion vs non-muti-apiversion

* Regenerating autorest tests

* Using 1.5.3 version of runtime (with support for LRO options)

* Don't generate LongRunningOperationOptions param for FinalStateVia.Default

* Regenerating autorest general tests