### PR TITLE
support additionalProperties in ObjectSchema

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/mapper/ModelMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ModelMapper.java
@@ -2,6 +2,9 @@ package com.azure.autorest.mapper;
 
 import com.azure.autorest.extension.base.model.codemodel.ArraySchema;
 import com.azure.autorest.extension.base.model.codemodel.ComplexSchema;
+import com.azure.autorest.extension.base.model.codemodel.DictionarySchema;
+import com.azure.autorest.extension.base.model.codemodel.Language;
+import com.azure.autorest.extension.base.model.codemodel.Languages;
 import com.azure.autorest.extension.base.model.codemodel.ObjectSchema;
 import com.azure.autorest.extension.base.model.codemodel.Property;
 import com.azure.autorest.extension.base.model.codemodel.XmlSerlializationFormat;
@@ -41,7 +44,9 @@ public class ModelMapper implements IMapper<ObjectSchema, ClientModel> {
             boolean isPolymorphic = compositeType.getDiscriminator() != null || compositeType.getDiscriminatorValue() != null;
 
             String parentModel = null;
+            boolean hasAdditionalProperties = false;
             if (compositeType.getParents() != null && compositeType.getParents().getImmediate() != null) {
+                if (!(compositeType.getParents().getImmediate().get(0) instanceof DictionarySchema)) {
 //                ComplexSchema baseSchema = compositeType.getParents().getImmediate().get(0);
 //                if (baseSchema instanceof ObjectSchema) {
 //                    parentModel = map((ObjectSchema) baseSchema);
@@ -49,7 +54,11 @@ public class ModelMapper implements IMapper<ObjectSchema, ClientModel> {
 //                } else {
 //                    throw new RuntimeException("Wait what? How? Parent is not an object but a " + baseSchema.getClass() + "?");
 //                }
-                parentModel = compositeType.getParents().getImmediate().get(0).getLanguage().getJava().getName();
+                    parentModel = compositeType.getParents().getImmediate().get(0).getLanguage().getJava().getName();
+                } else {
+                    // "additionalProperties"
+                    hasAdditionalProperties = true;
+                }
             }
 
             HashSet<String> modelImports = new HashSet<>();
@@ -149,6 +158,21 @@ public class ModelMapper implements IMapper<ObjectSchema, ClientModel> {
 //                {
 //                    needsFlatten = true;
 //                }
+            }
+
+            if (hasAdditionalProperties) {
+                DictionarySchema schema = (DictionarySchema) compositeType.getParents().getImmediate().get(0);
+                Property additionalProperties = new Property();
+                additionalProperties.setReadOnly(false);
+                additionalProperties.setSchema(schema);
+                additionalProperties.setSerializedName("");
+
+                additionalProperties.setLanguage(new Languages());
+                additionalProperties.getLanguage().setJava(new Language());
+                additionalProperties.getLanguage().getJava().setName("additionalProperties");
+                additionalProperties.getLanguage().getJava().setDescription(schema.getLanguage().getJava().getDescription());
+
+                properties.add(Mappers.getModelPropertyMapper().map(additionalProperties));
             }
 
             result = new ClientModel(modelPackage, compositeType.getLanguage().getJava().getName(),

--- a/javagen/src/main/java/com/azure/autorest/transformer/Transformer.java
+++ b/javagen/src/main/java/com/azure/autorest/transformer/Transformer.java
@@ -3,6 +3,7 @@ package com.azure.autorest.transformer;
 import com.azure.autorest.extension.base.model.codemodel.AndSchema;
 import com.azure.autorest.extension.base.model.codemodel.ChoiceSchema;
 import com.azure.autorest.extension.base.model.codemodel.CodeModel;
+import com.azure.autorest.extension.base.model.codemodel.DictionarySchema;
 import com.azure.autorest.extension.base.model.codemodel.Language;
 import com.azure.autorest.extension.base.model.codemodel.Languages;
 import com.azure.autorest.extension.base.model.codemodel.Metadata;
@@ -49,6 +50,9 @@ public class Transformer {
         }
         for (SealedChoiceSchema sealedChoiceSchema : schemas.getSealedChoices()) {
             renameType(sealedChoiceSchema);
+        }
+        for (DictionarySchema dictionarySchema : schemas.getDictionaries()) {
+            renameType(dictionarySchema);
         }
     }
 


### PR DESCRIPTION
FIx https://github.com/Azure/autorest.java/issues/477

Currently I did it in Mapper. Second thought that it might better be done in Transform (remove the parent and add a property with that schema). @jianghaolu Let me know which stage you prefer, and I will update the PR.