### PR TITLE
fix for fluent

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/mapper/ServiceClientMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ServiceClientMapper.java
@@ -20,6 +20,7 @@ import com.azure.autorest.util.CodeNamer;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -138,11 +139,22 @@ public class ServiceClientMapper implements IMapper<CodeModel, ServiceClient> {
                         ? Arrays.asList(ClassType.NonNull)
                         : new ArrayList<>());
 
+        ClientMethodParameter azureEnvironmentParameter = new ClientMethodParameter(
+                "The Azure environment",
+                false,
+                ClassType.AzureEnvironment,
+                "environment",
+                true,
+                false,
+                true,
+                null,
+                Collections.emptyList());
+
         List<Constructor> serviceClientConstructors = new ArrayList<>();
         String constructorDescription = String.format("Initializes an instance of %s client.", serviceClientInterfaceName);
         // TODO: Azure Fluent
-//        if (settings.isAzureOrFluent())
-//        {
+        if (settings.isAzureOrFluent())
+        {
 //            if (usesCredentials)
 //            {
 //                serviceClientConstructors.add(new Constructor(codeModel.ServiceClientCredentialsParameter.Value));
@@ -153,15 +165,16 @@ public class ServiceClientMapper implements IMapper<CodeModel, ServiceClient> {
 //                serviceClientConstructors.add(new Constructor());
 //                serviceClientConstructors.add(new Constructor(codeModel.AzureEnvironmentParameter.Value));
 //            }
-//
-//            serviceClientConstructors.add(new Constructor(codeModel.HttpPipelineParameter.Value));
-//            serviceClientConstructors.add(new Constructor(codeModel.HttpPipelineParameter.Value, codeModel.AzureEnvironmentParameter.Value));
-//        }
-//        else
-//        {
-        serviceClientConstructors.add(new Constructor(new ArrayList<>()));
-        serviceClientConstructors.add(new Constructor(Arrays.asList(httpPipelineParameter)));
-//        }
+
+            serviceClientConstructors.add(new Constructor(new ArrayList<>()));
+            serviceClientConstructors.add(new Constructor(Arrays.asList(httpPipelineParameter)));
+            serviceClientConstructors.add(new Constructor(Arrays.asList(httpPipelineParameter, azureEnvironmentParameter)));
+        }
+        else
+        {
+            serviceClientConstructors.add(new Constructor(new ArrayList<>()));
+            serviceClientConstructors.add(new Constructor(Arrays.asList(httpPipelineParameter)));
+        }
 
         return new ServiceClient(
                 packageName,
@@ -172,7 +185,7 @@ public class ServiceClientMapper implements IMapper<CodeModel, ServiceClient> {
                 serviceClientProperties,
                 serviceClientConstructors,
                 serviceClientMethods,
-                null,
+                azureEnvironmentParameter,
                 tokenCredentialParameter,
                 httpPipelineParameter);
     }

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
@@ -33,14 +33,14 @@ public class ClassType implements IType {
     public static final ClassType Object = new ClassType("java.lang", "Object");
     public static final ClassType TokenCredential = new ClassType("com.azure.core.credential", "TokenCredential");
     public static final ClassType AzureTokenCredentials = new ClassType("com.microsoft.azure.v3.credentials", "AzureTokenCredentials");
-    public static final ClassType CloudException = new ClassType("com.microsoft.azure.v3", "CloudException");
+    public static final ClassType CloudException = new ClassType("com.azure.core.management", "CloudException");
     public static final ClassType HttpResponseException = new ClassType("com.azure.core.exception", "HttpResponseException");
     public static final ClassType UnixTime = new ClassType("com.azure.core.implementation", "UnixTime");
     public static final ClassType UnixTimeDateTime = new ClassType("java.time", "OffsetDateTime");
     public static final ClassType UnixTimeLong = new ClassType("java.lang", "Long");
-    public static final ClassType AzureEnvironment = new ClassType("com.microsoft.azure.v3", "AzureEnvironment");
+    public static final ClassType AzureEnvironment = new ClassType("com.microsoft.azure.management", "AzureEnvironment");
     public static final ClassType HttpPipeline = new ClassType("com.azure.core.http", "HttpPipeline");
-    public static final ClassType AzureProxy = new ClassType("com.microsoft.azure.v3", "AzureProxy");
+    public static final ClassType AzureProxy = new ClassType("com.microsoft.azure.management", "AzureProxy");
     public static final ClassType RestProxy = new ClassType("com.azure.core.http.rest", "RestProxy");
     public static final ClassType Validator = new ClassType("com.azure.core.implementation", "Validator");
     public static final ClassType Function = new ClassType("io.reactivex.functions", "Function");

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientModel.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientModel.java
@@ -159,7 +159,7 @@ public class ClientModel {
 
         if (getParentModelName() != null && settings.isAzureOrFluent()) {
             if (getParentModelName().equals(ClassType.Resource.getName())) {
-                ClassType.Resource.addImportsTo(imports, false);
+                //ClassType.Resource.addImportsTo(imports, false);
             } else if (getParentModelName().equals(ClassType.SubResource.getName())) {
                 ClassType.SubResource.addImportsTo(imports, false);
             } else {

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/MethodGroupClient.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/MethodGroupClient.java
@@ -117,7 +117,8 @@ public class MethodGroupClient {
         }
 
         if (includeImplementationImports) {
-            ClassType proxyType = settings.isAzureOrFluent() ? ClassType.AzureProxy : ClassType.RestProxy;
+            //ClassType proxyType = settings.isAzureOrFluent() ? ClassType.AzureProxy : ClassType.RestProxy;
+            ClassType proxyType = ClassType.RestProxy;
             imports.add(proxyType.getFullName());
         }
 

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ServiceClient.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ServiceClient.java
@@ -134,8 +134,8 @@ public class ServiceClient {
 
         if (includeImplementationImports) {
             if (settings.isAzureOrFluent()) {
-                imports.add("com.microsoft.azure.v3.AzureServiceClient");
-                imports.add("com.microsoft.azure.v3.AzureProxy");
+                //imports.add("com.microsoft.azure.management.AzureProxy");
+                imports.add("com.microsoft.azure.management.AzureServiceClient");
             }
 
             if (!settings.isFluent() && settings.shouldGenerateClientInterfaces()) {

--- a/javagen/src/main/java/com/azure/autorest/template/MethodGroupTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/MethodGroupTemplate.java
@@ -55,7 +55,8 @@ public class MethodGroupTemplate implements IJavaTemplate<MethodGroupClient, Jav
             classBlock.publicConstructor(String.format("%1$s(%2$s client)", methodGroupClient.getClassName(), methodGroupClient.getServiceClientName()), constructor ->
             {
                 if (methodGroupClient.getProxy() != null) {
-                    ClassType proxyType = (settings.isAzureOrFluent() ? ClassType.AzureProxy : ClassType.RestProxy);
+                    //ClassType proxyType = (settings.isAzureOrFluent() ? ClassType.AzureProxy : ClassType.RestProxy);
+                    ClassType proxyType = ClassType.RestProxy;
                     constructor.line(String.format("this.service = %1$s.create(%2$s.class, client.getHttpPipeline());", proxyType.getName(), methodGroupClient.getProxy().getName()));
                 }
                 constructor.line("this.client = client;");

--- a/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
@@ -37,8 +37,8 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ServiceClient
 
         ArrayList<ServiceClientProperty> commonProperties = new ArrayList<ServiceClientProperty>();
         if (settings.isAzureOrFluent()) {
-            commonProperties.add(new ServiceClientProperty("The environment to connect to", ClassType.AzureEnvironment, "environment", false, "${ClassType.AzureEnvironment.Name}.AZURE"));
-            commonProperties.add(new ServiceClientProperty("The HTTP pipeline to send requests through", ClassType.HttpPipeline, "pipeline", false, String.format("%1$s.createDefaultPipeline(%2$s.class)", ClassType.AzureProxy.getName(), serviceClient.getClassName())));
+            commonProperties.add(new ServiceClientProperty("The environment to connect to", ClassType.AzureEnvironment, "environment", false, "AzureEnvironment.AZURE"));
+            commonProperties.add(new ServiceClientProperty("The HTTP pipeline to send requests through", ClassType.HttpPipeline, "pipeline", false, "new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build()"));
         } else {
             commonProperties.add(new ServiceClientProperty("The HTTP pipeline to send requests through", ClassType.HttpPipeline, "pipeline", false, "new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build()"));
         }
@@ -53,7 +53,7 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ServiceClient
 
         Set<String> imports = new HashSet<String>();
         serviceClient.addImportsTo(imports, true, settings);
-        imports.remove("com.azure.core.AzureServiceClient");
+        imports.remove("com.microsoft.azure.management.AzureServiceClient");
         imports.add("com.azure.core.annotation.ServiceClientBuilder");
         javaFile.declareImport(imports);
 

--- a/javagen/src/main/java/com/azure/autorest/template/ServiceClientTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ServiceClientTemplate.java
@@ -43,6 +43,9 @@ public class ServiceClientTemplate implements IJavaTemplate<ServiceClient, JavaF
         if (!settings.isFluent() && settings.shouldGenerateClientInterfaces()) {
             serviceClientClassDeclaration += String.format(" implements %1$s", serviceClient.getInterfaceName());
         }
+        if (settings.isAzureOrFluent()) {
+            serviceClientClassDeclaration += String.format(" extends %1$s", "AzureServiceClient");
+        }
 
         Set<String> imports = new HashSet<String>();
         serviceClient.addImportsTo(imports, true, settings);
@@ -132,13 +135,14 @@ public class ServiceClientTemplate implements IJavaTemplate<ServiceClient, JavaF
                         } else if (constructor.getParameters().equals(Arrays.asList(serviceClient.getTokenCredentialParameter(), serviceClient.getAzureEnvironmentParameter()))) {
                             constructorBlock.line(String.format("this(%1$s.createDefaultPipeline(%2$s.class, %3$s), %4$s);", ClassType.AzureProxy.getName(), serviceClient.getClassName(), serviceClient.getTokenCredentialParameter().getName(), serviceClient.getAzureEnvironmentParameter().getName()));
                         } else if (constructor.getParameters().isEmpty()) {
-                            constructorBlock.line(String.format("this(%1$s.createDefaultPipeline(%2$s.class));", ClassType.AzureProxy.getName(), serviceClient.getClassName()));
+                            constructorBlock.line("this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build(), null);");
                         } else if (constructor.getParameters().equals(Arrays.asList(serviceClient.getAzureEnvironmentParameter()))) {
                             constructorBlock.line(String.format("this(%1$s.createDefaultPipeline(%2$s.class), %3$s);", ClassType.AzureProxy.getName(), serviceClient.getClassName(), serviceClient.getAzureEnvironmentParameter().getName()));
                         } else if (constructor.getParameters().equals(Arrays.asList(serviceClient.getHttpPipelineParameter()))) {
                             constructorBlock.line(String.format("this(%1$s, null);", serviceClient.getHttpPipelineParameter().getName()));
                         } else if (constructor.getParameters().equals(Arrays.asList(serviceClient.getHttpPipelineParameter(), serviceClient.getAzureEnvironmentParameter()))) {
                             constructorBlock.line(String.format("super(%1$s, %2$s);", serviceClient.getHttpPipelineParameter().getName(), serviceClient.getAzureEnvironmentParameter().getName()));
+                            constructorBlock.line(String.format("this.httpPipeline = httpPipeline;"));
 
                             for (ServiceClientProperty serviceClientProperty : serviceClient.getProperties().stream().filter(ServiceClientProperty::isReadOnly).collect(Collectors.toList())) {
                                 if (serviceClientProperty.getDefaultValueExpression() != null) {


### PR DESCRIPTION
https://github.com/Azure/autorest.java/issues/442

AzureProxy is probably no longer needed.
AzureEnvironment seems not need to get into Client, but still keep there.

The namespace is certainly going to change.

Build pass now. Remaining issue is the apiVersion param in methods.