### PR TITLE
Prefer model xml name only if present in XML properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.java",
-  "version": "2.0.20",
+  "version": "2.0.21",
   "description": "The Java extension for classic generators in AutoRest.",
   "scripts": {
     "autorest": "autorest",

--- a/src/JavaCodeGenerator.cs
+++ b/src/JavaCodeGenerator.cs
@@ -1775,20 +1775,14 @@ namespace AutoRest.Java
             }
 
             string xmlName;
-            if (autoRestProperty.ModelType is AutoRestCompositeType)
+            try
             {
-                xmlName = autoRestProperty.ModelType.XmlName;
+                xmlName = autoRestProperty.ModelType.XmlProperties?.Name
+                    ?? autoRestProperty.XmlName;
             }
-            else
+            catch
             {
-                try
-                {
-                    xmlName = autoRestProperty.XmlName;
-                }
-                catch
-                {
-                    xmlName = null;
-                }
+                xmlName = null;
             }
 
             List<string> annotationArgumentList = new List<string>()


### PR DESCRIPTION
XmlProperties lets us distinguish whether the Swagger actually contained `xml: { name: "..." }` or whether it was inferred based on the name of the property or name of the class in accordance with the spec.

We basically want to use the xml name defined on a model type only if it was explicitly added-- so we have to go searching for it in XmlProperties, and if it's not there, fine, fall back to whatever XmlName was inferred for the property.