### PR TITLE
Fix for service client LRO operations.

### DIFF
--- a/src/azure/Model/CodeModelJva.cs
+++ b/src/azure/Model/CodeModelJva.cs
@@ -96,6 +96,14 @@ namespace AutoRest.Java.Azure.Model
                 imports.Remove("okhttp3.OkHttpClient");
                 imports.Remove("retrofit2.Retrofit");
                 imports.Add("com.microsoft.azure.AzureServiceClient");
+
+                bool hasLroOptions = this.Methods.OfType<MethodJva>().Any(m => m.HasLroOptions);
+                if (hasLroOptions && !imports.Contains("com.microsoft.azure.LongRunningFinalState"))
+                {
+                    imports.Add("com.microsoft.azure.LongRunningFinalState");
+                    imports.Add("com.microsoft.azure.LongRunningOperationOptions");
+                }
+
                 return imports.OrderBy(i => i).ToList();
             }
         }

--- a/src/azure/Templates/AzureMethodTemplate.cshtml
+++ b/src/azure/Templates/AzureMethodTemplate.cshtml
@@ -139,7 +139,14 @@ public Observable<@Model.ReturnTypeJva.ClientResponseTypeString> @(Model.Name)Wi
     @Model.BuildInputMappings(true)
     @Model.RequiredParameterConversion
     Observable<Response<@Model.CallType>> observable = service.@(Model.Name)(@Model.MethodRequiredParameterApiInvocation);
-    return client.getAzureClient().@(Model.PollingMethod)Async(observable, @(Model.PollingLroOptionsArgs)@(Model.PollingResourceTypeArgs));
+    @if (!@Model.Group.IsNullOrEmpty())
+    {
+@:    return client.getAzureClient().@(Model.PollingMethod)Async(observable, @(Model.PollingLroOptionsArgs)@(Model.PollingResourceTypeArgs));
+    }
+    else
+    {
+@:    return getAzureClient().@(Model.PollingMethod)Async(observable, @(Model.PollingLroOptionsArgs)@(Model.PollingResourceTypeArgs));
+    }
 }
 </text>
 }
@@ -263,7 +270,14 @@ public Observable<@Model.ReturnTypeJva.ClientResponseTypeString> @(Model.Name)Wi
     @Model.BuildInputMappings()
     @Model.ParameterConversion
     Observable<Response<@Model.CallType>> observable = service.@(Model.Name)(@Model.MethodParameterApiInvocation);
-    return client.getAzureClient().@(Model.PollingMethod)Async(observable, @(Model.PollingLroOptionsArgs)@(Model.PollingResourceTypeArgs));
+    @if (!@Model.Group.IsNullOrEmpty())
+    {
+@:    return client.getAzureClient().@(Model.PollingMethod)Async(observable, @(Model.PollingLroOptionsArgs)@(Model.PollingResourceTypeArgs));
+    }
+    else
+    {
+@:    return getAzureClient().@(Model.PollingMethod)Async(observable, @(Model.PollingLroOptionsArgs)@(Model.PollingResourceTypeArgs));
+    }
 }
 </text>
 }


### PR DESCRIPTION
@jianghaolu This fix will unblock the SDK generation for the latest (2019-08) network RP, which contains a root method on the service side for LRO.  