### PR TITLE
Fixes the issue of throwing NotImplemented exception when other method returns primitive

### DIFF
--- a/src/azurefluent/Model/FluentCommon/OtherMethods/OtherMethods.cs
+++ b/src/azurefluent/Model/FluentCommon/OtherMethods/OtherMethods.cs
@@ -369,6 +369,18 @@ namespace AutoRest.Java.Azure.Fluent.Model
                             rxReturnType = $"Observable<{returnModelClassName}>";
                             mapForWrappableModel = null;
                         }
+                        else if (returnModel is PrimitiveModel primitiveModel)
+                        {
+                            returnModelClassName = primitiveModel.RawModelName;
+                            rxReturnType = $"Observable<{returnModelClassName}>";
+                            mapForWrappableModel = null;
+                        }
+                        else if (returnModel is DictionaryModel dictionaryModel)
+                        {
+                            returnModelClassName = dictionaryModel.RawModelName;
+                            rxReturnType = $"Observable<{returnModelClassName}>";
+                            mapForWrappableModel = null;
+                        }
                         else
                         {
                             throw new NotImplementedException();


### PR DESCRIPTION
Fixes https://github.com/Azure/autorest.java/issues/276