### PR TITLE
Fix for issue #278 (Accessing non-existing id & items property) (#282)

### DIFF
--- a/src/azure/Model/MethodJva.cs
+++ b/src/azure/Model/MethodJva.cs
@@ -607,23 +607,14 @@ namespace AutoRest.Java.Azure.Model
             else if (this.IsPagingNonPollingOperation)
             {
                 IndentedStringBuilder builder = new IndentedStringBuilder();
-                if (ReturnTypeJva.GenericBodyWireTypeString.Contains("PageImpl1<"))
-                {
-                    builder.AppendLine("ServiceResponse<{0}> result = {1}Delegate(response);", ReturnTypeJva.GenericBodyWireTypeString, this.Name);
-                    builder.AppendLine("{0} items = null;", this.ReturnType.Body.Name);
-                    builder.AppendLine("if (result.body() != null) {")
-                            .Indent()
-                            .AppendLine("items = result.body().items();", this.ReturnType.Body.Name)
-                            .Outdent().AppendLine("}");
-                    builder.AppendLine("ServiceResponse<{0}> clientResponse = new ServiceResponse<{0}>(items, result.response());",
-                        ReturnTypeJva.ServiceFutureGenericParameterString);
-                }
-                else
-                {
-                    builder.AppendLine("ServiceResponse<{0}> result = {1}Delegate(response);", ReturnTypeJva.GenericBodyWireTypeString, this.Name);
-                    builder.AppendLine("ServiceResponse<{0}> clientResponse = new ServiceResponse<{0}>(result.body(), result.response());",
-                        ReturnTypeJva.ServiceFutureGenericParameterString);
-                }
+                builder.AppendLine("ServiceResponse<{0}> result = {1}Delegate(response);", ReturnTypeJva.GenericBodyWireTypeString, this.Name);
+                builder.AppendLine("{0} items = null;", this.ReturnType.Body.Name);
+                builder.AppendLine("if (result.body() != null) {")
+                        .Indent()
+                        .AppendLine("items = result.body().items();", this.ReturnType.Body.Name)
+                        .Outdent().AppendLine("}");
+                builder.AppendLine("ServiceResponse<{0}> clientResponse = new ServiceResponse<{0}>(items, result.response());",
+                    ReturnTypeJva.ServiceFutureGenericParameterString);
                 return builder.ToString();
             }
             else

--- a/src/azure/Model/MethodJva.cs
+++ b/src/azure/Model/MethodJva.cs
@@ -607,14 +607,23 @@ namespace AutoRest.Java.Azure.Model
             else if (this.IsPagingNonPollingOperation)
             {
                 IndentedStringBuilder builder = new IndentedStringBuilder();
-                builder.AppendLine("ServiceResponse<{0}> result = {1}Delegate(response);", ReturnTypeJva.GenericBodyWireTypeString, this.Name);
-                builder.AppendLine("{0} items = null;", this.ReturnType.Body.Name);
-                builder.AppendLine("if (result.body() != null) {")
-                        .Indent()
-                        .AppendLine("items = result.body().items();", this.ReturnType.Body.Name)
-                        .Outdent().AppendLine("}");
-                builder.AppendLine("ServiceResponse<{0}> clientResponse = new ServiceResponse<{0}>(items, result.response());",
-                    ReturnTypeJva.ServiceFutureGenericParameterString);
+                if (ReturnTypeJva.GenericBodyWireTypeString.Contains("PageImpl1<"))
+                {
+                    builder.AppendLine("ServiceResponse<{0}> result = {1}Delegate(response);", ReturnTypeJva.GenericBodyWireTypeString, this.Name);
+                    builder.AppendLine("{0} items = null;", this.ReturnType.Body.Name);
+                    builder.AppendLine("if (result.body() != null) {")
+                            .Indent()
+                            .AppendLine("items = result.body().items();", this.ReturnType.Body.Name)
+                            .Outdent().AppendLine("}");
+                    builder.AppendLine("ServiceResponse<{0}> clientResponse = new ServiceResponse<{0}>(items, result.response());",
+                        ReturnTypeJva.ServiceFutureGenericParameterString);
+                }
+                else
+                {
+                    builder.AppendLine("ServiceResponse<{0}> result = {1}Delegate(response);", ReturnTypeJva.GenericBodyWireTypeString, this.Name);
+                    builder.AppendLine("ServiceResponse<{0}> clientResponse = new ServiceResponse<{0}>(result.body(), result.response());",
+                        ReturnTypeJva.ServiceFutureGenericParameterString);
+                }
                 return builder.ToString();
             }
             else

