### PR TITLE
Sakintoye/varargs support

### DIFF
--- a/src/ClientModel/ClientModelProperty.cs
+++ b/src/ClientModel/ClientModelProperty.cs
@@ -28,7 +28,9 @@ namespace AutoRest.Java.Model
         /// <param name="defaultValue">The default value expression of this property.</param>
         /// <param name="isReadOnly">Whether or not this property's value can be changed by the client library.</param>
         /// <param name="headerCollectionPrefix">The prefix of the headers that make up this property's values.</param>
-        public ClientModelProperty(string name, string description, string annotationArguments, bool isXmlAttribute, string xmlName, string serializedName, bool isXmlWrapper, string xmlListElementName, IType wireType, IType clientType, bool isConstant, string defaultValue, bool isReadOnly, bool wasFlattened, string headerCollectionPrefix)
+        /// <param name="useVarArg">If true, the property's setter method will be represented as variable argument (Varargs) in the model.</param>
+        public ClientModelProperty(string name, string description, string annotationArguments, bool isXmlAttribute, string xmlName, string serializedName, bool isXmlWrapper,
+            string xmlListElementName, IType wireType, IType clientType, bool isConstant, string defaultValue, bool isReadOnly, bool wasFlattened, string headerCollectionPrefix, bool useVarArg)
         {
             Name = name;
             Description = description;
@@ -45,12 +47,15 @@ namespace AutoRest.Java.Model
             IsReadOnly = isReadOnly;
             WasFlattened = wasFlattened;
             HeaderCollectionPrefix = headerCollectionPrefix;
+            UseVarArg = useVarArg;
         }
 
         /// <summary>
         /// Get the name of this property.
         /// </summary>
         public string Name { get; }
+
+        public bool UseVarArg { get; }
 
         public string GetterName
         {

--- a/src/ClientModel/ClientModelProperty.cs
+++ b/src/ClientModel/ClientModelProperty.cs
@@ -55,8 +55,6 @@ namespace AutoRest.Java.Model
         /// </summary>
         public string Name { get; }
 
-        public bool UseVarArg { get; }
-
         public string GetterName
         {
             get
@@ -149,6 +147,11 @@ namespace AutoRest.Java.Model
         /// The prefix of the headers that make up this property's values.
         /// </summary>
         public string HeaderCollectionPrefix { get; }
+
+        /// <summary>
+        /// If true, the setter method of this property will have a variable arguments signature
+        /// </summary>
+        public bool UseVarArg { get; }
 
         /// <summary>
         /// Add this ServiceModelProperty's imports to the provided ISet of imports.

--- a/src/Mapper/ModelPropertyMapper.cs
+++ b/src/Mapper/ModelPropertyMapper.cs
@@ -120,7 +120,24 @@ namespace AutoRest.Java
 
             bool wasFlattened = property.WasFlattened();
 
-            return new ClientModelProperty(property.Name, description, annotationArguments, isXmlAttribute, xmlName, serializedName, isXmlWrapper, xmlListElementName, propertyWireType, propertyClientType, isConstant, defaultValue, isReadOnly, wasFlattened, headerCollectionPrefix);
+            bool useVarArgs = false;
+
+            if (property.Parent is CompositeType parent)
+            {
+                var modelPropertyName= $"{parent.Name}.{property.Name}";
+                if (Settings.Instance.CustomSettings["ModelProperties"] is Dictionary<string, Dictionary<string, bool>> modelProperties)
+                {
+                    if (modelProperties.ContainsKey(modelPropertyName) &&
+                        modelProperties[modelPropertyName].ContainsKey("varArgs") &&
+                        modelProperties[modelPropertyName]["varArgs"])
+                    {
+                        useVarArgs = true;
+                    }
+                }
+                
+            }
+
+            return new ClientModelProperty(property.Name, description, annotationArguments, isXmlAttribute, xmlName, serializedName, isXmlWrapper, xmlListElementName, propertyWireType, propertyClientType, isConstant, defaultValue, isReadOnly, wasFlattened, headerCollectionPrefix, useVarArgs);
         }
     }
 }

