### PR TITLE
Fixing missing import

### DIFF
--- a/src/vanilla/Model/ParameterJv.cs
+++ b/src/vanilla/Model/ParameterJv.cs
@@ -280,7 +280,7 @@ namespace AutoRest.Java.Model
                         imports.Add("com.microsoft.rest.CollectionFormat");
                     }
                 }
-                if (ModelType.IsPrimaryType(KnownPrimaryType.Stream) && Location == Core.Model.ParameterLocation.Body)
+                if (ModelType.IsPrimaryType(KnownPrimaryType.Stream) && (Location == Core.Model.ParameterLocation.Body || Location == Core.Model.ParameterLocation.FormData))
                 {
                     imports.Add("okhttp3.RequestBody");
                     imports.Add("okhttp3.MediaType");


### PR DESCRIPTION
@anuchandy @lmazuel

I posted this issue (https://github.com/Azure/autorest/issues/3278) and I was advised to create this pull request.

Some implementation class does not have following import statements.
This pull request is resolve this problem.

```
import okhttp3.MediaType;
import okhttp3.RequestBody;
```

Thanks.