--- a/src/azurefluent/Model/FluentCommon/Model/CreatableUpdatableModel.cs
+++ b/src/azurefluent/Model/FluentCommon/Model/CreatableUpdatableModel.cs
@@ -671,13 +671,26 @@ namespace AutoRest.Java.Azure.Fluent.Model
                     StringBuilder methodsBuilder = new StringBuilder();
                     methodsBuilder.AppendLine("@Override");
                     methodsBuilder.AppendLine("public boolean isInCreateMode() {");
-                    methodsBuilder.AppendLine("    return this.inner().id() == null;");
+                    if (this.SupportsUpdating)
+                    {
+                        // There is an assumption we take here - if updatable we assume inner has an "id" property.
+                        // There are resources those can are create-only but has no id, in such cases we fall to
+                        // else case and simply return "true".
+                        //
+                        // If updatable and if there is no "id" then we need to know about it hence below code cause compile time error.
+                        methodsBuilder.AppendLine("    return this.inner().id() == null;");
+                    }
+                    else
+                    {
+                        methodsBuilder.AppendLine("// This is a create-only resource");
+                        methodsBuilder.AppendLine("    return true;");
+                    }
                     methodsBuilder.AppendLine("}");
                     return methodsBuilder.ToString();
                 }
                 else
                 {
-                    return String.Empty;
+                    return string.Empty;
                 }
             }
         }

--- a/src/azurefluent/Model/NestedFluentResource/NestedFluentModelImpl.cs
+++ b/src/azurefluent/Model/NestedFluentResource/NestedFluentModelImpl.cs
@@ -166,20 +166,25 @@ namespace AutoRest.Java.Azure.Fluent.Model
                     methodBuilder.AppendLine($"}}");
                     yield return methodBuilder.ToString();
                     methodBuilder.Clear();
-
                     //
                     // Ctr2 FooImpl(FooInner inner, Manager manager): The ctr invoked to wrap inner model retrieved from "Collection.Get() and Collection.List()"
-                    //
+                    // 
                     methodBuilder.AppendLine($"{this.JavaClassName}({this.InnerModelName} inner, {managerTypeName} manager) {{");
                     methodBuilder.AppendLine($"    super(inner.name(), inner);");       // CreatableUpdatableImpl(name, inner)
                     methodBuilder.AppendLine($"    this.manager = manager;");
                     methodBuilder.AppendLine($"    // Set resource name");
                     methodBuilder.AppendLine($"    {MemberVariableAccessorHoldingResourceName} = inner.name();");
-                    // Init member variables
-                    methodBuilder.AppendLine($"    // set resource ancestor and positional variables");
-                    foreach (string initVariable in InitParentRefAndPosMemberVariablesFromId)
+                    // There are resources which are create-only and has no id, so before trying to parse the id ensure the resource
+                    // is either updatable or refresh-able.
+                    if (this.Interface.SupportsUpdating || this.Interface.SupportsRefreshing)
                     {
-                        methodBuilder.AppendLine($"    {initVariable}");
+                        // If type is updatable - inorder to invoke 'CreateOrUpdate'|'Update' we need the ancestor names, below we extract those from id.
+                        // If type is refreshable - inorder to invoke 'get' we need the ancestor names, below we extract those from id.
+                        methodBuilder.AppendLine($"    // set resource ancestor and positional variables");
+                        foreach (string initVariable in InitParentRefAndPosMemberVariablesFromId)
+                        {
+                            methodBuilder.AppendLine($"    {initVariable}");
+                        }
                     }
                     methodBuilder.AppendLine($"    //");
                     // init create update member variables


### PR DESCRIPTION
* Generate id parsing statements in NestedResource::ctr(inner, manager) body only if the resource is updatable|refreshable

* MethodJva.cs:: Emit body().items() accessor only if body() is of-type PageImpl