--- a/src/Mapper/ModelPropertyMapper.cs
+++ b/src/Mapper/ModelPropertyMapper.cs
@@ -128,8 +128,8 @@ namespace AutoRest.Java
                 if (Settings.Instance.CustomSettings["ModelProperties"] is Dictionary<string, Dictionary<string, bool>> modelProperties)
                 {
                     if (modelProperties.ContainsKey(modelPropertyName) &&
-                        modelProperties[modelPropertyName].ContainsKey("varArgs") &&
-                        modelProperties[modelPropertyName]["varArgs"])
+                        modelProperties[modelPropertyName].ContainsKey("varArg") &&
+                        modelProperties[modelPropertyName]["varArg"])
                     {
                         useVarArgs = true;
                     }

--- a/src/Mapper/ModelPropertyMapper.cs
+++ b/src/Mapper/ModelPropertyMapper.cs
@@ -125,11 +125,9 @@ namespace AutoRest.Java
             if (property.Parent is CompositeType parent)
             {
                 var modelPropertyName= $"{parent.Name}.{property.Name}";
-                if (Settings.Instance.CustomSettings["ModelProperties"] is Dictionary<string, Dictionary<string, bool>> modelProperties)
+                if (Settings.Instance.CustomSettings["vararg-properties"] is HashSet<string> varargs)
                 {
-                    if (modelProperties.ContainsKey(modelPropertyName) &&
-                        modelProperties[modelPropertyName].ContainsKey("varArg") &&
-                        modelProperties[modelPropertyName]["varArg"])
+                    if (varargs.Contains(modelPropertyName))
                     {
                         useVarArgs = true;
                     }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -99,8 +99,8 @@ namespace AutoRest.Java
 
             Settings.Instance.MaximumCommentColumns = await GetValue<int?>("max-comment-columns") ?? Settings.DefaultMaximumCommentColumns;
             Settings.Instance.OutputFileName = await GetValue<string>("output-file");
-            Settings.Instance.CustomSettings["ModelProperties"] = await GetValue<Dictionary<string, Dictionary<string, bool>>>("model-properties")
-                ?? new Dictionary<string, Dictionary<string, bool>>();
+            string varArgProperties = await GetValue<string>("vararg-properties") ?? "";
+            Settings.Instance.CustomSettings["vararg-properties"] = varArgProperties.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(e => e.Trim()).ToHashSet() ?? new HashSet<string>();
             
             // process
             IAnyPlugin plugin = new JavaPlugin();

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -99,6 +99,8 @@ namespace AutoRest.Java
 
             Settings.Instance.MaximumCommentColumns = await GetValue<int?>("max-comment-columns") ?? Settings.DefaultMaximumCommentColumns;
             Settings.Instance.OutputFileName = await GetValue<string>("output-file");
+            Settings.Instance.CustomSettings["ModelProperties"] = await GetValue<Dictionary<string, Dictionary<string, bool>>>("model-properties")
+                ?? new Dictionary<string, Dictionary<string, bool>>();
             
             // process
             IAnyPlugin plugin = new JavaPlugin();


### PR DESCRIPTION
Adds variable arguments as syntactic sugar to a Model's property setter method that accepts a List of elements.

This provides a convenient way for users to provide var args, rather `Arrays.asList(....)` which can be clunky.

When the `varArg` flag is set to `true`, it transforms the setter method from:

```java
public Foo setBar(List<String> bar) {
        this.bar = Arrays.asList(bar);
        return this;
}
```
to:
```java
public Foo setBar(String... bar) {
        this.bar = Arrays.asList(bar);
        return this;
}
```



### Usage

In an Autorest configuration file, a user will include something like below

```markdown
model-properties:
    Foo.bar:
        varArg: true
```
