### PR TITLE
Prefer the ElementType.XmlProperties.Name if present

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.java",
-  "version": "2.0.21",
+  "version": "2.0.22",
   "description": "The Java extension for classic generators in AutoRest.",
   "scripts": {
     "autorest": "autorest",

--- a/src/JavaCodeGenerator.cs
+++ b/src/JavaCodeGenerator.cs
@@ -1623,7 +1623,7 @@ namespace AutoRest.Java
                     if (parameterType is ListType parameterListType && parameter.ModelType is AutoRestSequenceType sequenceType)
                     {
                         string xmlRootElementName = sequenceType.XmlName;
-                        string xmlListElementName = sequenceType.ElementXmlName;
+                        string xmlListElementName = sequenceType.ElementType.XmlProperties?.Name ?? sequenceType.ElementXmlName;
                         if (!xmlSequenceWrappers.Any(existingWrapper => existingWrapper.XmlRootElementName == xmlRootElementName && existingWrapper.XmlListElementName == xmlListElementName))
                         {
                             HashSet<string> xmlSequenceWrapperImports = new HashSet<string>()
@@ -1812,7 +1812,15 @@ namespace AutoRest.Java
             IType propertyClientType = ConvertToClientType(propertyWireType);
 
             AutoRestIModelType autoRestPropertyModelType = autoRestProperty.ModelType;
-            string xmlListElementName = autoRestPropertyModelType is AutoRestSequenceType autoRestPropertyModelSequenceType ? autoRestPropertyModelSequenceType.ElementXmlName : null;
+            string xmlListElementName = null;
+            if (autoRestPropertyModelType is AutoRestSequenceType sequence)
+            {
+                try
+                {
+                    xmlListElementName = sequence.ElementType.XmlProperties?.Name ?? sequence.ElementXmlName;
+                }
+                catch { }
+            }
 
             bool isConstant = autoRestProperty.IsConstant;
 


### PR DESCRIPTION
Similar to the case for a property's XmlName, we have to check the ElementType.XmlProperties.Name before checking the property's ElementXmlName. I've been hashing this question out for a while and basically concluded that it's not realistic to move the code for these two workarounds over to the modeler.