### PR TITLE
Generate javadocs

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -96,7 +96,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
             IType syncReturnType = GenericType.PagedIterable(elementType);
 
             methods.add(new ClientMethod(
-                    operation.getDescription(),
+                    operation.getLanguage().getJava().getDescription(),
                     new ReturnValue(null, asyncSinglePageReturnType),
                     proxyMethod.getPagingAsyncSinglePageMethodName(),
                     parameters,
@@ -112,7 +112,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
 
             if (!isNextMethod) {
                 methods.add(new ClientMethod(
-                        operation.getDescription(),
+                        operation.getLanguage().getJava().getDescription(),
                         new ReturnValue(null, asyncReturnType),
                         proxyMethod.getSimpleAsyncMethodName(),
                         parameters,
@@ -127,7 +127,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                         new ArrayList<>()));
 
                 methods.add(new ClientMethod(
-                        operation.getDescription(),
+                        operation.getLanguage().getJava().getDescription(),
                         new ReturnValue(null, syncReturnType),
                         proxyMethod.getName(),
                         parameters,
@@ -145,7 +145,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
 
             // WithResponseAsync, with required and optional parameters
             methods.add(new ClientMethod(
-                    operation.getDescription(),
+                    operation.getLanguage().getJava().getDescription(),
                     new ReturnValue(null, proxyMethod.getReturnType().getClientType()),
                     proxyMethod.getSimpleAsyncRestResponseMethodName(),
                     parameters,
@@ -181,7 +181,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                 }
 
                 methods.add(new ClientMethod(
-                        operation.getDescription(),
+                        operation.getLanguage().getJava().getDescription(),
                         new ReturnValue(null, asyncMethodReturnType),
                         proxyMethod.getSimpleAsyncMethodName(),
                         parameters,
@@ -205,7 +205,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                     syncReturnType = responseBodyType.getClientType();
                 }
                 methods.add(new ClientMethod(
-                        operation.getDescription(),
+                        operation.getLanguage().getJava().getDescription(),
                         new ReturnValue(null, syncReturnType),
                         proxyMethod.getName(),
                         parameters,

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientParameterMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientParameterMapper.java
@@ -41,8 +41,12 @@ public class ClientParameterMapper implements IMapper<Parameter, ClientMethodPar
             defaultValue = objValue == null ? null : String.valueOf(objValue);
         }
 
+        String parameterDescription = null;
+        if (parameter.getSchema() != null && parameter.getSchema().getLanguage() != null) {
+            parameterDescription = parameter.getSchema().getLanguage().getDefault().getDescription();
+        }
         return new ClientMethodParameter(
-                parameter.getDescription(),
+                parameterDescription,
                 false,
                 wireType,
                 parameter.getLanguage().getJava().getName(),

--- a/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
@@ -247,23 +247,24 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
 
 
         boolean isFluentDelete = settings.isFluent() && restAPIMethod.getName().equalsIgnoreCase("Delete") && clientMethod.getMethodRequiredParameters().size() == 2;
+        typeBlock.javadocComment(comment -> {
+            comment.description(clientMethod.getDescription());
+            for (ClientMethodParameter parameter : clientMethod.getParameters()) {
+                comment.param(parameter.getName(), parameter.getDescription());
+            }
+            if (clientMethod.getParametersDeclaration() != null && !clientMethod.getParametersDeclaration().isEmpty()) {
+                comment.methodThrows("IllegalArgumentException", "thrown if parameters fail the validation");
+            }
+            if (restAPIMethod.getUnexpectedResponseExceptionType() != null) {
+                comment.methodThrows(restAPIMethod.getUnexpectedResponseExceptionType().toString(), "thrown if the request is rejected by server");
+            }
+            comment.methodThrows("RuntimeException", "all other wrapped checked exceptions if the request fails to be sent");
+            comment.methodReturns(clientMethod.getReturnValue().getDescription());
+        });
 
         switch (clientMethod.getType()) {
             case PagingSync:
-                typeBlock.javadocComment(comment -> {
-                    comment.description(clientMethod.getDescription());
-                    for (ClientMethodParameter parameter : clientMethod.getParameters()) {
-                        comment.param(parameter.getName(), parameter.getDescription());
-                    }
-                    if (clientMethod.getParametersDeclaration() != null && !clientMethod.getParametersDeclaration().isEmpty()) {
-                        comment.methodThrows("IllegalArgumentException", "thrown if parameters fail the validation");
-                    }
-                    if (restAPIMethod.getUnexpectedResponseExceptionType() != null) {
-                        comment.methodThrows(restAPIMethod.getUnexpectedResponseExceptionType().toString(), "thrown if the request is rejected by server");
-                    }
-                    comment.methodThrows("RuntimeException", "all other wrapped checked exceptions if the request fails to be sent");
-                    comment.methodReturns(clientMethod.getReturnValue().getDescription());
-                });
+
                 typeBlock.annotation("ServiceMethod(returns = ReturnType.COLLECTION)");
                 typeBlock.publicMethod(clientMethod.getDeclaration(), function -> {
                     function.methodReturn(String.format("new PagedIterable<>(%s(%s))", clientMethod.getSimpleAsyncMethodName(), clientMethod.getArgumentList()));

--- a/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
@@ -247,20 +247,7 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
 
 
         boolean isFluentDelete = settings.isFluent() && restAPIMethod.getName().equalsIgnoreCase("Delete") && clientMethod.getMethodRequiredParameters().size() == 2;
-        typeBlock.javadocComment(comment -> {
-            comment.description(clientMethod.getDescription());
-            for (ClientMethodParameter parameter : clientMethod.getParameters()) {
-                comment.param(parameter.getName(), parameter.getDescription());
-            }
-            if (clientMethod.getParametersDeclaration() != null && !clientMethod.getParametersDeclaration().isEmpty()) {
-                comment.methodThrows("IllegalArgumentException", "thrown if parameters fail the validation");
-            }
-            if (restAPIMethod.getUnexpectedResponseExceptionType() != null) {
-                comment.methodThrows(restAPIMethod.getUnexpectedResponseExceptionType().toString(), "thrown if the request is rejected by server");
-            }
-            comment.methodThrows("RuntimeException", "all other wrapped checked exceptions if the request fails to be sent");
-            comment.methodReturns(clientMethod.getReturnValue().getDescription());
-        });
+        generateJavadoc(clientMethod, typeBlock, restAPIMethod);
 
         switch (clientMethod.getType()) {
             case PagingSync:
@@ -468,5 +455,22 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
                 }));
                 break;
         }
+    }
+
+    protected void generateJavadoc(ClientMethod clientMethod, JavaType typeBlock, ProxyMethod restAPIMethod) {
+        typeBlock.javadocComment(comment -> {
+            comment.description(clientMethod.getDescription());
+            for (ClientMethodParameter parameter : clientMethod.getParameters()) {
+                comment.param(parameter.getName(), parameter.getDescription());
+            }
+            if (clientMethod.getParametersDeclaration() != null && !clientMethod.getParametersDeclaration().isEmpty()) {
+                comment.methodThrows("IllegalArgumentException", "thrown if parameters fail the validation");
+            }
+            if (restAPIMethod.getUnexpectedResponseExceptionType() != null) {
+                comment.methodThrows(restAPIMethod.getUnexpectedResponseExceptionType().toString(), "thrown if the request is rejected by server");
+            }
+            comment.methodThrows("RuntimeException", "all other wrapped checked exceptions if the request fails to be sent");
+            comment.methodReturns(clientMethod.getReturnValue().getDescription());
+        });
     }
 }

--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -26,6 +26,8 @@ import java.util.stream.Collectors;
  * Writes a ClientModel to a JavaFile.
  */
 public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
+
+    public static final String MISSING_SCHEMA = "MISSING·SCHEMA";
     private static ModelTemplate _instance = new ModelTemplate();
 
     private ModelTemplate() {
@@ -190,7 +192,12 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
 
                 if (!property.getIsReadOnly()) {
                     classBlock.javadocComment(settings.getMaximumJavadocCommentWidth(), (comment) -> {
-                        comment.description(String.format("Set the %s property: %s", property.getName(), property.getDescription()));
+                        if (property.getDescription() == null || property.getDescription().contains(MISSING_SCHEMA)) {
+                            comment.description(String.format("Set the %s property", property.getName()));
+                        } else {
+                            comment.description(String
+                                .format("Set the %s property: %s", property.getName(), property.getDescription()));
+                        }
                         comment.param(property.getName(), String.format("the %s value to set", property.getName()));
                         comment.methodReturns(String.format("the %s object itself.", model.getName()));
                     });

--- a/tests/src/main/java/fixtures/bodyboolean/Bools.java
+++ b/tests/src/main/java/fixtures/bodyboolean/Bools.java
@@ -79,6 +79,12 @@ public final class Bools {
         Mono<SimpleResponse<Boolean>> getInvalid(@HostParam("$host") String host);
     }
 
+    /**
+     * Get true Boolean value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Boolean>> getTrueWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -87,6 +93,12 @@ public final class Bools {
         return service.getTrue(this.client.getHost());
     }
 
+    /**
+     * Get true Boolean value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Boolean> getTrueAsync() {
         return getTrueWithResponseAsync()
@@ -99,11 +111,23 @@ public final class Bools {
             });
     }
 
+    /**
+     * Get true Boolean value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public boolean getTrue() {
         return getTrueAsync().block();
     }
 
+    /**
+     * Set Boolean value true.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putTrueWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -113,17 +137,35 @@ public final class Bools {
         return service.putTrue(this.client.getHost(), boolBody);
     }
 
+    /**
+     * Set Boolean value true.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putTrueAsync() {
         return putTrueWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Set Boolean value true.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putTrue() {
         putTrueAsync().block();
     }
 
+    /**
+     * Get false Boolean value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Boolean>> getFalseWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -132,6 +174,12 @@ public final class Bools {
         return service.getFalse(this.client.getHost());
     }
 
+    /**
+     * Get false Boolean value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Boolean> getFalseAsync() {
         return getFalseWithResponseAsync()
@@ -144,11 +192,23 @@ public final class Bools {
             });
     }
 
+    /**
+     * Get false Boolean value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public boolean getFalse() {
         return getFalseAsync().block();
     }
 
+    /**
+     * Set Boolean value false.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putFalseWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -158,17 +218,35 @@ public final class Bools {
         return service.putFalse(this.client.getHost(), boolBody);
     }
 
+    /**
+     * Set Boolean value false.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putFalseAsync() {
         return putFalseWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Set Boolean value false.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putFalse() {
         putFalseAsync().block();
     }
 
+    /**
+     * Get null Boolean value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Boolean>> getNullWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -177,6 +255,12 @@ public final class Bools {
         return service.getNull(this.client.getHost());
     }
 
+    /**
+     * Get null Boolean value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Boolean> getNullAsync() {
         return getNullWithResponseAsync()
@@ -189,11 +273,23 @@ public final class Bools {
             });
     }
 
+    /**
+     * Get null Boolean value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public boolean getNull() {
         return getNullAsync().block();
     }
 
+    /**
+     * Get invalid Boolean value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Boolean>> getInvalidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -202,6 +298,12 @@ public final class Bools {
         return service.getInvalid(this.client.getHost());
     }
 
+    /**
+     * Get invalid Boolean value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Boolean> getInvalidAsync() {
         return getInvalidWithResponseAsync()
@@ -214,6 +316,12 @@ public final class Bools {
             });
     }
 
+    /**
+     * Get invalid Boolean value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public boolean getInvalid() {
         return getInvalidAsync().block();

--- a/tests/src/main/java/fixtures/bodyboolean/quirks/Bools.java
+++ b/tests/src/main/java/fixtures/bodyboolean/quirks/Bools.java
@@ -79,6 +79,12 @@ public final class Bools {
         Mono<SimpleResponse<Boolean>> getInvalid(@HostParam("$host") String host);
     }
 
+    /**
+     * Get true Boolean value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Boolean>> getTrueWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -87,6 +93,12 @@ public final class Bools {
         return service.getTrue(this.client.getHost());
     }
 
+    /**
+     * Get true Boolean value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Boolean> getTrueAsync() {
         return getTrueWithResponseAsync()
@@ -99,11 +111,25 @@ public final class Bools {
             });
     }
 
+    /**
+     * Get true Boolean value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public boolean getTrue() {
         return getTrueAsync().block();
     }
 
+    /**
+     * Set Boolean value true.
+     * 
+     * @param boolBody MISSING·SCHEMA-DESCRIPTION-BOOLEAN.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putTrueWithResponseAsync(boolean boolBody) {
         if (this.client.getHost() == null) {
@@ -112,17 +138,39 @@ public final class Bools {
         return service.putTrue(this.client.getHost(), boolBody);
     }
 
+    /**
+     * Set Boolean value true.
+     * 
+     * @param boolBody MISSING·SCHEMA-DESCRIPTION-BOOLEAN.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putTrueAsync(boolean boolBody) {
         return putTrueWithResponseAsync(boolBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Set Boolean value true.
+     * 
+     * @param boolBody MISSING·SCHEMA-DESCRIPTION-BOOLEAN.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putTrue(boolean boolBody) {
         putTrueAsync(boolBody).block();
     }
 
+    /**
+     * Get false Boolean value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Boolean>> getFalseWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -131,6 +179,12 @@ public final class Bools {
         return service.getFalse(this.client.getHost());
     }
 
+    /**
+     * Get false Boolean value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Boolean> getFalseAsync() {
         return getFalseWithResponseAsync()
@@ -143,11 +197,25 @@ public final class Bools {
             });
     }
 
+    /**
+     * Get false Boolean value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public boolean getFalse() {
         return getFalseAsync().block();
     }
 
+    /**
+     * Set Boolean value false.
+     * 
+     * @param boolBody MISSING·SCHEMA-DESCRIPTION-BOOLEAN.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putFalseWithResponseAsync(boolean boolBody) {
         if (this.client.getHost() == null) {
@@ -156,17 +224,39 @@ public final class Bools {
         return service.putFalse(this.client.getHost(), boolBody);
     }
 
+    /**
+     * Set Boolean value false.
+     * 
+     * @param boolBody MISSING·SCHEMA-DESCRIPTION-BOOLEAN.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putFalseAsync(boolean boolBody) {
         return putFalseWithResponseAsync(boolBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Set Boolean value false.
+     * 
+     * @param boolBody MISSING·SCHEMA-DESCRIPTION-BOOLEAN.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putFalse(boolean boolBody) {
         putFalseAsync(boolBody).block();
     }
 
+    /**
+     * Get null Boolean value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Boolean>> getNullWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -175,6 +265,12 @@ public final class Bools {
         return service.getNull(this.client.getHost());
     }
 
+    /**
+     * Get null Boolean value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Boolean> getNullAsync() {
         return getNullWithResponseAsync()
@@ -187,11 +283,23 @@ public final class Bools {
             });
     }
 
+    /**
+     * Get null Boolean value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public boolean getNull() {
         return getNullAsync().block();
     }
 
+    /**
+     * Get invalid Boolean value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Boolean>> getInvalidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -200,6 +308,12 @@ public final class Bools {
         return service.getInvalid(this.client.getHost());
     }
 
+    /**
+     * Get invalid Boolean value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Boolean> getInvalidAsync() {
         return getInvalidWithResponseAsync()
@@ -212,6 +326,12 @@ public final class Bools {
             });
     }
 
+    /**
+     * Get invalid Boolean value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public boolean getInvalid() {
         return getInvalidAsync().block();

--- a/tests/src/main/java/fixtures/bodybyte/Bytes.java
+++ b/tests/src/main/java/fixtures/bodybyte/Bytes.java
@@ -75,6 +75,12 @@ public final class Bytes {
         Mono<SimpleResponse<byte[]>> getInvalid(@HostParam("$host") String host);
     }
 
+    /**
+     * Get null byte value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<byte[]>> getNullWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -83,6 +89,12 @@ public final class Bytes {
         return service.getNull(this.client.getHost());
     }
 
+    /**
+     * Get null byte value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<byte[]> getNullAsync() {
         return getNullWithResponseAsync()
@@ -95,11 +107,23 @@ public final class Bytes {
             });
     }
 
+    /**
+     * Get null byte value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public byte[] getNull() {
         return getNullAsync().block();
     }
 
+    /**
+     * Get empty byte value ''.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<byte[]>> getEmptyWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -108,6 +132,12 @@ public final class Bytes {
         return service.getEmpty(this.client.getHost());
     }
 
+    /**
+     * Get empty byte value ''.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<byte[]> getEmptyAsync() {
         return getEmptyWithResponseAsync()
@@ -120,11 +150,23 @@ public final class Bytes {
             });
     }
 
+    /**
+     * Get empty byte value ''.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public byte[] getEmpty() {
         return getEmptyAsync().block();
     }
 
+    /**
+     * Get non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<byte[]>> getNonAsciiWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -133,6 +175,12 @@ public final class Bytes {
         return service.getNonAscii(this.client.getHost());
     }
 
+    /**
+     * Get non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<byte[]> getNonAsciiAsync() {
         return getNonAsciiWithResponseAsync()
@@ -145,11 +193,25 @@ public final class Bytes {
             });
     }
 
+    /**
+     * Get non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public byte[] getNonAscii() {
         return getNonAsciiAsync().block();
     }
 
+    /**
+     * Put non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
+     * 
+     * @param byteBody Non-ascii base-64 encoded byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putNonAsciiWithResponseAsync(byte[] byteBody) {
         if (this.client.getHost() == null) {
@@ -161,17 +223,39 @@ public final class Bytes {
         return service.putNonAscii(this.client.getHost(), byteBody);
     }
 
+    /**
+     * Put non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
+     * 
+     * @param byteBody Non-ascii base-64 encoded byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putNonAsciiAsync(byte[] byteBody) {
         return putNonAsciiWithResponseAsync(byteBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
+     * 
+     * @param byteBody Non-ascii base-64 encoded byte string hex(FF FE FD FC FB FA F9 F8 F7 F6).
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putNonAscii(byte[] byteBody) {
         putNonAsciiAsync(byteBody).block();
     }
 
+    /**
+     * Get invalid byte value ':::SWAGGER::::'.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<byte[]>> getInvalidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -180,6 +264,12 @@ public final class Bytes {
         return service.getInvalid(this.client.getHost());
     }
 
+    /**
+     * Get invalid byte value ':::SWAGGER::::'.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<byte[]> getInvalidAsync() {
         return getInvalidWithResponseAsync()
@@ -192,6 +282,12 @@ public final class Bytes {
             });
     }
 
+    /**
+     * Get invalid byte value ':::SWAGGER::::'.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public byte[] getInvalid() {
         return getInvalidAsync().block();

--- a/tests/src/main/java/fixtures/bodycomplex/Arrays.java
+++ b/tests/src/main/java/fixtures/bodycomplex/Arrays.java
@@ -76,6 +76,12 @@ public final class Arrays {
         Mono<SimpleResponse<ArrayWrapper>> getNotProvided(@HostParam("$host") String host);
     }
 
+    /**
+     * Get complex types with array property.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<ArrayWrapper>> getValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -84,6 +90,12 @@ public final class Arrays {
         return service.getValid(this.client.getHost());
     }
 
+    /**
+     * Get complex types with array property.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<ArrayWrapper> getValidAsync() {
         return getValidWithResponseAsync()
@@ -96,11 +108,25 @@ public final class Arrays {
             });
     }
 
+    /**
+     * Get complex types with array property.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public ArrayWrapper getValid() {
         return getValidAsync().block();
     }
 
+    /**
+     * Put complex types with array property.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putValidWithResponseAsync(ArrayWrapper complexBody) {
         if (this.client.getHost() == null) {
@@ -114,17 +140,39 @@ public final class Arrays {
         return service.putValid(this.client.getHost(), complexBody);
     }
 
+    /**
+     * Put complex types with array property.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putValidAsync(ArrayWrapper complexBody) {
         return putValidWithResponseAsync(complexBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put complex types with array property.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putValid(ArrayWrapper complexBody) {
         putValidAsync(complexBody).block();
     }
 
+    /**
+     * Get complex types with array property which is empty.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<ArrayWrapper>> getEmptyWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -133,6 +181,12 @@ public final class Arrays {
         return service.getEmpty(this.client.getHost());
     }
 
+    /**
+     * Get complex types with array property which is empty.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<ArrayWrapper> getEmptyAsync() {
         return getEmptyWithResponseAsync()
@@ -145,11 +199,25 @@ public final class Arrays {
             });
     }
 
+    /**
+     * Get complex types with array property which is empty.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public ArrayWrapper getEmpty() {
         return getEmptyAsync().block();
     }
 
+    /**
+     * Put complex types with array property which is empty.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putEmptyWithResponseAsync(ArrayWrapper complexBody) {
         if (this.client.getHost() == null) {
@@ -163,17 +231,39 @@ public final class Arrays {
         return service.putEmpty(this.client.getHost(), complexBody);
     }
 
+    /**
+     * Put complex types with array property which is empty.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putEmptyAsync(ArrayWrapper complexBody) {
         return putEmptyWithResponseAsync(complexBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put complex types with array property which is empty.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putEmpty(ArrayWrapper complexBody) {
         putEmptyAsync(complexBody).block();
     }
 
+    /**
+     * Get complex types with array property while server doesn't provide a response payload.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<ArrayWrapper>> getNotProvidedWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -182,6 +272,12 @@ public final class Arrays {
         return service.getNotProvided(this.client.getHost());
     }
 
+    /**
+     * Get complex types with array property while server doesn't provide a response payload.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<ArrayWrapper> getNotProvidedAsync() {
         return getNotProvidedWithResponseAsync()
@@ -194,6 +290,12 @@ public final class Arrays {
             });
     }
 
+    /**
+     * Get complex types with array property while server doesn't provide a response payload.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public ArrayWrapper getNotProvided() {
         return getNotProvidedAsync().block();

--- a/tests/src/main/java/fixtures/bodycomplex/Basics.java
+++ b/tests/src/main/java/fixtures/bodycomplex/Basics.java
@@ -82,6 +82,12 @@ public final class Basics {
         Mono<SimpleResponse<Basic>> getNotProvided(@HostParam("$host") String host);
     }
 
+    /**
+     * Get complex type {id: 2, name: 'abc', color: 'YELLOW'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Basic>> getValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -90,6 +96,12 @@ public final class Basics {
         return service.getValid(this.client.getHost());
     }
 
+    /**
+     * Get complex type {id: 2, name: 'abc', color: 'YELLOW'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Basic> getValidAsync() {
         return getValidWithResponseAsync()
@@ -102,11 +114,25 @@ public final class Basics {
             });
     }
 
+    /**
+     * Get complex type {id: 2, name: 'abc', color: 'YELLOW'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Basic getValid() {
         return getValidAsync().block();
     }
 
+    /**
+     * Please put {id: 2, name: 'abc', color: 'Magenta'}.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putValidWithResponseAsync(Basic complexBody) {
         if (this.client.getHost() == null) {
@@ -120,17 +146,39 @@ public final class Basics {
         return service.putValid(this.client.getHost(), this.client.getApiVersion(), complexBody);
     }
 
+    /**
+     * Please put {id: 2, name: 'abc', color: 'Magenta'}.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putValidAsync(Basic complexBody) {
         return putValidWithResponseAsync(complexBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Please put {id: 2, name: 'abc', color: 'Magenta'}.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putValid(Basic complexBody) {
         putValidAsync(complexBody).block();
     }
 
+    /**
+     * Get a basic complex type that is invalid for the local strong type.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Basic>> getInvalidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -139,6 +187,12 @@ public final class Basics {
         return service.getInvalid(this.client.getHost());
     }
 
+    /**
+     * Get a basic complex type that is invalid for the local strong type.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Basic> getInvalidAsync() {
         return getInvalidWithResponseAsync()
@@ -151,11 +205,23 @@ public final class Basics {
             });
     }
 
+    /**
+     * Get a basic complex type that is invalid for the local strong type.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Basic getInvalid() {
         return getInvalidAsync().block();
     }
 
+    /**
+     * Get a basic complex type that is empty.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Basic>> getEmptyWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -164,6 +230,12 @@ public final class Basics {
         return service.getEmpty(this.client.getHost());
     }
 
+    /**
+     * Get a basic complex type that is empty.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Basic> getEmptyAsync() {
         return getEmptyWithResponseAsync()
@@ -176,11 +248,23 @@ public final class Basics {
             });
     }
 
+    /**
+     * Get a basic complex type that is empty.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Basic getEmpty() {
         return getEmptyAsync().block();
     }
 
+    /**
+     * Get a basic complex type whose properties are null.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Basic>> getNullWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -189,6 +273,12 @@ public final class Basics {
         return service.getNull(this.client.getHost());
     }
 
+    /**
+     * Get a basic complex type whose properties are null.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Basic> getNullAsync() {
         return getNullWithResponseAsync()
@@ -201,11 +291,23 @@ public final class Basics {
             });
     }
 
+    /**
+     * Get a basic complex type whose properties are null.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Basic getNull() {
         return getNullAsync().block();
     }
 
+    /**
+     * Get a basic complex type while the server doesn't provide a response payload.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Basic>> getNotProvidedWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -214,6 +316,12 @@ public final class Basics {
         return service.getNotProvided(this.client.getHost());
     }
 
+    /**
+     * Get a basic complex type while the server doesn't provide a response payload.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Basic> getNotProvidedAsync() {
         return getNotProvidedWithResponseAsync()
@@ -226,6 +334,12 @@ public final class Basics {
             });
     }
 
+    /**
+     * Get a basic complex type while the server doesn't provide a response payload.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Basic getNotProvided() {
         return getNotProvidedAsync().block();

--- a/tests/src/main/java/fixtures/bodycomplex/Dictionarys.java
+++ b/tests/src/main/java/fixtures/bodycomplex/Dictionarys.java
@@ -81,6 +81,12 @@ public final class Dictionarys {
         Mono<SimpleResponse<DictionaryWrapper>> getNotProvided(@HostParam("$host") String host);
     }
 
+    /**
+     * Get complex types with dictionary property.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<DictionaryWrapper>> getValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -89,6 +95,12 @@ public final class Dictionarys {
         return service.getValid(this.client.getHost());
     }
 
+    /**
+     * Get complex types with dictionary property.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<DictionaryWrapper> getValidAsync() {
         return getValidWithResponseAsync()
@@ -101,11 +113,25 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get complex types with dictionary property.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DictionaryWrapper getValid() {
         return getValidAsync().block();
     }
 
+    /**
+     * Put complex types with dictionary property.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putValidWithResponseAsync(DictionaryWrapper complexBody) {
         if (this.client.getHost() == null) {
@@ -119,17 +145,39 @@ public final class Dictionarys {
         return service.putValid(this.client.getHost(), complexBody);
     }
 
+    /**
+     * Put complex types with dictionary property.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putValidAsync(DictionaryWrapper complexBody) {
         return putValidWithResponseAsync(complexBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put complex types with dictionary property.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putValid(DictionaryWrapper complexBody) {
         putValidAsync(complexBody).block();
     }
 
+    /**
+     * Get complex types with dictionary property which is empty.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<DictionaryWrapper>> getEmptyWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -138,6 +186,12 @@ public final class Dictionarys {
         return service.getEmpty(this.client.getHost());
     }
 
+    /**
+     * Get complex types with dictionary property which is empty.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<DictionaryWrapper> getEmptyAsync() {
         return getEmptyWithResponseAsync()
@@ -150,11 +204,25 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get complex types with dictionary property which is empty.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DictionaryWrapper getEmpty() {
         return getEmptyAsync().block();
     }
 
+    /**
+     * Put complex types with dictionary property which is empty.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putEmptyWithResponseAsync(DictionaryWrapper complexBody) {
         if (this.client.getHost() == null) {
@@ -168,17 +236,39 @@ public final class Dictionarys {
         return service.putEmpty(this.client.getHost(), complexBody);
     }
 
+    /**
+     * Put complex types with dictionary property which is empty.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putEmptyAsync(DictionaryWrapper complexBody) {
         return putEmptyWithResponseAsync(complexBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put complex types with dictionary property which is empty.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putEmpty(DictionaryWrapper complexBody) {
         putEmptyAsync(complexBody).block();
     }
 
+    /**
+     * Get complex types with dictionary property which is null.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<DictionaryWrapper>> getNullWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -187,6 +277,12 @@ public final class Dictionarys {
         return service.getNull(this.client.getHost());
     }
 
+    /**
+     * Get complex types with dictionary property which is null.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<DictionaryWrapper> getNullAsync() {
         return getNullWithResponseAsync()
@@ -199,11 +295,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get complex types with dictionary property which is null.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DictionaryWrapper getNull() {
         return getNullAsync().block();
     }
 
+    /**
+     * Get complex types with dictionary property while server doesn't provide a response payload.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<DictionaryWrapper>> getNotProvidedWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -212,6 +320,12 @@ public final class Dictionarys {
         return service.getNotProvided(this.client.getHost());
     }
 
+    /**
+     * Get complex types with dictionary property while server doesn't provide a response payload.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<DictionaryWrapper> getNotProvidedAsync() {
         return getNotProvidedWithResponseAsync()
@@ -224,6 +338,12 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get complex types with dictionary property while server doesn't provide a response payload.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DictionaryWrapper getNotProvided() {
         return getNotProvidedAsync().block();

--- a/tests/src/main/java/fixtures/bodycomplex/Flattencomplexs.java
+++ b/tests/src/main/java/fixtures/bodycomplex/Flattencomplexs.java
@@ -53,6 +53,12 @@ public final class Flattencomplexs {
         Mono<SimpleResponse<MyBaseType>> getValid(@HostParam("$host") String host);
     }
 
+    /**
+     * MISSING·OPERATION-DESCRIPTION.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<MyBaseType>> getValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -61,6 +67,12 @@ public final class Flattencomplexs {
         return service.getValid(this.client.getHost());
     }
 
+    /**
+     * MISSING·OPERATION-DESCRIPTION.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<MyBaseType> getValidAsync() {
         return getValidWithResponseAsync()
@@ -73,6 +85,12 @@ public final class Flattencomplexs {
             });
     }
 
+    /**
+     * MISSING·OPERATION-DESCRIPTION.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyBaseType getValid() {
         return getValidAsync().block();

--- a/tests/src/main/java/fixtures/bodycomplex/Inheritances.java
+++ b/tests/src/main/java/fixtures/bodycomplex/Inheritances.java
@@ -61,6 +61,12 @@ public final class Inheritances {
         Mono<Response<Void>> putValid(@HostParam("$host") String host, @BodyParam("application/json") Siamese complexBody);
     }
 
+    /**
+     * Get complex types that extend others.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Siamese>> getValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -69,6 +75,12 @@ public final class Inheritances {
         return service.getValid(this.client.getHost());
     }
 
+    /**
+     * Get complex types that extend others.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Siamese> getValidAsync() {
         return getValidWithResponseAsync()
@@ -81,11 +93,25 @@ public final class Inheritances {
             });
     }
 
+    /**
+     * Get complex types that extend others.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Siamese getValid() {
         return getValidAsync().block();
     }
 
+    /**
+     * Put complex types that extend others.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putValidWithResponseAsync(Siamese complexBody) {
         if (this.client.getHost() == null) {
@@ -99,12 +125,28 @@ public final class Inheritances {
         return service.putValid(this.client.getHost(), complexBody);
     }
 
+    /**
+     * Put complex types that extend others.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putValidAsync(Siamese complexBody) {
         return putValidWithResponseAsync(complexBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put complex types that extend others.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putValid(Siamese complexBody) {
         putValidAsync(complexBody).block();

--- a/tests/src/main/java/fixtures/bodycomplex/Polymorphicrecursives.java
+++ b/tests/src/main/java/fixtures/bodycomplex/Polymorphicrecursives.java
@@ -61,6 +61,12 @@ public final class Polymorphicrecursives {
         Mono<Response<Void>> putValid(@HostParam("$host") String host, @BodyParam("application/json") Fish complexBody);
     }
 
+    /**
+     * Get complex types that are polymorphic and have recursive references.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Fish>> getValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -69,6 +75,12 @@ public final class Polymorphicrecursives {
         return service.getValid(this.client.getHost());
     }
 
+    /**
+     * Get complex types that are polymorphic and have recursive references.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Fish> getValidAsync() {
         return getValidWithResponseAsync()
@@ -81,11 +93,25 @@ public final class Polymorphicrecursives {
             });
     }
 
+    /**
+     * Get complex types that are polymorphic and have recursive references.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Fish getValid() {
         return getValidAsync().block();
     }
 
+    /**
+     * Put complex types that are polymorphic and have recursive references.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putValidWithResponseAsync(Fish complexBody) {
         if (this.client.getHost() == null) {
@@ -99,12 +125,28 @@ public final class Polymorphicrecursives {
         return service.putValid(this.client.getHost(), complexBody);
     }
 
+    /**
+     * Put complex types that are polymorphic and have recursive references.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putValidAsync(Fish complexBody) {
         return putValidWithResponseAsync(complexBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put complex types that are polymorphic and have recursive references.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putValid(Fish complexBody) {
         putValidAsync(complexBody).block();

--- a/tests/src/main/java/fixtures/bodycomplex/Polymorphisms.java
+++ b/tests/src/main/java/fixtures/bodycomplex/Polymorphisms.java
@@ -99,6 +99,12 @@ public final class Polymorphisms {
         Mono<Response<Void>> putValidMissingRequired(@HostParam("$host") String host, @BodyParam("application/json") Fish complexBody);
     }
 
+    /**
+     * Get complex types that are polymorphic.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Fish>> getValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -107,6 +113,12 @@ public final class Polymorphisms {
         return service.getValid(this.client.getHost());
     }
 
+    /**
+     * Get complex types that are polymorphic.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Fish> getValidAsync() {
         return getValidWithResponseAsync()
@@ -119,11 +131,25 @@ public final class Polymorphisms {
             });
     }
 
+    /**
+     * Get complex types that are polymorphic.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Fish getValid() {
         return getValidAsync().block();
     }
 
+    /**
+     * Put complex types that are polymorphic.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putValidWithResponseAsync(Fish complexBody) {
         if (this.client.getHost() == null) {
@@ -137,17 +163,39 @@ public final class Polymorphisms {
         return service.putValid(this.client.getHost(), complexBody);
     }
 
+    /**
+     * Put complex types that are polymorphic.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putValidAsync(Fish complexBody) {
         return putValidWithResponseAsync(complexBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put complex types that are polymorphic.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putValid(Fish complexBody) {
         putValidAsync(complexBody).block();
     }
 
+    /**
+     * Get complex types that are polymorphic, JSON key contains a dot.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<DotFish>> getDotSyntaxWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -156,6 +204,12 @@ public final class Polymorphisms {
         return service.getDotSyntax(this.client.getHost());
     }
 
+    /**
+     * Get complex types that are polymorphic, JSON key contains a dot.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<DotFish> getDotSyntaxAsync() {
         return getDotSyntaxWithResponseAsync()
@@ -168,11 +222,23 @@ public final class Polymorphisms {
             });
     }
 
+    /**
+     * Get complex types that are polymorphic, JSON key contains a dot.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DotFish getDotSyntax() {
         return getDotSyntaxAsync().block();
     }
 
+    /**
+     * Get complex object composing a polymorphic scalar property and array property with polymorphic element type, with discriminator specified. Deserialization must NOT fail and use the discriminator type specified on the wire.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<DotFishMarket>> getComposedWithDiscriminatorWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -181,6 +247,12 @@ public final class Polymorphisms {
         return service.getComposedWithDiscriminator(this.client.getHost());
     }
 
+    /**
+     * Get complex object composing a polymorphic scalar property and array property with polymorphic element type, with discriminator specified. Deserialization must NOT fail and use the discriminator type specified on the wire.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<DotFishMarket> getComposedWithDiscriminatorAsync() {
         return getComposedWithDiscriminatorWithResponseAsync()
@@ -193,11 +265,23 @@ public final class Polymorphisms {
             });
     }
 
+    /**
+     * Get complex object composing a polymorphic scalar property and array property with polymorphic element type, with discriminator specified. Deserialization must NOT fail and use the discriminator type specified on the wire.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DotFishMarket getComposedWithDiscriminator() {
         return getComposedWithDiscriminatorAsync().block();
     }
 
+    /**
+     * Get complex object composing a polymorphic scalar property and array property with polymorphic element type, without discriminator specified on wire. Deserialization must NOT fail and use the explicit type of the property.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<DotFishMarket>> getComposedWithoutDiscriminatorWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -206,6 +290,12 @@ public final class Polymorphisms {
         return service.getComposedWithoutDiscriminator(this.client.getHost());
     }
 
+    /**
+     * Get complex object composing a polymorphic scalar property and array property with polymorphic element type, without discriminator specified on wire. Deserialization must NOT fail and use the explicit type of the property.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<DotFishMarket> getComposedWithoutDiscriminatorAsync() {
         return getComposedWithoutDiscriminatorWithResponseAsync()
@@ -218,11 +308,23 @@ public final class Polymorphisms {
             });
     }
 
+    /**
+     * Get complex object composing a polymorphic scalar property and array property with polymorphic element type, without discriminator specified on wire. Deserialization must NOT fail and use the explicit type of the property.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DotFishMarket getComposedWithoutDiscriminator() {
         return getComposedWithoutDiscriminatorAsync().block();
     }
 
+    /**
+     * Get complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Salmon>> getComplicatedWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -231,6 +333,12 @@ public final class Polymorphisms {
         return service.getComplicated(this.client.getHost());
     }
 
+    /**
+     * Get complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Salmon> getComplicatedAsync() {
         return getComplicatedWithResponseAsync()
@@ -243,11 +351,25 @@ public final class Polymorphisms {
             });
     }
 
+    /**
+     * Get complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Salmon getComplicated() {
         return getComplicatedAsync().block();
     }
 
+    /**
+     * Put complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putComplicatedWithResponseAsync(Salmon complexBody) {
         if (this.client.getHost() == null) {
@@ -261,17 +383,41 @@ public final class Polymorphisms {
         return service.putComplicated(this.client.getHost(), complexBody);
     }
 
+    /**
+     * Put complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putComplicatedAsync(Salmon complexBody) {
         return putComplicatedWithResponseAsync(complexBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putComplicated(Salmon complexBody) {
         putComplicatedAsync(complexBody).block();
     }
 
+    /**
+     * Put complex types that are polymorphic, omitting the discriminator.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Salmon>> putMissingDiscriminatorWithResponseAsync(Salmon complexBody) {
         if (this.client.getHost() == null) {
@@ -285,6 +431,14 @@ public final class Polymorphisms {
         return service.putMissingDiscriminator(this.client.getHost(), complexBody);
     }
 
+    /**
+     * Put complex types that are polymorphic, omitting the discriminator.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Salmon> putMissingDiscriminatorAsync(Salmon complexBody) {
         return putMissingDiscriminatorWithResponseAsync(complexBody)
@@ -297,11 +451,27 @@ public final class Polymorphisms {
             });
     }
 
+    /**
+     * Put complex types that are polymorphic, omitting the discriminator.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Salmon putMissingDiscriminator(Salmon complexBody) {
         return putMissingDiscriminatorAsync(complexBody).block();
     }
 
+    /**
+     * Put complex types that are polymorphic, attempting to omit required 'birthday' field - the request should not be allowed from the client.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putValidMissingRequiredWithResponseAsync(Fish complexBody) {
         if (this.client.getHost() == null) {
@@ -315,12 +485,28 @@ public final class Polymorphisms {
         return service.putValidMissingRequired(this.client.getHost(), complexBody);
     }
 
+    /**
+     * Put complex types that are polymorphic, attempting to omit required 'birthday' field - the request should not be allowed from the client.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putValidMissingRequiredAsync(Fish complexBody) {
         return putValidMissingRequiredWithResponseAsync(complexBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put complex types that are polymorphic, attempting to omit required 'birthday' field - the request should not be allowed from the client.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putValidMissingRequired(Fish complexBody) {
         putValidMissingRequiredAsync(complexBody).block();

--- a/tests/src/main/java/fixtures/bodycomplex/Primitives.java
+++ b/tests/src/main/java/fixtures/bodycomplex/Primitives.java
@@ -171,6 +171,12 @@ public final class Primitives {
         Mono<Response<Void>> putByte(@HostParam("$host") String host, @BodyParam("application/json") ByteWrapper complexBody);
     }
 
+    /**
+     * Get complex types with integer properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<IntWrapper>> getIntWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -179,6 +185,12 @@ public final class Primitives {
         return service.getInt(this.client.getHost());
     }
 
+    /**
+     * Get complex types with integer properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<IntWrapper> getIntAsync() {
         return getIntWithResponseAsync()
@@ -191,11 +203,25 @@ public final class Primitives {
             });
     }
 
+    /**
+     * Get complex types with integer properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public IntWrapper getInt() {
         return getIntAsync().block();
     }
 
+    /**
+     * Put complex types with integer properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putIntWithResponseAsync(IntWrapper complexBody) {
         if (this.client.getHost() == null) {
@@ -209,17 +235,39 @@ public final class Primitives {
         return service.putInt(this.client.getHost(), complexBody);
     }
 
+    /**
+     * Put complex types with integer properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putIntAsync(IntWrapper complexBody) {
         return putIntWithResponseAsync(complexBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put complex types with integer properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putInt(IntWrapper complexBody) {
         putIntAsync(complexBody).block();
     }
 
+    /**
+     * Get complex types with long properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<LongWrapper>> getLongWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -228,6 +276,12 @@ public final class Primitives {
         return service.getLong(this.client.getHost());
     }
 
+    /**
+     * Get complex types with long properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<LongWrapper> getLongAsync() {
         return getLongWithResponseAsync()
@@ -240,11 +294,25 @@ public final class Primitives {
             });
     }
 
+    /**
+     * Get complex types with long properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public LongWrapper getLong() {
         return getLongAsync().block();
     }
 
+    /**
+     * Put complex types with long properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putLongWithResponseAsync(LongWrapper complexBody) {
         if (this.client.getHost() == null) {
@@ -258,17 +326,39 @@ public final class Primitives {
         return service.putLong(this.client.getHost(), complexBody);
     }
 
+    /**
+     * Put complex types with long properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putLongAsync(LongWrapper complexBody) {
         return putLongWithResponseAsync(complexBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put complex types with long properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putLong(LongWrapper complexBody) {
         putLongAsync(complexBody).block();
     }
 
+    /**
+     * Get complex types with float properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<FloatWrapper>> getFloatWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -277,6 +367,12 @@ public final class Primitives {
         return service.getFloat(this.client.getHost());
     }
 
+    /**
+     * Get complex types with float properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<FloatWrapper> getFloatAsync() {
         return getFloatWithResponseAsync()
@@ -289,11 +385,25 @@ public final class Primitives {
             });
     }
 
+    /**
+     * Get complex types with float properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public FloatWrapper getFloat() {
         return getFloatAsync().block();
     }
 
+    /**
+     * Put complex types with float properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putFloatWithResponseAsync(FloatWrapper complexBody) {
         if (this.client.getHost() == null) {
@@ -307,17 +417,39 @@ public final class Primitives {
         return service.putFloat(this.client.getHost(), complexBody);
     }
 
+    /**
+     * Put complex types with float properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putFloatAsync(FloatWrapper complexBody) {
         return putFloatWithResponseAsync(complexBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put complex types with float properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putFloat(FloatWrapper complexBody) {
         putFloatAsync(complexBody).block();
     }
 
+    /**
+     * Get complex types with double properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<DoubleWrapper>> getDoubleWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -326,6 +458,12 @@ public final class Primitives {
         return service.getDouble(this.client.getHost());
     }
 
+    /**
+     * Get complex types with double properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<DoubleWrapper> getDoubleAsync() {
         return getDoubleWithResponseAsync()
@@ -338,11 +476,25 @@ public final class Primitives {
             });
     }
 
+    /**
+     * Get complex types with double properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DoubleWrapper getDouble() {
         return getDoubleAsync().block();
     }
 
+    /**
+     * Put complex types with double properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putDoubleWithResponseAsync(DoubleWrapper complexBody) {
         if (this.client.getHost() == null) {
@@ -356,17 +508,39 @@ public final class Primitives {
         return service.putDouble(this.client.getHost(), complexBody);
     }
 
+    /**
+     * Put complex types with double properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putDoubleAsync(DoubleWrapper complexBody) {
         return putDoubleWithResponseAsync(complexBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put complex types with double properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDouble(DoubleWrapper complexBody) {
         putDoubleAsync(complexBody).block();
     }
 
+    /**
+     * Get complex types with bool properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<BooleanWrapper>> getBoolWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -375,6 +549,12 @@ public final class Primitives {
         return service.getBool(this.client.getHost());
     }
 
+    /**
+     * Get complex types with bool properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<BooleanWrapper> getBoolAsync() {
         return getBoolWithResponseAsync()
@@ -387,11 +567,25 @@ public final class Primitives {
             });
     }
 
+    /**
+     * Get complex types with bool properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public BooleanWrapper getBool() {
         return getBoolAsync().block();
     }
 
+    /**
+     * Put complex types with bool properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putBoolWithResponseAsync(BooleanWrapper complexBody) {
         if (this.client.getHost() == null) {
@@ -405,17 +599,39 @@ public final class Primitives {
         return service.putBool(this.client.getHost(), complexBody);
     }
 
+    /**
+     * Put complex types with bool properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putBoolAsync(BooleanWrapper complexBody) {
         return putBoolWithResponseAsync(complexBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put complex types with bool properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putBool(BooleanWrapper complexBody) {
         putBoolAsync(complexBody).block();
     }
 
+    /**
+     * Get complex types with string properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<StringWrapper>> getStringWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -424,6 +640,12 @@ public final class Primitives {
         return service.getString(this.client.getHost());
     }
 
+    /**
+     * Get complex types with string properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<StringWrapper> getStringAsync() {
         return getStringWithResponseAsync()
@@ -436,11 +658,25 @@ public final class Primitives {
             });
     }
 
+    /**
+     * Get complex types with string properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public StringWrapper getString() {
         return getStringAsync().block();
     }
 
+    /**
+     * Put complex types with string properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putStringWithResponseAsync(StringWrapper complexBody) {
         if (this.client.getHost() == null) {
@@ -454,17 +690,39 @@ public final class Primitives {
         return service.putString(this.client.getHost(), complexBody);
     }
 
+    /**
+     * Put complex types with string properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putStringAsync(StringWrapper complexBody) {
         return putStringWithResponseAsync(complexBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put complex types with string properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putString(StringWrapper complexBody) {
         putStringAsync(complexBody).block();
     }
 
+    /**
+     * Get complex types with date properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<DateWrapper>> getDateWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -473,6 +731,12 @@ public final class Primitives {
         return service.getDate(this.client.getHost());
     }
 
+    /**
+     * Get complex types with date properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<DateWrapper> getDateAsync() {
         return getDateWithResponseAsync()
@@ -485,11 +749,25 @@ public final class Primitives {
             });
     }
 
+    /**
+     * Get complex types with date properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DateWrapper getDate() {
         return getDateAsync().block();
     }
 
+    /**
+     * Put complex types with date properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putDateWithResponseAsync(DateWrapper complexBody) {
         if (this.client.getHost() == null) {
@@ -503,17 +781,39 @@ public final class Primitives {
         return service.putDate(this.client.getHost(), complexBody);
     }
 
+    /**
+     * Put complex types with date properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putDateAsync(DateWrapper complexBody) {
         return putDateWithResponseAsync(complexBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put complex types with date properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDate(DateWrapper complexBody) {
         putDateAsync(complexBody).block();
     }
 
+    /**
+     * Get complex types with datetime properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<DatetimeWrapper>> getDateTimeWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -522,6 +822,12 @@ public final class Primitives {
         return service.getDateTime(this.client.getHost());
     }
 
+    /**
+     * Get complex types with datetime properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<DatetimeWrapper> getDateTimeAsync() {
         return getDateTimeWithResponseAsync()
@@ -534,11 +840,25 @@ public final class Primitives {
             });
     }
 
+    /**
+     * Get complex types with datetime properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DatetimeWrapper getDateTime() {
         return getDateTimeAsync().block();
     }
 
+    /**
+     * Put complex types with datetime properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putDateTimeWithResponseAsync(DatetimeWrapper complexBody) {
         if (this.client.getHost() == null) {
@@ -552,17 +872,39 @@ public final class Primitives {
         return service.putDateTime(this.client.getHost(), complexBody);
     }
 
+    /**
+     * Put complex types with datetime properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putDateTimeAsync(DatetimeWrapper complexBody) {
         return putDateTimeWithResponseAsync(complexBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put complex types with datetime properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDateTime(DatetimeWrapper complexBody) {
         putDateTimeAsync(complexBody).block();
     }
 
+    /**
+     * Get complex types with datetimeRfc1123 properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Datetimerfc1123Wrapper>> getDateTimeRfc1123WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -571,6 +913,12 @@ public final class Primitives {
         return service.getDateTimeRfc1123(this.client.getHost());
     }
 
+    /**
+     * Get complex types with datetimeRfc1123 properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Datetimerfc1123Wrapper> getDateTimeRfc1123Async() {
         return getDateTimeRfc1123WithResponseAsync()
@@ -583,11 +931,25 @@ public final class Primitives {
             });
     }
 
+    /**
+     * Get complex types with datetimeRfc1123 properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Datetimerfc1123Wrapper getDateTimeRfc1123() {
         return getDateTimeRfc1123Async().block();
     }
 
+    /**
+     * Put complex types with datetimeRfc1123 properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putDateTimeRfc1123WithResponseAsync(Datetimerfc1123Wrapper complexBody) {
         if (this.client.getHost() == null) {
@@ -601,17 +963,39 @@ public final class Primitives {
         return service.putDateTimeRfc1123(this.client.getHost(), complexBody);
     }
 
+    /**
+     * Put complex types with datetimeRfc1123 properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putDateTimeRfc1123Async(Datetimerfc1123Wrapper complexBody) {
         return putDateTimeRfc1123WithResponseAsync(complexBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put complex types with datetimeRfc1123 properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDateTimeRfc1123(Datetimerfc1123Wrapper complexBody) {
         putDateTimeRfc1123Async(complexBody).block();
     }
 
+    /**
+     * Get complex types with duration properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<DurationWrapper>> getDurationWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -620,6 +1004,12 @@ public final class Primitives {
         return service.getDuration(this.client.getHost());
     }
 
+    /**
+     * Get complex types with duration properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<DurationWrapper> getDurationAsync() {
         return getDurationWithResponseAsync()
@@ -632,11 +1022,25 @@ public final class Primitives {
             });
     }
 
+    /**
+     * Get complex types with duration properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public DurationWrapper getDuration() {
         return getDurationAsync().block();
     }
 
+    /**
+     * Put complex types with duration properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putDurationWithResponseAsync(DurationWrapper complexBody) {
         if (this.client.getHost() == null) {
@@ -650,17 +1054,39 @@ public final class Primitives {
         return service.putDuration(this.client.getHost(), complexBody);
     }
 
+    /**
+     * Put complex types with duration properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putDurationAsync(DurationWrapper complexBody) {
         return putDurationWithResponseAsync(complexBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put complex types with duration properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDuration(DurationWrapper complexBody) {
         putDurationAsync(complexBody).block();
     }
 
+    /**
+     * Get complex types with byte properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<ByteWrapper>> getByteWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -669,6 +1095,12 @@ public final class Primitives {
         return service.getByte(this.client.getHost());
     }
 
+    /**
+     * Get complex types with byte properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<ByteWrapper> getByteAsync() {
         return getByteWithResponseAsync()
@@ -681,11 +1113,25 @@ public final class Primitives {
             });
     }
 
+    /**
+     * Get complex types with byte properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public ByteWrapper getByte() {
         return getByteAsync().block();
     }
 
+    /**
+     * Put complex types with byte properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putByteWithResponseAsync(ByteWrapper complexBody) {
         if (this.client.getHost() == null) {
@@ -699,12 +1145,28 @@ public final class Primitives {
         return service.putByte(this.client.getHost(), complexBody);
     }
 
+    /**
+     * Put complex types with byte properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putByteAsync(ByteWrapper complexBody) {
         return putByteWithResponseAsync(complexBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put complex types with byte properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putByte(ByteWrapper complexBody) {
         putByteAsync(complexBody).block();

--- a/tests/src/main/java/fixtures/bodycomplex/Readonlypropertys.java
+++ b/tests/src/main/java/fixtures/bodycomplex/Readonlypropertys.java
@@ -61,6 +61,12 @@ public final class Readonlypropertys {
         Mono<Response<Void>> putValid(@HostParam("$host") String host, @BodyParam("application/json") ReadonlyObj complexBody);
     }
 
+    /**
+     * Get complex types that have readonly properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<ReadonlyObj>> getValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -69,6 +75,12 @@ public final class Readonlypropertys {
         return service.getValid(this.client.getHost());
     }
 
+    /**
+     * Get complex types that have readonly properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<ReadonlyObj> getValidAsync() {
         return getValidWithResponseAsync()
@@ -81,11 +93,25 @@ public final class Readonlypropertys {
             });
     }
 
+    /**
+     * Get complex types that have readonly properties.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public ReadonlyObj getValid() {
         return getValidAsync().block();
     }
 
+    /**
+     * Put complex types that have readonly properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putValidWithResponseAsync(ReadonlyObj complexBody) {
         if (this.client.getHost() == null) {
@@ -99,12 +125,28 @@ public final class Readonlypropertys {
         return service.putValid(this.client.getHost(), complexBody);
     }
 
+    /**
+     * Put complex types that have readonly properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putValidAsync(ReadonlyObj complexBody) {
         return putValidWithResponseAsync(complexBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put complex types that have readonly properties.
+     * 
+     * @param complexBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putValid(ReadonlyObj complexBody) {
         putValidAsync(complexBody).block();

--- a/tests/src/main/java/fixtures/bodycomplex/models/GoblinSharkColor.java
+++ b/tests/src/main/java/fixtures/bodycomplex/models/GoblinSharkColor.java
@@ -24,6 +24,16 @@ public final class GoblinSharkColor extends ExpandableStringEnum<GoblinSharkColo
     public static final GoblinSharkColor BROWN = fromString("brown");
 
     /**
+     * Static value RED for GoblinSharkColor.
+     */
+    public static final GoblinSharkColor RED = fromString("RED");
+
+    /**
+     * Static value red for GoblinSharkColor.
+     */
+    public static final GoblinSharkColor RED = fromString("red");
+
+    /**
      * Creates or finds a GoblinSharkColor from its string representation.
      * 
      * @param name a name to look for.

--- a/tests/src/main/java/fixtures/bodydate/Dates.java
+++ b/tests/src/main/java/fixtures/bodydate/Dates.java
@@ -90,6 +90,12 @@ public final class Dates {
         Mono<SimpleResponse<LocalDate>> getMinDate(@HostParam("$host") String host);
     }
 
+    /**
+     * Get null date value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<LocalDate>> getNullWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -98,6 +104,12 @@ public final class Dates {
         return service.getNull(this.client.getHost());
     }
 
+    /**
+     * Get null date value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<LocalDate> getNullAsync() {
         return getNullWithResponseAsync()
@@ -110,11 +122,23 @@ public final class Dates {
             });
     }
 
+    /**
+     * Get null date value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public LocalDate getNull() {
         return getNullAsync().block();
     }
 
+    /**
+     * Get invalid date value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<LocalDate>> getInvalidDateWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -123,6 +147,12 @@ public final class Dates {
         return service.getInvalidDate(this.client.getHost());
     }
 
+    /**
+     * Get invalid date value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<LocalDate> getInvalidDateAsync() {
         return getInvalidDateWithResponseAsync()
@@ -135,11 +165,23 @@ public final class Dates {
             });
     }
 
+    /**
+     * Get invalid date value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public LocalDate getInvalidDate() {
         return getInvalidDateAsync().block();
     }
 
+    /**
+     * Get overflow date value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<LocalDate>> getOverflowDateWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -148,6 +190,12 @@ public final class Dates {
         return service.getOverflowDate(this.client.getHost());
     }
 
+    /**
+     * Get overflow date value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<LocalDate> getOverflowDateAsync() {
         return getOverflowDateWithResponseAsync()
@@ -160,11 +208,23 @@ public final class Dates {
             });
     }
 
+    /**
+     * Get overflow date value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public LocalDate getOverflowDate() {
         return getOverflowDateAsync().block();
     }
 
+    /**
+     * Get underflow date value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<LocalDate>> getUnderflowDateWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -173,6 +233,12 @@ public final class Dates {
         return service.getUnderflowDate(this.client.getHost());
     }
 
+    /**
+     * Get underflow date value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<LocalDate> getUnderflowDateAsync() {
         return getUnderflowDateWithResponseAsync()
@@ -185,11 +251,25 @@ public final class Dates {
             });
     }
 
+    /**
+     * Get underflow date value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public LocalDate getUnderflowDate() {
         return getUnderflowDateAsync().block();
     }
 
+    /**
+     * Put max date value 9999-12-31.
+     * 
+     * @param dateBody MISSING·SCHEMA-DESCRIPTION-DATE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putMaxDateWithResponseAsync(LocalDate dateBody) {
         if (this.client.getHost() == null) {
@@ -201,17 +281,39 @@ public final class Dates {
         return service.putMaxDate(this.client.getHost(), dateBody);
     }
 
+    /**
+     * Put max date value 9999-12-31.
+     * 
+     * @param dateBody MISSING·SCHEMA-DESCRIPTION-DATE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putMaxDateAsync(LocalDate dateBody) {
         return putMaxDateWithResponseAsync(dateBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put max date value 9999-12-31.
+     * 
+     * @param dateBody MISSING·SCHEMA-DESCRIPTION-DATE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putMaxDate(LocalDate dateBody) {
         putMaxDateAsync(dateBody).block();
     }
 
+    /**
+     * Get max date value 9999-12-31.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<LocalDate>> getMaxDateWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -220,6 +322,12 @@ public final class Dates {
         return service.getMaxDate(this.client.getHost());
     }
 
+    /**
+     * Get max date value 9999-12-31.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<LocalDate> getMaxDateAsync() {
         return getMaxDateWithResponseAsync()
@@ -232,11 +340,25 @@ public final class Dates {
             });
     }
 
+    /**
+     * Get max date value 9999-12-31.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public LocalDate getMaxDate() {
         return getMaxDateAsync().block();
     }
 
+    /**
+     * Put min date value 0000-01-01.
+     * 
+     * @param dateBody MISSING·SCHEMA-DESCRIPTION-DATE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putMinDateWithResponseAsync(LocalDate dateBody) {
         if (this.client.getHost() == null) {
@@ -248,17 +370,39 @@ public final class Dates {
         return service.putMinDate(this.client.getHost(), dateBody);
     }
 
+    /**
+     * Put min date value 0000-01-01.
+     * 
+     * @param dateBody MISSING·SCHEMA-DESCRIPTION-DATE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putMinDateAsync(LocalDate dateBody) {
         return putMinDateWithResponseAsync(dateBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put min date value 0000-01-01.
+     * 
+     * @param dateBody MISSING·SCHEMA-DESCRIPTION-DATE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putMinDate(LocalDate dateBody) {
         putMinDateAsync(dateBody).block();
     }
 
+    /**
+     * Get min date value 0000-01-01.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<LocalDate>> getMinDateWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -267,6 +411,12 @@ public final class Dates {
         return service.getMinDate(this.client.getHost());
     }
 
+    /**
+     * Get min date value 0000-01-01.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<LocalDate> getMinDateAsync() {
         return getMinDateWithResponseAsync()
@@ -279,6 +429,12 @@ public final class Dates {
             });
     }
 
+    /**
+     * Get min date value 0000-01-01.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public LocalDate getMinDate() {
         return getMinDateAsync().block();

--- a/tests/src/main/java/fixtures/bodydatetime/Datetimes.java
+++ b/tests/src/main/java/fixtures/bodydatetime/Datetimes.java
@@ -80,6 +80,11 @@ public final class Datetimes {
         @UnexpectedResponseExceptionType(ErrorException.class)
         Mono<Response<Void>> putUtcMaxDateTime(@HostParam("$host") String host, @BodyParam("application/json") OffsetDateTime datetimeBody);
 
+        @Put("/datetime/max/utc7ms")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<Void>> putUtcMaxDateTime7Digits(@HostParam("$host") String host, @BodyParam("application/json") OffsetDateTime datetimeBody);
+
         @Get("/datetime/max/utc/lowercase")
         @ExpectedResponses({200})
         @ReturnValueWireType(OffsetDateTime.class)
@@ -91,6 +96,12 @@ public final class Datetimes {
         @ReturnValueWireType(OffsetDateTime.class)
         @UnexpectedResponseExceptionType(ErrorException.class)
         Mono<SimpleResponse<OffsetDateTime>> getUtcUppercaseMaxDateTime(@HostParam("$host") String host);
+
+        @Get("/datetime/max/utc7ms/uppercase")
+        @ExpectedResponses({200})
+        @ReturnValueWireType(OffsetDateTime.class)
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<SimpleResponse<OffsetDateTime>> getUtcUppercaseMaxDateTime7Digits(@HostParam("$host") String host);
 
         @Put("/datetime/max/localpositiveoffset")
         @ExpectedResponses({200})
@@ -160,6 +171,12 @@ public final class Datetimes {
         Mono<SimpleResponse<OffsetDateTime>> getLocalNegativeOffsetMinDateTime(@HostParam("$host") String host);
     }
 
+    /**
+     * Get null datetime value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<OffsetDateTime>> getNullWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -168,6 +185,12 @@ public final class Datetimes {
         return service.getNull(this.client.getHost());
     }
 
+    /**
+     * Get null datetime value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<OffsetDateTime> getNullAsync() {
         return getNullWithResponseAsync()
@@ -180,11 +203,23 @@ public final class Datetimes {
             });
     }
 
+    /**
+     * Get null datetime value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getNull() {
         return getNullAsync().block();
     }
 
+    /**
+     * Get invalid datetime value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<OffsetDateTime>> getInvalidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -193,6 +228,12 @@ public final class Datetimes {
         return service.getInvalid(this.client.getHost());
     }
 
+    /**
+     * Get invalid datetime value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<OffsetDateTime> getInvalidAsync() {
         return getInvalidWithResponseAsync()
@@ -205,11 +246,23 @@ public final class Datetimes {
             });
     }
 
+    /**
+     * Get invalid datetime value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getInvalid() {
         return getInvalidAsync().block();
     }
 
+    /**
+     * Get overflow datetime value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<OffsetDateTime>> getOverflowWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -218,6 +271,12 @@ public final class Datetimes {
         return service.getOverflow(this.client.getHost());
     }
 
+    /**
+     * Get overflow datetime value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<OffsetDateTime> getOverflowAsync() {
         return getOverflowWithResponseAsync()
@@ -230,11 +289,23 @@ public final class Datetimes {
             });
     }
 
+    /**
+     * Get overflow datetime value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getOverflow() {
         return getOverflowAsync().block();
     }
 
+    /**
+     * Get underflow datetime value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<OffsetDateTime>> getUnderflowWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -243,6 +314,12 @@ public final class Datetimes {
         return service.getUnderflow(this.client.getHost());
     }
 
+    /**
+     * Get underflow datetime value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<OffsetDateTime> getUnderflowAsync() {
         return getUnderflowWithResponseAsync()
@@ -255,11 +332,25 @@ public final class Datetimes {
             });
     }
 
+    /**
+     * Get underflow datetime value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getUnderflow() {
         return getUnderflowAsync().block();
     }
 
+    /**
+     * Put max datetime value 9999-12-31T23:59:59.999Z.
+     * 
+     * @param datetimeBody MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putUtcMaxDateTimeWithResponseAsync(OffsetDateTime datetimeBody) {
         if (this.client.getHost() == null) {
@@ -271,17 +362,85 @@ public final class Datetimes {
         return service.putUtcMaxDateTime(this.client.getHost(), datetimeBody);
     }
 
+    /**
+     * Put max datetime value 9999-12-31T23:59:59.999Z.
+     * 
+     * @param datetimeBody MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putUtcMaxDateTimeAsync(OffsetDateTime datetimeBody) {
         return putUtcMaxDateTimeWithResponseAsync(datetimeBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put max datetime value 9999-12-31T23:59:59.999Z.
+     * 
+     * @param datetimeBody MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putUtcMaxDateTime(OffsetDateTime datetimeBody) {
         putUtcMaxDateTimeAsync(datetimeBody).block();
     }
 
+    /**
+     * Put max datetime value 9999-12-31T23:59:59.9999999Z.
+     * 
+     * @param datetimeBody MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putUtcMaxDateTime7DigitsWithResponseAsync(OffsetDateTime datetimeBody) {
+        if (this.client.getHost() == null) {
+            throw new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null.");
+        }
+        if (datetimeBody == null) {
+            throw new IllegalArgumentException("Parameter datetimeBody is required and cannot be null.");
+        }
+        return service.putUtcMaxDateTime7Digits(this.client.getHost(), datetimeBody);
+    }
+
+    /**
+     * Put max datetime value 9999-12-31T23:59:59.9999999Z.
+     * 
+     * @param datetimeBody MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putUtcMaxDateTime7DigitsAsync(OffsetDateTime datetimeBody) {
+        return putUtcMaxDateTime7DigitsWithResponseAsync(datetimeBody)
+            .flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Put max datetime value 9999-12-31T23:59:59.9999999Z.
+     * 
+     * @param datetimeBody MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void putUtcMaxDateTime7Digits(OffsetDateTime datetimeBody) {
+        putUtcMaxDateTime7DigitsAsync(datetimeBody).block();
+    }
+
+    /**
+     * Get max datetime value 9999-12-31t23:59:59.999z.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<OffsetDateTime>> getUtcLowercaseMaxDateTimeWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -290,6 +449,12 @@ public final class Datetimes {
         return service.getUtcLowercaseMaxDateTime(this.client.getHost());
     }
 
+    /**
+     * Get max datetime value 9999-12-31t23:59:59.999z.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<OffsetDateTime> getUtcLowercaseMaxDateTimeAsync() {
         return getUtcLowercaseMaxDateTimeWithResponseAsync()
@@ -302,11 +467,23 @@ public final class Datetimes {
             });
     }
 
+    /**
+     * Get max datetime value 9999-12-31t23:59:59.999z.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getUtcLowercaseMaxDateTime() {
         return getUtcLowercaseMaxDateTimeAsync().block();
     }
 
+    /**
+     * Get max datetime value 9999-12-31T23:59:59.999Z.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<OffsetDateTime>> getUtcUppercaseMaxDateTimeWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -315,6 +492,12 @@ public final class Datetimes {
         return service.getUtcUppercaseMaxDateTime(this.client.getHost());
     }
 
+    /**
+     * Get max datetime value 9999-12-31T23:59:59.999Z.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<OffsetDateTime> getUtcUppercaseMaxDateTimeAsync() {
         return getUtcUppercaseMaxDateTimeWithResponseAsync()
@@ -327,11 +510,68 @@ public final class Datetimes {
             });
     }
 
+    /**
+     * Get max datetime value 9999-12-31T23:59:59.999Z.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getUtcUppercaseMaxDateTime() {
         return getUtcUppercaseMaxDateTimeAsync().block();
     }
 
+    /**
+     * Get max datetime value 9999-12-31T23:59:59.9999999Z.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<SimpleResponse<OffsetDateTime>> getUtcUppercaseMaxDateTime7DigitsWithResponseAsync() {
+        if (this.client.getHost() == null) {
+            throw new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null.");
+        }
+        return service.getUtcUppercaseMaxDateTime7Digits(this.client.getHost());
+    }
+
+    /**
+     * Get max datetime value 9999-12-31T23:59:59.9999999Z.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<OffsetDateTime> getUtcUppercaseMaxDateTime7DigitsAsync() {
+        return getUtcUppercaseMaxDateTime7DigitsWithResponseAsync()
+            .flatMap((SimpleResponse<OffsetDateTime> res) -> {
+                if (res.getValue() != null) {
+                    return Mono.just(res.getValue());
+                } else {
+                    return Mono.empty();
+                }
+            });
+    }
+
+    /**
+     * Get max datetime value 9999-12-31T23:59:59.9999999Z.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public OffsetDateTime getUtcUppercaseMaxDateTime7Digits() {
+        return getUtcUppercaseMaxDateTime7DigitsAsync().block();
+    }
+
+    /**
+     * Put max datetime value with positive numoffset 9999-12-31t23:59:59.999+14:00.
+     * 
+     * @param datetimeBody MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putLocalPositiveOffsetMaxDateTimeWithResponseAsync(OffsetDateTime datetimeBody) {
         if (this.client.getHost() == null) {
@@ -343,17 +583,39 @@ public final class Datetimes {
         return service.putLocalPositiveOffsetMaxDateTime(this.client.getHost(), datetimeBody);
     }
 
+    /**
+     * Put max datetime value with positive numoffset 9999-12-31t23:59:59.999+14:00.
+     * 
+     * @param datetimeBody MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putLocalPositiveOffsetMaxDateTimeAsync(OffsetDateTime datetimeBody) {
         return putLocalPositiveOffsetMaxDateTimeWithResponseAsync(datetimeBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put max datetime value with positive numoffset 9999-12-31t23:59:59.999+14:00.
+     * 
+     * @param datetimeBody MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putLocalPositiveOffsetMaxDateTime(OffsetDateTime datetimeBody) {
         putLocalPositiveOffsetMaxDateTimeAsync(datetimeBody).block();
     }
 
+    /**
+     * Get max datetime value with positive num offset 9999-12-31t23:59:59.999+14:00.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<OffsetDateTime>> getLocalPositiveOffsetLowercaseMaxDateTimeWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -362,6 +624,12 @@ public final class Datetimes {
         return service.getLocalPositiveOffsetLowercaseMaxDateTime(this.client.getHost());
     }
 
+    /**
+     * Get max datetime value with positive num offset 9999-12-31t23:59:59.999+14:00.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<OffsetDateTime> getLocalPositiveOffsetLowercaseMaxDateTimeAsync() {
         return getLocalPositiveOffsetLowercaseMaxDateTimeWithResponseAsync()
@@ -374,11 +642,23 @@ public final class Datetimes {
             });
     }
 
+    /**
+     * Get max datetime value with positive num offset 9999-12-31t23:59:59.999+14:00.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getLocalPositiveOffsetLowercaseMaxDateTime() {
         return getLocalPositiveOffsetLowercaseMaxDateTimeAsync().block();
     }
 
+    /**
+     * Get max datetime value with positive num offset 9999-12-31T23:59:59.999+14:00.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<OffsetDateTime>> getLocalPositiveOffsetUppercaseMaxDateTimeWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -387,6 +667,12 @@ public final class Datetimes {
         return service.getLocalPositiveOffsetUppercaseMaxDateTime(this.client.getHost());
     }
 
+    /**
+     * Get max datetime value with positive num offset 9999-12-31T23:59:59.999+14:00.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<OffsetDateTime> getLocalPositiveOffsetUppercaseMaxDateTimeAsync() {
         return getLocalPositiveOffsetUppercaseMaxDateTimeWithResponseAsync()
@@ -399,11 +685,25 @@ public final class Datetimes {
             });
     }
 
+    /**
+     * Get max datetime value with positive num offset 9999-12-31T23:59:59.999+14:00.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getLocalPositiveOffsetUppercaseMaxDateTime() {
         return getLocalPositiveOffsetUppercaseMaxDateTimeAsync().block();
     }
 
+    /**
+     * Put max datetime value with positive numoffset 9999-12-31t23:59:59.999-14:00.
+     * 
+     * @param datetimeBody MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putLocalNegativeOffsetMaxDateTimeWithResponseAsync(OffsetDateTime datetimeBody) {
         if (this.client.getHost() == null) {
@@ -415,17 +715,39 @@ public final class Datetimes {
         return service.putLocalNegativeOffsetMaxDateTime(this.client.getHost(), datetimeBody);
     }
 
+    /**
+     * Put max datetime value with positive numoffset 9999-12-31t23:59:59.999-14:00.
+     * 
+     * @param datetimeBody MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putLocalNegativeOffsetMaxDateTimeAsync(OffsetDateTime datetimeBody) {
         return putLocalNegativeOffsetMaxDateTimeWithResponseAsync(datetimeBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put max datetime value with positive numoffset 9999-12-31t23:59:59.999-14:00.
+     * 
+     * @param datetimeBody MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putLocalNegativeOffsetMaxDateTime(OffsetDateTime datetimeBody) {
         putLocalNegativeOffsetMaxDateTimeAsync(datetimeBody).block();
     }
 
+    /**
+     * Get max datetime value with positive num offset 9999-12-31T23:59:59.999-14:00.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<OffsetDateTime>> getLocalNegativeOffsetUppercaseMaxDateTimeWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -434,6 +756,12 @@ public final class Datetimes {
         return service.getLocalNegativeOffsetUppercaseMaxDateTime(this.client.getHost());
     }
 
+    /**
+     * Get max datetime value with positive num offset 9999-12-31T23:59:59.999-14:00.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<OffsetDateTime> getLocalNegativeOffsetUppercaseMaxDateTimeAsync() {
         return getLocalNegativeOffsetUppercaseMaxDateTimeWithResponseAsync()
@@ -446,11 +774,23 @@ public final class Datetimes {
             });
     }
 
+    /**
+     * Get max datetime value with positive num offset 9999-12-31T23:59:59.999-14:00.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getLocalNegativeOffsetUppercaseMaxDateTime() {
         return getLocalNegativeOffsetUppercaseMaxDateTimeAsync().block();
     }
 
+    /**
+     * Get max datetime value with positive num offset 9999-12-31t23:59:59.999-14:00.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<OffsetDateTime>> getLocalNegativeOffsetLowercaseMaxDateTimeWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -459,6 +799,12 @@ public final class Datetimes {
         return service.getLocalNegativeOffsetLowercaseMaxDateTime(this.client.getHost());
     }
 
+    /**
+     * Get max datetime value with positive num offset 9999-12-31t23:59:59.999-14:00.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<OffsetDateTime> getLocalNegativeOffsetLowercaseMaxDateTimeAsync() {
         return getLocalNegativeOffsetLowercaseMaxDateTimeWithResponseAsync()
@@ -471,11 +817,25 @@ public final class Datetimes {
             });
     }
 
+    /**
+     * Get max datetime value with positive num offset 9999-12-31t23:59:59.999-14:00.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getLocalNegativeOffsetLowercaseMaxDateTime() {
         return getLocalNegativeOffsetLowercaseMaxDateTimeAsync().block();
     }
 
+    /**
+     * Put min datetime value 0001-01-01T00:00:00Z.
+     * 
+     * @param datetimeBody MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putUtcMinDateTimeWithResponseAsync(OffsetDateTime datetimeBody) {
         if (this.client.getHost() == null) {
@@ -487,17 +847,39 @@ public final class Datetimes {
         return service.putUtcMinDateTime(this.client.getHost(), datetimeBody);
     }
 
+    /**
+     * Put min datetime value 0001-01-01T00:00:00Z.
+     * 
+     * @param datetimeBody MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putUtcMinDateTimeAsync(OffsetDateTime datetimeBody) {
         return putUtcMinDateTimeWithResponseAsync(datetimeBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put min datetime value 0001-01-01T00:00:00Z.
+     * 
+     * @param datetimeBody MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putUtcMinDateTime(OffsetDateTime datetimeBody) {
         putUtcMinDateTimeAsync(datetimeBody).block();
     }
 
+    /**
+     * Get min datetime value 0001-01-01T00:00:00Z.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<OffsetDateTime>> getUtcMinDateTimeWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -506,6 +888,12 @@ public final class Datetimes {
         return service.getUtcMinDateTime(this.client.getHost());
     }
 
+    /**
+     * Get min datetime value 0001-01-01T00:00:00Z.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<OffsetDateTime> getUtcMinDateTimeAsync() {
         return getUtcMinDateTimeWithResponseAsync()
@@ -518,11 +906,25 @@ public final class Datetimes {
             });
     }
 
+    /**
+     * Get min datetime value 0001-01-01T00:00:00Z.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getUtcMinDateTime() {
         return getUtcMinDateTimeAsync().block();
     }
 
+    /**
+     * Put min datetime value 0001-01-01T00:00:00+14:00.
+     * 
+     * @param datetimeBody MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putLocalPositiveOffsetMinDateTimeWithResponseAsync(OffsetDateTime datetimeBody) {
         if (this.client.getHost() == null) {
@@ -534,17 +936,39 @@ public final class Datetimes {
         return service.putLocalPositiveOffsetMinDateTime(this.client.getHost(), datetimeBody);
     }
 
+    /**
+     * Put min datetime value 0001-01-01T00:00:00+14:00.
+     * 
+     * @param datetimeBody MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putLocalPositiveOffsetMinDateTimeAsync(OffsetDateTime datetimeBody) {
         return putLocalPositiveOffsetMinDateTimeWithResponseAsync(datetimeBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put min datetime value 0001-01-01T00:00:00+14:00.
+     * 
+     * @param datetimeBody MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putLocalPositiveOffsetMinDateTime(OffsetDateTime datetimeBody) {
         putLocalPositiveOffsetMinDateTimeAsync(datetimeBody).block();
     }
 
+    /**
+     * Get min datetime value 0001-01-01T00:00:00+14:00.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<OffsetDateTime>> getLocalPositiveOffsetMinDateTimeWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -553,6 +977,12 @@ public final class Datetimes {
         return service.getLocalPositiveOffsetMinDateTime(this.client.getHost());
     }
 
+    /**
+     * Get min datetime value 0001-01-01T00:00:00+14:00.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<OffsetDateTime> getLocalPositiveOffsetMinDateTimeAsync() {
         return getLocalPositiveOffsetMinDateTimeWithResponseAsync()
@@ -565,11 +995,25 @@ public final class Datetimes {
             });
     }
 
+    /**
+     * Get min datetime value 0001-01-01T00:00:00+14:00.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getLocalPositiveOffsetMinDateTime() {
         return getLocalPositiveOffsetMinDateTimeAsync().block();
     }
 
+    /**
+     * Put min datetime value 0001-01-01T00:00:00-14:00.
+     * 
+     * @param datetimeBody MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putLocalNegativeOffsetMinDateTimeWithResponseAsync(OffsetDateTime datetimeBody) {
         if (this.client.getHost() == null) {
@@ -581,17 +1025,39 @@ public final class Datetimes {
         return service.putLocalNegativeOffsetMinDateTime(this.client.getHost(), datetimeBody);
     }
 
+    /**
+     * Put min datetime value 0001-01-01T00:00:00-14:00.
+     * 
+     * @param datetimeBody MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putLocalNegativeOffsetMinDateTimeAsync(OffsetDateTime datetimeBody) {
         return putLocalNegativeOffsetMinDateTimeWithResponseAsync(datetimeBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put min datetime value 0001-01-01T00:00:00-14:00.
+     * 
+     * @param datetimeBody MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putLocalNegativeOffsetMinDateTime(OffsetDateTime datetimeBody) {
         putLocalNegativeOffsetMinDateTimeAsync(datetimeBody).block();
     }
 
+    /**
+     * Get min datetime value 0001-01-01T00:00:00-14:00.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<OffsetDateTime>> getLocalNegativeOffsetMinDateTimeWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -600,6 +1066,12 @@ public final class Datetimes {
         return service.getLocalNegativeOffsetMinDateTime(this.client.getHost());
     }
 
+    /**
+     * Get min datetime value 0001-01-01T00:00:00-14:00.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<OffsetDateTime> getLocalNegativeOffsetMinDateTimeAsync() {
         return getLocalNegativeOffsetMinDateTimeWithResponseAsync()
@@ -612,6 +1084,12 @@ public final class Datetimes {
             });
     }
 
+    /**
+     * Get min datetime value 0001-01-01T00:00:00-14:00.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getLocalNegativeOffsetMinDateTime() {
         return getLocalNegativeOffsetMinDateTimeAsync().block();

--- a/tests/src/main/java/fixtures/bodydatetimerfc1123/Datetimerfc1123s.java
+++ b/tests/src/main/java/fixtures/bodydatetimerfc1123/Datetimerfc1123s.java
@@ -105,6 +105,12 @@ public final class Datetimerfc1123s {
         Mono<SimpleResponse<OffsetDateTime>> getUtcMinDateTime(@HostParam("$host") String host);
     }
 
+    /**
+     * Get null datetime value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<OffsetDateTime>> getNullWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -113,6 +119,12 @@ public final class Datetimerfc1123s {
         return service.getNull(this.client.getHost());
     }
 
+    /**
+     * Get null datetime value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<OffsetDateTime> getNullAsync() {
         return getNullWithResponseAsync()
@@ -125,11 +137,23 @@ public final class Datetimerfc1123s {
             });
     }
 
+    /**
+     * Get null datetime value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getNull() {
         return getNullAsync().block();
     }
 
+    /**
+     * Get invalid datetime value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<OffsetDateTime>> getInvalidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -138,6 +162,12 @@ public final class Datetimerfc1123s {
         return service.getInvalid(this.client.getHost());
     }
 
+    /**
+     * Get invalid datetime value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<OffsetDateTime> getInvalidAsync() {
         return getInvalidWithResponseAsync()
@@ -150,11 +180,23 @@ public final class Datetimerfc1123s {
             });
     }
 
+    /**
+     * Get invalid datetime value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getInvalid() {
         return getInvalidAsync().block();
     }
 
+    /**
+     * Get overflow datetime value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<OffsetDateTime>> getOverflowWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -163,6 +205,12 @@ public final class Datetimerfc1123s {
         return service.getOverflow(this.client.getHost());
     }
 
+    /**
+     * Get overflow datetime value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<OffsetDateTime> getOverflowAsync() {
         return getOverflowWithResponseAsync()
@@ -175,11 +223,23 @@ public final class Datetimerfc1123s {
             });
     }
 
+    /**
+     * Get overflow datetime value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getOverflow() {
         return getOverflowAsync().block();
     }
 
+    /**
+     * Get underflow datetime value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<OffsetDateTime>> getUnderflowWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -188,6 +248,12 @@ public final class Datetimerfc1123s {
         return service.getUnderflow(this.client.getHost());
     }
 
+    /**
+     * Get underflow datetime value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<OffsetDateTime> getUnderflowAsync() {
         return getUnderflowWithResponseAsync()
@@ -200,11 +266,25 @@ public final class Datetimerfc1123s {
             });
     }
 
+    /**
+     * Get underflow datetime value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getUnderflow() {
         return getUnderflowAsync().block();
     }
 
+    /**
+     * Put max datetime value Fri, 31 Dec 9999 23:59:59 GMT.
+     * 
+     * @param datetimeBody MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putUtcMaxDateTimeWithResponseAsync(OffsetDateTime datetimeBody) {
         if (this.client.getHost() == null) {
@@ -217,17 +297,39 @@ public final class Datetimerfc1123s {
         return service.putUtcMaxDateTime(this.client.getHost(), datetimeBodyConverted);
     }
 
+    /**
+     * Put max datetime value Fri, 31 Dec 9999 23:59:59 GMT.
+     * 
+     * @param datetimeBody MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putUtcMaxDateTimeAsync(OffsetDateTime datetimeBody) {
         return putUtcMaxDateTimeWithResponseAsync(datetimeBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put max datetime value Fri, 31 Dec 9999 23:59:59 GMT.
+     * 
+     * @param datetimeBody MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putUtcMaxDateTime(OffsetDateTime datetimeBody) {
         putUtcMaxDateTimeAsync(datetimeBody).block();
     }
 
+    /**
+     * Get max datetime value fri, 31 dec 9999 23:59:59 gmt.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<OffsetDateTime>> getUtcLowercaseMaxDateTimeWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -236,6 +338,12 @@ public final class Datetimerfc1123s {
         return service.getUtcLowercaseMaxDateTime(this.client.getHost());
     }
 
+    /**
+     * Get max datetime value fri, 31 dec 9999 23:59:59 gmt.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<OffsetDateTime> getUtcLowercaseMaxDateTimeAsync() {
         return getUtcLowercaseMaxDateTimeWithResponseAsync()
@@ -248,11 +356,23 @@ public final class Datetimerfc1123s {
             });
     }
 
+    /**
+     * Get max datetime value fri, 31 dec 9999 23:59:59 gmt.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getUtcLowercaseMaxDateTime() {
         return getUtcLowercaseMaxDateTimeAsync().block();
     }
 
+    /**
+     * Get max datetime value FRI, 31 DEC 9999 23:59:59 GMT.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<OffsetDateTime>> getUtcUppercaseMaxDateTimeWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -261,6 +381,12 @@ public final class Datetimerfc1123s {
         return service.getUtcUppercaseMaxDateTime(this.client.getHost());
     }
 
+    /**
+     * Get max datetime value FRI, 31 DEC 9999 23:59:59 GMT.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<OffsetDateTime> getUtcUppercaseMaxDateTimeAsync() {
         return getUtcUppercaseMaxDateTimeWithResponseAsync()
@@ -273,11 +399,25 @@ public final class Datetimerfc1123s {
             });
     }
 
+    /**
+     * Get max datetime value FRI, 31 DEC 9999 23:59:59 GMT.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getUtcUppercaseMaxDateTime() {
         return getUtcUppercaseMaxDateTimeAsync().block();
     }
 
+    /**
+     * Put min datetime value Mon, 1 Jan 0001 00:00:00 GMT.
+     * 
+     * @param datetimeBody MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putUtcMinDateTimeWithResponseAsync(OffsetDateTime datetimeBody) {
         if (this.client.getHost() == null) {
@@ -290,17 +430,39 @@ public final class Datetimerfc1123s {
         return service.putUtcMinDateTime(this.client.getHost(), datetimeBodyConverted);
     }
 
+    /**
+     * Put min datetime value Mon, 1 Jan 0001 00:00:00 GMT.
+     * 
+     * @param datetimeBody MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putUtcMinDateTimeAsync(OffsetDateTime datetimeBody) {
         return putUtcMinDateTimeWithResponseAsync(datetimeBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put min datetime value Mon, 1 Jan 0001 00:00:00 GMT.
+     * 
+     * @param datetimeBody MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putUtcMinDateTime(OffsetDateTime datetimeBody) {
         putUtcMinDateTimeAsync(datetimeBody).block();
     }
 
+    /**
+     * Get min datetime value Mon, 1 Jan 0001 00:00:00 GMT.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<OffsetDateTime>> getUtcMinDateTimeWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -309,6 +471,12 @@ public final class Datetimerfc1123s {
         return service.getUtcMinDateTime(this.client.getHost());
     }
 
+    /**
+     * Get min datetime value Mon, 1 Jan 0001 00:00:00 GMT.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<OffsetDateTime> getUtcMinDateTimeAsync() {
         return getUtcMinDateTimeWithResponseAsync()
@@ -321,6 +489,12 @@ public final class Datetimerfc1123s {
             });
     }
 
+    /**
+     * Get min datetime value Mon, 1 Jan 0001 00:00:00 GMT.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getUtcMinDateTime() {
         return getUtcMinDateTimeAsync().block();

--- a/tests/src/main/java/fixtures/bodydictionary/Dictionarys.java
+++ b/tests/src/main/java/fixtures/bodydictionary/Dictionarys.java
@@ -389,6 +389,12 @@ public final class Dictionarys {
         Mono<Response<Void>> putDictionaryValid(@HostParam("$host") String host, @BodyParam("application/json") Map<String, Object> arrayBody);
     }
 
+    /**
+     * Get null dictionary value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, Integer>>> getNullWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -397,6 +403,12 @@ public final class Dictionarys {
         return service.getNull(this.client.getHost());
     }
 
+    /**
+     * Get null dictionary value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Integer>> getNullAsync() {
         return getNullWithResponseAsync()
@@ -409,11 +421,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get null dictionary value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Integer> getNull() {
         return getNullAsync().block();
     }
 
+    /**
+     * Get empty dictionary value {}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, Integer>>> getEmptyWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -422,6 +446,12 @@ public final class Dictionarys {
         return service.getEmpty(this.client.getHost());
     }
 
+    /**
+     * Get empty dictionary value {}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Integer>> getEmptyAsync() {
         return getEmptyWithResponseAsync()
@@ -434,11 +464,25 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get empty dictionary value {}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Integer> getEmpty() {
         return getEmptyAsync().block();
     }
 
+    /**
+     * Set dictionary value empty {}.
+     * 
+     * @param arrayBody Dictionary of &lt;paths·dictionary-nullvalue·get·responses·200·content·application-json·schema·additionalproperties&gt;.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putEmptyWithResponseAsync(Map<String, String> arrayBody) {
         if (this.client.getHost() == null) {
@@ -450,17 +494,39 @@ public final class Dictionarys {
         return service.putEmpty(this.client.getHost(), arrayBody);
     }
 
+    /**
+     * Set dictionary value empty {}.
+     * 
+     * @param arrayBody Dictionary of &lt;paths·dictionary-nullvalue·get·responses·200·content·application-json·schema·additionalproperties&gt;.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putEmptyAsync(Map<String, String> arrayBody) {
         return putEmptyWithResponseAsync(arrayBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Set dictionary value empty {}.
+     * 
+     * @param arrayBody Dictionary of &lt;paths·dictionary-nullvalue·get·responses·200·content·application-json·schema·additionalproperties&gt;.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putEmpty(Map<String, String> arrayBody) {
         putEmptyAsync(arrayBody).block();
     }
 
+    /**
+     * Get Dictionary with null value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, String>>> getNullValueWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -469,6 +535,12 @@ public final class Dictionarys {
         return service.getNullValue(this.client.getHost());
     }
 
+    /**
+     * Get Dictionary with null value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, String>> getNullValueAsync() {
         return getNullValueWithResponseAsync()
@@ -481,11 +553,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get Dictionary with null value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, String> getNullValue() {
         return getNullValueAsync().block();
     }
 
+    /**
+     * Get Dictionary with null key.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, String>>> getNullKeyWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -494,6 +578,12 @@ public final class Dictionarys {
         return service.getNullKey(this.client.getHost());
     }
 
+    /**
+     * Get Dictionary with null key.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, String>> getNullKeyAsync() {
         return getNullKeyWithResponseAsync()
@@ -506,11 +596,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get Dictionary with null key.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, String> getNullKey() {
         return getNullKeyAsync().block();
     }
 
+    /**
+     * Get Dictionary with key as empty string.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, String>>> getEmptyStringKeyWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -519,6 +621,12 @@ public final class Dictionarys {
         return service.getEmptyStringKey(this.client.getHost());
     }
 
+    /**
+     * Get Dictionary with key as empty string.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, String>> getEmptyStringKeyAsync() {
         return getEmptyStringKeyWithResponseAsync()
@@ -531,11 +639,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get Dictionary with key as empty string.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, String> getEmptyStringKey() {
         return getEmptyStringKeyAsync().block();
     }
 
+    /**
+     * Get invalid Dictionary value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, String>>> getInvalidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -544,6 +664,12 @@ public final class Dictionarys {
         return service.getInvalid(this.client.getHost());
     }
 
+    /**
+     * Get invalid Dictionary value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, String>> getInvalidAsync() {
         return getInvalidWithResponseAsync()
@@ -556,11 +682,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get invalid Dictionary value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, String> getInvalid() {
         return getInvalidAsync().block();
     }
 
+    /**
+     * Get boolean dictionary value {"0": true, "1": false, "2": false, "3": true }.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, Boolean>>> getBooleanTfftWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -569,6 +707,12 @@ public final class Dictionarys {
         return service.getBooleanTfft(this.client.getHost());
     }
 
+    /**
+     * Get boolean dictionary value {"0": true, "1": false, "2": false, "3": true }.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Boolean>> getBooleanTfftAsync() {
         return getBooleanTfftWithResponseAsync()
@@ -581,11 +725,25 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get boolean dictionary value {"0": true, "1": false, "2": false, "3": true }.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Boolean> getBooleanTfft() {
         return getBooleanTfftAsync().block();
     }
 
+    /**
+     * Set dictionary value empty {"0": true, "1": false, "2": false, "3": true }.
+     * 
+     * @param arrayBody The dictionary value {"0": true, "1": false, "2": false, "3": true }.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putBooleanTfftWithResponseAsync(Map<String, Boolean> arrayBody) {
         if (this.client.getHost() == null) {
@@ -597,17 +755,39 @@ public final class Dictionarys {
         return service.putBooleanTfft(this.client.getHost(), arrayBody);
     }
 
+    /**
+     * Set dictionary value empty {"0": true, "1": false, "2": false, "3": true }.
+     * 
+     * @param arrayBody The dictionary value {"0": true, "1": false, "2": false, "3": true }.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putBooleanTfftAsync(Map<String, Boolean> arrayBody) {
         return putBooleanTfftWithResponseAsync(arrayBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Set dictionary value empty {"0": true, "1": false, "2": false, "3": true }.
+     * 
+     * @param arrayBody The dictionary value {"0": true, "1": false, "2": false, "3": true }.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putBooleanTfft(Map<String, Boolean> arrayBody) {
         putBooleanTfftAsync(arrayBody).block();
     }
 
+    /**
+     * Get boolean dictionary value {"0": true, "1": null, "2": false }.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, Boolean>>> getBooleanInvalidNullWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -616,6 +796,12 @@ public final class Dictionarys {
         return service.getBooleanInvalidNull(this.client.getHost());
     }
 
+    /**
+     * Get boolean dictionary value {"0": true, "1": null, "2": false }.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Boolean>> getBooleanInvalidNullAsync() {
         return getBooleanInvalidNullWithResponseAsync()
@@ -628,11 +814,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get boolean dictionary value {"0": true, "1": null, "2": false }.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Boolean> getBooleanInvalidNull() {
         return getBooleanInvalidNullAsync().block();
     }
 
+    /**
+     * Get boolean dictionary value '{"0": true, "1": "boolean", "2": false}'.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, Boolean>>> getBooleanInvalidStringWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -641,6 +839,12 @@ public final class Dictionarys {
         return service.getBooleanInvalidString(this.client.getHost());
     }
 
+    /**
+     * Get boolean dictionary value '{"0": true, "1": "boolean", "2": false}'.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Boolean>> getBooleanInvalidStringAsync() {
         return getBooleanInvalidStringWithResponseAsync()
@@ -653,11 +857,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get boolean dictionary value '{"0": true, "1": "boolean", "2": false}'.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Boolean> getBooleanInvalidString() {
         return getBooleanInvalidStringAsync().block();
     }
 
+    /**
+     * Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, Integer>>> getIntegerValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -666,6 +882,12 @@ public final class Dictionarys {
         return service.getIntegerValid(this.client.getHost());
     }
 
+    /**
+     * Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Integer>> getIntegerValidAsync() {
         return getIntegerValidWithResponseAsync()
@@ -678,11 +900,25 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Integer> getIntegerValid() {
         return getIntegerValidAsync().block();
     }
 
+    /**
+     * Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}.
+     * 
+     * @param arrayBody The null dictionary value.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putIntegerValidWithResponseAsync(Map<String, Integer> arrayBody) {
         if (this.client.getHost() == null) {
@@ -694,17 +930,39 @@ public final class Dictionarys {
         return service.putIntegerValid(this.client.getHost(), arrayBody);
     }
 
+    /**
+     * Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}.
+     * 
+     * @param arrayBody The null dictionary value.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putIntegerValidAsync(Map<String, Integer> arrayBody) {
         return putIntegerValidWithResponseAsync(arrayBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}.
+     * 
+     * @param arrayBody The null dictionary value.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putIntegerValid(Map<String, Integer> arrayBody) {
         putIntegerValidAsync(arrayBody).block();
     }
 
+    /**
+     * Get integer dictionary value {"0": 1, "1": null, "2": 0}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, Integer>>> getIntInvalidNullWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -713,6 +971,12 @@ public final class Dictionarys {
         return service.getIntInvalidNull(this.client.getHost());
     }
 
+    /**
+     * Get integer dictionary value {"0": 1, "1": null, "2": 0}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Integer>> getIntInvalidNullAsync() {
         return getIntInvalidNullWithResponseAsync()
@@ -725,11 +989,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get integer dictionary value {"0": 1, "1": null, "2": 0}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Integer> getIntInvalidNull() {
         return getIntInvalidNullAsync().block();
     }
 
+    /**
+     * Get integer dictionary value {"0": 1, "1": "integer", "2": 0}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, Integer>>> getIntInvalidStringWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -738,6 +1014,12 @@ public final class Dictionarys {
         return service.getIntInvalidString(this.client.getHost());
     }
 
+    /**
+     * Get integer dictionary value {"0": 1, "1": "integer", "2": 0}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Integer>> getIntInvalidStringAsync() {
         return getIntInvalidStringWithResponseAsync()
@@ -750,11 +1032,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get integer dictionary value {"0": 1, "1": "integer", "2": 0}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Integer> getIntInvalidString() {
         return getIntInvalidStringAsync().block();
     }
 
+    /**
+     * Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, Long>>> getLongValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -763,6 +1057,12 @@ public final class Dictionarys {
         return service.getLongValid(this.client.getHost());
     }
 
+    /**
+     * Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Long>> getLongValidAsync() {
         return getLongValidWithResponseAsync()
@@ -775,11 +1075,25 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Long> getLongValid() {
         return getLongValidAsync().block();
     }
 
+    /**
+     * Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}.
+     * 
+     * @param arrayBody The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putLongValidWithResponseAsync(Map<String, Long> arrayBody) {
         if (this.client.getHost() == null) {
@@ -791,17 +1105,39 @@ public final class Dictionarys {
         return service.putLongValid(this.client.getHost(), arrayBody);
     }
 
+    /**
+     * Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}.
+     * 
+     * @param arrayBody The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putLongValidAsync(Map<String, Long> arrayBody) {
         return putLongValidWithResponseAsync(arrayBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}.
+     * 
+     * @param arrayBody The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putLongValid(Map<String, Long> arrayBody) {
         putLongValidAsync(arrayBody).block();
     }
 
+    /**
+     * Get long dictionary value {"0": 1, "1": null, "2": 0}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, Long>>> getLongInvalidNullWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -810,6 +1146,12 @@ public final class Dictionarys {
         return service.getLongInvalidNull(this.client.getHost());
     }
 
+    /**
+     * Get long dictionary value {"0": 1, "1": null, "2": 0}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Long>> getLongInvalidNullAsync() {
         return getLongInvalidNullWithResponseAsync()
@@ -822,11 +1164,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get long dictionary value {"0": 1, "1": null, "2": 0}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Long> getLongInvalidNull() {
         return getLongInvalidNullAsync().block();
     }
 
+    /**
+     * Get long dictionary value {"0": 1, "1": "integer", "2": 0}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, Long>>> getLongInvalidStringWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -835,6 +1189,12 @@ public final class Dictionarys {
         return service.getLongInvalidString(this.client.getHost());
     }
 
+    /**
+     * Get long dictionary value {"0": 1, "1": "integer", "2": 0}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Long>> getLongInvalidStringAsync() {
         return getLongInvalidStringWithResponseAsync()
@@ -847,11 +1207,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get long dictionary value {"0": 1, "1": "integer", "2": 0}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Long> getLongInvalidString() {
         return getLongInvalidStringAsync().block();
     }
 
+    /**
+     * Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, Float>>> getFloatValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -860,6 +1232,12 @@ public final class Dictionarys {
         return service.getFloatValid(this.client.getHost());
     }
 
+    /**
+     * Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Float>> getFloatValidAsync() {
         return getFloatValidWithResponseAsync()
@@ -872,11 +1250,25 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Float> getFloatValid() {
         return getFloatValidAsync().block();
     }
 
+    /**
+     * Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     * 
+     * @param arrayBody The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putFloatValidWithResponseAsync(Map<String, Float> arrayBody) {
         if (this.client.getHost() == null) {
@@ -888,17 +1280,39 @@ public final class Dictionarys {
         return service.putFloatValid(this.client.getHost(), arrayBody);
     }
 
+    /**
+     * Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     * 
+     * @param arrayBody The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putFloatValidAsync(Map<String, Float> arrayBody) {
         return putFloatValidWithResponseAsync(arrayBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     * 
+     * @param arrayBody The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putFloatValid(Map<String, Float> arrayBody) {
         putFloatValidAsync(arrayBody).block();
     }
 
+    /**
+     * Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, Float>>> getFloatInvalidNullWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -907,6 +1321,12 @@ public final class Dictionarys {
         return service.getFloatInvalidNull(this.client.getHost());
     }
 
+    /**
+     * Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Float>> getFloatInvalidNullAsync() {
         return getFloatInvalidNullWithResponseAsync()
@@ -919,11 +1339,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Float> getFloatInvalidNull() {
         return getFloatInvalidNullAsync().block();
     }
 
+    /**
+     * Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, Float>>> getFloatInvalidStringWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -932,6 +1364,12 @@ public final class Dictionarys {
         return service.getFloatInvalidString(this.client.getHost());
     }
 
+    /**
+     * Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Float>> getFloatInvalidStringAsync() {
         return getFloatInvalidStringWithResponseAsync()
@@ -944,11 +1382,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Float> getFloatInvalidString() {
         return getFloatInvalidStringAsync().block();
     }
 
+    /**
+     * Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, Double>>> getDoubleValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -957,6 +1407,12 @@ public final class Dictionarys {
         return service.getDoubleValid(this.client.getHost());
     }
 
+    /**
+     * Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Double>> getDoubleValidAsync() {
         return getDoubleValidWithResponseAsync()
@@ -969,11 +1425,25 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Double> getDoubleValid() {
         return getDoubleValidAsync().block();
     }
 
+    /**
+     * Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     * 
+     * @param arrayBody The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putDoubleValidWithResponseAsync(Map<String, Double> arrayBody) {
         if (this.client.getHost() == null) {
@@ -985,17 +1455,39 @@ public final class Dictionarys {
         return service.putDoubleValid(this.client.getHost(), arrayBody);
     }
 
+    /**
+     * Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     * 
+     * @param arrayBody The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putDoubleValidAsync(Map<String, Double> arrayBody) {
         return putDoubleValidWithResponseAsync(arrayBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     * 
+     * @param arrayBody The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDoubleValid(Map<String, Double> arrayBody) {
         putDoubleValidAsync(arrayBody).block();
     }
 
+    /**
+     * Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, Double>>> getDoubleInvalidNullWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -1004,6 +1496,12 @@ public final class Dictionarys {
         return service.getDoubleInvalidNull(this.client.getHost());
     }
 
+    /**
+     * Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Double>> getDoubleInvalidNullAsync() {
         return getDoubleInvalidNullWithResponseAsync()
@@ -1016,11 +1514,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Double> getDoubleInvalidNull() {
         return getDoubleInvalidNullAsync().block();
     }
 
+    /**
+     * Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, Double>>> getDoubleInvalidStringWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -1029,6 +1539,12 @@ public final class Dictionarys {
         return service.getDoubleInvalidString(this.client.getHost());
     }
 
+    /**
+     * Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Double>> getDoubleInvalidStringAsync() {
         return getDoubleInvalidStringWithResponseAsync()
@@ -1041,11 +1557,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Double> getDoubleInvalidString() {
         return getDoubleInvalidStringAsync().block();
     }
 
+    /**
+     * Get string dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, String>>> getStringValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -1054,6 +1582,12 @@ public final class Dictionarys {
         return service.getStringValid(this.client.getHost());
     }
 
+    /**
+     * Get string dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, String>> getStringValidAsync() {
         return getStringValidWithResponseAsync()
@@ -1066,11 +1600,25 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get string dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, String> getStringValid() {
         return getStringValidAsync().block();
     }
 
+    /**
+     * Set dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
+     * 
+     * @param arrayBody Dictionary of &lt;paths·dictionary-nullvalue·get·responses·200·content·application-json·schema·additionalproperties&gt;.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putStringValidWithResponseAsync(Map<String, String> arrayBody) {
         if (this.client.getHost() == null) {
@@ -1082,17 +1630,39 @@ public final class Dictionarys {
         return service.putStringValid(this.client.getHost(), arrayBody);
     }
 
+    /**
+     * Set dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
+     * 
+     * @param arrayBody Dictionary of &lt;paths·dictionary-nullvalue·get·responses·200·content·application-json·schema·additionalproperties&gt;.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putStringValidAsync(Map<String, String> arrayBody) {
         return putStringValidWithResponseAsync(arrayBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Set dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}.
+     * 
+     * @param arrayBody Dictionary of &lt;paths·dictionary-nullvalue·get·responses·200·content·application-json·schema·additionalproperties&gt;.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putStringValid(Map<String, String> arrayBody) {
         putStringValidAsync(arrayBody).block();
     }
 
+    /**
+     * Get string dictionary value {"0": "foo", "1": null, "2": "foo2"}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, String>>> getStringWithNullWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -1101,6 +1671,12 @@ public final class Dictionarys {
         return service.getStringWithNull(this.client.getHost());
     }
 
+    /**
+     * Get string dictionary value {"0": "foo", "1": null, "2": "foo2"}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, String>> getStringWithNullAsync() {
         return getStringWithNullWithResponseAsync()
@@ -1113,11 +1689,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get string dictionary value {"0": "foo", "1": null, "2": "foo2"}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, String> getStringWithNull() {
         return getStringWithNullAsync().block();
     }
 
+    /**
+     * Get string dictionary value {"0": "foo", "1": 123, "2": "foo2"}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, String>>> getStringWithInvalidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -1126,6 +1714,12 @@ public final class Dictionarys {
         return service.getStringWithInvalid(this.client.getHost());
     }
 
+    /**
+     * Get string dictionary value {"0": "foo", "1": 123, "2": "foo2"}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, String>> getStringWithInvalidAsync() {
         return getStringWithInvalidWithResponseAsync()
@@ -1138,11 +1732,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get string dictionary value {"0": "foo", "1": 123, "2": "foo2"}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, String> getStringWithInvalid() {
         return getStringWithInvalidAsync().block();
     }
 
+    /**
+     * Get integer dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, LocalDate>>> getDateValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -1151,6 +1757,12 @@ public final class Dictionarys {
         return service.getDateValid(this.client.getHost());
     }
 
+    /**
+     * Get integer dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, LocalDate>> getDateValidAsync() {
         return getDateValidWithResponseAsync()
@@ -1163,11 +1775,25 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get integer dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, LocalDate> getDateValid() {
         return getDateValidAsync().block();
     }
 
+    /**
+     * Set dictionary value  {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
+     * 
+     * @param arrayBody The dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putDateValidWithResponseAsync(Map<String, LocalDate> arrayBody) {
         if (this.client.getHost() == null) {
@@ -1179,17 +1805,39 @@ public final class Dictionarys {
         return service.putDateValid(this.client.getHost(), arrayBody);
     }
 
+    /**
+     * Set dictionary value  {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
+     * 
+     * @param arrayBody The dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putDateValidAsync(Map<String, LocalDate> arrayBody) {
         return putDateValidWithResponseAsync(arrayBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Set dictionary value  {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
+     * 
+     * @param arrayBody The dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDateValid(Map<String, LocalDate> arrayBody) {
         putDateValidAsync(arrayBody).block();
     }
 
+    /**
+     * Get date dictionary value {"0": "2012-01-01", "1": null, "2": "1776-07-04"}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, LocalDate>>> getDateInvalidNullWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -1198,6 +1846,12 @@ public final class Dictionarys {
         return service.getDateInvalidNull(this.client.getHost());
     }
 
+    /**
+     * Get date dictionary value {"0": "2012-01-01", "1": null, "2": "1776-07-04"}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, LocalDate>> getDateInvalidNullAsync() {
         return getDateInvalidNullWithResponseAsync()
@@ -1210,11 +1864,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get date dictionary value {"0": "2012-01-01", "1": null, "2": "1776-07-04"}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, LocalDate> getDateInvalidNull() {
         return getDateInvalidNullAsync().block();
     }
 
+    /**
+     * Get date dictionary value {"0": "2011-03-22", "1": "date"}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, LocalDate>>> getDateInvalidCharsWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -1223,6 +1889,12 @@ public final class Dictionarys {
         return service.getDateInvalidChars(this.client.getHost());
     }
 
+    /**
+     * Get date dictionary value {"0": "2011-03-22", "1": "date"}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, LocalDate>> getDateInvalidCharsAsync() {
         return getDateInvalidCharsWithResponseAsync()
@@ -1235,11 +1907,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get date dictionary value {"0": "2011-03-22", "1": "date"}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, LocalDate> getDateInvalidChars() {
         return getDateInvalidCharsAsync().block();
     }
 
+    /**
+     * Get date-time dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, OffsetDateTime>>> getDateTimeValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -1248,6 +1932,12 @@ public final class Dictionarys {
         return service.getDateTimeValid(this.client.getHost());
     }
 
+    /**
+     * Get date-time dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, OffsetDateTime>> getDateTimeValidAsync() {
         return getDateTimeValidWithResponseAsync()
@@ -1260,11 +1950,25 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get date-time dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, OffsetDateTime> getDateTimeValid() {
         return getDateTimeValidAsync().block();
     }
 
+    /**
+     * Set dictionary value  {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}.
+     * 
+     * @param arrayBody The dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putDateTimeValidWithResponseAsync(Map<String, OffsetDateTime> arrayBody) {
         if (this.client.getHost() == null) {
@@ -1276,17 +1980,39 @@ public final class Dictionarys {
         return service.putDateTimeValid(this.client.getHost(), arrayBody);
     }
 
+    /**
+     * Set dictionary value  {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}.
+     * 
+     * @param arrayBody The dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putDateTimeValidAsync(Map<String, OffsetDateTime> arrayBody) {
         return putDateTimeValidWithResponseAsync(arrayBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Set dictionary value  {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}.
+     * 
+     * @param arrayBody The dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDateTimeValid(Map<String, OffsetDateTime> arrayBody) {
         putDateTimeValidAsync(arrayBody).block();
     }
 
+    /**
+     * Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": null}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, OffsetDateTime>>> getDateTimeInvalidNullWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -1295,6 +2021,12 @@ public final class Dictionarys {
         return service.getDateTimeInvalidNull(this.client.getHost());
     }
 
+    /**
+     * Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": null}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, OffsetDateTime>> getDateTimeInvalidNullAsync() {
         return getDateTimeInvalidNullWithResponseAsync()
@@ -1307,11 +2039,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": null}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, OffsetDateTime> getDateTimeInvalidNull() {
         return getDateTimeInvalidNullAsync().block();
     }
 
+    /**
+     * Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": "date-time"}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, OffsetDateTime>>> getDateTimeInvalidCharsWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -1320,6 +2064,12 @@ public final class Dictionarys {
         return service.getDateTimeInvalidChars(this.client.getHost());
     }
 
+    /**
+     * Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": "date-time"}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, OffsetDateTime>> getDateTimeInvalidCharsAsync() {
         return getDateTimeInvalidCharsWithResponseAsync()
@@ -1332,11 +2082,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": "date-time"}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, OffsetDateTime> getDateTimeInvalidChars() {
         return getDateTimeInvalidCharsAsync().block();
     }
 
+    /**
+     * Get date-time-rfc1123 dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, OffsetDateTime>>> getDateTimeRfc1123ValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -1345,6 +2107,12 @@ public final class Dictionarys {
         return service.getDateTimeRfc1123Valid(this.client.getHost());
     }
 
+    /**
+     * Get date-time-rfc1123 dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, OffsetDateTime>> getDateTimeRfc1123ValidAsync() {
         return getDateTimeRfc1123ValidWithResponseAsync()
@@ -1357,11 +2125,25 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get date-time-rfc1123 dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, OffsetDateTime> getDateTimeRfc1123Valid() {
         return getDateTimeRfc1123ValidAsync().block();
     }
 
+    /**
+     * Set dictionary value empty {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}.
+     * 
+     * @param arrayBody The dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putDateTimeRfc1123ValidWithResponseAsync(Map<String, OffsetDateTime> arrayBody) {
         if (this.client.getHost() == null) {
@@ -1374,17 +2156,39 @@ public final class Dictionarys {
         return service.putDateTimeRfc1123Valid(this.client.getHost(), arrayBodyConverted);
     }
 
+    /**
+     * Set dictionary value empty {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}.
+     * 
+     * @param arrayBody The dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putDateTimeRfc1123ValidAsync(Map<String, OffsetDateTime> arrayBody) {
         return putDateTimeRfc1123ValidWithResponseAsync(arrayBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Set dictionary value empty {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}.
+     * 
+     * @param arrayBody The dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDateTimeRfc1123Valid(Map<String, OffsetDateTime> arrayBody) {
         putDateTimeRfc1123ValidAsync(arrayBody).block();
     }
 
+    /**
+     * Get duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, Duration>>> getDurationValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -1393,6 +2197,12 @@ public final class Dictionarys {
         return service.getDurationValid(this.client.getHost());
     }
 
+    /**
+     * Get duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Duration>> getDurationValidAsync() {
         return getDurationValidWithResponseAsync()
@@ -1405,11 +2215,25 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Duration> getDurationValid() {
         return getDurationValidAsync().block();
     }
 
+    /**
+     * Set dictionary value  {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
+     * 
+     * @param arrayBody The dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putDurationValidWithResponseAsync(Map<String, Duration> arrayBody) {
         if (this.client.getHost() == null) {
@@ -1421,17 +2245,39 @@ public final class Dictionarys {
         return service.putDurationValid(this.client.getHost(), arrayBody);
     }
 
+    /**
+     * Set dictionary value  {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
+     * 
+     * @param arrayBody The dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putDurationValidAsync(Map<String, Duration> arrayBody) {
         return putDurationValidWithResponseAsync(arrayBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Set dictionary value  {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
+     * 
+     * @param arrayBody The dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDurationValid(Map<String, Duration> arrayBody) {
         putDurationValidAsync(arrayBody).block();
     }
 
+    /**
+     * Get byte dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each item encoded in base64.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, byte[]>>> getByteValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -1440,6 +2286,12 @@ public final class Dictionarys {
         return service.getByteValid(this.client.getHost());
     }
 
+    /**
+     * Get byte dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each item encoded in base64.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, byte[]>> getByteValidAsync() {
         return getByteValidWithResponseAsync()
@@ -1452,11 +2304,25 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get byte dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each item encoded in base64.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, byte[]> getByteValid() {
         return getByteValidAsync().block();
     }
 
+    /**
+     * Put the dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each elementencoded in base 64.
+     * 
+     * @param arrayBody The dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each elementencoded in base 64.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putByteValidWithResponseAsync(Map<String, byte[]> arrayBody) {
         if (this.client.getHost() == null) {
@@ -1468,17 +2334,39 @@ public final class Dictionarys {
         return service.putByteValid(this.client.getHost(), arrayBody);
     }
 
+    /**
+     * Put the dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each elementencoded in base 64.
+     * 
+     * @param arrayBody The dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each elementencoded in base 64.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putByteValidAsync(Map<String, byte[]> arrayBody) {
         return putByteValidWithResponseAsync(arrayBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put the dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each elementencoded in base 64.
+     * 
+     * @param arrayBody The dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each elementencoded in base 64.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putByteValid(Map<String, byte[]> arrayBody) {
         putByteValidAsync(arrayBody).block();
     }
 
+    /**
+     * Get byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first item base64 encoded.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, byte[]>>> getByteInvalidNullWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -1487,6 +2375,12 @@ public final class Dictionarys {
         return service.getByteInvalidNull(this.client.getHost());
     }
 
+    /**
+     * Get byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first item base64 encoded.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, byte[]>> getByteInvalidNullAsync() {
         return getByteInvalidNullWithResponseAsync()
@@ -1499,11 +2393,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first item base64 encoded.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, byte[]> getByteInvalidNull() {
         return getByteInvalidNullAsync().block();
     }
 
+    /**
+     * Get base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2": "Lorem ipsum"}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, byte[]>>> getBase64UrlWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -1512,6 +2418,12 @@ public final class Dictionarys {
         return service.getBase64Url(this.client.getHost());
     }
 
+    /**
+     * Get base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2": "Lorem ipsum"}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, byte[]>> getBase64UrlAsync() {
         return getBase64UrlWithResponseAsync()
@@ -1524,11 +2436,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2": "Lorem ipsum"}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, byte[]> getBase64Url() {
         return getBase64UrlAsync().block();
     }
 
+    /**
+     * Get dictionary of complex type null value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, Widget>>> getComplexNullWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -1537,6 +2461,12 @@ public final class Dictionarys {
         return service.getComplexNull(this.client.getHost());
     }
 
+    /**
+     * Get dictionary of complex type null value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Widget>> getComplexNullAsync() {
         return getComplexNullWithResponseAsync()
@@ -1549,11 +2479,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get dictionary of complex type null value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Widget> getComplexNull() {
         return getComplexNullAsync().block();
     }
 
+    /**
+     * Get empty dictionary of complex type {}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, Widget>>> getComplexEmptyWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -1562,6 +2504,12 @@ public final class Dictionarys {
         return service.getComplexEmpty(this.client.getHost());
     }
 
+    /**
+     * Get empty dictionary of complex type {}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Widget>> getComplexEmptyAsync() {
         return getComplexEmptyWithResponseAsync()
@@ -1574,11 +2522,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get empty dictionary of complex type {}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Widget> getComplexEmpty() {
         return getComplexEmptyAsync().block();
     }
 
+    /**
+     * Get dictionary of complex type with null item {"0": {"integer": 1, "string": "2"}, "1": null, "2": {"integer": 5, "string": "6"}}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, Widget>>> getComplexItemNullWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -1587,6 +2547,12 @@ public final class Dictionarys {
         return service.getComplexItemNull(this.client.getHost());
     }
 
+    /**
+     * Get dictionary of complex type with null item {"0": {"integer": 1, "string": "2"}, "1": null, "2": {"integer": 5, "string": "6"}}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Widget>> getComplexItemNullAsync() {
         return getComplexItemNullWithResponseAsync()
@@ -1599,11 +2565,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get dictionary of complex type with null item {"0": {"integer": 1, "string": "2"}, "1": null, "2": {"integer": 5, "string": "6"}}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Widget> getComplexItemNull() {
         return getComplexItemNullAsync().block();
     }
 
+    /**
+     * Get dictionary of complex type with empty item {"0": {"integer": 1, "string": "2"}, "1:" {}, "2": {"integer": 5, "string": "6"}}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, Widget>>> getComplexItemEmptyWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -1612,6 +2590,12 @@ public final class Dictionarys {
         return service.getComplexItemEmpty(this.client.getHost());
     }
 
+    /**
+     * Get dictionary of complex type with empty item {"0": {"integer": 1, "string": "2"}, "1:" {}, "2": {"integer": 5, "string": "6"}}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Widget>> getComplexItemEmptyAsync() {
         return getComplexItemEmptyWithResponseAsync()
@@ -1624,11 +2608,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get dictionary of complex type with empty item {"0": {"integer": 1, "string": "2"}, "1:" {}, "2": {"integer": 5, "string": "6"}}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Widget> getComplexItemEmpty() {
         return getComplexItemEmptyAsync().block();
     }
 
+    /**
+     * Get dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, Widget>>> getComplexValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -1637,6 +2633,12 @@ public final class Dictionarys {
         return service.getComplexValid(this.client.getHost());
     }
 
+    /**
+     * Get dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Widget>> getComplexValidAsync() {
         return getComplexValidWithResponseAsync()
@@ -1649,11 +2651,25 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Widget> getComplexValid() {
         return getComplexValidAsync().block();
     }
 
+    /**
+     * Put an dictionary of complex type with values {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}.
+     * 
+     * @param arrayBody Dictionary of complex type with null value.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putComplexValidWithResponseAsync(Map<String, Widget> arrayBody) {
         if (this.client.getHost() == null) {
@@ -1667,17 +2683,39 @@ public final class Dictionarys {
         return service.putComplexValid(this.client.getHost(), arrayBody);
     }
 
+    /**
+     * Put an dictionary of complex type with values {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}.
+     * 
+     * @param arrayBody Dictionary of complex type with null value.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putComplexValidAsync(Map<String, Widget> arrayBody) {
         return putComplexValidWithResponseAsync(arrayBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put an dictionary of complex type with values {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}.
+     * 
+     * @param arrayBody Dictionary of complex type with null value.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putComplexValid(Map<String, Widget> arrayBody) {
         putComplexValidAsync(arrayBody).block();
     }
 
+    /**
+     * Get a null array.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, List<String>>>> getArrayNullWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -1686,6 +2724,12 @@ public final class Dictionarys {
         return service.getArrayNull(this.client.getHost());
     }
 
+    /**
+     * Get a null array.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, List<String>>> getArrayNullAsync() {
         return getArrayNullWithResponseAsync()
@@ -1698,11 +2742,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get a null array.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, List<String>> getArrayNull() {
         return getArrayNullAsync().block();
     }
 
+    /**
+     * Get an empty dictionary {}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, List<String>>>> getArrayEmptyWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -1711,6 +2767,12 @@ public final class Dictionarys {
         return service.getArrayEmpty(this.client.getHost());
     }
 
+    /**
+     * Get an empty dictionary {}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, List<String>>> getArrayEmptyAsync() {
         return getArrayEmptyWithResponseAsync()
@@ -1723,11 +2785,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get an empty dictionary {}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, List<String>> getArrayEmpty() {
         return getArrayEmptyAsync().block();
     }
 
+    /**
+     * Get an dictionary of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, List<String>>>> getArrayItemNullWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -1736,6 +2810,12 @@ public final class Dictionarys {
         return service.getArrayItemNull(this.client.getHost());
     }
 
+    /**
+     * Get an dictionary of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, List<String>>> getArrayItemNullAsync() {
         return getArrayItemNullWithResponseAsync()
@@ -1748,11 +2828,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get an dictionary of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, List<String>> getArrayItemNull() {
         return getArrayItemNullAsync().block();
     }
 
+    /**
+     * Get an array of array of strings [{"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, List<String>>>> getArrayItemEmptyWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -1761,6 +2853,12 @@ public final class Dictionarys {
         return service.getArrayItemEmpty(this.client.getHost());
     }
 
+    /**
+     * Get an array of array of strings [{"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, List<String>>> getArrayItemEmptyAsync() {
         return getArrayItemEmptyWithResponseAsync()
@@ -1773,11 +2871,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get an array of array of strings [{"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, List<String>> getArrayItemEmpty() {
         return getArrayItemEmptyAsync().block();
     }
 
+    /**
+     * Get an array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, List<String>>>> getArrayValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -1786,6 +2896,12 @@ public final class Dictionarys {
         return service.getArrayValid(this.client.getHost());
     }
 
+    /**
+     * Get an array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, List<String>>> getArrayValidAsync() {
         return getArrayValidWithResponseAsync()
@@ -1798,11 +2914,25 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get an array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, List<String>> getArrayValid() {
         return getArrayValidAsync().block();
     }
 
+    /**
+     * Put An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
+     * 
+     * @param arrayBody An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putArrayValidWithResponseAsync(Map<String, List<String>> arrayBody) {
         if (this.client.getHost() == null) {
@@ -1814,17 +2944,39 @@ public final class Dictionarys {
         return service.putArrayValid(this.client.getHost(), arrayBody);
     }
 
+    /**
+     * Put An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
+     * 
+     * @param arrayBody An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putArrayValidAsync(Map<String, List<String>> arrayBody) {
         return putArrayValidWithResponseAsync(arrayBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
+     * 
+     * @param arrayBody An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putArrayValid(Map<String, List<String>> arrayBody) {
         putArrayValidAsync(arrayBody).block();
     }
 
+    /**
+     * Get an dictionaries of dictionaries with value null.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, Object>>> getDictionaryNullWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -1833,6 +2985,12 @@ public final class Dictionarys {
         return service.getDictionaryNull(this.client.getHost());
     }
 
+    /**
+     * Get an dictionaries of dictionaries with value null.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Object>> getDictionaryNullAsync() {
         return getDictionaryNullWithResponseAsync()
@@ -1845,11 +3003,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get an dictionaries of dictionaries with value null.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Object> getDictionaryNull() {
         return getDictionaryNullAsync().block();
     }
 
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, Object>>> getDictionaryEmptyWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -1858,6 +3028,12 @@ public final class Dictionarys {
         return service.getDictionaryEmpty(this.client.getHost());
     }
 
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Object>> getDictionaryEmptyAsync() {
         return getDictionaryEmptyWithResponseAsync()
@@ -1870,11 +3046,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Object> getDictionaryEmpty() {
         return getDictionaryEmptyAsync().block();
     }
 
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": null, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, Object>>> getDictionaryItemNullWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -1883,6 +3071,12 @@ public final class Dictionarys {
         return service.getDictionaryItemNull(this.client.getHost());
     }
 
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": null, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Object>> getDictionaryItemNullAsync() {
         return getDictionaryItemNullWithResponseAsync()
@@ -1895,11 +3089,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": null, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Object> getDictionaryItemNull() {
         return getDictionaryItemNullAsync().block();
     }
 
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, Object>>> getDictionaryItemEmptyWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -1908,6 +3114,12 @@ public final class Dictionarys {
         return service.getDictionaryItemEmpty(this.client.getHost());
     }
 
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Object>> getDictionaryItemEmptyAsync() {
         return getDictionaryItemEmptyWithResponseAsync()
@@ -1920,11 +3132,23 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Object> getDictionaryItemEmpty() {
         return getDictionaryItemEmptyAsync().block();
     }
 
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Map<String, Object>>> getDictionaryValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -1933,6 +3157,12 @@ public final class Dictionarys {
         return service.getDictionaryValid(this.client.getHost());
     }
 
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Object>> getDictionaryValidAsync() {
         return getDictionaryValidWithResponseAsync()
@@ -1945,11 +3175,25 @@ public final class Dictionarys {
             });
     }
 
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Object> getDictionaryValid() {
         return getDictionaryValidAsync().block();
     }
 
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     * 
+     * @param arrayBody An dictionaries of dictionaries with value null.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putDictionaryValidWithResponseAsync(Map<String, Object> arrayBody) {
         if (this.client.getHost() == null) {
@@ -1961,12 +3205,28 @@ public final class Dictionarys {
         return service.putDictionaryValid(this.client.getHost(), arrayBody);
     }
 
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     * 
+     * @param arrayBody An dictionaries of dictionaries with value null.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putDictionaryValidAsync(Map<String, Object> arrayBody) {
         return putDictionaryValidWithResponseAsync(arrayBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get an dictionaries of dictionaries of type &lt;string, string&gt; with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}.
+     * 
+     * @param arrayBody An dictionaries of dictionaries with value null.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDictionaryValid(Map<String, Object> arrayBody) {
         putDictionaryValidAsync(arrayBody).block();

--- a/tests/src/main/java/fixtures/bodyduration/Durations.java
+++ b/tests/src/main/java/fixtures/bodyduration/Durations.java
@@ -71,6 +71,12 @@ public final class Durations {
         Mono<SimpleResponse<Duration>> getInvalid(@HostParam("$host") String host);
     }
 
+    /**
+     * Get null duration value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Duration>> getNullWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -79,6 +85,12 @@ public final class Durations {
         return service.getNull(this.client.getHost());
     }
 
+    /**
+     * Get null duration value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Duration> getNullAsync() {
         return getNullWithResponseAsync()
@@ -91,11 +103,25 @@ public final class Durations {
             });
     }
 
+    /**
+     * Get null duration value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Duration getNull() {
         return getNullAsync().block();
     }
 
+    /**
+     * Put a positive duration value.
+     * 
+     * @param durationBody MISSING·SCHEMA-DESCRIPTION-DURATION.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putPositiveDurationWithResponseAsync(Duration durationBody) {
         if (this.client.getHost() == null) {
@@ -107,17 +133,39 @@ public final class Durations {
         return service.putPositiveDuration(this.client.getHost(), durationBody);
     }
 
+    /**
+     * Put a positive duration value.
+     * 
+     * @param durationBody MISSING·SCHEMA-DESCRIPTION-DURATION.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putPositiveDurationAsync(Duration durationBody) {
         return putPositiveDurationWithResponseAsync(durationBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put a positive duration value.
+     * 
+     * @param durationBody MISSING·SCHEMA-DESCRIPTION-DURATION.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putPositiveDuration(Duration durationBody) {
         putPositiveDurationAsync(durationBody).block();
     }
 
+    /**
+     * Get a positive duration value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Duration>> getPositiveDurationWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -126,6 +174,12 @@ public final class Durations {
         return service.getPositiveDuration(this.client.getHost());
     }
 
+    /**
+     * Get a positive duration value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Duration> getPositiveDurationAsync() {
         return getPositiveDurationWithResponseAsync()
@@ -138,11 +192,23 @@ public final class Durations {
             });
     }
 
+    /**
+     * Get a positive duration value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Duration getPositiveDuration() {
         return getPositiveDurationAsync().block();
     }
 
+    /**
+     * Get an invalid duration value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Duration>> getInvalidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -151,6 +217,12 @@ public final class Durations {
         return service.getInvalid(this.client.getHost());
     }
 
+    /**
+     * Get an invalid duration value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Duration> getInvalidAsync() {
         return getInvalidWithResponseAsync()
@@ -163,6 +235,12 @@ public final class Durations {
             });
     }
 
+    /**
+     * Get an invalid duration value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Duration getInvalid() {
         return getInvalidAsync().block();

--- a/tests/src/main/java/fixtures/bodyfile/Files.java
+++ b/tests/src/main/java/fixtures/bodyfile/Files.java
@@ -68,6 +68,12 @@ public final class Files {
         Mono<StreamResponse> getEmptyFile(@HostParam("$host") String host);
     }
 
+    /**
+     * Get file.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<StreamResponse> getFileWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -76,11 +82,23 @@ public final class Files {
         return service.getFile(this.client.getHost());
     }
 
+    /**
+     * Get file.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Flux<ByteBuffer> getFileAsync() {
         return getFileWithResponseAsync()
             .flatMapMany(StreamResponse::getValue);}
 
+    /**
+     * Get file.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public InputStream getFile() {
         return getFileAsync()
@@ -90,6 +108,12 @@ public final class Files {
             .block();
     }
 
+    /**
+     * Get a large file.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<StreamResponse> getFileLargeWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -98,11 +122,23 @@ public final class Files {
         return service.getFileLarge(this.client.getHost());
     }
 
+    /**
+     * Get a large file.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Flux<ByteBuffer> getFileLargeAsync() {
         return getFileLargeWithResponseAsync()
             .flatMapMany(StreamResponse::getValue);}
 
+    /**
+     * Get a large file.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public InputStream getFileLarge() {
         return getFileLargeAsync()
@@ -112,6 +148,12 @@ public final class Files {
             .block();
     }
 
+    /**
+     * Get empty file.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<StreamResponse> getEmptyFileWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -120,11 +162,23 @@ public final class Files {
         return service.getEmptyFile(this.client.getHost());
     }
 
+    /**
+     * Get empty file.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Flux<ByteBuffer> getEmptyFileAsync() {
         return getEmptyFileWithResponseAsync()
             .flatMapMany(StreamResponse::getValue);}
 
+    /**
+     * Get empty file.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public InputStream getEmptyFile() {
         return getEmptyFileAsync()

--- a/tests/src/main/java/fixtures/bodyinteger/Ints.java
+++ b/tests/src/main/java/fixtures/bodyinteger/Ints.java
@@ -125,6 +125,12 @@ public final class Ints {
         Mono<SimpleResponse<OffsetDateTime>> getNullUnixTime(@HostParam("$host") String host);
     }
 
+    /**
+     * Get null Int value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Integer>> getNullWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -133,6 +139,12 @@ public final class Ints {
         return service.getNull(this.client.getHost());
     }
 
+    /**
+     * Get null Int value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Integer> getNullAsync() {
         return getNullWithResponseAsync()
@@ -145,11 +157,23 @@ public final class Ints {
             });
     }
 
+    /**
+     * Get null Int value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public int getNull() {
         return getNullAsync().block();
     }
 
+    /**
+     * Get invalid Int value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Integer>> getInvalidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -158,6 +182,12 @@ public final class Ints {
         return service.getInvalid(this.client.getHost());
     }
 
+    /**
+     * Get invalid Int value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Integer> getInvalidAsync() {
         return getInvalidWithResponseAsync()
@@ -170,11 +200,23 @@ public final class Ints {
             });
     }
 
+    /**
+     * Get invalid Int value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public int getInvalid() {
         return getInvalidAsync().block();
     }
 
+    /**
+     * Get overflow Int32 value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Integer>> getOverflowInt32WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -183,6 +225,12 @@ public final class Ints {
         return service.getOverflowInt32(this.client.getHost());
     }
 
+    /**
+     * Get overflow Int32 value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Integer> getOverflowInt32Async() {
         return getOverflowInt32WithResponseAsync()
@@ -195,11 +243,23 @@ public final class Ints {
             });
     }
 
+    /**
+     * Get overflow Int32 value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public int getOverflowInt32() {
         return getOverflowInt32Async().block();
     }
 
+    /**
+     * Get underflow Int32 value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Integer>> getUnderflowInt32WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -208,6 +268,12 @@ public final class Ints {
         return service.getUnderflowInt32(this.client.getHost());
     }
 
+    /**
+     * Get underflow Int32 value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Integer> getUnderflowInt32Async() {
         return getUnderflowInt32WithResponseAsync()
@@ -220,11 +286,23 @@ public final class Ints {
             });
     }
 
+    /**
+     * Get underflow Int32 value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public int getUnderflowInt32() {
         return getUnderflowInt32Async().block();
     }
 
+    /**
+     * Get overflow Int64 value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Long>> getOverflowInt64WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -233,6 +311,12 @@ public final class Ints {
         return service.getOverflowInt64(this.client.getHost());
     }
 
+    /**
+     * Get overflow Int64 value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Long> getOverflowInt64Async() {
         return getOverflowInt64WithResponseAsync()
@@ -245,11 +329,23 @@ public final class Ints {
             });
     }
 
+    /**
+     * Get overflow Int64 value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public long getOverflowInt64() {
         return getOverflowInt64Async().block();
     }
 
+    /**
+     * Get underflow Int64 value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Long>> getUnderflowInt64WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -258,6 +354,12 @@ public final class Ints {
         return service.getUnderflowInt64(this.client.getHost());
     }
 
+    /**
+     * Get underflow Int64 value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Long> getUnderflowInt64Async() {
         return getUnderflowInt64WithResponseAsync()
@@ -270,11 +372,25 @@ public final class Ints {
             });
     }
 
+    /**
+     * Get underflow Int64 value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public long getUnderflowInt64() {
         return getUnderflowInt64Async().block();
     }
 
+    /**
+     * Put max int32 value.
+     * 
+     * @param intBody MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putMax32WithResponseAsync(int intBody) {
         if (this.client.getHost() == null) {
@@ -283,17 +399,41 @@ public final class Ints {
         return service.putMax32(this.client.getHost(), intBody);
     }
 
+    /**
+     * Put max int32 value.
+     * 
+     * @param intBody MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putMax32Async(int intBody) {
         return putMax32WithResponseAsync(intBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put max int32 value.
+     * 
+     * @param intBody MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putMax32(int intBody) {
         putMax32Async(intBody).block();
     }
 
+    /**
+     * Put max int64 value.
+     * 
+     * @param intBody MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putMax64WithResponseAsync(long intBody) {
         if (this.client.getHost() == null) {
@@ -302,17 +442,41 @@ public final class Ints {
         return service.putMax64(this.client.getHost(), intBody);
     }
 
+    /**
+     * Put max int64 value.
+     * 
+     * @param intBody MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putMax64Async(long intBody) {
         return putMax64WithResponseAsync(intBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put max int64 value.
+     * 
+     * @param intBody MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putMax64(long intBody) {
         putMax64Async(intBody).block();
     }
 
+    /**
+     * Put min int32 value.
+     * 
+     * @param intBody MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putMin32WithResponseAsync(int intBody) {
         if (this.client.getHost() == null) {
@@ -321,17 +485,41 @@ public final class Ints {
         return service.putMin32(this.client.getHost(), intBody);
     }
 
+    /**
+     * Put min int32 value.
+     * 
+     * @param intBody MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putMin32Async(int intBody) {
         return putMin32WithResponseAsync(intBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put min int32 value.
+     * 
+     * @param intBody MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putMin32(int intBody) {
         putMin32Async(intBody).block();
     }
 
+    /**
+     * Put min int64 value.
+     * 
+     * @param intBody MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putMin64WithResponseAsync(long intBody) {
         if (this.client.getHost() == null) {
@@ -340,17 +528,39 @@ public final class Ints {
         return service.putMin64(this.client.getHost(), intBody);
     }
 
+    /**
+     * Put min int64 value.
+     * 
+     * @param intBody MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putMin64Async(long intBody) {
         return putMin64WithResponseAsync(intBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put min int64 value.
+     * 
+     * @param intBody MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putMin64(long intBody) {
         putMin64Async(intBody).block();
     }
 
+    /**
+     * Get datetime encoded as Unix time value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<OffsetDateTime>> getUnixTimeWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -359,6 +569,12 @@ public final class Ints {
         return service.getUnixTime(this.client.getHost());
     }
 
+    /**
+     * Get datetime encoded as Unix time value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<OffsetDateTime> getUnixTimeAsync() {
         return getUnixTimeWithResponseAsync()
@@ -371,11 +587,25 @@ public final class Ints {
             });
     }
 
+    /**
+     * Get datetime encoded as Unix time value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getUnixTime() {
         return getUnixTimeAsync().block();
     }
 
+    /**
+     * Put datetime encoded as Unix time.
+     * 
+     * @param intBody date in seconds since 1970-01-01T00:00:00Z.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putUnixTimeDateWithResponseAsync(OffsetDateTime intBody) {
         if (this.client.getHost() == null) {
@@ -388,17 +618,39 @@ public final class Ints {
         return service.putUnixTimeDate(this.client.getHost(), intBodyConverted);
     }
 
+    /**
+     * Put datetime encoded as Unix time.
+     * 
+     * @param intBody date in seconds since 1970-01-01T00:00:00Z.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putUnixTimeDateAsync(OffsetDateTime intBody) {
         return putUnixTimeDateWithResponseAsync(intBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put datetime encoded as Unix time.
+     * 
+     * @param intBody date in seconds since 1970-01-01T00:00:00Z.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putUnixTimeDate(OffsetDateTime intBody) {
         putUnixTimeDateAsync(intBody).block();
     }
 
+    /**
+     * Get invalid Unix time value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<OffsetDateTime>> getInvalidUnixTimeWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -407,6 +659,12 @@ public final class Ints {
         return service.getInvalidUnixTime(this.client.getHost());
     }
 
+    /**
+     * Get invalid Unix time value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<OffsetDateTime> getInvalidUnixTimeAsync() {
         return getInvalidUnixTimeWithResponseAsync()
@@ -419,11 +677,23 @@ public final class Ints {
             });
     }
 
+    /**
+     * Get invalid Unix time value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getInvalidUnixTime() {
         return getInvalidUnixTimeAsync().block();
     }
 
+    /**
+     * Get null Unix time value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<OffsetDateTime>> getNullUnixTimeWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -432,6 +702,12 @@ public final class Ints {
         return service.getNullUnixTime(this.client.getHost());
     }
 
+    /**
+     * Get null Unix time value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<OffsetDateTime> getNullUnixTimeAsync() {
         return getNullUnixTimeWithResponseAsync()
@@ -444,6 +720,12 @@ public final class Ints {
             });
     }
 
+    /**
+     * Get null Unix time value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getNullUnixTime() {
         return getNullUnixTimeAsync().block();

--- a/tests/src/main/java/fixtures/bodynumber/Numbers.java
+++ b/tests/src/main/java/fixtures/bodynumber/Numbers.java
@@ -171,6 +171,12 @@ public final class Numbers {
         Mono<SimpleResponse<BigDecimal>> getSmallDecimal(@HostParam("$host") String host);
     }
 
+    /**
+     * Get null Number value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Float>> getNullWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -179,6 +185,12 @@ public final class Numbers {
         return service.getNull(this.client.getHost());
     }
 
+    /**
+     * Get null Number value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Float> getNullAsync() {
         return getNullWithResponseAsync()
@@ -191,11 +203,23 @@ public final class Numbers {
             });
     }
 
+    /**
+     * Get null Number value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public float getNull() {
         return getNullAsync().block();
     }
 
+    /**
+     * Get invalid float Number value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Float>> getInvalidFloatWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -204,6 +228,12 @@ public final class Numbers {
         return service.getInvalidFloat(this.client.getHost());
     }
 
+    /**
+     * Get invalid float Number value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Float> getInvalidFloatAsync() {
         return getInvalidFloatWithResponseAsync()
@@ -216,11 +246,23 @@ public final class Numbers {
             });
     }
 
+    /**
+     * Get invalid float Number value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public float getInvalidFloat() {
         return getInvalidFloatAsync().block();
     }
 
+    /**
+     * Get invalid double Number value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Double>> getInvalidDoubleWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -229,6 +271,12 @@ public final class Numbers {
         return service.getInvalidDouble(this.client.getHost());
     }
 
+    /**
+     * Get invalid double Number value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Double> getInvalidDoubleAsync() {
         return getInvalidDoubleWithResponseAsync()
@@ -241,11 +289,23 @@ public final class Numbers {
             });
     }
 
+    /**
+     * Get invalid double Number value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public double getInvalidDouble() {
         return getInvalidDoubleAsync().block();
     }
 
+    /**
+     * Get invalid decimal Number value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<BigDecimal>> getInvalidDecimalWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -254,6 +314,12 @@ public final class Numbers {
         return service.getInvalidDecimal(this.client.getHost());
     }
 
+    /**
+     * Get invalid decimal Number value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<BigDecimal> getInvalidDecimalAsync() {
         return getInvalidDecimalWithResponseAsync()
@@ -266,11 +332,25 @@ public final class Numbers {
             });
     }
 
+    /**
+     * Get invalid decimal Number value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public BigDecimal getInvalidDecimal() {
         return getInvalidDecimalAsync().block();
     }
 
+    /**
+     * Put big float value 3.402823e+20.
+     * 
+     * @param numberBody MISSING·SCHEMA-DESCRIPTION-NUMBER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putBigFloatWithResponseAsync(float numberBody) {
         if (this.client.getHost() == null) {
@@ -279,17 +359,39 @@ public final class Numbers {
         return service.putBigFloat(this.client.getHost(), numberBody);
     }
 
+    /**
+     * Put big float value 3.402823e+20.
+     * 
+     * @param numberBody MISSING·SCHEMA-DESCRIPTION-NUMBER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putBigFloatAsync(float numberBody) {
         return putBigFloatWithResponseAsync(numberBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put big float value 3.402823e+20.
+     * 
+     * @param numberBody MISSING·SCHEMA-DESCRIPTION-NUMBER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putBigFloat(float numberBody) {
         putBigFloatAsync(numberBody).block();
     }
 
+    /**
+     * Get big float value 3.402823e+20.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Float>> getBigFloatWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -298,6 +400,12 @@ public final class Numbers {
         return service.getBigFloat(this.client.getHost());
     }
 
+    /**
+     * Get big float value 3.402823e+20.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Float> getBigFloatAsync() {
         return getBigFloatWithResponseAsync()
@@ -310,11 +418,25 @@ public final class Numbers {
             });
     }
 
+    /**
+     * Get big float value 3.402823e+20.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public float getBigFloat() {
         return getBigFloatAsync().block();
     }
 
+    /**
+     * Put big double value 2.5976931e+101.
+     * 
+     * @param numberBody MISSING·SCHEMA-DESCRIPTION-NUMBER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putBigDoubleWithResponseAsync(double numberBody) {
         if (this.client.getHost() == null) {
@@ -323,17 +445,39 @@ public final class Numbers {
         return service.putBigDouble(this.client.getHost(), numberBody);
     }
 
+    /**
+     * Put big double value 2.5976931e+101.
+     * 
+     * @param numberBody MISSING·SCHEMA-DESCRIPTION-NUMBER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putBigDoubleAsync(double numberBody) {
         return putBigDoubleWithResponseAsync(numberBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put big double value 2.5976931e+101.
+     * 
+     * @param numberBody MISSING·SCHEMA-DESCRIPTION-NUMBER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putBigDouble(double numberBody) {
         putBigDoubleAsync(numberBody).block();
     }
 
+    /**
+     * Get big double value 2.5976931e+101.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Double>> getBigDoubleWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -342,6 +486,12 @@ public final class Numbers {
         return service.getBigDouble(this.client.getHost());
     }
 
+    /**
+     * Get big double value 2.5976931e+101.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Double> getBigDoubleAsync() {
         return getBigDoubleWithResponseAsync()
@@ -354,11 +504,23 @@ public final class Numbers {
             });
     }
 
+    /**
+     * Get big double value 2.5976931e+101.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public double getBigDouble() {
         return getBigDoubleAsync().block();
     }
 
+    /**
+     * Put big double value 99999999.99.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putBigDoublePositiveDecimalWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -368,17 +530,35 @@ public final class Numbers {
         return service.putBigDoublePositiveDecimal(this.client.getHost(), numberBody);
     }
 
+    /**
+     * Put big double value 99999999.99.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putBigDoublePositiveDecimalAsync() {
         return putBigDoublePositiveDecimalWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put big double value 99999999.99.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putBigDoublePositiveDecimal() {
         putBigDoublePositiveDecimalAsync().block();
     }
 
+    /**
+     * Get big double value 99999999.99.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Double>> getBigDoublePositiveDecimalWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -387,6 +567,12 @@ public final class Numbers {
         return service.getBigDoublePositiveDecimal(this.client.getHost());
     }
 
+    /**
+     * Get big double value 99999999.99.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Double> getBigDoublePositiveDecimalAsync() {
         return getBigDoublePositiveDecimalWithResponseAsync()
@@ -399,11 +585,23 @@ public final class Numbers {
             });
     }
 
+    /**
+     * Get big double value 99999999.99.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public double getBigDoublePositiveDecimal() {
         return getBigDoublePositiveDecimalAsync().block();
     }
 
+    /**
+     * Put big double value -99999999.99.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putBigDoubleNegativeDecimalWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -413,17 +611,35 @@ public final class Numbers {
         return service.putBigDoubleNegativeDecimal(this.client.getHost(), numberBody);
     }
 
+    /**
+     * Put big double value -99999999.99.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putBigDoubleNegativeDecimalAsync() {
         return putBigDoubleNegativeDecimalWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put big double value -99999999.99.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putBigDoubleNegativeDecimal() {
         putBigDoubleNegativeDecimalAsync().block();
     }
 
+    /**
+     * Get big double value -99999999.99.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Double>> getBigDoubleNegativeDecimalWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -432,6 +648,12 @@ public final class Numbers {
         return service.getBigDoubleNegativeDecimal(this.client.getHost());
     }
 
+    /**
+     * Get big double value -99999999.99.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Double> getBigDoubleNegativeDecimalAsync() {
         return getBigDoubleNegativeDecimalWithResponseAsync()
@@ -444,11 +666,25 @@ public final class Numbers {
             });
     }
 
+    /**
+     * Get big double value -99999999.99.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public double getBigDoubleNegativeDecimal() {
         return getBigDoubleNegativeDecimalAsync().block();
     }
 
+    /**
+     * Put big decimal value 2.5976931e+101.
+     * 
+     * @param numberBody MISSING·SCHEMA-DESCRIPTION-NUMBER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putBigDecimalWithResponseAsync(BigDecimal numberBody) {
         if (this.client.getHost() == null) {
@@ -460,17 +696,39 @@ public final class Numbers {
         return service.putBigDecimal(this.client.getHost(), numberBody);
     }
 
+    /**
+     * Put big decimal value 2.5976931e+101.
+     * 
+     * @param numberBody MISSING·SCHEMA-DESCRIPTION-NUMBER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putBigDecimalAsync(BigDecimal numberBody) {
         return putBigDecimalWithResponseAsync(numberBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put big decimal value 2.5976931e+101.
+     * 
+     * @param numberBody MISSING·SCHEMA-DESCRIPTION-NUMBER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putBigDecimal(BigDecimal numberBody) {
         putBigDecimalAsync(numberBody).block();
     }
 
+    /**
+     * Get big decimal value 2.5976931e+101.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<BigDecimal>> getBigDecimalWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -479,6 +737,12 @@ public final class Numbers {
         return service.getBigDecimal(this.client.getHost());
     }
 
+    /**
+     * Get big decimal value 2.5976931e+101.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<BigDecimal> getBigDecimalAsync() {
         return getBigDecimalWithResponseAsync()
@@ -491,11 +755,23 @@ public final class Numbers {
             });
     }
 
+    /**
+     * Get big decimal value 2.5976931e+101.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public BigDecimal getBigDecimal() {
         return getBigDecimalAsync().block();
     }
 
+    /**
+     * Put big decimal value 99999999.99.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putBigDecimalPositiveDecimalWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -505,17 +781,35 @@ public final class Numbers {
         return service.putBigDecimalPositiveDecimal(this.client.getHost(), numberBody);
     }
 
+    /**
+     * Put big decimal value 99999999.99.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putBigDecimalPositiveDecimalAsync() {
         return putBigDecimalPositiveDecimalWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put big decimal value 99999999.99.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putBigDecimalPositiveDecimal() {
         putBigDecimalPositiveDecimalAsync().block();
     }
 
+    /**
+     * Get big decimal value 99999999.99.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<BigDecimal>> getBigDecimalPositiveDecimalWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -524,6 +818,12 @@ public final class Numbers {
         return service.getBigDecimalPositiveDecimal(this.client.getHost());
     }
 
+    /**
+     * Get big decimal value 99999999.99.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<BigDecimal> getBigDecimalPositiveDecimalAsync() {
         return getBigDecimalPositiveDecimalWithResponseAsync()
@@ -536,11 +836,23 @@ public final class Numbers {
             });
     }
 
+    /**
+     * Get big decimal value 99999999.99.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public BigDecimal getBigDecimalPositiveDecimal() {
         return getBigDecimalPositiveDecimalAsync().block();
     }
 
+    /**
+     * Put big decimal value -99999999.99.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putBigDecimalNegativeDecimalWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -550,17 +862,35 @@ public final class Numbers {
         return service.putBigDecimalNegativeDecimal(this.client.getHost(), numberBody);
     }
 
+    /**
+     * Put big decimal value -99999999.99.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putBigDecimalNegativeDecimalAsync() {
         return putBigDecimalNegativeDecimalWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put big decimal value -99999999.99.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putBigDecimalNegativeDecimal() {
         putBigDecimalNegativeDecimalAsync().block();
     }
 
+    /**
+     * Get big decimal value -99999999.99.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<BigDecimal>> getBigDecimalNegativeDecimalWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -569,6 +899,12 @@ public final class Numbers {
         return service.getBigDecimalNegativeDecimal(this.client.getHost());
     }
 
+    /**
+     * Get big decimal value -99999999.99.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<BigDecimal> getBigDecimalNegativeDecimalAsync() {
         return getBigDecimalNegativeDecimalWithResponseAsync()
@@ -581,11 +917,25 @@ public final class Numbers {
             });
     }
 
+    /**
+     * Get big decimal value -99999999.99.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public BigDecimal getBigDecimalNegativeDecimal() {
         return getBigDecimalNegativeDecimalAsync().block();
     }
 
+    /**
+     * Put small float value 3.402823e-20.
+     * 
+     * @param numberBody MISSING·SCHEMA-DESCRIPTION-NUMBER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putSmallFloatWithResponseAsync(float numberBody) {
         if (this.client.getHost() == null) {
@@ -594,17 +944,39 @@ public final class Numbers {
         return service.putSmallFloat(this.client.getHost(), numberBody);
     }
 
+    /**
+     * Put small float value 3.402823e-20.
+     * 
+     * @param numberBody MISSING·SCHEMA-DESCRIPTION-NUMBER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putSmallFloatAsync(float numberBody) {
         return putSmallFloatWithResponseAsync(numberBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put small float value 3.402823e-20.
+     * 
+     * @param numberBody MISSING·SCHEMA-DESCRIPTION-NUMBER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putSmallFloat(float numberBody) {
         putSmallFloatAsync(numberBody).block();
     }
 
+    /**
+     * Get big double value 3.402823e-20.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Double>> getSmallFloatWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -613,6 +985,12 @@ public final class Numbers {
         return service.getSmallFloat(this.client.getHost());
     }
 
+    /**
+     * Get big double value 3.402823e-20.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Double> getSmallFloatAsync() {
         return getSmallFloatWithResponseAsync()
@@ -625,11 +1003,25 @@ public final class Numbers {
             });
     }
 
+    /**
+     * Get big double value 3.402823e-20.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public double getSmallFloat() {
         return getSmallFloatAsync().block();
     }
 
+    /**
+     * Put small double value 2.5976931e-101.
+     * 
+     * @param numberBody MISSING·SCHEMA-DESCRIPTION-NUMBER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putSmallDoubleWithResponseAsync(double numberBody) {
         if (this.client.getHost() == null) {
@@ -638,17 +1030,39 @@ public final class Numbers {
         return service.putSmallDouble(this.client.getHost(), numberBody);
     }
 
+    /**
+     * Put small double value 2.5976931e-101.
+     * 
+     * @param numberBody MISSING·SCHEMA-DESCRIPTION-NUMBER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putSmallDoubleAsync(double numberBody) {
         return putSmallDoubleWithResponseAsync(numberBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put small double value 2.5976931e-101.
+     * 
+     * @param numberBody MISSING·SCHEMA-DESCRIPTION-NUMBER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putSmallDouble(double numberBody) {
         putSmallDoubleAsync(numberBody).block();
     }
 
+    /**
+     * Get big double value 2.5976931e-101.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Double>> getSmallDoubleWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -657,6 +1071,12 @@ public final class Numbers {
         return service.getSmallDouble(this.client.getHost());
     }
 
+    /**
+     * Get big double value 2.5976931e-101.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Double> getSmallDoubleAsync() {
         return getSmallDoubleWithResponseAsync()
@@ -669,11 +1089,25 @@ public final class Numbers {
             });
     }
 
+    /**
+     * Get big double value 2.5976931e-101.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public double getSmallDouble() {
         return getSmallDoubleAsync().block();
     }
 
+    /**
+     * Put small decimal value 2.5976931e-101.
+     * 
+     * @param numberBody MISSING·SCHEMA-DESCRIPTION-NUMBER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putSmallDecimalWithResponseAsync(BigDecimal numberBody) {
         if (this.client.getHost() == null) {
@@ -685,17 +1119,39 @@ public final class Numbers {
         return service.putSmallDecimal(this.client.getHost(), numberBody);
     }
 
+    /**
+     * Put small decimal value 2.5976931e-101.
+     * 
+     * @param numberBody MISSING·SCHEMA-DESCRIPTION-NUMBER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putSmallDecimalAsync(BigDecimal numberBody) {
         return putSmallDecimalWithResponseAsync(numberBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put small decimal value 2.5976931e-101.
+     * 
+     * @param numberBody MISSING·SCHEMA-DESCRIPTION-NUMBER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putSmallDecimal(BigDecimal numberBody) {
         putSmallDecimalAsync(numberBody).block();
     }
 
+    /**
+     * Get small decimal value 2.5976931e-101.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<BigDecimal>> getSmallDecimalWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -704,6 +1160,12 @@ public final class Numbers {
         return service.getSmallDecimal(this.client.getHost());
     }
 
+    /**
+     * Get small decimal value 2.5976931e-101.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<BigDecimal> getSmallDecimalAsync() {
         return getSmallDecimalWithResponseAsync()
@@ -716,6 +1178,12 @@ public final class Numbers {
             });
     }
 
+    /**
+     * Get small decimal value 2.5976931e-101.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public BigDecimal getSmallDecimal() {
         return getSmallDecimalAsync().block();

--- a/tests/src/main/java/fixtures/bodystring/Enums.java
+++ b/tests/src/main/java/fixtures/bodystring/Enums.java
@@ -82,6 +82,12 @@ public final class Enums {
         Mono<Response<Void>> putReferencedConstant(@HostParam("$host") String host, @BodyParam("application/json") RefColorConstant enumStringBody);
     }
 
+    /**
+     * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Colors>> getNotExpandableWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -90,6 +96,12 @@ public final class Enums {
         return service.getNotExpandable(this.client.getHost());
     }
 
+    /**
+     * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Colors> getNotExpandableAsync() {
         return getNotExpandableWithResponseAsync()
@@ -102,11 +114,25 @@ public final class Enums {
             });
     }
 
+    /**
+     * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Colors getNotExpandable() {
         return getNotExpandableAsync().block();
     }
 
+    /**
+     * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     * 
+     * @param stringBody MISSING·SCHEMA-DESCRIPTION-CHOICE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putNotExpandableWithResponseAsync(Colors stringBody) {
         if (this.client.getHost() == null) {
@@ -118,17 +144,39 @@ public final class Enums {
         return service.putNotExpandable(this.client.getHost(), stringBody);
     }
 
+    /**
+     * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     * 
+     * @param stringBody MISSING·SCHEMA-DESCRIPTION-CHOICE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putNotExpandableAsync(Colors stringBody) {
         return putNotExpandableWithResponseAsync(stringBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     * 
+     * @param stringBody MISSING·SCHEMA-DESCRIPTION-CHOICE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putNotExpandable(Colors stringBody) {
         putNotExpandableAsync(stringBody).block();
     }
 
+    /**
+     * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Colors>> getReferencedWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -137,6 +185,12 @@ public final class Enums {
         return service.getReferenced(this.client.getHost());
     }
 
+    /**
+     * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Colors> getReferencedAsync() {
         return getReferencedWithResponseAsync()
@@ -149,11 +203,25 @@ public final class Enums {
             });
     }
 
+    /**
+     * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Colors getReferenced() {
         return getReferencedAsync().block();
     }
 
+    /**
+     * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     * 
+     * @param enumStringBody MISSING·SCHEMA-DESCRIPTION-CHOICE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putReferencedWithResponseAsync(Colors enumStringBody) {
         if (this.client.getHost() == null) {
@@ -165,17 +233,39 @@ public final class Enums {
         return service.putReferenced(this.client.getHost(), enumStringBody);
     }
 
+    /**
+     * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     * 
+     * @param enumStringBody MISSING·SCHEMA-DESCRIPTION-CHOICE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putReferencedAsync(Colors enumStringBody) {
         return putReferencedWithResponseAsync(enumStringBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     * 
+     * @param enumStringBody MISSING·SCHEMA-DESCRIPTION-CHOICE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putReferenced(Colors enumStringBody) {
         putReferencedAsync(enumStringBody).block();
     }
 
+    /**
+     * Get value 'green-color' from the constant.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<RefColorConstant>> getReferencedConstantWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -184,6 +274,12 @@ public final class Enums {
         return service.getReferencedConstant(this.client.getHost());
     }
 
+    /**
+     * Get value 'green-color' from the constant.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<RefColorConstant> getReferencedConstantAsync() {
         return getReferencedConstantWithResponseAsync()
@@ -196,11 +292,25 @@ public final class Enums {
             });
     }
 
+    /**
+     * Get value 'green-color' from the constant.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public RefColorConstant getReferencedConstant() {
         return getReferencedConstantAsync().block();
     }
 
+    /**
+     * Sends value 'green-color' from a constant.
+     * 
+     * @param enumStringBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putReferencedConstantWithResponseAsync(RefColorConstant enumStringBody) {
         if (this.client.getHost() == null) {
@@ -214,12 +324,28 @@ public final class Enums {
         return service.putReferencedConstant(this.client.getHost(), enumStringBody);
     }
 
+    /**
+     * Sends value 'green-color' from a constant.
+     * 
+     * @param enumStringBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putReferencedConstantAsync(RefColorConstant enumStringBody) {
         return putReferencedConstantWithResponseAsync(enumStringBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Sends value 'green-color' from a constant.
+     * 
+     * @param enumStringBody MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putReferencedConstant(RefColorConstant enumStringBody) {
         putReferencedConstantAsync(enumStringBody).block();

--- a/tests/src/main/java/fixtures/bodystring/Strings.java
+++ b/tests/src/main/java/fixtures/bodystring/Strings.java
@@ -120,6 +120,12 @@ public final class Strings {
         Mono<SimpleResponse<byte[]>> getNullBase64UrlEncoded(@HostParam("$host") String host);
     }
 
+    /**
+     * Get null string value value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<String>> getNullWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -128,6 +134,12 @@ public final class Strings {
         return service.getNull(this.client.getHost());
     }
 
+    /**
+     * Get null string value value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<String> getNullAsync() {
         return getNullWithResponseAsync()
@@ -140,11 +152,23 @@ public final class Strings {
             });
     }
 
+    /**
+     * Get null string value value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String getNull() {
         return getNullAsync().block();
     }
 
+    /**
+     * Set string value null.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putNullWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -154,17 +178,35 @@ public final class Strings {
         return service.putNull(this.client.getHost(), stringBody);
     }
 
+    /**
+     * Set string value null.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putNullAsync() {
         return putNullWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Set string value null.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putNull() {
         putNullAsync().block();
     }
 
+    /**
+     * Get empty string value value ''.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<String>> getEmptyWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -173,6 +215,12 @@ public final class Strings {
         return service.getEmpty(this.client.getHost());
     }
 
+    /**
+     * Get empty string value value ''.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<String> getEmptyAsync() {
         return getEmptyWithResponseAsync()
@@ -185,11 +233,23 @@ public final class Strings {
             });
     }
 
+    /**
+     * Get empty string value value ''.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String getEmpty() {
         return getEmptyAsync().block();
     }
 
+    /**
+     * Set string value empty ''.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putEmptyWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -199,17 +259,35 @@ public final class Strings {
         return service.putEmpty(this.client.getHost(), stringBody);
     }
 
+    /**
+     * Set string value empty ''.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putEmptyAsync() {
         return putEmptyWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Set string value empty ''.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putEmpty() {
         putEmptyAsync().block();
     }
 
+    /**
+     * Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<String>> getMbcsWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -218,6 +296,12 @@ public final class Strings {
         return service.getMbcs(this.client.getHost());
     }
 
+    /**
+     * Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<String> getMbcsAsync() {
         return getMbcsWithResponseAsync()
@@ -230,11 +314,23 @@ public final class Strings {
             });
     }
 
+    /**
+     * Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String getMbcs() {
         return getMbcsAsync().block();
     }
 
+    /**
+     * Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putMbcsWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -244,17 +340,35 @@ public final class Strings {
         return service.putMbcs(this.client.getHost(), stringBody);
     }
 
+    /**
+     * Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putMbcsAsync() {
         return putMbcsWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putMbcs() {
         putMbcsAsync().block();
     }
 
+    /**
+     * Get string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<String>> getWhitespaceWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -263,6 +377,12 @@ public final class Strings {
         return service.getWhitespace(this.client.getHost());
     }
 
+    /**
+     * Get string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<String> getWhitespaceAsync() {
         return getWhitespaceWithResponseAsync()
@@ -275,11 +395,23 @@ public final class Strings {
             });
     }
 
+    /**
+     * Get string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String getWhitespace() {
         return getWhitespaceAsync().block();
     }
 
+    /**
+     * Set String value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putWhitespaceWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -289,17 +421,35 @@ public final class Strings {
         return service.putWhitespace(this.client.getHost(), stringBody);
     }
 
+    /**
+     * Set String value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putWhitespaceAsync() {
         return putWhitespaceWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Set String value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putWhitespace() {
         putWhitespaceAsync().block();
     }
 
+    /**
+     * Get String value when no string value is sent in response payload.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<String>> getNotProvidedWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -308,6 +458,12 @@ public final class Strings {
         return service.getNotProvided(this.client.getHost());
     }
 
+    /**
+     * Get String value when no string value is sent in response payload.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<String> getNotProvidedAsync() {
         return getNotProvidedWithResponseAsync()
@@ -320,11 +476,23 @@ public final class Strings {
             });
     }
 
+    /**
+     * Get String value when no string value is sent in response payload.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String getNotProvided() {
         return getNotProvidedAsync().block();
     }
 
+    /**
+     * Get value that is base64 encoded.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<byte[]>> getBase64EncodedWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -333,6 +501,12 @@ public final class Strings {
         return service.getBase64Encoded(this.client.getHost());
     }
 
+    /**
+     * Get value that is base64 encoded.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<byte[]> getBase64EncodedAsync() {
         return getBase64EncodedWithResponseAsync()
@@ -345,11 +519,23 @@ public final class Strings {
             });
     }
 
+    /**
+     * Get value that is base64 encoded.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public byte[] getBase64Encoded() {
         return getBase64EncodedAsync().block();
     }
 
+    /**
+     * Get value that is base64url encoded.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<byte[]>> getBase64UrlEncodedWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -358,6 +544,12 @@ public final class Strings {
         return service.getBase64UrlEncoded(this.client.getHost());
     }
 
+    /**
+     * Get value that is base64url encoded.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<byte[]> getBase64UrlEncodedAsync() {
         return getBase64UrlEncodedWithResponseAsync()
@@ -370,11 +562,25 @@ public final class Strings {
             });
     }
 
+    /**
+     * Get value that is base64url encoded.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public byte[] getBase64UrlEncoded() {
         return getBase64UrlEncodedAsync().block();
     }
 
+    /**
+     * Put value that is base64url encoded.
+     * 
+     * @param stringBody MISSING·SCHEMA-DESCRIPTION-BYTEARRAY.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putBase64UrlEncodedWithResponseAsync(byte[] stringBody) {
         if (this.client.getHost() == null) {
@@ -387,17 +593,39 @@ public final class Strings {
         return service.putBase64UrlEncoded(this.client.getHost(), stringBodyConverted);
     }
 
+    /**
+     * Put value that is base64url encoded.
+     * 
+     * @param stringBody MISSING·SCHEMA-DESCRIPTION-BYTEARRAY.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putBase64UrlEncodedAsync(byte[] stringBody) {
         return putBase64UrlEncodedWithResponseAsync(stringBody)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put value that is base64url encoded.
+     * 
+     * @param stringBody MISSING·SCHEMA-DESCRIPTION-BYTEARRAY.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putBase64UrlEncoded(byte[] stringBody) {
         putBase64UrlEncodedAsync(stringBody).block();
     }
 
+    /**
+     * Get null value that is expected to be base64url encoded.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<byte[]>> getNullBase64UrlEncodedWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -406,6 +634,12 @@ public final class Strings {
         return service.getNullBase64UrlEncoded(this.client.getHost());
     }
 
+    /**
+     * Get null value that is expected to be base64url encoded.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<byte[]> getNullBase64UrlEncodedAsync() {
         return getNullBase64UrlEncodedWithResponseAsync()
@@ -418,6 +652,12 @@ public final class Strings {
             });
     }
 
+    /**
+     * Get null value that is expected to be base64url encoded.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public byte[] getNullBase64UrlEncoded() {
         return getNullBase64UrlEncodedAsync().block();

--- a/tests/src/main/java/fixtures/custombaseuri/AutoRestParameterizedHostTestClient.java
+++ b/tests/src/main/java/fixtures/custombaseuri/AutoRestParameterizedHostTestClient.java
@@ -11,31 +11,6 @@ import com.azure.core.http.policy.UserAgentPolicy;
  */
 public final class AutoRestParameterizedHostTestClient {
     /**
-     * host.
-     */
-    private String host;
-
-    /**
-     * Gets host.
-     * 
-     * @return the host value.
-     */
-    public String getHost() {
-        return this.host;
-    }
-
-    /**
-     * Sets host.
-     * 
-     * @param host the host value.
-     * @return the service client itself.
-     */
-    AutoRestParameterizedHostTestClient setHost(String host) {
-        this.host = host;
-        return this;
-    }
-
-    /**
      * The HTTP pipeline to send requests through.
      */
     private HttpPipeline httpPipeline;

--- a/tests/src/main/java/fixtures/custombaseuri/AutoRestParameterizedHostTestClientBuilder.java
+++ b/tests/src/main/java/fixtures/custombaseuri/AutoRestParameterizedHostTestClientBuilder.java
@@ -13,22 +13,6 @@ import com.azure.core.http.policy.UserAgentPolicy;
 @ServiceClientBuilder(serviceClients = AutoRestParameterizedHostTestClient.class)
 public final class AutoRestParameterizedHostTestClientBuilder {
     /*
-     * host
-     */
-    private String host;
-
-    /**
-     * Sets host.
-     * 
-     * @param host the host value.
-     * @return the AutoRestParameterizedHostTestClientBuilder.
-     */
-    public AutoRestParameterizedHostTestClientBuilder host(String host) {
-        this.host = host;
-        return this;
-    }
-
-    /*
      * The HTTP pipeline to send requests through
      */
     private HttpPipeline pipeline;
@@ -50,14 +34,10 @@ public final class AutoRestParameterizedHostTestClientBuilder {
      * @return an instance of AutoRestParameterizedHostTestClient.
      */
     public AutoRestParameterizedHostTestClient build() {
-        if (host == null) {
-            this.host = "host";
-        }
         if (pipeline == null) {
             this.pipeline = new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build();
         }
         AutoRestParameterizedHostTestClient client = new AutoRestParameterizedHostTestClient(pipeline);
-        client.setHost(this.host);
         return client;
     }
 }

--- a/tests/src/main/java/fixtures/custombaseuri/Paths.java
+++ b/tests/src/main/java/fixtures/custombaseuri/Paths.java
@@ -52,25 +52,52 @@ public final class Paths {
         Mono<Response<Void>> getEmpty(@HostParam("accountName") String accountName, @HostParam("host") String host);
     }
 
+    /**
+     * Get a 200 to test a valid base uri.
+     * 
+     * @param accountName simple string.
+     * @param host simple string.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<Void>> getEmptyWithResponseAsync(String accountName) {
+    public Mono<Response<Void>> getEmptyWithResponseAsync(String accountName, String host) {
         if (accountName == null) {
             throw new IllegalArgumentException("Parameter accountName is required and cannot be null.");
         }
-        if (this.client.getHost() == null) {
-            throw new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null.");
+        if (host == null) {
+            throw new IllegalArgumentException("Parameter host is required and cannot be null.");
         }
-        return service.getEmpty(accountName, this.client.getHost());
+        return service.getEmpty(accountName, host);
     }
 
+    /**
+     * Get a 200 to test a valid base uri.
+     * 
+     * @param accountName simple string.
+     * @param host simple string.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Void> getEmptyAsync(String accountName) {
-        return getEmptyWithResponseAsync(accountName)
+    public Mono<Void> getEmptyAsync(String accountName, String host) {
+        return getEmptyWithResponseAsync(accountName, host)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get a 200 to test a valid base uri.
+     * 
+     * @param accountName simple string.
+     * @param host simple string.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public void getEmpty(String accountName) {
-        getEmptyAsync(accountName).block();
+    public void getEmpty(String accountName, String host) {
+        getEmptyAsync(accountName, host).block();
     }
 }

--- a/tests/src/main/java/fixtures/custombaseuri/moreoptions/AutoRestParameterizedCustomHostTestClient.java
+++ b/tests/src/main/java/fixtures/custombaseuri/moreoptions/AutoRestParameterizedCustomHostTestClient.java
@@ -35,31 +35,6 @@ public final class AutoRestParameterizedCustomHostTestClient {
     }
 
     /**
-     * host.
-     */
-    private String dnsSuffix;
-
-    /**
-     * Gets host.
-     * 
-     * @return the dnsSuffix value.
-     */
-    public String getDnsSuffix() {
-        return this.dnsSuffix;
-    }
-
-    /**
-     * Sets host.
-     * 
-     * @param dnsSuffix the dnsSuffix value.
-     * @return the service client itself.
-     */
-    AutoRestParameterizedCustomHostTestClient setDnsSuffix(String dnsSuffix) {
-        this.dnsSuffix = dnsSuffix;
-        return this;
-    }
-
-    /**
      * The HTTP pipeline to send requests through.
      */
     private HttpPipeline httpPipeline;

--- a/tests/src/main/java/fixtures/custombaseuri/moreoptions/AutoRestParameterizedCustomHostTestClientBuilder.java
+++ b/tests/src/main/java/fixtures/custombaseuri/moreoptions/AutoRestParameterizedCustomHostTestClientBuilder.java
@@ -29,22 +29,6 @@ public final class AutoRestParameterizedCustomHostTestClientBuilder {
     }
 
     /*
-     * host
-     */
-    private String dnsSuffix;
-
-    /**
-     * Sets host.
-     * 
-     * @param dnsSuffix the dnsSuffix value.
-     * @return the AutoRestParameterizedCustomHostTestClientBuilder.
-     */
-    public AutoRestParameterizedCustomHostTestClientBuilder dnsSuffix(String dnsSuffix) {
-        this.dnsSuffix = dnsSuffix;
-        return this;
-    }
-
-    /*
      * The HTTP pipeline to send requests through
      */
     private HttpPipeline pipeline;
@@ -66,15 +50,11 @@ public final class AutoRestParameterizedCustomHostTestClientBuilder {
      * @return an instance of AutoRestParameterizedCustomHostTestClient.
      */
     public AutoRestParameterizedCustomHostTestClient build() {
-        if (dnsSuffix == null) {
-            this.dnsSuffix = "host";
-        }
         if (pipeline == null) {
             this.pipeline = new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build();
         }
         AutoRestParameterizedCustomHostTestClient client = new AutoRestParameterizedCustomHostTestClient(pipeline);
         client.setSubscriptionId(this.subscriptionId);
-        client.setDnsSuffix(this.dnsSuffix);
         return client;
     }
 }

--- a/tests/src/main/java/fixtures/custombaseuri/moreoptions/Paths.java
+++ b/tests/src/main/java/fixtures/custombaseuri/moreoptions/Paths.java
@@ -54,16 +54,28 @@ public final class Paths {
         Mono<Response<Void>> getEmpty(@HostParam("vault") String vault, @HostParam("secret") String secret, @HostParam("dnsSuffix") String dnsSuffix, @PathParam("keyName") String keyName, @PathParam("subscriptionId") String subscriptionId, @QueryParam("keyVersion") String keyVersion);
     }
 
+    /**
+     * Get a 200 to test a valid base uri.
+     * 
+     * @param vault simple string.
+     * @param secret simple string.
+     * @param dnsSuffix simple string.
+     * @param keyName MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param keyVersion MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<Void>> getEmptyWithResponseAsync(String vault, String secret, String keyName, String keyVersion) {
+    public Mono<Response<Void>> getEmptyWithResponseAsync(String vault, String secret, String dnsSuffix, String keyName, String keyVersion) {
         if (vault == null) {
             throw new IllegalArgumentException("Parameter vault is required and cannot be null.");
         }
         if (secret == null) {
             throw new IllegalArgumentException("Parameter secret is required and cannot be null.");
         }
-        if (this.client.getDnsSuffix() == null) {
-            throw new IllegalArgumentException("Parameter this.client.getDnsSuffix() is required and cannot be null.");
+        if (dnsSuffix == null) {
+            throw new IllegalArgumentException("Parameter dnsSuffix is required and cannot be null.");
         }
         if (keyName == null) {
             throw new IllegalArgumentException("Parameter keyName is required and cannot be null.");
@@ -71,17 +83,41 @@ public final class Paths {
         if (this.client.getSubscriptionId() == null) {
             throw new IllegalArgumentException("Parameter this.client.getSubscriptionId() is required and cannot be null.");
         }
-        return service.getEmpty(vault, secret, this.client.getDnsSuffix(), keyName, this.client.getSubscriptionId(), keyVersion);
+        return service.getEmpty(vault, secret, dnsSuffix, keyName, this.client.getSubscriptionId(), keyVersion);
     }
 
+    /**
+     * Get a 200 to test a valid base uri.
+     * 
+     * @param vault simple string.
+     * @param secret simple string.
+     * @param dnsSuffix simple string.
+     * @param keyName MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param keyVersion MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Void> getEmptyAsync(String vault, String secret, String keyName, String keyVersion) {
-        return getEmptyWithResponseAsync(vault, secret, keyName, keyVersion)
+    public Mono<Void> getEmptyAsync(String vault, String secret, String dnsSuffix, String keyName, String keyVersion) {
+        return getEmptyWithResponseAsync(vault, secret, dnsSuffix, keyName, keyVersion)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get a 200 to test a valid base uri.
+     * 
+     * @param vault simple string.
+     * @param secret simple string.
+     * @param dnsSuffix simple string.
+     * @param keyName MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param keyVersion MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public void getEmpty(String vault, String secret, String keyName, String keyVersion) {
-        getEmptyAsync(vault, secret, keyName, keyVersion).block();
+    public void getEmpty(String vault, String secret, String dnsSuffix, String keyName, String keyVersion) {
+        getEmptyAsync(vault, secret, dnsSuffix, keyName, keyVersion).block();
     }
 }

--- a/tests/src/main/java/fixtures/extensibleenums/Pets.java
+++ b/tests/src/main/java/fixtures/extensibleenums/Pets.java
@@ -60,6 +60,14 @@ public final class Pets {
         Mono<SimpleResponse<Pet>> addPet(@HostParam("$host") String host, @BodyParam("application/json") Pet petParam);
     }
 
+    /**
+     * MISSING·OPERATION-DESCRIPTION.
+     * 
+     * @param petId MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Pet>> getByPetIdWithResponseAsync(String petId) {
         if (this.client.getHost() == null) {
@@ -71,6 +79,14 @@ public final class Pets {
         return service.getByPetId(this.client.getHost(), petId);
     }
 
+    /**
+     * MISSING·OPERATION-DESCRIPTION.
+     * 
+     * @param petId MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Pet> getByPetIdAsync(String petId) {
         return getByPetIdWithResponseAsync(petId)
@@ -83,11 +99,27 @@ public final class Pets {
             });
     }
 
+    /**
+     * MISSING·OPERATION-DESCRIPTION.
+     * 
+     * @param petId MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Pet getByPetId(String petId) {
         return getByPetIdAsync(petId).block();
     }
 
+    /**
+     * MISSING·OPERATION-DESCRIPTION.
+     * 
+     * @param petParam MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Pet>> addPetWithResponseAsync(Pet petParam) {
         if (this.client.getHost() == null) {
@@ -99,6 +131,14 @@ public final class Pets {
         return service.addPet(this.client.getHost(), petParam);
     }
 
+    /**
+     * MISSING·OPERATION-DESCRIPTION.
+     * 
+     * @param petParam MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Pet> addPetAsync(Pet petParam) {
         return addPetWithResponseAsync(petParam)
@@ -111,6 +151,14 @@ public final class Pets {
             });
     }
 
+    /**
+     * MISSING·OPERATION-DESCRIPTION.
+     * 
+     * @param petParam MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Pet addPet(Pet petParam) {
         return addPetAsync(petParam).block();

--- a/tests/src/main/java/fixtures/head/HttpSuccess.java
+++ b/tests/src/main/java/fixtures/head/HttpSuccess.java
@@ -62,6 +62,12 @@ public final class HttpSuccess {
         Mono<Response<Void>> head404(@HostParam("$host") String host);
     }
 
+    /**
+     * Return 200 status code if successful.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> head200WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -70,17 +76,35 @@ public final class HttpSuccess {
         return service.head200(this.client.getHost());
     }
 
+    /**
+     * Return 200 status code if successful.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> head200Async() {
         return head200WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 200 status code if successful.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head200() {
         head200Async().block();
     }
 
+    /**
+     * Return 204 status code if successful.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> head204WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -89,17 +113,35 @@ public final class HttpSuccess {
         return service.head204(this.client.getHost());
     }
 
+    /**
+     * Return 204 status code if successful.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> head204Async() {
         return head204WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 204 status code if successful.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head204() {
         head204Async().block();
     }
 
+    /**
+     * Return 404 status code if successful.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> head404WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -108,12 +150,24 @@ public final class HttpSuccess {
         return service.head404(this.client.getHost());
     }
 
+    /**
+     * Return 404 status code if successful.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> head404Async() {
         return head404WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 404 status code if successful.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head404() {
         head404Async().block();

--- a/tests/src/main/java/fixtures/header/Headers.java
+++ b/tests/src/main/java/fixtures/header/Headers.java
@@ -213,6 +213,14 @@ public final class Headers {
         Mono<Response<Void>> customRequestId(@HostParam("$host") String host);
     }
 
+    /**
+     * Send a post request with header value "User-Agent": "overwrite".
+     * 
+     * @param userAgent MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> paramExistingKeyWithResponseAsync(String userAgent) {
         if (this.client.getHost() == null) {
@@ -224,17 +232,39 @@ public final class Headers {
         return service.paramExistingKey(this.client.getHost(), userAgent);
     }
 
+    /**
+     * Send a post request with header value "User-Agent": "overwrite".
+     * 
+     * @param userAgent MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> paramExistingKeyAsync(String userAgent) {
         return paramExistingKeyWithResponseAsync(userAgent)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Send a post request with header value "User-Agent": "overwrite".
+     * 
+     * @param userAgent MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void paramExistingKey(String userAgent) {
         paramExistingKeyAsync(userAgent).block();
     }
 
+    /**
+     * Get a response with header value "User-Agent": "overwrite".
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HeadersResponseExistingKeyResponse> responseExistingKeyWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -243,17 +273,37 @@ public final class Headers {
         return service.responseExistingKey(this.client.getHost());
     }
 
+    /**
+     * Get a response with header value "User-Agent": "overwrite".
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> responseExistingKeyAsync() {
         return responseExistingKeyWithResponseAsync()
             .flatMap((HeadersResponseExistingKeyResponse res) -> Mono.empty());
     }
 
+    /**
+     * Get a response with header value "User-Agent": "overwrite".
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void responseExistingKey() {
         responseExistingKeyAsync().block();
     }
 
+    /**
+     * Send a post request with header value "Content-Type": "text/html".
+     * 
+     * @param contentType MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> paramProtectedKeyWithResponseAsync(String contentType) {
         if (this.client.getHost() == null) {
@@ -265,17 +315,39 @@ public final class Headers {
         return service.paramProtectedKey(this.client.getHost(), contentType);
     }
 
+    /**
+     * Send a post request with header value "Content-Type": "text/html".
+     * 
+     * @param contentType MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> paramProtectedKeyAsync(String contentType) {
         return paramProtectedKeyWithResponseAsync(contentType)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Send a post request with header value "Content-Type": "text/html".
+     * 
+     * @param contentType MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void paramProtectedKey(String contentType) {
         paramProtectedKeyAsync(contentType).block();
     }
 
+    /**
+     * Get a response with header value "Content-Type": "text/html".
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HeadersResponseProtectedKeyResponse> responseProtectedKeyWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -284,17 +356,38 @@ public final class Headers {
         return service.responseProtectedKey(this.client.getHost());
     }
 
+    /**
+     * Get a response with header value "Content-Type": "text/html".
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> responseProtectedKeyAsync() {
         return responseProtectedKeyWithResponseAsync()
             .flatMap((HeadersResponseProtectedKeyResponse res) -> Mono.empty());
     }
 
+    /**
+     * Get a response with header value "Content-Type": "text/html".
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void responseProtectedKey() {
         responseProtectedKeyAsync().block();
     }
 
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 1 or "scenario": "negative", "value": -2.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> paramIntegerWithResponseAsync(String scenario, int value) {
         if (this.client.getHost() == null) {
@@ -306,17 +399,43 @@ public final class Headers {
         return service.paramInteger(this.client.getHost(), scenario, value);
     }
 
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 1 or "scenario": "negative", "value": -2.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> paramIntegerAsync(String scenario, int value) {
         return paramIntegerWithResponseAsync(scenario, value)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 1 or "scenario": "negative", "value": -2.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void paramInteger(String scenario, int value) {
         paramIntegerAsync(scenario, value).block();
     }
 
+    /**
+     * Get a response with header value "value": 1 or -2.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HeadersResponseIntegerResponse> responseIntegerWithResponseAsync(String scenario) {
         if (this.client.getHost() == null) {
@@ -328,17 +447,42 @@ public final class Headers {
         return service.responseInteger(this.client.getHost(), scenario);
     }
 
+    /**
+     * Get a response with header value "value": 1 or -2.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> responseIntegerAsync(String scenario) {
         return responseIntegerWithResponseAsync(scenario)
             .flatMap((HeadersResponseIntegerResponse res) -> Mono.empty());
     }
 
+    /**
+     * Get a response with header value "value": 1 or -2.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void responseInteger(String scenario) {
         responseIntegerAsync(scenario).block();
     }
 
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 105 or "scenario": "negative", "value": -2.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> paramLongWithResponseAsync(String scenario, long value) {
         if (this.client.getHost() == null) {
@@ -350,17 +494,43 @@ public final class Headers {
         return service.paramLong(this.client.getHost(), scenario, value);
     }
 
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 105 or "scenario": "negative", "value": -2.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> paramLongAsync(String scenario, long value) {
         return paramLongWithResponseAsync(scenario, value)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 105 or "scenario": "negative", "value": -2.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void paramLong(String scenario, long value) {
         paramLongAsync(scenario, value).block();
     }
 
+    /**
+     * Get a response with header value "value": 105 or -2.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HeadersResponseLongResponse> responseLongWithResponseAsync(String scenario) {
         if (this.client.getHost() == null) {
@@ -372,17 +542,42 @@ public final class Headers {
         return service.responseLong(this.client.getHost(), scenario);
     }
 
+    /**
+     * Get a response with header value "value": 105 or -2.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> responseLongAsync(String scenario) {
         return responseLongWithResponseAsync(scenario)
             .flatMap((HeadersResponseLongResponse res) -> Mono.empty());
     }
 
+    /**
+     * Get a response with header value "value": 105 or -2.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void responseLong(String scenario) {
         responseLongAsync(scenario).block();
     }
 
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 0.07 or "scenario": "negative", "value": -3.0.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-NUMBER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> paramFloatWithResponseAsync(String scenario, float value) {
         if (this.client.getHost() == null) {
@@ -394,17 +589,43 @@ public final class Headers {
         return service.paramFloat(this.client.getHost(), scenario, value);
     }
 
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 0.07 or "scenario": "negative", "value": -3.0.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-NUMBER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> paramFloatAsync(String scenario, float value) {
         return paramFloatWithResponseAsync(scenario, value)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 0.07 or "scenario": "negative", "value": -3.0.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-NUMBER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void paramFloat(String scenario, float value) {
         paramFloatAsync(scenario, value).block();
     }
 
+    /**
+     * Get a response with header value "value": 0.07 or -3.0.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HeadersResponseFloatResponse> responseFloatWithResponseAsync(String scenario) {
         if (this.client.getHost() == null) {
@@ -416,17 +637,42 @@ public final class Headers {
         return service.responseFloat(this.client.getHost(), scenario);
     }
 
+    /**
+     * Get a response with header value "value": 0.07 or -3.0.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> responseFloatAsync(String scenario) {
         return responseFloatWithResponseAsync(scenario)
             .flatMap((HeadersResponseFloatResponse res) -> Mono.empty());
     }
 
+    /**
+     * Get a response with header value "value": 0.07 or -3.0.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void responseFloat(String scenario) {
         responseFloatAsync(scenario).block();
     }
 
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 7e120 or "scenario": "negative", "value": -3.0.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-NUMBER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> paramDoubleWithResponseAsync(String scenario, double value) {
         if (this.client.getHost() == null) {
@@ -438,17 +684,43 @@ public final class Headers {
         return service.paramDouble(this.client.getHost(), scenario, value);
     }
 
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 7e120 or "scenario": "negative", "value": -3.0.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-NUMBER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> paramDoubleAsync(String scenario, double value) {
         return paramDoubleWithResponseAsync(scenario, value)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 7e120 or "scenario": "negative", "value": -3.0.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-NUMBER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void paramDouble(String scenario, double value) {
         paramDoubleAsync(scenario, value).block();
     }
 
+    /**
+     * Get a response with header value "value": 7e120 or -3.0.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HeadersResponseDoubleResponse> responseDoubleWithResponseAsync(String scenario) {
         if (this.client.getHost() == null) {
@@ -460,17 +732,42 @@ public final class Headers {
         return service.responseDouble(this.client.getHost(), scenario);
     }
 
+    /**
+     * Get a response with header value "value": 7e120 or -3.0.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> responseDoubleAsync(String scenario) {
         return responseDoubleWithResponseAsync(scenario)
             .flatMap((HeadersResponseDoubleResponse res) -> Mono.empty());
     }
 
+    /**
+     * Get a response with header value "value": 7e120 or -3.0.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void responseDouble(String scenario) {
         responseDoubleAsync(scenario).block();
     }
 
+    /**
+     * Send a post request with header values "scenario": "true", "value": true or "scenario": "false", "value": false.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-BOOLEAN.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> paramBoolWithResponseAsync(String scenario, boolean value) {
         if (this.client.getHost() == null) {
@@ -482,17 +779,43 @@ public final class Headers {
         return service.paramBool(this.client.getHost(), scenario, value);
     }
 
+    /**
+     * Send a post request with header values "scenario": "true", "value": true or "scenario": "false", "value": false.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-BOOLEAN.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> paramBoolAsync(String scenario, boolean value) {
         return paramBoolWithResponseAsync(scenario, value)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Send a post request with header values "scenario": "true", "value": true or "scenario": "false", "value": false.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-BOOLEAN.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void paramBool(String scenario, boolean value) {
         paramBoolAsync(scenario, value).block();
     }
 
+    /**
+     * Get a response with header value "value": true or false.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HeadersResponseBoolResponse> responseBoolWithResponseAsync(String scenario) {
         if (this.client.getHost() == null) {
@@ -504,17 +827,42 @@ public final class Headers {
         return service.responseBool(this.client.getHost(), scenario);
     }
 
+    /**
+     * Get a response with header value "value": true or false.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> responseBoolAsync(String scenario) {
         return responseBoolWithResponseAsync(scenario)
             .flatMap((HeadersResponseBoolResponse res) -> Mono.empty());
     }
 
+    /**
+     * Get a response with header value "value": true or false.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void responseBool(String scenario) {
         responseBoolAsync(scenario).block();
     }
 
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": "".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> paramStringWithResponseAsync(String scenario, String value) {
         if (this.client.getHost() == null) {
@@ -526,17 +874,43 @@ public final class Headers {
         return service.paramString(this.client.getHost(), scenario, value);
     }
 
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": "".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> paramStringAsync(String scenario, String value) {
         return paramStringWithResponseAsync(scenario, value)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": "".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void paramString(String scenario, String value) {
         paramStringAsync(scenario, value).block();
     }
 
+    /**
+     * Get a response with header values "The quick brown fox jumps over the lazy dog" or null or "".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HeadersResponseStringResponse> responseStringWithResponseAsync(String scenario) {
         if (this.client.getHost() == null) {
@@ -548,17 +922,42 @@ public final class Headers {
         return service.responseString(this.client.getHost(), scenario);
     }
 
+    /**
+     * Get a response with header values "The quick brown fox jumps over the lazy dog" or null or "".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> responseStringAsync(String scenario) {
         return responseStringWithResponseAsync(scenario)
             .flatMap((HeadersResponseStringResponse res) -> Mono.empty());
     }
 
+    /**
+     * Get a response with header values "The quick brown fox jumps over the lazy dog" or null or "".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void responseString(String scenario) {
         responseStringAsync(scenario).block();
     }
 
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "2010-01-01" or "scenario": "min", "value": "0001-01-01".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-DATE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> paramDateWithResponseAsync(String scenario, LocalDate value) {
         if (this.client.getHost() == null) {
@@ -573,17 +972,43 @@ public final class Headers {
         return service.paramDate(this.client.getHost(), scenario, value);
     }
 
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "2010-01-01" or "scenario": "min", "value": "0001-01-01".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-DATE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> paramDateAsync(String scenario, LocalDate value) {
         return paramDateWithResponseAsync(scenario, value)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "2010-01-01" or "scenario": "min", "value": "0001-01-01".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-DATE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void paramDate(String scenario, LocalDate value) {
         paramDateAsync(scenario, value).block();
     }
 
+    /**
+     * Get a response with header values "2010-01-01" or "0001-01-01".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HeadersResponseDateResponse> responseDateWithResponseAsync(String scenario) {
         if (this.client.getHost() == null) {
@@ -595,17 +1020,42 @@ public final class Headers {
         return service.responseDate(this.client.getHost(), scenario);
     }
 
+    /**
+     * Get a response with header values "2010-01-01" or "0001-01-01".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> responseDateAsync(String scenario) {
         return responseDateWithResponseAsync(scenario)
             .flatMap((HeadersResponseDateResponse res) -> Mono.empty());
     }
 
+    /**
+     * Get a response with header values "2010-01-01" or "0001-01-01".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void responseDate(String scenario) {
         responseDateAsync(scenario).block();
     }
 
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "2010-01-01T12:34:56Z" or "scenario": "min", "value": "0001-01-01T00:00:00Z".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> paramDatetimeWithResponseAsync(String scenario, OffsetDateTime value) {
         if (this.client.getHost() == null) {
@@ -620,17 +1070,43 @@ public final class Headers {
         return service.paramDatetime(this.client.getHost(), scenario, value);
     }
 
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "2010-01-01T12:34:56Z" or "scenario": "min", "value": "0001-01-01T00:00:00Z".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> paramDatetimeAsync(String scenario, OffsetDateTime value) {
         return paramDatetimeWithResponseAsync(scenario, value)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "2010-01-01T12:34:56Z" or "scenario": "min", "value": "0001-01-01T00:00:00Z".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void paramDatetime(String scenario, OffsetDateTime value) {
         paramDatetimeAsync(scenario, value).block();
     }
 
+    /**
+     * Get a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HeadersResponseDatetimeResponse> responseDatetimeWithResponseAsync(String scenario) {
         if (this.client.getHost() == null) {
@@ -642,17 +1118,42 @@ public final class Headers {
         return service.responseDatetime(this.client.getHost(), scenario);
     }
 
+    /**
+     * Get a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> responseDatetimeAsync(String scenario) {
         return responseDatetimeWithResponseAsync(scenario)
             .flatMap((HeadersResponseDatetimeResponse res) -> Mono.empty());
     }
 
+    /**
+     * Get a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void responseDatetime(String scenario) {
         responseDatetimeAsync(scenario).block();
     }
 
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> paramDatetimeRfc1123WithResponseAsync(String scenario, OffsetDateTime value) {
         if (this.client.getHost() == null) {
@@ -665,17 +1166,43 @@ public final class Headers {
         return service.paramDatetimeRfc1123(this.client.getHost(), scenario, valueConverted);
     }
 
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> paramDatetimeRfc1123Async(String scenario, OffsetDateTime value) {
         return paramDatetimeRfc1123WithResponseAsync(scenario, value)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void paramDatetimeRfc1123(String scenario, OffsetDateTime value) {
         paramDatetimeRfc1123Async(scenario, value).block();
     }
 
+    /**
+     * Get a response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HeadersResponseDatetimeRfc1123Response> responseDatetimeRfc1123WithResponseAsync(String scenario) {
         if (this.client.getHost() == null) {
@@ -687,17 +1214,42 @@ public final class Headers {
         return service.responseDatetimeRfc1123(this.client.getHost(), scenario);
     }
 
+    /**
+     * Get a response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> responseDatetimeRfc1123Async(String scenario) {
         return responseDatetimeRfc1123WithResponseAsync(scenario)
             .flatMap((HeadersResponseDatetimeRfc1123Response res) -> Mono.empty());
     }
 
+    /**
+     * Get a response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void responseDatetimeRfc1123(String scenario) {
         responseDatetimeRfc1123Async(scenario).block();
     }
 
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "P123DT22H14M12.011S".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-DURATION.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> paramDurationWithResponseAsync(String scenario, Duration value) {
         if (this.client.getHost() == null) {
@@ -712,17 +1264,43 @@ public final class Headers {
         return service.paramDuration(this.client.getHost(), scenario, value);
     }
 
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "P123DT22H14M12.011S".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-DURATION.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> paramDurationAsync(String scenario, Duration value) {
         return paramDurationWithResponseAsync(scenario, value)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "P123DT22H14M12.011S".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-DURATION.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void paramDuration(String scenario, Duration value) {
         paramDurationAsync(scenario, value).block();
     }
 
+    /**
+     * Get a response with header values "P123DT22H14M12.011S".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HeadersResponseDurationResponse> responseDurationWithResponseAsync(String scenario) {
         if (this.client.getHost() == null) {
@@ -734,17 +1312,42 @@ public final class Headers {
         return service.responseDuration(this.client.getHost(), scenario);
     }
 
+    /**
+     * Get a response with header values "P123DT22H14M12.011S".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> responseDurationAsync(String scenario) {
         return responseDurationWithResponseAsync(scenario)
             .flatMap((HeadersResponseDurationResponse res) -> Mono.empty());
     }
 
+    /**
+     * Get a response with header values "P123DT22H14M12.011S".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void responseDuration(String scenario) {
         responseDurationAsync(scenario).block();
     }
 
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "啊齄丂狛狜隣郎隣兀﨩".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-BYTEARRAY.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> paramByteWithResponseAsync(String scenario, byte[] value) {
         if (this.client.getHost() == null) {
@@ -760,17 +1363,43 @@ public final class Headers {
         return service.paramByte(this.client.getHost(), scenario, valueConverted);
     }
 
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "啊齄丂狛狜隣郎隣兀﨩".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-BYTEARRAY.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> paramByteAsync(String scenario, byte[] value) {
         return paramByteWithResponseAsync(scenario, value)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "啊齄丂狛狜隣郎隣兀﨩".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-BYTEARRAY.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void paramByte(String scenario, byte[] value) {
         paramByteAsync(scenario, value).block();
     }
 
+    /**
+     * Get a response with header values "啊齄丂狛狜隣郎隣兀﨩".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HeadersResponseByteResponse> responseByteWithResponseAsync(String scenario) {
         if (this.client.getHost() == null) {
@@ -782,17 +1411,42 @@ public final class Headers {
         return service.responseByte(this.client.getHost(), scenario);
     }
 
+    /**
+     * Get a response with header values "啊齄丂狛狜隣郎隣兀﨩".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> responseByteAsync(String scenario) {
         return responseByteWithResponseAsync(scenario)
             .flatMap((HeadersResponseByteResponse res) -> Mono.empty());
     }
 
+    /**
+     * Get a response with header values "啊齄丂狛狜隣郎隣兀﨩".
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void responseByte(String scenario) {
         responseByteAsync(scenario).block();
     }
 
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-CHOICE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> paramEnumWithResponseAsync(String scenario, GreyscaleColors value) {
         if (this.client.getHost() == null) {
@@ -804,17 +1458,43 @@ public final class Headers {
         return service.paramEnum(this.client.getHost(), scenario, value);
     }
 
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-CHOICE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> paramEnumAsync(String scenario, GreyscaleColors value) {
         return paramEnumWithResponseAsync(scenario, value)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param value MISSING·SCHEMA-DESCRIPTION-CHOICE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void paramEnum(String scenario, GreyscaleColors value) {
         paramEnumAsync(scenario, value).block();
     }
 
+    /**
+     * Get a response with header values "GREY" or null.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HeadersResponseEnumResponse> responseEnumWithResponseAsync(String scenario) {
         if (this.client.getHost() == null) {
@@ -826,17 +1506,39 @@ public final class Headers {
         return service.responseEnum(this.client.getHost(), scenario);
     }
 
+    /**
+     * Get a response with header values "GREY" or null.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> responseEnumAsync(String scenario) {
         return responseEnumWithResponseAsync(scenario)
             .flatMap((HeadersResponseEnumResponse res) -> Mono.empty());
     }
 
+    /**
+     * Get a response with header values "GREY" or null.
+     * 
+     * @param scenario MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void responseEnum(String scenario) {
         responseEnumAsync(scenario).block();
     }
 
+    /**
+     * Send x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> customRequestIdWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -845,12 +1547,24 @@ public final class Headers {
         return service.customRequestId(this.client.getHost());
     }
 
+    /**
+     * Send x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> customRequestIdAsync() {
         return customRequestIdWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Send x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void customRequestId() {
         customRequestIdAsync().block();

--- a/tests/src/main/java/fixtures/headexceptions/HeadExceptions.java
+++ b/tests/src/main/java/fixtures/headexceptions/HeadExceptions.java
@@ -62,6 +62,12 @@ public final class HeadExceptions {
         Mono<Response<Void>> head404(@HostParam("$host") String host);
     }
 
+    /**
+     * Return 200 status code if successful.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> head200WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -70,17 +76,35 @@ public final class HeadExceptions {
         return service.head200(this.client.getHost());
     }
 
+    /**
+     * Return 200 status code if successful.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> head200Async() {
         return head200WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 200 status code if successful.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head200() {
         head200Async().block();
     }
 
+    /**
+     * Return 204 status code if successful.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> head204WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -89,17 +113,35 @@ public final class HeadExceptions {
         return service.head204(this.client.getHost());
     }
 
+    /**
+     * Return 204 status code if successful.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> head204Async() {
         return head204WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 204 status code if successful.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head204() {
         head204Async().block();
     }
 
+    /**
+     * Return 404 status code if successful.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> head404WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -108,12 +150,24 @@ public final class HeadExceptions {
         return service.head404(this.client.getHost());
     }
 
+    /**
+     * Return 404 status code if successful.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> head404Async() {
         return head404WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 404 status code if successful.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head404() {
         head404Async().block();

--- a/tests/src/main/java/fixtures/httpinfrastructure/HttpClientFailures.java
+++ b/tests/src/main/java/fixtures/httpinfrastructure/HttpClientFailures.java
@@ -145,6 +145,12 @@ public final class HttpClientFailures {
         Mono<Response<Void>> head429(@HostParam("$host") String host);
     }
 
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> head400WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -153,17 +159,35 @@ public final class HttpClientFailures {
         return service.head400(this.client.getHost());
     }
 
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> head400Async() {
         return head400WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head400() {
         head400Async().block();
     }
 
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> get400WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -172,17 +196,35 @@ public final class HttpClientFailures {
         return service.get400(this.client.getHost());
     }
 
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> get400Async() {
         return get400WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get400() {
         get400Async().block();
     }
 
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> put400WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -192,17 +234,35 @@ public final class HttpClientFailures {
         return service.put400(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> put400Async() {
         return put400WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void put400() {
         put400Async().block();
     }
 
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> patch400WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -212,17 +272,35 @@ public final class HttpClientFailures {
         return service.patch400(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> patch400Async() {
         return patch400WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void patch400() {
         patch400Async().block();
     }
 
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> post400WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -232,17 +310,35 @@ public final class HttpClientFailures {
         return service.post400(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> post400Async() {
         return post400WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void post400() {
         post400Async().block();
     }
 
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> delete400WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -252,17 +348,35 @@ public final class HttpClientFailures {
         return service.delete400(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> delete400Async() {
         return delete400WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void delete400() {
         delete400Async().block();
     }
 
+    /**
+     * Return 401 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> head401WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -271,17 +385,35 @@ public final class HttpClientFailures {
         return service.head401(this.client.getHost());
     }
 
+    /**
+     * Return 401 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> head401Async() {
         return head401WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 401 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head401() {
         head401Async().block();
     }
 
+    /**
+     * Return 402 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> get402WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -290,17 +422,35 @@ public final class HttpClientFailures {
         return service.get402(this.client.getHost());
     }
 
+    /**
+     * Return 402 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> get402Async() {
         return get402WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 402 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get402() {
         get402Async().block();
     }
 
+    /**
+     * Return 403 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> get403WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -309,17 +459,35 @@ public final class HttpClientFailures {
         return service.get403(this.client.getHost());
     }
 
+    /**
+     * Return 403 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> get403Async() {
         return get403WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 403 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get403() {
         get403Async().block();
     }
 
+    /**
+     * Return 404 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> put404WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -329,17 +497,35 @@ public final class HttpClientFailures {
         return service.put404(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Return 404 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> put404Async() {
         return put404WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 404 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void put404() {
         put404Async().block();
     }
 
+    /**
+     * Return 405 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> patch405WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -349,17 +535,35 @@ public final class HttpClientFailures {
         return service.patch405(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Return 405 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> patch405Async() {
         return patch405WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 405 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void patch405() {
         patch405Async().block();
     }
 
+    /**
+     * Return 406 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> post406WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -369,17 +573,35 @@ public final class HttpClientFailures {
         return service.post406(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Return 406 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> post406Async() {
         return post406WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 406 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void post406() {
         post406Async().block();
     }
 
+    /**
+     * Return 407 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> delete407WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -389,17 +611,35 @@ public final class HttpClientFailures {
         return service.delete407(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Return 407 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> delete407Async() {
         return delete407WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 407 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void delete407() {
         delete407Async().block();
     }
 
+    /**
+     * Return 409 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> put409WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -409,17 +649,35 @@ public final class HttpClientFailures {
         return service.put409(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Return 409 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> put409Async() {
         return put409WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 409 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void put409() {
         put409Async().block();
     }
 
+    /**
+     * Return 410 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> head410WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -428,17 +686,35 @@ public final class HttpClientFailures {
         return service.head410(this.client.getHost());
     }
 
+    /**
+     * Return 410 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> head410Async() {
         return head410WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 410 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head410() {
         head410Async().block();
     }
 
+    /**
+     * Return 411 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> get411WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -447,17 +723,35 @@ public final class HttpClientFailures {
         return service.get411(this.client.getHost());
     }
 
+    /**
+     * Return 411 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> get411Async() {
         return get411WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 411 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get411() {
         get411Async().block();
     }
 
+    /**
+     * Return 412 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> get412WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -466,17 +760,35 @@ public final class HttpClientFailures {
         return service.get412(this.client.getHost());
     }
 
+    /**
+     * Return 412 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> get412Async() {
         return get412WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 412 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get412() {
         get412Async().block();
     }
 
+    /**
+     * Return 413 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> put413WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -486,17 +798,35 @@ public final class HttpClientFailures {
         return service.put413(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Return 413 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> put413Async() {
         return put413WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 413 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void put413() {
         put413Async().block();
     }
 
+    /**
+     * Return 414 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> patch414WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -506,17 +836,35 @@ public final class HttpClientFailures {
         return service.patch414(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Return 414 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> patch414Async() {
         return patch414WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 414 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void patch414() {
         patch414Async().block();
     }
 
+    /**
+     * Return 415 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> post415WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -526,17 +874,35 @@ public final class HttpClientFailures {
         return service.post415(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Return 415 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> post415Async() {
         return post415WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 415 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void post415() {
         post415Async().block();
     }
 
+    /**
+     * Return 416 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> get416WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -545,17 +911,35 @@ public final class HttpClientFailures {
         return service.get416(this.client.getHost());
     }
 
+    /**
+     * Return 416 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> get416Async() {
         return get416WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 416 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get416() {
         get416Async().block();
     }
 
+    /**
+     * Return 417 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> delete417WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -565,17 +949,35 @@ public final class HttpClientFailures {
         return service.delete417(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Return 417 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> delete417Async() {
         return delete417WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 417 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void delete417() {
         delete417Async().block();
     }
 
+    /**
+     * Return 429 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> head429WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -584,12 +986,24 @@ public final class HttpClientFailures {
         return service.head429(this.client.getHost());
     }
 
+    /**
+     * Return 429 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> head429Async() {
         return head429WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 429 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head429() {
         head429Async().block();

--- a/tests/src/main/java/fixtures/httpinfrastructure/HttpFailures.java
+++ b/tests/src/main/java/fixtures/httpinfrastructure/HttpFailures.java
@@ -63,6 +63,12 @@ public final class HttpFailures {
         Mono<SimpleResponse<Boolean>> getNoModelEmpty(@HostParam("$host") String host);
     }
 
+    /**
+     * Get empty error form server.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Boolean>> getEmptyErrorWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -71,6 +77,12 @@ public final class HttpFailures {
         return service.getEmptyError(this.client.getHost());
     }
 
+    /**
+     * Get empty error form server.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Boolean> getEmptyErrorAsync() {
         return getEmptyErrorWithResponseAsync()
@@ -83,11 +95,23 @@ public final class HttpFailures {
             });
     }
 
+    /**
+     * Get empty error form server.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public boolean getEmptyError() {
         return getEmptyErrorAsync().block();
     }
 
+    /**
+     * Get empty error form server.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Boolean>> getNoModelErrorWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -96,6 +120,12 @@ public final class HttpFailures {
         return service.getNoModelError(this.client.getHost());
     }
 
+    /**
+     * Get empty error form server.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Boolean> getNoModelErrorAsync() {
         return getNoModelErrorWithResponseAsync()
@@ -108,11 +138,23 @@ public final class HttpFailures {
             });
     }
 
+    /**
+     * Get empty error form server.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public boolean getNoModelError() {
         return getNoModelErrorAsync().block();
     }
 
+    /**
+     * Get empty response from server.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Boolean>> getNoModelEmptyWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -121,6 +163,12 @@ public final class HttpFailures {
         return service.getNoModelEmpty(this.client.getHost());
     }
 
+    /**
+     * Get empty response from server.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Boolean> getNoModelEmptyAsync() {
         return getNoModelEmptyWithResponseAsync()
@@ -133,6 +181,12 @@ public final class HttpFailures {
             });
     }
 
+    /**
+     * Get empty response from server.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public boolean getNoModelEmpty() {
         return getNoModelEmptyAsync().block();

--- a/tests/src/main/java/fixtures/httpinfrastructure/HttpRedirects.java
+++ b/tests/src/main/java/fixtures/httpinfrastructure/HttpRedirects.java
@@ -143,6 +143,12 @@ public final class HttpRedirects {
         Mono<HttpRedirectsDelete307Response> delete307(@HostParam("$host") String host, @BodyParam("application/json") Boolean booleanValue);
     }
 
+    /**
+     * Return 300 status code and redirect to /http/success/200.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HttpRedirectsHead300Response> head300WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -151,17 +157,35 @@ public final class HttpRedirects {
         return service.head300(this.client.getHost());
     }
 
+    /**
+     * Return 300 status code and redirect to /http/success/200.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> head300Async() {
         return head300WithResponseAsync()
             .flatMap((HttpRedirectsHead300Response res) -> Mono.empty());
     }
 
+    /**
+     * Return 300 status code and redirect to /http/success/200.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head300() {
         head300Async().block();
     }
 
+    /**
+     * Return 300 status code and redirect to /http/success/200.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HttpRedirectsGet300Response> get300WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -170,6 +194,12 @@ public final class HttpRedirects {
         return service.get300(this.client.getHost());
     }
 
+    /**
+     * Return 300 status code and redirect to /http/success/200.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<List<String>> get300Async() {
         return get300WithResponseAsync()
@@ -182,11 +212,23 @@ public final class HttpRedirects {
             });
     }
 
+    /**
+     * Return 300 status code and redirect to /http/success/200.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<String> get300() {
         return get300Async().block();
     }
 
+    /**
+     * Return 301 status code and redirect to /http/success/200.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HttpRedirectsHead301Response> head301WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -195,17 +237,35 @@ public final class HttpRedirects {
         return service.head301(this.client.getHost());
     }
 
+    /**
+     * Return 301 status code and redirect to /http/success/200.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> head301Async() {
         return head301WithResponseAsync()
             .flatMap((HttpRedirectsHead301Response res) -> Mono.empty());
     }
 
+    /**
+     * Return 301 status code and redirect to /http/success/200.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head301() {
         head301Async().block();
     }
 
+    /**
+     * Return 301 status code and redirect to /http/success/200.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HttpRedirectsGet301Response> get301WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -214,17 +274,35 @@ public final class HttpRedirects {
         return service.get301(this.client.getHost());
     }
 
+    /**
+     * Return 301 status code and redirect to /http/success/200.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> get301Async() {
         return get301WithResponseAsync()
             .flatMap((HttpRedirectsGet301Response res) -> Mono.empty());
     }
 
+    /**
+     * Return 301 status code and redirect to /http/success/200.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get301() {
         get301Async().block();
     }
 
+    /**
+     * Put true Boolean value in request returns 301.  This request should not be automatically redirected, but should return the received 301 to the caller for evaluation.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HttpRedirectsPut301Response> put301WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -234,17 +312,35 @@ public final class HttpRedirects {
         return service.put301(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Put true Boolean value in request returns 301.  This request should not be automatically redirected, but should return the received 301 to the caller for evaluation.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> put301Async() {
         return put301WithResponseAsync()
             .flatMap((HttpRedirectsPut301Response res) -> Mono.empty());
     }
 
+    /**
+     * Put true Boolean value in request returns 301.  This request should not be automatically redirected, but should return the received 301 to the caller for evaluation.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void put301() {
         put301Async().block();
     }
 
+    /**
+     * Return 302 status code and redirect to /http/success/200.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HttpRedirectsHead302Response> head302WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -253,17 +349,35 @@ public final class HttpRedirects {
         return service.head302(this.client.getHost());
     }
 
+    /**
+     * Return 302 status code and redirect to /http/success/200.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> head302Async() {
         return head302WithResponseAsync()
             .flatMap((HttpRedirectsHead302Response res) -> Mono.empty());
     }
 
+    /**
+     * Return 302 status code and redirect to /http/success/200.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head302() {
         head302Async().block();
     }
 
+    /**
+     * Return 302 status code and redirect to /http/success/200.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HttpRedirectsGet302Response> get302WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -272,17 +386,35 @@ public final class HttpRedirects {
         return service.get302(this.client.getHost());
     }
 
+    /**
+     * Return 302 status code and redirect to /http/success/200.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> get302Async() {
         return get302WithResponseAsync()
             .flatMap((HttpRedirectsGet302Response res) -> Mono.empty());
     }
 
+    /**
+     * Return 302 status code and redirect to /http/success/200.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get302() {
         get302Async().block();
     }
 
+    /**
+     * Patch true Boolean value in request returns 302.  This request should not be automatically redirected, but should return the received 302 to the caller for evaluation.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HttpRedirectsPatch302Response> patch302WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -292,17 +424,35 @@ public final class HttpRedirects {
         return service.patch302(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Patch true Boolean value in request returns 302.  This request should not be automatically redirected, but should return the received 302 to the caller for evaluation.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> patch302Async() {
         return patch302WithResponseAsync()
             .flatMap((HttpRedirectsPatch302Response res) -> Mono.empty());
     }
 
+    /**
+     * Patch true Boolean value in request returns 302.  This request should not be automatically redirected, but should return the received 302 to the caller for evaluation.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void patch302() {
         patch302Async().block();
     }
 
+    /**
+     * Post true Boolean value in request returns 303.  This request should be automatically redirected usign a get, ultimately returning a 200 status code.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HttpRedirectsPost303Response> post303WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -312,17 +462,35 @@ public final class HttpRedirects {
         return service.post303(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Post true Boolean value in request returns 303.  This request should be automatically redirected usign a get, ultimately returning a 200 status code.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> post303Async() {
         return post303WithResponseAsync()
             .flatMap((HttpRedirectsPost303Response res) -> Mono.empty());
     }
 
+    /**
+     * Post true Boolean value in request returns 303.  This request should be automatically redirected usign a get, ultimately returning a 200 status code.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void post303() {
         post303Async().block();
     }
 
+    /**
+     * Redirect with 307, resulting in a 200 success.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HttpRedirectsHead307Response> head307WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -331,17 +499,35 @@ public final class HttpRedirects {
         return service.head307(this.client.getHost());
     }
 
+    /**
+     * Redirect with 307, resulting in a 200 success.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> head307Async() {
         return head307WithResponseAsync()
             .flatMap((HttpRedirectsHead307Response res) -> Mono.empty());
     }
 
+    /**
+     * Redirect with 307, resulting in a 200 success.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head307() {
         head307Async().block();
     }
 
+    /**
+     * Redirect get with 307, resulting in a 200 success.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HttpRedirectsGet307Response> get307WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -350,17 +536,35 @@ public final class HttpRedirects {
         return service.get307(this.client.getHost());
     }
 
+    /**
+     * Redirect get with 307, resulting in a 200 success.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> get307Async() {
         return get307WithResponseAsync()
             .flatMap((HttpRedirectsGet307Response res) -> Mono.empty());
     }
 
+    /**
+     * Redirect get with 307, resulting in a 200 success.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get307() {
         get307Async().block();
     }
 
+    /**
+     * Put redirected with 307, resulting in a 200 after redirect.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HttpRedirectsPut307Response> put307WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -370,17 +574,35 @@ public final class HttpRedirects {
         return service.put307(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Put redirected with 307, resulting in a 200 after redirect.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> put307Async() {
         return put307WithResponseAsync()
             .flatMap((HttpRedirectsPut307Response res) -> Mono.empty());
     }
 
+    /**
+     * Put redirected with 307, resulting in a 200 after redirect.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void put307() {
         put307Async().block();
     }
 
+    /**
+     * Patch redirected with 307, resulting in a 200 after redirect.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HttpRedirectsPatch307Response> patch307WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -390,17 +612,35 @@ public final class HttpRedirects {
         return service.patch307(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Patch redirected with 307, resulting in a 200 after redirect.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> patch307Async() {
         return patch307WithResponseAsync()
             .flatMap((HttpRedirectsPatch307Response res) -> Mono.empty());
     }
 
+    /**
+     * Patch redirected with 307, resulting in a 200 after redirect.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void patch307() {
         patch307Async().block();
     }
 
+    /**
+     * Post redirected with 307, resulting in a 200 after redirect.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HttpRedirectsPost307Response> post307WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -410,17 +650,35 @@ public final class HttpRedirects {
         return service.post307(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Post redirected with 307, resulting in a 200 after redirect.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> post307Async() {
         return post307WithResponseAsync()
             .flatMap((HttpRedirectsPost307Response res) -> Mono.empty());
     }
 
+    /**
+     * Post redirected with 307, resulting in a 200 after redirect.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void post307() {
         post307Async().block();
     }
 
+    /**
+     * Delete redirected with 307, resulting in a 200 after redirect.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HttpRedirectsDelete307Response> delete307WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -430,12 +688,24 @@ public final class HttpRedirects {
         return service.delete307(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Delete redirected with 307, resulting in a 200 after redirect.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> delete307Async() {
         return delete307WithResponseAsync()
             .flatMap((HttpRedirectsDelete307Response res) -> Mono.empty());
     }
 
+    /**
+     * Delete redirected with 307, resulting in a 200 after redirect.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void delete307() {
         delete307Async().block();

--- a/tests/src/main/java/fixtures/httpinfrastructure/HttpRetrys.java
+++ b/tests/src/main/java/fixtures/httpinfrastructure/HttpRetrys.java
@@ -93,6 +93,12 @@ public final class HttpRetrys {
         Mono<Response<Void>> patch504(@HostParam("$host") String host, @BodyParam("application/json") Boolean booleanValue);
     }
 
+    /**
+     * Return 408 status code, then 200 after retry.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> head408WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -101,17 +107,35 @@ public final class HttpRetrys {
         return service.head408(this.client.getHost());
     }
 
+    /**
+     * Return 408 status code, then 200 after retry.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> head408Async() {
         return head408WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 408 status code, then 200 after retry.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head408() {
         head408Async().block();
     }
 
+    /**
+     * Return 500 status code, then 200 after retry.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> put500WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -121,17 +145,35 @@ public final class HttpRetrys {
         return service.put500(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Return 500 status code, then 200 after retry.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> put500Async() {
         return put500WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 500 status code, then 200 after retry.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void put500() {
         put500Async().block();
     }
 
+    /**
+     * Return 500 status code, then 200 after retry.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> patch500WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -141,17 +183,35 @@ public final class HttpRetrys {
         return service.patch500(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Return 500 status code, then 200 after retry.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> patch500Async() {
         return patch500WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 500 status code, then 200 after retry.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void patch500() {
         patch500Async().block();
     }
 
+    /**
+     * Return 502 status code, then 200 after retry.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> get502WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -160,17 +220,35 @@ public final class HttpRetrys {
         return service.get502(this.client.getHost());
     }
 
+    /**
+     * Return 502 status code, then 200 after retry.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> get502Async() {
         return get502WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 502 status code, then 200 after retry.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get502() {
         get502Async().block();
     }
 
+    /**
+     * Return 503 status code, then 200 after retry.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> post503WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -180,17 +258,35 @@ public final class HttpRetrys {
         return service.post503(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Return 503 status code, then 200 after retry.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> post503Async() {
         return post503WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 503 status code, then 200 after retry.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void post503() {
         post503Async().block();
     }
 
+    /**
+     * Return 503 status code, then 200 after retry.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> delete503WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -200,17 +296,35 @@ public final class HttpRetrys {
         return service.delete503(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Return 503 status code, then 200 after retry.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> delete503Async() {
         return delete503WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 503 status code, then 200 after retry.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void delete503() {
         delete503Async().block();
     }
 
+    /**
+     * Return 504 status code, then 200 after retry.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> put504WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -220,17 +334,35 @@ public final class HttpRetrys {
         return service.put504(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Return 504 status code, then 200 after retry.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> put504Async() {
         return put504WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 504 status code, then 200 after retry.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void put504() {
         put504Async().block();
     }
 
+    /**
+     * Return 504 status code, then 200 after retry.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> patch504WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -240,12 +372,24 @@ public final class HttpRetrys {
         return service.patch504(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Return 504 status code, then 200 after retry.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> patch504Async() {
         return patch504WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 504 status code, then 200 after retry.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void patch504() {
         patch504Async().block();

--- a/tests/src/main/java/fixtures/httpinfrastructure/HttpServerFailures.java
+++ b/tests/src/main/java/fixtures/httpinfrastructure/HttpServerFailures.java
@@ -67,6 +67,12 @@ public final class HttpServerFailures {
         Mono<Response<Void>> delete505(@HostParam("$host") String host, @BodyParam("application/json") Boolean booleanValue);
     }
 
+    /**
+     * Return 501 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> head501WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -75,17 +81,35 @@ public final class HttpServerFailures {
         return service.head501(this.client.getHost());
     }
 
+    /**
+     * Return 501 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> head501Async() {
         return head501WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 501 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head501() {
         head501Async().block();
     }
 
+    /**
+     * Return 501 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> get501WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -94,17 +118,35 @@ public final class HttpServerFailures {
         return service.get501(this.client.getHost());
     }
 
+    /**
+     * Return 501 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> get501Async() {
         return get501WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 501 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get501() {
         get501Async().block();
     }
 
+    /**
+     * Return 505 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> post505WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -114,17 +156,35 @@ public final class HttpServerFailures {
         return service.post505(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Return 505 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> post505Async() {
         return post505WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 505 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void post505() {
         post505Async().block();
     }
 
+    /**
+     * Return 505 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> delete505WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -134,12 +194,24 @@ public final class HttpServerFailures {
         return service.delete505(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Return 505 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> delete505Async() {
         return delete505WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 505 status code - should be represented in the client as an error.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void delete505() {
         delete505Async().block();

--- a/tests/src/main/java/fixtures/httpinfrastructure/HttpSuccess.java
+++ b/tests/src/main/java/fixtures/httpinfrastructure/HttpSuccess.java
@@ -144,6 +144,12 @@ public final class HttpSuccess {
         Mono<Response<Void>> head404(@HostParam("$host") String host);
     }
 
+    /**
+     * Return 200 status code if successful.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> head200WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -152,17 +158,35 @@ public final class HttpSuccess {
         return service.head200(this.client.getHost());
     }
 
+    /**
+     * Return 200 status code if successful.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> head200Async() {
         return head200WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 200 status code if successful.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head200() {
         head200Async().block();
     }
 
+    /**
+     * Get 200 success.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Boolean>> get200WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -171,6 +195,12 @@ public final class HttpSuccess {
         return service.get200(this.client.getHost());
     }
 
+    /**
+     * Get 200 success.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Boolean> get200Async() {
         return get200WithResponseAsync()
@@ -183,11 +213,23 @@ public final class HttpSuccess {
             });
     }
 
+    /**
+     * Get 200 success.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public boolean get200() {
         return get200Async().block();
     }
 
+    /**
+     * Put boolean value true returning 200 success.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> put200WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -197,17 +239,35 @@ public final class HttpSuccess {
         return service.put200(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Put boolean value true returning 200 success.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> put200Async() {
         return put200WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put boolean value true returning 200 success.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void put200() {
         put200Async().block();
     }
 
+    /**
+     * Patch true Boolean value in request returning 200.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> patch200WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -217,17 +277,35 @@ public final class HttpSuccess {
         return service.patch200(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Patch true Boolean value in request returning 200.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> patch200Async() {
         return patch200WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Patch true Boolean value in request returning 200.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void patch200() {
         patch200Async().block();
     }
 
+    /**
+     * Post bollean value true in request that returns a 200.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> post200WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -237,17 +315,35 @@ public final class HttpSuccess {
         return service.post200(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Post bollean value true in request that returns a 200.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> post200Async() {
         return post200WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Post bollean value true in request that returns a 200.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void post200() {
         post200Async().block();
     }
 
+    /**
+     * Delete simple boolean value true returns 200.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> delete200WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -257,17 +353,35 @@ public final class HttpSuccess {
         return service.delete200(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Delete simple boolean value true returns 200.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> delete200Async() {
         return delete200WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Delete simple boolean value true returns 200.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void delete200() {
         delete200Async().block();
     }
 
+    /**
+     * Put true Boolean value in request returns 201.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> put201WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -277,17 +391,35 @@ public final class HttpSuccess {
         return service.put201(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Put true Boolean value in request returns 201.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> put201Async() {
         return put201WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put true Boolean value in request returns 201.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void put201() {
         put201Async().block();
     }
 
+    /**
+     * Post true Boolean value in request returns 201 (Created).
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> post201WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -297,17 +429,35 @@ public final class HttpSuccess {
         return service.post201(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Post true Boolean value in request returns 201 (Created).
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> post201Async() {
         return post201WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Post true Boolean value in request returns 201 (Created).
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void post201() {
         post201Async().block();
     }
 
+    /**
+     * Put true Boolean value in request returns 202 (Accepted).
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> put202WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -317,17 +467,35 @@ public final class HttpSuccess {
         return service.put202(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Put true Boolean value in request returns 202 (Accepted).
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> put202Async() {
         return put202WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put true Boolean value in request returns 202 (Accepted).
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void put202() {
         put202Async().block();
     }
 
+    /**
+     * Patch true Boolean value in request returns 202.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> patch202WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -337,17 +505,35 @@ public final class HttpSuccess {
         return service.patch202(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Patch true Boolean value in request returns 202.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> patch202Async() {
         return patch202WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Patch true Boolean value in request returns 202.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void patch202() {
         patch202Async().block();
     }
 
+    /**
+     * Post true Boolean value in request returns 202 (Accepted).
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> post202WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -357,17 +543,35 @@ public final class HttpSuccess {
         return service.post202(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Post true Boolean value in request returns 202 (Accepted).
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> post202Async() {
         return post202WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Post true Boolean value in request returns 202 (Accepted).
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void post202() {
         post202Async().block();
     }
 
+    /**
+     * Delete true Boolean value in request returns 202 (accepted).
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> delete202WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -377,17 +581,35 @@ public final class HttpSuccess {
         return service.delete202(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Delete true Boolean value in request returns 202 (accepted).
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> delete202Async() {
         return delete202WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Delete true Boolean value in request returns 202 (accepted).
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void delete202() {
         delete202Async().block();
     }
 
+    /**
+     * Return 204 status code if successful.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> head204WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -396,17 +618,35 @@ public final class HttpSuccess {
         return service.head204(this.client.getHost());
     }
 
+    /**
+     * Return 204 status code if successful.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> head204Async() {
         return head204WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 204 status code if successful.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head204() {
         head204Async().block();
     }
 
+    /**
+     * Put true Boolean value in request returns 204 (no content).
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> put204WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -416,17 +656,35 @@ public final class HttpSuccess {
         return service.put204(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Put true Boolean value in request returns 204 (no content).
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> put204Async() {
         return put204WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put true Boolean value in request returns 204 (no content).
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void put204() {
         put204Async().block();
     }
 
+    /**
+     * Patch true Boolean value in request returns 204 (no content).
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> patch204WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -436,17 +694,35 @@ public final class HttpSuccess {
         return service.patch204(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Patch true Boolean value in request returns 204 (no content).
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> patch204Async() {
         return patch204WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Patch true Boolean value in request returns 204 (no content).
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void patch204() {
         patch204Async().block();
     }
 
+    /**
+     * Post true Boolean value in request returns 204 (no content).
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> post204WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -456,17 +732,35 @@ public final class HttpSuccess {
         return service.post204(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Post true Boolean value in request returns 204 (no content).
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> post204Async() {
         return post204WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Post true Boolean value in request returns 204 (no content).
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void post204() {
         post204Async().block();
     }
 
+    /**
+     * Delete true Boolean value in request returns 204 (no content).
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> delete204WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -476,17 +770,35 @@ public final class HttpSuccess {
         return service.delete204(this.client.getHost(), booleanValue);
     }
 
+    /**
+     * Delete true Boolean value in request returns 204 (no content).
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> delete204Async() {
         return delete204WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Delete true Boolean value in request returns 204 (no content).
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void delete204() {
         delete204Async().block();
     }
 
+    /**
+     * Return 404 status code.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> head404WithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -495,12 +807,24 @@ public final class HttpSuccess {
         return service.head404(this.client.getHost());
     }
 
+    /**
+     * Return 404 status code.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> head404Async() {
         return head404WithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Return 404 status code.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void head404() {
         head404Async().block();

--- a/tests/src/main/java/fixtures/httpinfrastructure/MultipleResponses.java
+++ b/tests/src/main/java/fixtures/httpinfrastructure/MultipleResponses.java
@@ -221,6 +221,12 @@ public final class MultipleResponses {
         Mono<SimpleResponse<MyException>> get200ModelA202Valid(@HostParam("$host") String host);
     }
 
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<MyException>> get200Model204NoModelDefaultError200ValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -229,6 +235,12 @@ public final class MultipleResponses {
         return service.get200Model204NoModelDefaultError200Valid(this.client.getHost());
     }
 
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<MyException> get200Model204NoModelDefaultError200ValidAsync() {
         return get200Model204NoModelDefaultError200ValidWithResponseAsync()
@@ -241,11 +253,23 @@ public final class MultipleResponses {
             });
     }
 
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyException get200Model204NoModelDefaultError200Valid() {
         return get200Model204NoModelDefaultError200ValidAsync().block();
     }
 
+    /**
+     * Send a 204 response with no payload.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<MyException>> get200Model204NoModelDefaultError204ValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -254,6 +278,12 @@ public final class MultipleResponses {
         return service.get200Model204NoModelDefaultError204Valid(this.client.getHost());
     }
 
+    /**
+     * Send a 204 response with no payload.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<MyException> get200Model204NoModelDefaultError204ValidAsync() {
         return get200Model204NoModelDefaultError204ValidWithResponseAsync()
@@ -266,11 +296,23 @@ public final class MultipleResponses {
             });
     }
 
+    /**
+     * Send a 204 response with no payload.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyException get200Model204NoModelDefaultError204Valid() {
         return get200Model204NoModelDefaultError204ValidAsync().block();
     }
 
+    /**
+     * Send a 201 response with valid payload: {'statusCode': '201'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<MyException>> get200Model204NoModelDefaultError201InvalidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -279,6 +321,12 @@ public final class MultipleResponses {
         return service.get200Model204NoModelDefaultError201Invalid(this.client.getHost());
     }
 
+    /**
+     * Send a 201 response with valid payload: {'statusCode': '201'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<MyException> get200Model204NoModelDefaultError201InvalidAsync() {
         return get200Model204NoModelDefaultError201InvalidWithResponseAsync()
@@ -291,11 +339,23 @@ public final class MultipleResponses {
             });
     }
 
+    /**
+     * Send a 201 response with valid payload: {'statusCode': '201'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyException get200Model204NoModelDefaultError201Invalid() {
         return get200Model204NoModelDefaultError201InvalidAsync().block();
     }
 
+    /**
+     * Send a 202 response with no payload:.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<MyException>> get200Model204NoModelDefaultError202NoneWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -304,6 +364,12 @@ public final class MultipleResponses {
         return service.get200Model204NoModelDefaultError202None(this.client.getHost());
     }
 
+    /**
+     * Send a 202 response with no payload:.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<MyException> get200Model204NoModelDefaultError202NoneAsync() {
         return get200Model204NoModelDefaultError202NoneWithResponseAsync()
@@ -316,11 +382,23 @@ public final class MultipleResponses {
             });
     }
 
+    /**
+     * Send a 202 response with no payload:.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyException get200Model204NoModelDefaultError202None() {
         return get200Model204NoModelDefaultError202NoneAsync().block();
     }
 
+    /**
+     * Send a 400 response with valid error payload: {'status': 400, 'message': 'client error'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<MyException>> get200Model204NoModelDefaultError400ValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -329,6 +407,12 @@ public final class MultipleResponses {
         return service.get200Model204NoModelDefaultError400Valid(this.client.getHost());
     }
 
+    /**
+     * Send a 400 response with valid error payload: {'status': 400, 'message': 'client error'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<MyException> get200Model204NoModelDefaultError400ValidAsync() {
         return get200Model204NoModelDefaultError400ValidWithResponseAsync()
@@ -341,11 +425,23 @@ public final class MultipleResponses {
             });
     }
 
+    /**
+     * Send a 400 response with valid error payload: {'status': 400, 'message': 'client error'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyException get200Model204NoModelDefaultError400Valid() {
         return get200Model204NoModelDefaultError400ValidAsync().block();
     }
 
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<MyException>> get200Model201ModelDefaultError200ValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -354,6 +450,12 @@ public final class MultipleResponses {
         return service.get200Model201ModelDefaultError200Valid(this.client.getHost());
     }
 
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<MyException> get200Model201ModelDefaultError200ValidAsync() {
         return get200Model201ModelDefaultError200ValidWithResponseAsync()
@@ -366,11 +468,23 @@ public final class MultipleResponses {
             });
     }
 
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyException get200Model201ModelDefaultError200Valid() {
         return get200Model201ModelDefaultError200ValidAsync().block();
     }
 
+    /**
+     * Send a 201 response with valid payload: {'statusCode': '201', 'textStatusCode': 'Created'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<MyException>> get200Model201ModelDefaultError201ValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -379,6 +493,12 @@ public final class MultipleResponses {
         return service.get200Model201ModelDefaultError201Valid(this.client.getHost());
     }
 
+    /**
+     * Send a 201 response with valid payload: {'statusCode': '201', 'textStatusCode': 'Created'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<MyException> get200Model201ModelDefaultError201ValidAsync() {
         return get200Model201ModelDefaultError201ValidWithResponseAsync()
@@ -391,11 +511,23 @@ public final class MultipleResponses {
             });
     }
 
+    /**
+     * Send a 201 response with valid payload: {'statusCode': '201', 'textStatusCode': 'Created'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyException get200Model201ModelDefaultError201Valid() {
         return get200Model201ModelDefaultError201ValidAsync().block();
     }
 
+    /**
+     * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<MyException>> get200Model201ModelDefaultError400ValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -404,6 +536,12 @@ public final class MultipleResponses {
         return service.get200Model201ModelDefaultError400Valid(this.client.getHost());
     }
 
+    /**
+     * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<MyException> get200Model201ModelDefaultError400ValidAsync() {
         return get200Model201ModelDefaultError400ValidWithResponseAsync()
@@ -416,11 +554,23 @@ public final class MultipleResponses {
             });
     }
 
+    /**
+     * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyException get200Model201ModelDefaultError400Valid() {
         return get200Model201ModelDefaultError400ValidAsync().block();
     }
 
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Object>> get200ModelA201ModelC404ModelDDefaultError200ValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -429,6 +579,12 @@ public final class MultipleResponses {
         return service.get200ModelA201ModelC404ModelDDefaultError200Valid(this.client.getHost());
     }
 
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Object> get200ModelA201ModelC404ModelDDefaultError200ValidAsync() {
         return get200ModelA201ModelC404ModelDDefaultError200ValidWithResponseAsync()
@@ -441,11 +597,23 @@ public final class MultipleResponses {
             });
     }
 
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Object get200ModelA201ModelC404ModelDDefaultError200Valid() {
         return get200ModelA201ModelC404ModelDDefaultError200ValidAsync().block();
     }
 
+    /**
+     * Send a 200 response with valid payload: {'httpCode': '201'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Object>> get200ModelA201ModelC404ModelDDefaultError201ValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -454,6 +622,12 @@ public final class MultipleResponses {
         return service.get200ModelA201ModelC404ModelDDefaultError201Valid(this.client.getHost());
     }
 
+    /**
+     * Send a 200 response with valid payload: {'httpCode': '201'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Object> get200ModelA201ModelC404ModelDDefaultError201ValidAsync() {
         return get200ModelA201ModelC404ModelDDefaultError201ValidWithResponseAsync()
@@ -466,11 +640,23 @@ public final class MultipleResponses {
             });
     }
 
+    /**
+     * Send a 200 response with valid payload: {'httpCode': '201'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Object get200ModelA201ModelC404ModelDDefaultError201Valid() {
         return get200ModelA201ModelC404ModelDDefaultError201ValidAsync().block();
     }
 
+    /**
+     * Send a 200 response with valid payload: {'httpStatusCode': '404'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Object>> get200ModelA201ModelC404ModelDDefaultError404ValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -479,6 +665,12 @@ public final class MultipleResponses {
         return service.get200ModelA201ModelC404ModelDDefaultError404Valid(this.client.getHost());
     }
 
+    /**
+     * Send a 200 response with valid payload: {'httpStatusCode': '404'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Object> get200ModelA201ModelC404ModelDDefaultError404ValidAsync() {
         return get200ModelA201ModelC404ModelDDefaultError404ValidWithResponseAsync()
@@ -491,11 +683,23 @@ public final class MultipleResponses {
             });
     }
 
+    /**
+     * Send a 200 response with valid payload: {'httpStatusCode': '404'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Object get200ModelA201ModelC404ModelDDefaultError404Valid() {
         return get200ModelA201ModelC404ModelDDefaultError404ValidAsync().block();
     }
 
+    /**
+     * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Object>> get200ModelA201ModelC404ModelDDefaultError400ValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -504,6 +708,12 @@ public final class MultipleResponses {
         return service.get200ModelA201ModelC404ModelDDefaultError400Valid(this.client.getHost());
     }
 
+    /**
+     * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Object> get200ModelA201ModelC404ModelDDefaultError400ValidAsync() {
         return get200ModelA201ModelC404ModelDDefaultError400ValidWithResponseAsync()
@@ -516,11 +726,23 @@ public final class MultipleResponses {
             });
     }
 
+    /**
+     * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Object get200ModelA201ModelC404ModelDDefaultError400Valid() {
         return get200ModelA201ModelC404ModelDDefaultError400ValidAsync().block();
     }
 
+    /**
+     * Send a 202 response with no payload.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> get202None204NoneDefaultError202NoneWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -529,17 +751,35 @@ public final class MultipleResponses {
         return service.get202None204NoneDefaultError202None(this.client.getHost());
     }
 
+    /**
+     * Send a 202 response with no payload.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> get202None204NoneDefaultError202NoneAsync() {
         return get202None204NoneDefaultError202NoneWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Send a 202 response with no payload.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get202None204NoneDefaultError202None() {
         get202None204NoneDefaultError202NoneAsync().block();
     }
 
+    /**
+     * Send a 204 response with no payload.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> get202None204NoneDefaultError204NoneWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -548,17 +788,35 @@ public final class MultipleResponses {
         return service.get202None204NoneDefaultError204None(this.client.getHost());
     }
 
+    /**
+     * Send a 204 response with no payload.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> get202None204NoneDefaultError204NoneAsync() {
         return get202None204NoneDefaultError204NoneWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Send a 204 response with no payload.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get202None204NoneDefaultError204None() {
         get202None204NoneDefaultError204NoneAsync().block();
     }
 
+    /**
+     * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> get202None204NoneDefaultError400ValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -567,17 +825,35 @@ public final class MultipleResponses {
         return service.get202None204NoneDefaultError400Valid(this.client.getHost());
     }
 
+    /**
+     * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> get202None204NoneDefaultError400ValidAsync() {
         return get202None204NoneDefaultError400ValidWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get202None204NoneDefaultError400Valid() {
         get202None204NoneDefaultError400ValidAsync().block();
     }
 
+    /**
+     * Send a 202 response with an unexpected payload {'property': 'value'}.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> get202None204NoneDefaultNone202InvalidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -586,17 +862,35 @@ public final class MultipleResponses {
         return service.get202None204NoneDefaultNone202Invalid(this.client.getHost());
     }
 
+    /**
+     * Send a 202 response with an unexpected payload {'property': 'value'}.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> get202None204NoneDefaultNone202InvalidAsync() {
         return get202None204NoneDefaultNone202InvalidWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Send a 202 response with an unexpected payload {'property': 'value'}.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get202None204NoneDefaultNone202Invalid() {
         get202None204NoneDefaultNone202InvalidAsync().block();
     }
 
+    /**
+     * Send a 204 response with no payload.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> get202None204NoneDefaultNone204NoneWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -605,17 +899,35 @@ public final class MultipleResponses {
         return service.get202None204NoneDefaultNone204None(this.client.getHost());
     }
 
+    /**
+     * Send a 204 response with no payload.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> get202None204NoneDefaultNone204NoneAsync() {
         return get202None204NoneDefaultNone204NoneWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Send a 204 response with no payload.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get202None204NoneDefaultNone204None() {
         get202None204NoneDefaultNone204NoneAsync().block();
     }
 
+    /**
+     * Send a 400 response with no payload.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> get202None204NoneDefaultNone400NoneWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -624,17 +936,35 @@ public final class MultipleResponses {
         return service.get202None204NoneDefaultNone400None(this.client.getHost());
     }
 
+    /**
+     * Send a 400 response with no payload.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> get202None204NoneDefaultNone400NoneAsync() {
         return get202None204NoneDefaultNone400NoneWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Send a 400 response with no payload.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get202None204NoneDefaultNone400None() {
         get202None204NoneDefaultNone400NoneAsync().block();
     }
 
+    /**
+     * Send a 400 response with an unexpected payload {'property': 'value'}.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> get202None204NoneDefaultNone400InvalidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -643,17 +973,35 @@ public final class MultipleResponses {
         return service.get202None204NoneDefaultNone400Invalid(this.client.getHost());
     }
 
+    /**
+     * Send a 400 response with an unexpected payload {'property': 'value'}.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> get202None204NoneDefaultNone400InvalidAsync() {
         return get202None204NoneDefaultNone400InvalidWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Send a 400 response with an unexpected payload {'property': 'value'}.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void get202None204NoneDefaultNone400Invalid() {
         get202None204NoneDefaultNone400InvalidAsync().block();
     }
 
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<MyException>> getDefaultModelA200ValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -662,6 +1010,12 @@ public final class MultipleResponses {
         return service.getDefaultModelA200Valid(this.client.getHost());
     }
 
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<MyException> getDefaultModelA200ValidAsync() {
         return getDefaultModelA200ValidWithResponseAsync()
@@ -674,11 +1028,23 @@ public final class MultipleResponses {
             });
     }
 
+    /**
+     * Send a 200 response with valid payload: {'statusCode': '200'}.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyException getDefaultModelA200Valid() {
         return getDefaultModelA200ValidAsync().block();
     }
 
+    /**
+     * Send a 200 response with no payload.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<MyException>> getDefaultModelA200NoneWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -687,6 +1053,12 @@ public final class MultipleResponses {
         return service.getDefaultModelA200None(this.client.getHost());
     }
 
+    /**
+     * Send a 200 response with no payload.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<MyException> getDefaultModelA200NoneAsync() {
         return getDefaultModelA200NoneWithResponseAsync()
@@ -699,11 +1071,23 @@ public final class MultipleResponses {
             });
     }
 
+    /**
+     * Send a 200 response with no payload.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyException getDefaultModelA200None() {
         return getDefaultModelA200NoneAsync().block();
     }
 
+    /**
+     * Send a 400 response with valid payload: {'statusCode': '400'}.
+     * 
+     * @throws MyExceptionException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> getDefaultModelA400ValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -712,17 +1096,35 @@ public final class MultipleResponses {
         return service.getDefaultModelA400Valid(this.client.getHost());
     }
 
+    /**
+     * Send a 400 response with valid payload: {'statusCode': '400'}.
+     * 
+     * @throws MyExceptionException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> getDefaultModelA400ValidAsync() {
         return getDefaultModelA400ValidWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Send a 400 response with valid payload: {'statusCode': '400'}.
+     * 
+     * @throws MyExceptionException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getDefaultModelA400Valid() {
         getDefaultModelA400ValidAsync().block();
     }
 
+    /**
+     * Send a 400 response with no payload.
+     * 
+     * @throws MyExceptionException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> getDefaultModelA400NoneWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -731,17 +1133,35 @@ public final class MultipleResponses {
         return service.getDefaultModelA400None(this.client.getHost());
     }
 
+    /**
+     * Send a 400 response with no payload.
+     * 
+     * @throws MyExceptionException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> getDefaultModelA400NoneAsync() {
         return getDefaultModelA400NoneWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Send a 400 response with no payload.
+     * 
+     * @throws MyExceptionException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getDefaultModelA400None() {
         getDefaultModelA400NoneAsync().block();
     }
 
+    /**
+     * Send a 200 response with invalid payload: {'statusCode': '200'}.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> getDefaultNone200InvalidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -750,17 +1170,35 @@ public final class MultipleResponses {
         return service.getDefaultNone200Invalid(this.client.getHost());
     }
 
+    /**
+     * Send a 200 response with invalid payload: {'statusCode': '200'}.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> getDefaultNone200InvalidAsync() {
         return getDefaultNone200InvalidWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Send a 200 response with invalid payload: {'statusCode': '200'}.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getDefaultNone200Invalid() {
         getDefaultNone200InvalidAsync().block();
     }
 
+    /**
+     * Send a 200 response with no payload.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> getDefaultNone200NoneWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -769,17 +1207,35 @@ public final class MultipleResponses {
         return service.getDefaultNone200None(this.client.getHost());
     }
 
+    /**
+     * Send a 200 response with no payload.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> getDefaultNone200NoneAsync() {
         return getDefaultNone200NoneWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Send a 200 response with no payload.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getDefaultNone200None() {
         getDefaultNone200NoneAsync().block();
     }
 
+    /**
+     * Send a 400 response with valid payload: {'statusCode': '400'}.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> getDefaultNone400InvalidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -788,17 +1244,35 @@ public final class MultipleResponses {
         return service.getDefaultNone400Invalid(this.client.getHost());
     }
 
+    /**
+     * Send a 400 response with valid payload: {'statusCode': '400'}.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> getDefaultNone400InvalidAsync() {
         return getDefaultNone400InvalidWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Send a 400 response with valid payload: {'statusCode': '400'}.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getDefaultNone400Invalid() {
         getDefaultNone400InvalidAsync().block();
     }
 
+    /**
+     * Send a 400 response with no payload.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> getDefaultNone400NoneWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -807,17 +1281,35 @@ public final class MultipleResponses {
         return service.getDefaultNone400None(this.client.getHost());
     }
 
+    /**
+     * Send a 400 response with no payload.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> getDefaultNone400NoneAsync() {
         return getDefaultNone400NoneWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Send a 400 response with no payload.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getDefaultNone400None() {
         getDefaultNone400NoneAsync().block();
     }
 
+    /**
+     * Send a 200 response with no payload, when a payload is expected - client should return a null object of thde type for model A.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<MyException>> get200ModelA200NoneWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -826,6 +1318,12 @@ public final class MultipleResponses {
         return service.get200ModelA200None(this.client.getHost());
     }
 
+    /**
+     * Send a 200 response with no payload, when a payload is expected - client should return a null object of thde type for model A.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<MyException> get200ModelA200NoneAsync() {
         return get200ModelA200NoneWithResponseAsync()
@@ -838,11 +1336,23 @@ public final class MultipleResponses {
             });
     }
 
+    /**
+     * Send a 200 response with no payload, when a payload is expected - client should return a null object of thde type for model A.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyException get200ModelA200None() {
         return get200ModelA200NoneAsync().block();
     }
 
+    /**
+     * Send a 200 response with payload {'statusCode': '200'}.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<MyException>> get200ModelA200ValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -851,6 +1361,12 @@ public final class MultipleResponses {
         return service.get200ModelA200Valid(this.client.getHost());
     }
 
+    /**
+     * Send a 200 response with payload {'statusCode': '200'}.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<MyException> get200ModelA200ValidAsync() {
         return get200ModelA200ValidWithResponseAsync()
@@ -863,11 +1379,23 @@ public final class MultipleResponses {
             });
     }
 
+    /**
+     * Send a 200 response with payload {'statusCode': '200'}.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyException get200ModelA200Valid() {
         return get200ModelA200ValidAsync().block();
     }
 
+    /**
+     * Send a 200 response with invalid payload {'statusCodeInvalid': '200'}.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<MyException>> get200ModelA200InvalidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -876,6 +1404,12 @@ public final class MultipleResponses {
         return service.get200ModelA200Invalid(this.client.getHost());
     }
 
+    /**
+     * Send a 200 response with invalid payload {'statusCodeInvalid': '200'}.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<MyException> get200ModelA200InvalidAsync() {
         return get200ModelA200InvalidWithResponseAsync()
@@ -888,11 +1422,23 @@ public final class MultipleResponses {
             });
     }
 
+    /**
+     * Send a 200 response with invalid payload {'statusCodeInvalid': '200'}.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyException get200ModelA200Invalid() {
         return get200ModelA200InvalidAsync().block();
     }
 
+    /**
+     * Send a 400 response with no payload client should treat as an http error with no error model.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<MyException>> get200ModelA400NoneWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -901,6 +1447,12 @@ public final class MultipleResponses {
         return service.get200ModelA400None(this.client.getHost());
     }
 
+    /**
+     * Send a 400 response with no payload client should treat as an http error with no error model.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<MyException> get200ModelA400NoneAsync() {
         return get200ModelA400NoneWithResponseAsync()
@@ -913,11 +1465,23 @@ public final class MultipleResponses {
             });
     }
 
+    /**
+     * Send a 400 response with no payload client should treat as an http error with no error model.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyException get200ModelA400None() {
         return get200ModelA400NoneAsync().block();
     }
 
+    /**
+     * Send a 200 response with payload {'statusCode': '400'}.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<MyException>> get200ModelA400ValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -926,6 +1490,12 @@ public final class MultipleResponses {
         return service.get200ModelA400Valid(this.client.getHost());
     }
 
+    /**
+     * Send a 200 response with payload {'statusCode': '400'}.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<MyException> get200ModelA400ValidAsync() {
         return get200ModelA400ValidWithResponseAsync()
@@ -938,11 +1508,23 @@ public final class MultipleResponses {
             });
     }
 
+    /**
+     * Send a 200 response with payload {'statusCode': '400'}.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyException get200ModelA400Valid() {
         return get200ModelA400ValidAsync().block();
     }
 
+    /**
+     * Send a 200 response with invalid payload {'statusCodeInvalid': '400'}.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<MyException>> get200ModelA400InvalidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -951,6 +1533,12 @@ public final class MultipleResponses {
         return service.get200ModelA400Invalid(this.client.getHost());
     }
 
+    /**
+     * Send a 200 response with invalid payload {'statusCodeInvalid': '400'}.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<MyException> get200ModelA400InvalidAsync() {
         return get200ModelA400InvalidWithResponseAsync()
@@ -963,11 +1551,23 @@ public final class MultipleResponses {
             });
     }
 
+    /**
+     * Send a 200 response with invalid payload {'statusCodeInvalid': '400'}.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyException get200ModelA400Invalid() {
         return get200ModelA400InvalidAsync().block();
     }
 
+    /**
+     * Send a 202 response with payload {'statusCode': '202'}.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<MyException>> get200ModelA202ValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -976,6 +1576,12 @@ public final class MultipleResponses {
         return service.get200ModelA202Valid(this.client.getHost());
     }
 
+    /**
+     * Send a 202 response with payload {'statusCode': '202'}.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<MyException> get200ModelA202ValidAsync() {
         return get200ModelA202ValidWithResponseAsync()
@@ -988,6 +1594,12 @@ public final class MultipleResponses {
             });
     }
 
+    /**
+     * Send a 202 response with payload {'statusCode': '202'}.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public MyException get200ModelA202Valid() {
         return get200ModelA202ValidAsync().block();

--- a/tests/src/main/java/fixtures/paging/Pagings.java
+++ b/tests/src/main/java/fixtures/paging/Pagings.java
@@ -194,6 +194,12 @@ public final class Pagings {
         Mono<SimpleResponse<ProductResult>> getMultiplePagesLRONext(@PathParam(value = "nextLink", encoded = true) String nextLink);
     }
 
+    /**
+     * A paging operation that must return result of the default 'value' node.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<PagedResponse<Product>> getNoItemNamePagesSinglePageAsync() {
         return service.getNoItemNamePages(this.client.getHost()).map(res -> new PagedResponseBase<>(
@@ -205,6 +211,12 @@ public final class Pagings {
             null));
     }
 
+    /**
+     * A paging operation that must return result of the default 'value' node.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.COLLECTION)
     public PagedFlux<Product> getNoItemNamePagesAsync() {
         return new PagedFlux<>(
@@ -213,6 +225,8 @@ public final class Pagings {
     }
 
     /**
+     * A paging operation that must return result of the default 'value' node.
+     * 
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
@@ -221,6 +235,12 @@ public final class Pagings {
         return new PagedIterable<>(getNoItemNamePagesAsync());
     }
 
+    /**
+     * A paging operation that must ignore any kind of nextLink, and stop after page 1.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<PagedResponse<Product>> getNullNextLinkNamePagesSinglePageAsync() {
         return service.getNullNextLinkNamePages(this.client.getHost()).map(res -> new PagedResponseBase<>(
@@ -232,6 +252,12 @@ public final class Pagings {
             null));
     }
 
+    /**
+     * A paging operation that must ignore any kind of nextLink, and stop after page 1.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.COLLECTION)
     public PagedFlux<Product> getNullNextLinkNamePagesAsync() {
         return new PagedFlux<>(
@@ -239,6 +265,8 @@ public final class Pagings {
     }
 
     /**
+     * A paging operation that must ignore any kind of nextLink, and stop after page 1.
+     * 
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
@@ -247,6 +275,12 @@ public final class Pagings {
         return new PagedIterable<>(getNullNextLinkNamePagesAsync());
     }
 
+    /**
+     * A paging operation that finishes on the first call without a nextlink.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<PagedResponse<Product>> getSinglePagesSinglePageAsync() {
         return service.getSinglePages(this.client.getHost()).map(res -> new PagedResponseBase<>(
@@ -258,6 +292,12 @@ public final class Pagings {
             null));
     }
 
+    /**
+     * A paging operation that finishes on the first call without a nextlink.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.COLLECTION)
     public PagedFlux<Product> getSinglePagesAsync() {
         return new PagedFlux<>(
@@ -266,6 +306,8 @@ public final class Pagings {
     }
 
     /**
+     * A paging operation that finishes on the first call without a nextlink.
+     * 
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
@@ -274,6 +316,16 @@ public final class Pagings {
         return new PagedIterable<>(getSinglePagesAsync());
     }
 
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     * 
+     * @param clientRequestId MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param maxresults MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @param timeout MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<PagedResponse<Product>> getMultiplePagesSinglePageAsync(String clientRequestId, Integer maxresults, Integer timeout) {
         return service.getMultiplePages(this.client.getHost(), clientRequestId, maxresults, timeout).map(res -> new PagedResponseBase<>(
@@ -285,6 +337,16 @@ public final class Pagings {
             null));
     }
 
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     * 
+     * @param clientRequestId MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param maxresults MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @param timeout MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.COLLECTION)
     public PagedFlux<Product> getMultiplePagesAsync(String clientRequestId, Integer maxresults, Integer timeout) {
         return new PagedFlux<>(
@@ -293,9 +355,11 @@ public final class Pagings {
     }
 
     /**
-     * @param clientRequestId null
-     * @param maxresults null
-     * @param timeout null
+     * A paging operation that includes a nextLink that has 10 pages.
+     * 
+     * @param clientRequestId MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param maxresults MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @param timeout MISSING·SCHEMA-DESCRIPTION-INTEGER.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -305,6 +369,16 @@ public final class Pagings {
         return new PagedIterable<>(getMultiplePagesAsync(clientRequestId, maxresults, timeout));
     }
 
+    /**
+     * A paging operation that includes a nextLink in odata format that has 10 pages.
+     * 
+     * @param clientRequestId MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param maxresults MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @param timeout MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<PagedResponse<Product>> getOdataMultiplePagesSinglePageAsync(String clientRequestId, Integer maxresults, Integer timeout) {
         return service.getOdataMultiplePages(this.client.getHost(), clientRequestId, maxresults, timeout).map(res -> new PagedResponseBase<>(
@@ -316,6 +390,16 @@ public final class Pagings {
             null));
     }
 
+    /**
+     * A paging operation that includes a nextLink in odata format that has 10 pages.
+     * 
+     * @param clientRequestId MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param maxresults MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @param timeout MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.COLLECTION)
     public PagedFlux<Product> getOdataMultiplePagesAsync(String clientRequestId, Integer maxresults, Integer timeout) {
         return new PagedFlux<>(
@@ -324,9 +408,11 @@ public final class Pagings {
     }
 
     /**
-     * @param clientRequestId null
-     * @param maxresults null
-     * @param timeout null
+     * A paging operation that includes a nextLink in odata format that has 10 pages.
+     * 
+     * @param clientRequestId MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param maxresults MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @param timeout MISSING·SCHEMA-DESCRIPTION-INTEGER.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -336,6 +422,17 @@ public final class Pagings {
         return new PagedIterable<>(getOdataMultiplePagesAsync(clientRequestId, maxresults, timeout));
     }
 
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     * 
+     * @param clientRequestId MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param maxresults MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @param offset MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @param timeout MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<PagedResponse<Product>> getMultiplePagesWithOffsetSinglePageAsync(String clientRequestId, Integer maxresults, int offset, Integer timeout) {
         return service.getMultiplePagesWithOffset(this.client.getHost(), clientRequestId, maxresults, offset, timeout).map(res -> new PagedResponseBase<>(
@@ -347,6 +444,17 @@ public final class Pagings {
             null));
     }
 
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     * 
+     * @param clientRequestId MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param maxresults MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @param offset MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @param timeout MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.COLLECTION)
     public PagedFlux<Product> getMultiplePagesWithOffsetAsync(String clientRequestId, Integer maxresults, int offset, Integer timeout) {
         return new PagedFlux<>(
@@ -355,10 +463,12 @@ public final class Pagings {
     }
 
     /**
-     * @param clientRequestId null
-     * @param maxresults null
-     * @param offset null
-     * @param timeout null
+     * A paging operation that includes a nextLink that has 10 pages.
+     * 
+     * @param clientRequestId MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param maxresults MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @param offset MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @param timeout MISSING·SCHEMA-DESCRIPTION-INTEGER.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -368,6 +478,12 @@ public final class Pagings {
         return new PagedIterable<>(getMultiplePagesWithOffsetAsync(clientRequestId, maxresults, offset, timeout));
     }
 
+    /**
+     * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<PagedResponse<Product>> getMultiplePagesRetryFirstSinglePageAsync() {
         return service.getMultiplePagesRetryFirst(this.client.getHost()).map(res -> new PagedResponseBase<>(
@@ -379,6 +495,12 @@ public final class Pagings {
             null));
     }
 
+    /**
+     * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.COLLECTION)
     public PagedFlux<Product> getMultiplePagesRetryFirstAsync() {
         return new PagedFlux<>(
@@ -387,6 +509,8 @@ public final class Pagings {
     }
 
     /**
+     * A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages.
+     * 
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
@@ -395,6 +519,12 @@ public final class Pagings {
         return new PagedIterable<>(getMultiplePagesRetryFirstAsync());
     }
 
+    /**
+     * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<PagedResponse<Product>> getMultiplePagesRetrySecondSinglePageAsync() {
         return service.getMultiplePagesRetrySecond(this.client.getHost()).map(res -> new PagedResponseBase<>(
@@ -406,6 +536,12 @@ public final class Pagings {
             null));
     }
 
+    /**
+     * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.COLLECTION)
     public PagedFlux<Product> getMultiplePagesRetrySecondAsync() {
         return new PagedFlux<>(
@@ -414,6 +550,8 @@ public final class Pagings {
     }
 
     /**
+     * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
+     * 
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
@@ -422,6 +560,12 @@ public final class Pagings {
         return new PagedIterable<>(getMultiplePagesRetrySecondAsync());
     }
 
+    /**
+     * A paging operation that receives a 400 on the first call.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<PagedResponse<Product>> getSinglePagesFailureSinglePageAsync() {
         return service.getSinglePagesFailure(this.client.getHost()).map(res -> new PagedResponseBase<>(
@@ -433,6 +577,12 @@ public final class Pagings {
             null));
     }
 
+    /**
+     * A paging operation that receives a 400 on the first call.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.COLLECTION)
     public PagedFlux<Product> getSinglePagesFailureAsync() {
         return new PagedFlux<>(
@@ -441,6 +591,8 @@ public final class Pagings {
     }
 
     /**
+     * A paging operation that receives a 400 on the first call.
+     * 
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
@@ -449,6 +601,12 @@ public final class Pagings {
         return new PagedIterable<>(getSinglePagesFailureAsync());
     }
 
+    /**
+     * A paging operation that receives a 400 on the second call.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<PagedResponse<Product>> getMultiplePagesFailureSinglePageAsync() {
         return service.getMultiplePagesFailure(this.client.getHost()).map(res -> new PagedResponseBase<>(
@@ -460,6 +618,12 @@ public final class Pagings {
             null));
     }
 
+    /**
+     * A paging operation that receives a 400 on the second call.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.COLLECTION)
     public PagedFlux<Product> getMultiplePagesFailureAsync() {
         return new PagedFlux<>(
@@ -468,6 +632,8 @@ public final class Pagings {
     }
 
     /**
+     * A paging operation that receives a 400 on the second call.
+     * 
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
@@ -476,6 +642,12 @@ public final class Pagings {
         return new PagedIterable<>(getMultiplePagesFailureAsync());
     }
 
+    /**
+     * A paging operation that receives an invalid nextLink.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<PagedResponse<Product>> getMultiplePagesFailureUriSinglePageAsync() {
         return service.getMultiplePagesFailureUri(this.client.getHost()).map(res -> new PagedResponseBase<>(
@@ -487,6 +659,12 @@ public final class Pagings {
             null));
     }
 
+    /**
+     * A paging operation that receives an invalid nextLink.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.COLLECTION)
     public PagedFlux<Product> getMultiplePagesFailureUriAsync() {
         return new PagedFlux<>(
@@ -495,6 +673,8 @@ public final class Pagings {
     }
 
     /**
+     * A paging operation that receives an invalid nextLink.
+     * 
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
@@ -503,6 +683,15 @@ public final class Pagings {
         return new PagedIterable<>(getMultiplePagesFailureUriAsync());
     }
 
+    /**
+     * A paging operation that doesn't return a full URL, just a fragment.
+     * 
+     * @param apiVersion MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param tenant MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<PagedResponse<Product>> getMultiplePagesFragmentNextLinkSinglePageAsync(String apiVersion, String tenant) {
         return service.getMultiplePagesFragmentNextLink(this.client.getHost(), apiVersion, tenant).map(res -> new PagedResponseBase<>(
@@ -514,6 +703,15 @@ public final class Pagings {
             null));
     }
 
+    /**
+     * A paging operation that doesn't return a full URL, just a fragment.
+     * 
+     * @param apiVersion MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param tenant MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.COLLECTION)
     public PagedFlux<Product> getMultiplePagesFragmentNextLinkAsync(String apiVersion, String tenant) {
         return new PagedFlux<>(
@@ -522,8 +720,10 @@ public final class Pagings {
     }
 
     /**
-     * @param apiVersion null
-     * @param tenant null
+     * A paging operation that doesn't return a full URL, just a fragment.
+     * 
+     * @param apiVersion MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param tenant MISSING·SCHEMA-DESCRIPTION-STRING.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -533,6 +733,15 @@ public final class Pagings {
         return new PagedIterable<>(getMultiplePagesFragmentNextLinkAsync(apiVersion, tenant));
     }
 
+    /**
+     * A paging operation that doesn't return a full URL, just a fragment with parameters grouped.
+     * 
+     * @param apiVersion MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param tenant MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<PagedResponse<Product>> getMultiplePagesFragmentWithGroupingNextLinkSinglePageAsync(String apiVersion, String tenant) {
         return service.getMultiplePagesFragmentWithGroupingNextLink(this.client.getHost(), apiVersion, tenant).map(res -> new PagedResponseBase<>(
@@ -544,6 +753,15 @@ public final class Pagings {
             null));
     }
 
+    /**
+     * A paging operation that doesn't return a full URL, just a fragment with parameters grouped.
+     * 
+     * @param apiVersion MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param tenant MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.COLLECTION)
     public PagedFlux<Product> getMultiplePagesFragmentWithGroupingNextLinkAsync(String apiVersion, String tenant) {
         return new PagedFlux<>(
@@ -552,8 +770,10 @@ public final class Pagings {
     }
 
     /**
-     * @param apiVersion null
-     * @param tenant null
+     * A paging operation that doesn't return a full URL, just a fragment with parameters grouped.
+     * 
+     * @param apiVersion MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param tenant MISSING·SCHEMA-DESCRIPTION-STRING.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -563,6 +783,16 @@ public final class Pagings {
         return new PagedIterable<>(getMultiplePagesFragmentWithGroupingNextLinkAsync(apiVersion, tenant));
     }
 
+    /**
+     * A long-running paging operation that includes a nextLink that has 10 pages.
+     * 
+     * @param clientRequestId MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param maxresults MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @param timeout MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<PagedResponse<Product>> getMultiplePagesLROSinglePageAsync(String clientRequestId, Integer maxresults, Integer timeout) {
         return service.getMultiplePagesLRO(this.client.getHost(), clientRequestId, maxresults, timeout).map(res -> new PagedResponseBase<>(
@@ -574,6 +804,16 @@ public final class Pagings {
             null));
     }
 
+    /**
+     * A long-running paging operation that includes a nextLink that has 10 pages.
+     * 
+     * @param clientRequestId MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param maxresults MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @param timeout MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.COLLECTION)
     public PagedFlux<Product> getMultiplePagesLROAsync(String clientRequestId, Integer maxresults, Integer timeout) {
         return new PagedFlux<>(
@@ -582,9 +822,11 @@ public final class Pagings {
     }
 
     /**
-     * @param clientRequestId null
-     * @param maxresults null
-     * @param timeout null
+     * A long-running paging operation that includes a nextLink that has 10 pages.
+     * 
+     * @param clientRequestId MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param maxresults MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @param timeout MISSING·SCHEMA-DESCRIPTION-INTEGER.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -594,6 +836,16 @@ public final class Pagings {
         return new PagedIterable<>(getMultiplePagesLROAsync(clientRequestId, maxresults, timeout));
     }
 
+    /**
+     * A paging operation that doesn't return a full URL, just a fragment.
+     * 
+     * @param apiVersion MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param tenant MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param nextLink MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<PagedResponse<Product>> nextFragmentSinglePageAsync(String apiVersion, String tenant, String nextLink) {
         return service.nextFragment(this.client.getHost(), apiVersion, tenant, nextLink).map(res -> new PagedResponseBase<>(
@@ -605,6 +857,16 @@ public final class Pagings {
             null));
     }
 
+    /**
+     * A paging operation that doesn't return a full URL, just a fragment.
+     * 
+     * @param apiVersion MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param tenant MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param nextLink MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<PagedResponse<Product>> nextFragmentWithGroupingSinglePageAsync(String apiVersion, String tenant, String nextLink) {
         return service.nextFragmentWithGrouping(this.client.getHost(), apiVersion, tenant, nextLink).map(res -> new PagedResponseBase<>(
@@ -616,6 +878,14 @@ public final class Pagings {
             null));
     }
 
+    /**
+     * Get the next page of items.
+     * 
+     * @param nextLink null
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<PagedResponse<Product>> getNoItemNamePagesNextSinglePageAsync(String nextLink) {
         return service.getNoItemNamePagesNext(nextLink).map(res -> new PagedResponseBase<>(
@@ -627,6 +897,14 @@ public final class Pagings {
             null));
     }
 
+    /**
+     * Get the next page of items.
+     * 
+     * @param nextLink null
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<PagedResponse<Product>> getSinglePagesNextSinglePageAsync(String nextLink) {
         return service.getSinglePagesNext(nextLink).map(res -> new PagedResponseBase<>(
@@ -638,6 +916,14 @@ public final class Pagings {
             null));
     }
 
+    /**
+     * Get the next page of items.
+     * 
+     * @param nextLink null
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<PagedResponse<Product>> getMultiplePagesNextSinglePageAsync(String nextLink) {
         return service.getMultiplePagesNext(nextLink).map(res -> new PagedResponseBase<>(
@@ -649,6 +935,14 @@ public final class Pagings {
             null));
     }
 
+    /**
+     * Get the next page of items.
+     * 
+     * @param nextLink null
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<PagedResponse<Product>> getOdataMultiplePagesNextSinglePageAsync(String nextLink) {
         return service.getOdataMultiplePagesNext(nextLink).map(res -> new PagedResponseBase<>(
@@ -660,6 +954,14 @@ public final class Pagings {
             null));
     }
 
+    /**
+     * Get the next page of items.
+     * 
+     * @param nextLink null
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<PagedResponse<Product>> getMultiplePagesWithOffsetNextSinglePageAsync(String nextLink) {
         return service.getMultiplePagesWithOffsetNext(nextLink).map(res -> new PagedResponseBase<>(
@@ -671,6 +973,14 @@ public final class Pagings {
             null));
     }
 
+    /**
+     * Get the next page of items.
+     * 
+     * @param nextLink null
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<PagedResponse<Product>> getMultiplePagesRetryFirstNextSinglePageAsync(String nextLink) {
         return service.getMultiplePagesRetryFirstNext(nextLink).map(res -> new PagedResponseBase<>(
@@ -682,6 +992,14 @@ public final class Pagings {
             null));
     }
 
+    /**
+     * Get the next page of items.
+     * 
+     * @param nextLink null
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<PagedResponse<Product>> getMultiplePagesRetrySecondNextSinglePageAsync(String nextLink) {
         return service.getMultiplePagesRetrySecondNext(nextLink).map(res -> new PagedResponseBase<>(
@@ -693,6 +1011,14 @@ public final class Pagings {
             null));
     }
 
+    /**
+     * Get the next page of items.
+     * 
+     * @param nextLink null
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<PagedResponse<Product>> getSinglePagesFailureNextSinglePageAsync(String nextLink) {
         return service.getSinglePagesFailureNext(nextLink).map(res -> new PagedResponseBase<>(
@@ -704,6 +1030,14 @@ public final class Pagings {
             null));
     }
 
+    /**
+     * Get the next page of items.
+     * 
+     * @param nextLink null
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<PagedResponse<Product>> getMultiplePagesFailureNextSinglePageAsync(String nextLink) {
         return service.getMultiplePagesFailureNext(nextLink).map(res -> new PagedResponseBase<>(
@@ -715,6 +1049,14 @@ public final class Pagings {
             null));
     }
 
+    /**
+     * Get the next page of items.
+     * 
+     * @param nextLink null
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<PagedResponse<Product>> getMultiplePagesFailureUriNextSinglePageAsync(String nextLink) {
         return service.getMultiplePagesFailureUriNext(nextLink).map(res -> new PagedResponseBase<>(
@@ -726,6 +1068,14 @@ public final class Pagings {
             null));
     }
 
+    /**
+     * Get the next page of items.
+     * 
+     * @param nextLink null
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<PagedResponse<Product>> getMultiplePagesLRONextSinglePageAsync(String nextLink) {
         return service.getMultiplePagesLRONext(nextLink).map(res -> new PagedResponseBase<>(

--- a/tests/src/main/java/fixtures/requiredoptional/Explicits.java
+++ b/tests/src/main/java/fixtures/requiredoptional/Explicits.java
@@ -171,6 +171,14 @@ public final class Explicits {
         Mono<Response<Void>> postOptionalArrayHeader(@HostParam("$host") String host, @HeaderParam("headerParameter") String headerParameter);
     }
 
+    /**
+     * Test explicitly required integer. Please put null and the client library should throw before the request is sent.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> postRequiredIntegerParameterWithResponseAsync(int bodyParameter) {
         if (this.client.getHost() == null) {
@@ -179,17 +187,41 @@ public final class Explicits {
         return service.postRequiredIntegerParameter(this.client.getHost(), bodyParameter);
     }
 
+    /**
+     * Test explicitly required integer. Please put null and the client library should throw before the request is sent.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> postRequiredIntegerParameterAsync(int bodyParameter) {
         return postRequiredIntegerParameterWithResponseAsync(bodyParameter)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Test explicitly required integer. Please put null and the client library should throw before the request is sent.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postRequiredIntegerParameter(int bodyParameter) {
         postRequiredIntegerParameterAsync(bodyParameter).block();
     }
 
+    /**
+     * Test explicitly optional integer. Please put null.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> postOptionalIntegerParameterWithResponseAsync(Integer bodyParameter) {
         if (this.client.getHost() == null) {
@@ -198,17 +230,41 @@ public final class Explicits {
         return service.postOptionalIntegerParameter(this.client.getHost(), bodyParameter);
     }
 
+    /**
+     * Test explicitly optional integer. Please put null.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> postOptionalIntegerParameterAsync(Integer bodyParameter) {
         return postOptionalIntegerParameterWithResponseAsync(bodyParameter)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Test explicitly optional integer. Please put null.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptionalIntegerParameter(Integer bodyParameter) {
         postOptionalIntegerParameterAsync(bodyParameter).block();
     }
 
+    /**
+     * Test explicitly required integer. Please put a valid int-wrapper with 'value' = null and the client library should throw before the request is sent.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> postRequiredIntegerPropertyWithResponseAsync(IntWrapper bodyParameter) {
         if (this.client.getHost() == null) {
@@ -222,17 +278,41 @@ public final class Explicits {
         return service.postRequiredIntegerProperty(this.client.getHost(), bodyParameter);
     }
 
+    /**
+     * Test explicitly required integer. Please put a valid int-wrapper with 'value' = null and the client library should throw before the request is sent.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> postRequiredIntegerPropertyAsync(IntWrapper bodyParameter) {
         return postRequiredIntegerPropertyWithResponseAsync(bodyParameter)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Test explicitly required integer. Please put a valid int-wrapper with 'value' = null and the client library should throw before the request is sent.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postRequiredIntegerProperty(IntWrapper bodyParameter) {
         postRequiredIntegerPropertyAsync(bodyParameter).block();
     }
 
+    /**
+     * Test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> postOptionalIntegerPropertyWithResponseAsync(IntOptionalWrapper bodyParameter) {
         if (this.client.getHost() == null) {
@@ -244,17 +324,41 @@ public final class Explicits {
         return service.postOptionalIntegerProperty(this.client.getHost(), bodyParameter);
     }
 
+    /**
+     * Test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> postOptionalIntegerPropertyAsync(IntOptionalWrapper bodyParameter) {
         return postOptionalIntegerPropertyWithResponseAsync(bodyParameter)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptionalIntegerProperty(IntOptionalWrapper bodyParameter) {
         postOptionalIntegerPropertyAsync(bodyParameter).block();
     }
 
+    /**
+     * Test explicitly required integer. Please put a header 'headerParameter' =&gt; null and the client library should throw before the request is sent.
+     * 
+     * @param headerParameter MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> postRequiredIntegerHeaderWithResponseAsync(int headerParameter) {
         if (this.client.getHost() == null) {
@@ -263,17 +367,41 @@ public final class Explicits {
         return service.postRequiredIntegerHeader(this.client.getHost(), headerParameter);
     }
 
+    /**
+     * Test explicitly required integer. Please put a header 'headerParameter' =&gt; null and the client library should throw before the request is sent.
+     * 
+     * @param headerParameter MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> postRequiredIntegerHeaderAsync(int headerParameter) {
         return postRequiredIntegerHeaderWithResponseAsync(headerParameter)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Test explicitly required integer. Please put a header 'headerParameter' =&gt; null and the client library should throw before the request is sent.
+     * 
+     * @param headerParameter MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postRequiredIntegerHeader(int headerParameter) {
         postRequiredIntegerHeaderAsync(headerParameter).block();
     }
 
+    /**
+     * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
+     * 
+     * @param headerParameter MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> postOptionalIntegerHeaderWithResponseAsync(Integer headerParameter) {
         if (this.client.getHost() == null) {
@@ -282,17 +410,41 @@ public final class Explicits {
         return service.postOptionalIntegerHeader(this.client.getHost(), headerParameter);
     }
 
+    /**
+     * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
+     * 
+     * @param headerParameter MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> postOptionalIntegerHeaderAsync(Integer headerParameter) {
         return postOptionalIntegerHeaderWithResponseAsync(headerParameter)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
+     * 
+     * @param headerParameter MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptionalIntegerHeader(Integer headerParameter) {
         postOptionalIntegerHeaderAsync(headerParameter).block();
     }
 
+    /**
+     * Test explicitly required string. Please put null and the client library should throw before the request is sent.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> postRequiredStringParameterWithResponseAsync(String bodyParameter) {
         if (this.client.getHost() == null) {
@@ -304,17 +456,41 @@ public final class Explicits {
         return service.postRequiredStringParameter(this.client.getHost(), bodyParameter);
     }
 
+    /**
+     * Test explicitly required string. Please put null and the client library should throw before the request is sent.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> postRequiredStringParameterAsync(String bodyParameter) {
         return postRequiredStringParameterWithResponseAsync(bodyParameter)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Test explicitly required string. Please put null and the client library should throw before the request is sent.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postRequiredStringParameter(String bodyParameter) {
         postRequiredStringParameterAsync(bodyParameter).block();
     }
 
+    /**
+     * Test explicitly optional string. Please put null.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> postOptionalStringParameterWithResponseAsync(String bodyParameter) {
         if (this.client.getHost() == null) {
@@ -323,17 +499,41 @@ public final class Explicits {
         return service.postOptionalStringParameter(this.client.getHost(), bodyParameter);
     }
 
+    /**
+     * Test explicitly optional string. Please put null.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> postOptionalStringParameterAsync(String bodyParameter) {
         return postOptionalStringParameterWithResponseAsync(bodyParameter)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Test explicitly optional string. Please put null.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptionalStringParameter(String bodyParameter) {
         postOptionalStringParameterAsync(bodyParameter).block();
     }
 
+    /**
+     * Test explicitly required string. Please put a valid string-wrapper with 'value' = null and the client library should throw before the request is sent.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> postRequiredStringPropertyWithResponseAsync(StringWrapper bodyParameter) {
         if (this.client.getHost() == null) {
@@ -347,17 +547,41 @@ public final class Explicits {
         return service.postRequiredStringProperty(this.client.getHost(), bodyParameter);
     }
 
+    /**
+     * Test explicitly required string. Please put a valid string-wrapper with 'value' = null and the client library should throw before the request is sent.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> postRequiredStringPropertyAsync(StringWrapper bodyParameter) {
         return postRequiredStringPropertyWithResponseAsync(bodyParameter)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Test explicitly required string. Please put a valid string-wrapper with 'value' = null and the client library should throw before the request is sent.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postRequiredStringProperty(StringWrapper bodyParameter) {
         postRequiredStringPropertyAsync(bodyParameter).block();
     }
 
+    /**
+     * Test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> postOptionalStringPropertyWithResponseAsync(StringOptionalWrapper bodyParameter) {
         if (this.client.getHost() == null) {
@@ -369,17 +593,41 @@ public final class Explicits {
         return service.postOptionalStringProperty(this.client.getHost(), bodyParameter);
     }
 
+    /**
+     * Test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> postOptionalStringPropertyAsync(StringOptionalWrapper bodyParameter) {
         return postOptionalStringPropertyWithResponseAsync(bodyParameter)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptionalStringProperty(StringOptionalWrapper bodyParameter) {
         postOptionalStringPropertyAsync(bodyParameter).block();
     }
 
+    /**
+     * Test explicitly required string. Please put a header 'headerParameter' =&gt; null and the client library should throw before the request is sent.
+     * 
+     * @param headerParameter MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> postRequiredStringHeaderWithResponseAsync(String headerParameter) {
         if (this.client.getHost() == null) {
@@ -391,17 +639,41 @@ public final class Explicits {
         return service.postRequiredStringHeader(this.client.getHost(), headerParameter);
     }
 
+    /**
+     * Test explicitly required string. Please put a header 'headerParameter' =&gt; null and the client library should throw before the request is sent.
+     * 
+     * @param headerParameter MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> postRequiredStringHeaderAsync(String headerParameter) {
         return postRequiredStringHeaderWithResponseAsync(headerParameter)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Test explicitly required string. Please put a header 'headerParameter' =&gt; null and the client library should throw before the request is sent.
+     * 
+     * @param headerParameter MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postRequiredStringHeader(String headerParameter) {
         postRequiredStringHeaderAsync(headerParameter).block();
     }
 
+    /**
+     * Test explicitly optional string. Please put a header 'headerParameter' =&gt; null.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> postOptionalStringHeaderWithResponseAsync(String bodyParameter) {
         if (this.client.getHost() == null) {
@@ -410,17 +682,41 @@ public final class Explicits {
         return service.postOptionalStringHeader(this.client.getHost(), bodyParameter);
     }
 
+    /**
+     * Test explicitly optional string. Please put a header 'headerParameter' =&gt; null.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> postOptionalStringHeaderAsync(String bodyParameter) {
         return postOptionalStringHeaderWithResponseAsync(bodyParameter)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Test explicitly optional string. Please put a header 'headerParameter' =&gt; null.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptionalStringHeader(String bodyParameter) {
         postOptionalStringHeaderAsync(bodyParameter).block();
     }
 
+    /**
+     * Test explicitly required complex object. Please put null and the client library should throw before the request is sent.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> postRequiredClassParameterWithResponseAsync(Product bodyParameter) {
         if (this.client.getHost() == null) {
@@ -434,17 +730,41 @@ public final class Explicits {
         return service.postRequiredClassParameter(this.client.getHost(), bodyParameter);
     }
 
+    /**
+     * Test explicitly required complex object. Please put null and the client library should throw before the request is sent.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> postRequiredClassParameterAsync(Product bodyParameter) {
         return postRequiredClassParameterWithResponseAsync(bodyParameter)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Test explicitly required complex object. Please put null and the client library should throw before the request is sent.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postRequiredClassParameter(Product bodyParameter) {
         postRequiredClassParameterAsync(bodyParameter).block();
     }
 
+    /**
+     * Test explicitly optional complex object. Please put null.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> postOptionalClassParameterWithResponseAsync(Product bodyParameter) {
         if (this.client.getHost() == null) {
@@ -456,17 +776,41 @@ public final class Explicits {
         return service.postOptionalClassParameter(this.client.getHost(), bodyParameter);
     }
 
+    /**
+     * Test explicitly optional complex object. Please put null.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> postOptionalClassParameterAsync(Product bodyParameter) {
         return postOptionalClassParameterWithResponseAsync(bodyParameter)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Test explicitly optional complex object. Please put null.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptionalClassParameter(Product bodyParameter) {
         postOptionalClassParameterAsync(bodyParameter).block();
     }
 
+    /**
+     * Test explicitly required complex object. Please put a valid class-wrapper with 'value' = null and the client library should throw before the request is sent.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> postRequiredClassPropertyWithResponseAsync(ClassWrapper bodyParameter) {
         if (this.client.getHost() == null) {
@@ -480,17 +824,41 @@ public final class Explicits {
         return service.postRequiredClassProperty(this.client.getHost(), bodyParameter);
     }
 
+    /**
+     * Test explicitly required complex object. Please put a valid class-wrapper with 'value' = null and the client library should throw before the request is sent.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> postRequiredClassPropertyAsync(ClassWrapper bodyParameter) {
         return postRequiredClassPropertyWithResponseAsync(bodyParameter)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Test explicitly required complex object. Please put a valid class-wrapper with 'value' = null and the client library should throw before the request is sent.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postRequiredClassProperty(ClassWrapper bodyParameter) {
         postRequiredClassPropertyAsync(bodyParameter).block();
     }
 
+    /**
+     * Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> postOptionalClassPropertyWithResponseAsync(ClassOptionalWrapper bodyParameter) {
         if (this.client.getHost() == null) {
@@ -502,17 +870,41 @@ public final class Explicits {
         return service.postOptionalClassProperty(this.client.getHost(), bodyParameter);
     }
 
+    /**
+     * Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> postOptionalClassPropertyAsync(ClassOptionalWrapper bodyParameter) {
         return postOptionalClassPropertyWithResponseAsync(bodyParameter)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptionalClassProperty(ClassOptionalWrapper bodyParameter) {
         postOptionalClassPropertyAsync(bodyParameter).block();
     }
 
+    /**
+     * Test explicitly required array. Please put null and the client library should throw before the request is sent.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> postRequiredArrayParameterWithResponseAsync(List<String> bodyParameter) {
         if (this.client.getHost() == null) {
@@ -524,17 +916,41 @@ public final class Explicits {
         return service.postRequiredArrayParameter(this.client.getHost(), bodyParameter);
     }
 
+    /**
+     * Test explicitly required array. Please put null and the client library should throw before the request is sent.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> postRequiredArrayParameterAsync(List<String> bodyParameter) {
         return postRequiredArrayParameterWithResponseAsync(bodyParameter)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Test explicitly required array. Please put null and the client library should throw before the request is sent.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postRequiredArrayParameter(List<String> bodyParameter) {
         postRequiredArrayParameterAsync(bodyParameter).block();
     }
 
+    /**
+     * Test explicitly optional array. Please put null.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> postOptionalArrayParameterWithResponseAsync(List<String> bodyParameter) {
         if (this.client.getHost() == null) {
@@ -543,17 +959,41 @@ public final class Explicits {
         return service.postOptionalArrayParameter(this.client.getHost(), bodyParameter);
     }
 
+    /**
+     * Test explicitly optional array. Please put null.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> postOptionalArrayParameterAsync(List<String> bodyParameter) {
         return postOptionalArrayParameterWithResponseAsync(bodyParameter)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Test explicitly optional array. Please put null.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptionalArrayParameter(List<String> bodyParameter) {
         postOptionalArrayParameterAsync(bodyParameter).block();
     }
 
+    /**
+     * Test explicitly required array. Please put a valid array-wrapper with 'value' = null and the client library should throw before the request is sent.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> postRequiredArrayPropertyWithResponseAsync(ArrayWrapper bodyParameter) {
         if (this.client.getHost() == null) {
@@ -567,17 +1007,41 @@ public final class Explicits {
         return service.postRequiredArrayProperty(this.client.getHost(), bodyParameter);
     }
 
+    /**
+     * Test explicitly required array. Please put a valid array-wrapper with 'value' = null and the client library should throw before the request is sent.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> postRequiredArrayPropertyAsync(ArrayWrapper bodyParameter) {
         return postRequiredArrayPropertyWithResponseAsync(bodyParameter)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Test explicitly required array. Please put a valid array-wrapper with 'value' = null and the client library should throw before the request is sent.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postRequiredArrayProperty(ArrayWrapper bodyParameter) {
         postRequiredArrayPropertyAsync(bodyParameter).block();
     }
 
+    /**
+     * Test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> postOptionalArrayPropertyWithResponseAsync(ArrayOptionalWrapper bodyParameter) {
         if (this.client.getHost() == null) {
@@ -589,17 +1053,41 @@ public final class Explicits {
         return service.postOptionalArrayProperty(this.client.getHost(), bodyParameter);
     }
 
+    /**
+     * Test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> postOptionalArrayPropertyAsync(ArrayOptionalWrapper bodyParameter) {
         return postOptionalArrayPropertyWithResponseAsync(bodyParameter)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptionalArrayProperty(ArrayOptionalWrapper bodyParameter) {
         postOptionalArrayPropertyAsync(bodyParameter).block();
     }
 
+    /**
+     * Test explicitly required array. Please put a header 'headerParameter' =&gt; null and the client library should throw before the request is sent.
+     * 
+     * @param headerParameter MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> postRequiredArrayHeaderWithResponseAsync(List<String> headerParameter) {
         if (this.client.getHost() == null) {
@@ -612,17 +1100,41 @@ public final class Explicits {
         return service.postRequiredArrayHeader(this.client.getHost(), headerParameterConverted);
     }
 
+    /**
+     * Test explicitly required array. Please put a header 'headerParameter' =&gt; null and the client library should throw before the request is sent.
+     * 
+     * @param headerParameter MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> postRequiredArrayHeaderAsync(List<String> headerParameter) {
         return postRequiredArrayHeaderWithResponseAsync(headerParameter)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Test explicitly required array. Please put a header 'headerParameter' =&gt; null and the client library should throw before the request is sent.
+     * 
+     * @param headerParameter MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postRequiredArrayHeader(List<String> headerParameter) {
         postRequiredArrayHeaderAsync(headerParameter).block();
     }
 
+    /**
+     * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
+     * 
+     * @param headerParameter MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> postOptionalArrayHeaderWithResponseAsync(List<String> headerParameter) {
         if (this.client.getHost() == null) {
@@ -632,12 +1144,28 @@ public final class Explicits {
         return service.postOptionalArrayHeader(this.client.getHost(), headerParameterConverted);
     }
 
+    /**
+     * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
+     * 
+     * @param headerParameter MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> postOptionalArrayHeaderAsync(List<String> headerParameter) {
         return postOptionalArrayHeaderWithResponseAsync(headerParameter)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Test explicitly optional integer. Please put a header 'headerParameter' =&gt; null.
+     * 
+     * @param headerParameter MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void postOptionalArrayHeader(List<String> headerParameter) {
         postOptionalArrayHeaderAsync(headerParameter).block();

--- a/tests/src/main/java/fixtures/requiredoptional/Implicits.java
+++ b/tests/src/main/java/fixtures/requiredoptional/Implicits.java
@@ -87,6 +87,14 @@ public final class Implicits {
         Mono<Response<Void>> getOptionalGlobalQuery(@HostParam("$host") String host, @QueryParam("optional-global-query") Integer optionalGlobalQuery);
     }
 
+    /**
+     * Test implicitly required path parameter.
+     * 
+     * @param pathParameter MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> getRequiredPathWithResponseAsync(String pathParameter) {
         if (this.client.getHost() == null) {
@@ -98,17 +106,41 @@ public final class Implicits {
         return service.getRequiredPath(this.client.getHost(), pathParameter);
     }
 
+    /**
+     * Test implicitly required path parameter.
+     * 
+     * @param pathParameter MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> getRequiredPathAsync(String pathParameter) {
         return getRequiredPathWithResponseAsync(pathParameter)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Test implicitly required path parameter.
+     * 
+     * @param pathParameter MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getRequiredPath(String pathParameter) {
         getRequiredPathAsync(pathParameter).block();
     }
 
+    /**
+     * Test implicitly optional query parameter.
+     * 
+     * @param queryParameter MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putOptionalQueryWithResponseAsync(String queryParameter) {
         if (this.client.getHost() == null) {
@@ -117,17 +149,41 @@ public final class Implicits {
         return service.putOptionalQuery(this.client.getHost(), queryParameter);
     }
 
+    /**
+     * Test implicitly optional query parameter.
+     * 
+     * @param queryParameter MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putOptionalQueryAsync(String queryParameter) {
         return putOptionalQueryWithResponseAsync(queryParameter)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Test implicitly optional query parameter.
+     * 
+     * @param queryParameter MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putOptionalQuery(String queryParameter) {
         putOptionalQueryAsync(queryParameter).block();
     }
 
+    /**
+     * Test implicitly optional header parameter.
+     * 
+     * @param queryParameter MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putOptionalHeaderWithResponseAsync(String queryParameter) {
         if (this.client.getHost() == null) {
@@ -136,17 +192,41 @@ public final class Implicits {
         return service.putOptionalHeader(this.client.getHost(), queryParameter);
     }
 
+    /**
+     * Test implicitly optional header parameter.
+     * 
+     * @param queryParameter MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putOptionalHeaderAsync(String queryParameter) {
         return putOptionalHeaderWithResponseAsync(queryParameter)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Test implicitly optional header parameter.
+     * 
+     * @param queryParameter MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putOptionalHeader(String queryParameter) {
         putOptionalHeaderAsync(queryParameter).block();
     }
 
+    /**
+     * Test implicitly optional body parameter.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putOptionalBodyWithResponseAsync(String bodyParameter) {
         if (this.client.getHost() == null) {
@@ -155,17 +235,39 @@ public final class Implicits {
         return service.putOptionalBody(this.client.getHost(), bodyParameter);
     }
 
+    /**
+     * Test implicitly optional body parameter.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putOptionalBodyAsync(String bodyParameter) {
         return putOptionalBodyWithResponseAsync(bodyParameter)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Test implicitly optional body parameter.
+     * 
+     * @param bodyParameter MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putOptionalBody(String bodyParameter) {
         putOptionalBodyAsync(bodyParameter).block();
     }
 
+    /**
+     * Test implicitly required path parameter.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> getRequiredGlobalPathWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -177,17 +279,35 @@ public final class Implicits {
         return service.getRequiredGlobalPath(this.client.getHost(), this.client.getRequiredGlobalPath());
     }
 
+    /**
+     * Test implicitly required path parameter.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> getRequiredGlobalPathAsync() {
         return getRequiredGlobalPathWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Test implicitly required path parameter.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getRequiredGlobalPath() {
         getRequiredGlobalPathAsync().block();
     }
 
+    /**
+     * Test implicitly required query parameter.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> getRequiredGlobalQueryWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -199,17 +319,35 @@ public final class Implicits {
         return service.getRequiredGlobalQuery(this.client.getHost(), this.client.getRequiredGlobalQuery());
     }
 
+    /**
+     * Test implicitly required query parameter.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> getRequiredGlobalQueryAsync() {
         return getRequiredGlobalQueryWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Test implicitly required query parameter.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getRequiredGlobalQuery() {
         getRequiredGlobalQueryAsync().block();
     }
 
+    /**
+     * Test implicitly optional query parameter.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> getOptionalGlobalQueryWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -218,12 +356,24 @@ public final class Implicits {
         return service.getOptionalGlobalQuery(this.client.getHost(), this.client.getOptionalGlobalQuery());
     }
 
+    /**
+     * Test implicitly optional query parameter.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> getOptionalGlobalQueryAsync() {
         return getOptionalGlobalQueryWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Test implicitly optional query parameter.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getOptionalGlobalQuery() {
         getOptionalGlobalQueryAsync().block();

--- a/tests/src/main/java/fixtures/url/AutoRestUrlTestService.java
+++ b/tests/src/main/java/fixtures/url/AutoRestUrlTestService.java
@@ -11,54 +11,6 @@ import com.azure.core.http.policy.UserAgentPolicy;
  */
 public final class AutoRestUrlTestService {
     /**
-     */
-    private String globalStringPath;
-
-    /**
-     * Gets null.
-     * 
-     * @return the globalStringPath value.
-     */
-    public String getGlobalStringPath() {
-        return this.globalStringPath;
-    }
-
-    /**
-     * Sets null.
-     * 
-     * @param globalStringPath the globalStringPath value.
-     * @return the service client itself.
-     */
-    AutoRestUrlTestService setGlobalStringPath(String globalStringPath) {
-        this.globalStringPath = globalStringPath;
-        return this;
-    }
-
-    /**
-     */
-    private String globalStringQuery;
-
-    /**
-     * Gets null.
-     * 
-     * @return the globalStringQuery value.
-     */
-    public String getGlobalStringQuery() {
-        return this.globalStringQuery;
-    }
-
-    /**
-     * Sets null.
-     * 
-     * @param globalStringQuery the globalStringQuery value.
-     * @return the service client itself.
-     */
-    AutoRestUrlTestService setGlobalStringQuery(String globalStringQuery) {
-        this.globalStringQuery = globalStringQuery;
-        return this;
-    }
-
-    /**
      * http://localhost:3000.
      */
     private String host;

--- a/tests/src/main/java/fixtures/url/AutoRestUrlTestServiceBuilder.java
+++ b/tests/src/main/java/fixtures/url/AutoRestUrlTestServiceBuilder.java
@@ -13,38 +13,6 @@ import com.azure.core.http.policy.UserAgentPolicy;
 @ServiceClientBuilder(serviceClients = AutoRestUrlTestService.class)
 public final class AutoRestUrlTestServiceBuilder {
     /*
-     * null
-     */
-    private String globalStringPath;
-
-    /**
-     * Sets null.
-     * 
-     * @param globalStringPath the globalStringPath value.
-     * @return the AutoRestUrlTestServiceBuilder.
-     */
-    public AutoRestUrlTestServiceBuilder globalStringPath(String globalStringPath) {
-        this.globalStringPath = globalStringPath;
-        return this;
-    }
-
-    /*
-     * null
-     */
-    private String globalStringQuery;
-
-    /**
-     * Sets null.
-     * 
-     * @param globalStringQuery the globalStringQuery value.
-     * @return the AutoRestUrlTestServiceBuilder.
-     */
-    public AutoRestUrlTestServiceBuilder globalStringQuery(String globalStringQuery) {
-        this.globalStringQuery = globalStringQuery;
-        return this;
-    }
-
-    /*
      * http://localhost:3000
      */
     private String host;
@@ -89,8 +57,6 @@ public final class AutoRestUrlTestServiceBuilder {
             this.pipeline = new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build();
         }
         AutoRestUrlTestService client = new AutoRestUrlTestService(pipeline);
-        client.setGlobalStringPath(this.globalStringPath);
-        client.setGlobalStringQuery(this.globalStringQuery);
         client.setHost(this.host);
         return client;
     }

--- a/tests/src/main/java/fixtures/url/PathItems.java
+++ b/tests/src/main/java/fixtures/url/PathItems.java
@@ -51,24 +51,35 @@ public final class PathItems {
         @Get("/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/pathItemStringQuery/localStringQuery")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Mono<Response<Void>> getAllWithValues(@HostParam("$host") String host, @PathParam("pathItemStringPath") String pathItemStringPath, @QueryParam("pathItemStringQuery") String pathItemStringQuery, @PathParam("globalStringPath") String globalStringPath, @QueryParam("globalStringQuery") String globalStringQuery, @PathParam("localStringPath") String localStringPath, @QueryParam("localStringQuery") String localStringQuery);
+        Mono<Response<Void>> getAllWithValues(@HostParam("$host") String host, @PathParam("pathItemStringPath") String pathItemStringPath, @QueryParam("pathItemStringQuery") String pathItemStringQuery, @PathParam("localStringPath") String localStringPath, @QueryParam("localStringQuery") String localStringQuery);
 
         @Get("/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/localStringQuery")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Mono<Response<Void>> getGlobalQueryNull(@HostParam("$host") String host, @PathParam("pathItemStringPath") String pathItemStringPath, @QueryParam("pathItemStringQuery") String pathItemStringQuery, @PathParam("globalStringPath") String globalStringPath, @QueryParam("globalStringQuery") String globalStringQuery, @PathParam("localStringPath") String localStringPath, @QueryParam("localStringQuery") String localStringQuery);
+        Mono<Response<Void>> getGlobalQueryNull(@HostParam("$host") String host, @PathParam("pathItemStringPath") String pathItemStringPath, @QueryParam("pathItemStringQuery") String pathItemStringQuery, @PathParam("localStringPath") String localStringPath, @QueryParam("localStringQuery") String localStringQuery);
 
         @Get("/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Mono<Response<Void>> getGlobalAndLocalQueryNull(@HostParam("$host") String host, @PathParam("pathItemStringPath") String pathItemStringPath, @QueryParam("pathItemStringQuery") String pathItemStringQuery, @PathParam("globalStringPath") String globalStringPath, @QueryParam("globalStringQuery") String globalStringQuery, @PathParam("localStringPath") String localStringPath, @QueryParam("localStringQuery") String localStringQuery);
+        Mono<Response<Void>> getGlobalAndLocalQueryNull(@HostParam("$host") String host, @PathParam("pathItemStringPath") String pathItemStringPath, @QueryParam("pathItemStringQuery") String pathItemStringQuery, @PathParam("localStringPath") String localStringPath, @QueryParam("localStringQuery") String localStringQuery);
 
         @Get("/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/null/null")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
-        Mono<Response<Void>> getLocalPathItemQueryNull(@HostParam("$host") String host, @PathParam("pathItemStringPath") String pathItemStringPath, @QueryParam("pathItemStringQuery") String pathItemStringQuery, @PathParam("globalStringPath") String globalStringPath, @QueryParam("globalStringQuery") String globalStringQuery, @PathParam("localStringPath") String localStringPath, @QueryParam("localStringQuery") String localStringQuery);
+        Mono<Response<Void>> getLocalPathItemQueryNull(@HostParam("$host") String host, @PathParam("pathItemStringPath") String pathItemStringPath, @QueryParam("pathItemStringQuery") String pathItemStringQuery, @PathParam("localStringPath") String localStringPath, @QueryParam("localStringQuery") String localStringQuery);
     }
 
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
+     * 
+     * @param pathItemStringPath MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param pathItemStringQuery MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param localStringPath MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param localStringQuery MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> getAllWithValuesWithResponseAsync(String pathItemStringPath, String pathItemStringQuery, String localStringPath, String localStringQuery) {
         if (this.client.getHost() == null) {
@@ -77,26 +88,56 @@ public final class PathItems {
         if (pathItemStringPath == null) {
             throw new IllegalArgumentException("Parameter pathItemStringPath is required and cannot be null.");
         }
-        if (this.client.getGlobalStringPath() == null) {
-            throw new IllegalArgumentException("Parameter this.client.getGlobalStringPath() is required and cannot be null.");
-        }
         if (localStringPath == null) {
             throw new IllegalArgumentException("Parameter localStringPath is required and cannot be null.");
         }
-        return service.getAllWithValues(this.client.getHost(), pathItemStringPath, pathItemStringQuery, this.client.getGlobalStringPath(), this.client.getGlobalStringQuery(), localStringPath, localStringQuery);
+        return service.getAllWithValues(this.client.getHost(), pathItemStringPath, pathItemStringQuery, localStringPath, localStringQuery);
     }
 
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
+     * 
+     * @param pathItemStringPath MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param pathItemStringQuery MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param localStringPath MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param localStringQuery MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> getAllWithValuesAsync(String pathItemStringPath, String pathItemStringQuery, String localStringPath, String localStringQuery) {
         return getAllWithValuesWithResponseAsync(pathItemStringPath, pathItemStringQuery, localStringPath, localStringQuery)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
+     * 
+     * @param pathItemStringPath MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param pathItemStringQuery MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param localStringPath MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param localStringQuery MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getAllWithValues(String pathItemStringPath, String pathItemStringQuery, String localStringPath, String localStringQuery) {
         getAllWithValuesAsync(pathItemStringPath, pathItemStringQuery, localStringPath, localStringQuery).block();
     }
 
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
+     * 
+     * @param pathItemStringPath MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param pathItemStringQuery MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param localStringPath MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param localStringQuery MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> getGlobalQueryNullWithResponseAsync(String pathItemStringPath, String pathItemStringQuery, String localStringPath, String localStringQuery) {
         if (this.client.getHost() == null) {
@@ -105,26 +146,56 @@ public final class PathItems {
         if (pathItemStringPath == null) {
             throw new IllegalArgumentException("Parameter pathItemStringPath is required and cannot be null.");
         }
-        if (this.client.getGlobalStringPath() == null) {
-            throw new IllegalArgumentException("Parameter this.client.getGlobalStringPath() is required and cannot be null.");
-        }
         if (localStringPath == null) {
             throw new IllegalArgumentException("Parameter localStringPath is required and cannot be null.");
         }
-        return service.getGlobalQueryNull(this.client.getHost(), pathItemStringPath, pathItemStringQuery, this.client.getGlobalStringPath(), this.client.getGlobalStringQuery(), localStringPath, localStringQuery);
+        return service.getGlobalQueryNull(this.client.getHost(), pathItemStringPath, pathItemStringQuery, localStringPath, localStringQuery);
     }
 
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
+     * 
+     * @param pathItemStringPath MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param pathItemStringQuery MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param localStringPath MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param localStringQuery MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> getGlobalQueryNullAsync(String pathItemStringPath, String pathItemStringQuery, String localStringPath, String localStringQuery) {
         return getGlobalQueryNullWithResponseAsync(pathItemStringPath, pathItemStringQuery, localStringPath, localStringQuery)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'.
+     * 
+     * @param pathItemStringPath MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param pathItemStringQuery MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param localStringPath MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param localStringQuery MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getGlobalQueryNull(String pathItemStringPath, String pathItemStringQuery, String localStringPath, String localStringQuery) {
         getGlobalQueryNullAsync(pathItemStringPath, pathItemStringQuery, localStringPath, localStringQuery).block();
     }
 
+    /**
+     * send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery=null.
+     * 
+     * @param pathItemStringPath MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param pathItemStringQuery MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param localStringPath MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param localStringQuery MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> getGlobalAndLocalQueryNullWithResponseAsync(String pathItemStringPath, String pathItemStringQuery, String localStringPath, String localStringQuery) {
         if (this.client.getHost() == null) {
@@ -133,26 +204,56 @@ public final class PathItems {
         if (pathItemStringPath == null) {
             throw new IllegalArgumentException("Parameter pathItemStringPath is required and cannot be null.");
         }
-        if (this.client.getGlobalStringPath() == null) {
-            throw new IllegalArgumentException("Parameter this.client.getGlobalStringPath() is required and cannot be null.");
-        }
         if (localStringPath == null) {
             throw new IllegalArgumentException("Parameter localStringPath is required and cannot be null.");
         }
-        return service.getGlobalAndLocalQueryNull(this.client.getHost(), pathItemStringPath, pathItemStringQuery, this.client.getGlobalStringPath(), this.client.getGlobalStringQuery(), localStringPath, localStringQuery);
+        return service.getGlobalAndLocalQueryNull(this.client.getHost(), pathItemStringPath, pathItemStringQuery, localStringPath, localStringQuery);
     }
 
+    /**
+     * send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery=null.
+     * 
+     * @param pathItemStringPath MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param pathItemStringQuery MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param localStringPath MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param localStringQuery MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> getGlobalAndLocalQueryNullAsync(String pathItemStringPath, String pathItemStringQuery, String localStringPath, String localStringQuery) {
         return getGlobalAndLocalQueryNullWithResponseAsync(pathItemStringPath, pathItemStringQuery, localStringPath, localStringQuery)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery=null.
+     * 
+     * @param pathItemStringPath MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param pathItemStringQuery MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param localStringPath MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param localStringQuery MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getGlobalAndLocalQueryNull(String pathItemStringPath, String pathItemStringQuery, String localStringPath, String localStringQuery) {
         getGlobalAndLocalQueryNullAsync(pathItemStringPath, pathItemStringQuery, localStringPath, localStringQuery).block();
     }
 
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null, localStringQuery=null.
+     * 
+     * @param pathItemStringPath MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param pathItemStringQuery MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param localStringPath MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param localStringQuery MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> getLocalPathItemQueryNullWithResponseAsync(String pathItemStringPath, String pathItemStringQuery, String localStringPath, String localStringQuery) {
         if (this.client.getHost() == null) {
@@ -161,21 +262,40 @@ public final class PathItems {
         if (pathItemStringPath == null) {
             throw new IllegalArgumentException("Parameter pathItemStringPath is required and cannot be null.");
         }
-        if (this.client.getGlobalStringPath() == null) {
-            throw new IllegalArgumentException("Parameter this.client.getGlobalStringPath() is required and cannot be null.");
-        }
         if (localStringPath == null) {
             throw new IllegalArgumentException("Parameter localStringPath is required and cannot be null.");
         }
-        return service.getLocalPathItemQueryNull(this.client.getHost(), pathItemStringPath, pathItemStringQuery, this.client.getGlobalStringPath(), this.client.getGlobalStringQuery(), localStringPath, localStringQuery);
+        return service.getLocalPathItemQueryNull(this.client.getHost(), pathItemStringPath, pathItemStringQuery, localStringPath, localStringQuery);
     }
 
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null, localStringQuery=null.
+     * 
+     * @param pathItemStringPath MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param pathItemStringQuery MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param localStringPath MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param localStringQuery MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> getLocalPathItemQueryNullAsync(String pathItemStringPath, String pathItemStringQuery, String localStringPath, String localStringQuery) {
         return getLocalPathItemQueryNullWithResponseAsync(pathItemStringPath, pathItemStringQuery, localStringPath, localStringQuery)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null, localStringQuery=null.
+     * 
+     * @param pathItemStringPath MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param pathItemStringQuery MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param localStringPath MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @param localStringQuery MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getLocalPathItemQueryNull(String pathItemStringPath, String pathItemStringQuery, String localStringPath, String localStringQuery) {
         getLocalPathItemQueryNullAsync(pathItemStringPath, pathItemStringQuery, localStringPath, localStringQuery).block();

--- a/tests/src/main/java/fixtures/url/Paths.java
+++ b/tests/src/main/java/fixtures/url/Paths.java
@@ -114,6 +114,11 @@ public final class Paths {
         @UnexpectedResponseExceptionType(ErrorException.class)
         Mono<Response<Void>> stringUrlEncoded(@HostParam("$host") String host, @PathParam("stringPath") String stringPath);
 
+        @Get("/paths/string/begin!*'();:@&=+$,end/{stringPath}")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<Void>> stringUrlNonEncoded(@HostParam("$host") String host, @PathParam(value = "stringPath", encoded = true) String stringPath);
+
         @Get("/paths/string/empty/{stringPath}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(ErrorException.class)
@@ -185,6 +190,12 @@ public final class Paths {
         Mono<Response<Void>> unixTimeUrl(@HostParam("$host") String host, @PathParam("unixTimeUrlPath") long unixTimeUrlPath);
     }
 
+    /**
+     * Get true Boolean value on path.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> getBooleanTrueWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -194,17 +205,35 @@ public final class Paths {
         return service.getBooleanTrue(this.client.getHost(), boolPath);
     }
 
+    /**
+     * Get true Boolean value on path.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> getBooleanTrueAsync() {
         return getBooleanTrueWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get true Boolean value on path.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getBooleanTrue() {
         getBooleanTrueAsync().block();
     }
 
+    /**
+     * Get false Boolean value on path.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> getBooleanFalseWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -214,17 +243,35 @@ public final class Paths {
         return service.getBooleanFalse(this.client.getHost(), boolPath);
     }
 
+    /**
+     * Get false Boolean value on path.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> getBooleanFalseAsync() {
         return getBooleanFalseWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get false Boolean value on path.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getBooleanFalse() {
         getBooleanFalseAsync().block();
     }
 
+    /**
+     * Get '1000000' integer value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> getIntOneMillionWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -234,17 +281,35 @@ public final class Paths {
         return service.getIntOneMillion(this.client.getHost(), intPath);
     }
 
+    /**
+     * Get '1000000' integer value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> getIntOneMillionAsync() {
         return getIntOneMillionWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get '1000000' integer value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getIntOneMillion() {
         getIntOneMillionAsync().block();
     }
 
+    /**
+     * Get '-1000000' integer value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> getIntNegativeOneMillionWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -254,17 +319,35 @@ public final class Paths {
         return service.getIntNegativeOneMillion(this.client.getHost(), intPath);
     }
 
+    /**
+     * Get '-1000000' integer value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> getIntNegativeOneMillionAsync() {
         return getIntNegativeOneMillionWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get '-1000000' integer value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getIntNegativeOneMillion() {
         getIntNegativeOneMillionAsync().block();
     }
 
+    /**
+     * Get '10000000000' 64 bit integer value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> getTenBillionWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -274,17 +357,35 @@ public final class Paths {
         return service.getTenBillion(this.client.getHost(), longPath);
     }
 
+    /**
+     * Get '10000000000' 64 bit integer value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> getTenBillionAsync() {
         return getTenBillionWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get '10000000000' 64 bit integer value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getTenBillion() {
         getTenBillionAsync().block();
     }
 
+    /**
+     * Get '-10000000000' 64 bit integer value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> getNegativeTenBillionWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -294,17 +395,35 @@ public final class Paths {
         return service.getNegativeTenBillion(this.client.getHost(), longPath);
     }
 
+    /**
+     * Get '-10000000000' 64 bit integer value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> getNegativeTenBillionAsync() {
         return getNegativeTenBillionWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get '-10000000000' 64 bit integer value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getNegativeTenBillion() {
         getNegativeTenBillionAsync().block();
     }
 
+    /**
+     * Get '1.034E+20' numeric value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> floatScientificPositiveWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -314,17 +433,35 @@ public final class Paths {
         return service.floatScientificPositive(this.client.getHost(), floatPath);
     }
 
+    /**
+     * Get '1.034E+20' numeric value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> floatScientificPositiveAsync() {
         return floatScientificPositiveWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get '1.034E+20' numeric value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void floatScientificPositive() {
         floatScientificPositiveAsync().block();
     }
 
+    /**
+     * Get '-1.034E-20' numeric value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> floatScientificNegativeWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -334,17 +471,35 @@ public final class Paths {
         return service.floatScientificNegative(this.client.getHost(), floatPath);
     }
 
+    /**
+     * Get '-1.034E-20' numeric value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> floatScientificNegativeAsync() {
         return floatScientificNegativeWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get '-1.034E-20' numeric value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void floatScientificNegative() {
         floatScientificNegativeAsync().block();
     }
 
+    /**
+     * Get '9999999.999' numeric value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> doubleDecimalPositiveWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -354,17 +509,35 @@ public final class Paths {
         return service.doubleDecimalPositive(this.client.getHost(), doublePath);
     }
 
+    /**
+     * Get '9999999.999' numeric value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> doubleDecimalPositiveAsync() {
         return doubleDecimalPositiveWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get '9999999.999' numeric value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void doubleDecimalPositive() {
         doubleDecimalPositiveAsync().block();
     }
 
+    /**
+     * Get '-9999999.999' numeric value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> doubleDecimalNegativeWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -374,17 +547,35 @@ public final class Paths {
         return service.doubleDecimalNegative(this.client.getHost(), doublePath);
     }
 
+    /**
+     * Get '-9999999.999' numeric value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> doubleDecimalNegativeAsync() {
         return doubleDecimalNegativeWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get '-9999999.999' numeric value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void doubleDecimalNegative() {
         doubleDecimalNegativeAsync().block();
     }
 
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> stringUnicodeWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -394,17 +585,35 @@ public final class Paths {
         return service.stringUnicode(this.client.getHost(), stringPath);
     }
 
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> stringUnicodeAsync() {
         return stringUnicodeWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void stringUnicode() {
         stringUnicodeAsync().block();
     }
 
+    /**
+     * Get 'begin!*'();:@ &amp;=+$,/?#[]end.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> stringUrlEncodedWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -414,17 +623,73 @@ public final class Paths {
         return service.stringUrlEncoded(this.client.getHost(), stringPath);
     }
 
+    /**
+     * Get 'begin!*'();:@ &amp;=+$,/?#[]end.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> stringUrlEncodedAsync() {
         return stringUrlEncodedWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get 'begin!*'();:@ &amp;=+$,/?#[]end.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void stringUrlEncoded() {
         stringUrlEncodedAsync().block();
     }
 
+    /**
+     * Get 'begin!*'();:@&amp;=+$,end.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> stringUrlNonEncodedWithResponseAsync() {
+        if (this.client.getHost() == null) {
+            throw new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null.");
+        }
+        final String stringPath = "begin!*'();:@&=+$,end";
+        return service.stringUrlNonEncoded(this.client.getHost(), stringPath);
+    }
+
+    /**
+     * Get 'begin!*'();:@&amp;=+$,end.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> stringUrlNonEncodedAsync() {
+        return stringUrlNonEncodedWithResponseAsync()
+            .flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Get 'begin!*'();:@&amp;=+$,end.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void stringUrlNonEncoded() {
+        stringUrlNonEncodedAsync().block();
+    }
+
+    /**
+     * Get ''.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> stringEmptyWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -434,17 +699,37 @@ public final class Paths {
         return service.stringEmpty(this.client.getHost(), stringPath);
     }
 
+    /**
+     * Get ''.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> stringEmptyAsync() {
         return stringEmptyWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get ''.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void stringEmpty() {
         stringEmptyAsync().block();
     }
 
+    /**
+     * Get null (should throw).
+     * 
+     * @param stringPath MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> stringNullWithResponseAsync(String stringPath) {
         if (this.client.getHost() == null) {
@@ -456,17 +741,41 @@ public final class Paths {
         return service.stringNull(this.client.getHost(), stringPath);
     }
 
+    /**
+     * Get null (should throw).
+     * 
+     * @param stringPath MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> stringNullAsync(String stringPath) {
         return stringNullWithResponseAsync(stringPath)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get null (should throw).
+     * 
+     * @param stringPath MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void stringNull(String stringPath) {
         stringNullAsync(stringPath).block();
     }
 
+    /**
+     * Get using uri with 'green color' in path parameter.
+     * 
+     * @param enumPath MISSING·SCHEMA-DESCRIPTION-CHOICE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> enumValidWithResponseAsync(UriColor enumPath) {
         if (this.client.getHost() == null) {
@@ -478,17 +787,41 @@ public final class Paths {
         return service.enumValid(this.client.getHost(), enumPath);
     }
 
+    /**
+     * Get using uri with 'green color' in path parameter.
+     * 
+     * @param enumPath MISSING·SCHEMA-DESCRIPTION-CHOICE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> enumValidAsync(UriColor enumPath) {
         return enumValidWithResponseAsync(enumPath)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get using uri with 'green color' in path parameter.
+     * 
+     * @param enumPath MISSING·SCHEMA-DESCRIPTION-CHOICE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void enumValid(UriColor enumPath) {
         enumValidAsync(enumPath).block();
     }
 
+    /**
+     * Get null (should throw on the client before the request is sent on wire).
+     * 
+     * @param enumPath MISSING·SCHEMA-DESCRIPTION-CHOICE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> enumNullWithResponseAsync(UriColor enumPath) {
         if (this.client.getHost() == null) {
@@ -500,17 +833,41 @@ public final class Paths {
         return service.enumNull(this.client.getHost(), enumPath);
     }
 
+    /**
+     * Get null (should throw on the client before the request is sent on wire).
+     * 
+     * @param enumPath MISSING·SCHEMA-DESCRIPTION-CHOICE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> enumNullAsync(UriColor enumPath) {
         return enumNullWithResponseAsync(enumPath)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get null (should throw on the client before the request is sent on wire).
+     * 
+     * @param enumPath MISSING·SCHEMA-DESCRIPTION-CHOICE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void enumNull(UriColor enumPath) {
         enumNullAsync(enumPath).block();
     }
 
+    /**
+     * Get '啊齄丂��狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
+     * 
+     * @param bytePath MISSING·SCHEMA-DESCRIPTION-BYTEARRAY.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> byteMultiByteWithResponseAsync(byte[] bytePath) {
         if (this.client.getHost() == null) {
@@ -523,17 +880,39 @@ public final class Paths {
         return service.byteMultiByte(this.client.getHost(), bytePathConverted);
     }
 
+    /**
+     * Get '啊齄丂��狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
+     * 
+     * @param bytePath MISSING·SCHEMA-DESCRIPTION-BYTEARRAY.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> byteMultiByteAsync(byte[] bytePath) {
         return byteMultiByteWithResponseAsync(bytePath)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get '啊齄丂��狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
+     * 
+     * @param bytePath MISSING·SCHEMA-DESCRIPTION-BYTEARRAY.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void byteMultiByte(byte[] bytePath) {
         byteMultiByteAsync(bytePath).block();
     }
 
+    /**
+     * Get '' as byte array.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> byteEmptyWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -544,17 +923,37 @@ public final class Paths {
         return service.byteEmpty(this.client.getHost(), bytePathConverted);
     }
 
+    /**
+     * Get '' as byte array.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> byteEmptyAsync() {
         return byteEmptyWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get '' as byte array.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void byteEmpty() {
         byteEmptyAsync().block();
     }
 
+    /**
+     * Get null as byte array (should throw).
+     * 
+     * @param bytePath MISSING·SCHEMA-DESCRIPTION-BYTEARRAY.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> byteNullWithResponseAsync(byte[] bytePath) {
         if (this.client.getHost() == null) {
@@ -567,17 +966,39 @@ public final class Paths {
         return service.byteNull(this.client.getHost(), bytePathConverted);
     }
 
+    /**
+     * Get null as byte array (should throw).
+     * 
+     * @param bytePath MISSING·SCHEMA-DESCRIPTION-BYTEARRAY.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> byteNullAsync(byte[] bytePath) {
         return byteNullWithResponseAsync(bytePath)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get null as byte array (should throw).
+     * 
+     * @param bytePath MISSING·SCHEMA-DESCRIPTION-BYTEARRAY.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void byteNull(byte[] bytePath) {
         byteNullAsync(bytePath).block();
     }
 
+    /**
+     * Get '2012-01-01' as date.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> dateValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -587,17 +1008,37 @@ public final class Paths {
         return service.dateValid(this.client.getHost(), datePath);
     }
 
+    /**
+     * Get '2012-01-01' as date.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> dateValidAsync() {
         return dateValidWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get '2012-01-01' as date.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void dateValid() {
         dateValidAsync().block();
     }
 
+    /**
+     * Get null as date - this should throw or be unusable on the client side, depending on date representation.
+     * 
+     * @param datePath MISSING·SCHEMA-DESCRIPTION-DATE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> dateNullWithResponseAsync(LocalDate datePath) {
         if (this.client.getHost() == null) {
@@ -609,17 +1050,39 @@ public final class Paths {
         return service.dateNull(this.client.getHost(), datePath);
     }
 
+    /**
+     * Get null as date - this should throw or be unusable on the client side, depending on date representation.
+     * 
+     * @param datePath MISSING·SCHEMA-DESCRIPTION-DATE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> dateNullAsync(LocalDate datePath) {
         return dateNullWithResponseAsync(datePath)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get null as date - this should throw or be unusable on the client side, depending on date representation.
+     * 
+     * @param datePath MISSING·SCHEMA-DESCRIPTION-DATE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void dateNull(LocalDate datePath) {
         dateNullAsync(datePath).block();
     }
 
+    /**
+     * Get '2012-01-01T01:01:01Z' as date-time.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> dateTimeValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -629,17 +1092,37 @@ public final class Paths {
         return service.dateTimeValid(this.client.getHost(), dateTimePath);
     }
 
+    /**
+     * Get '2012-01-01T01:01:01Z' as date-time.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> dateTimeValidAsync() {
         return dateTimeValidWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get '2012-01-01T01:01:01Z' as date-time.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void dateTimeValid() {
         dateTimeValidAsync().block();
     }
 
+    /**
+     * Get null as date-time, should be disallowed or throw depending on representation of date-time.
+     * 
+     * @param dateTimePath MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> dateTimeNullWithResponseAsync(OffsetDateTime dateTimePath) {
         if (this.client.getHost() == null) {
@@ -651,17 +1134,41 @@ public final class Paths {
         return service.dateTimeNull(this.client.getHost(), dateTimePath);
     }
 
+    /**
+     * Get null as date-time, should be disallowed or throw depending on representation of date-time.
+     * 
+     * @param dateTimePath MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> dateTimeNullAsync(OffsetDateTime dateTimePath) {
         return dateTimeNullWithResponseAsync(dateTimePath)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get null as date-time, should be disallowed or throw depending on representation of date-time.
+     * 
+     * @param dateTimePath MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void dateTimeNull(OffsetDateTime dateTimePath) {
         dateTimeNullAsync(dateTimePath).block();
     }
 
+    /**
+     * Get 'lorem' encoded value as 'bG9yZW0' (base64url).
+     * 
+     * @param base64UrlPath MISSING·SCHEMA-DESCRIPTION-BYTEARRAY.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> base64UrlWithResponseAsync(byte[] base64UrlPath) {
         if (this.client.getHost() == null) {
@@ -674,17 +1181,41 @@ public final class Paths {
         return service.base64Url(this.client.getHost(), base64UrlPathConverted);
     }
 
+    /**
+     * Get 'lorem' encoded value as 'bG9yZW0' (base64url).
+     * 
+     * @param base64UrlPath MISSING·SCHEMA-DESCRIPTION-BYTEARRAY.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> base64UrlAsync(byte[] base64UrlPath) {
         return base64UrlWithResponseAsync(base64UrlPath)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get 'lorem' encoded value as 'bG9yZW0' (base64url).
+     * 
+     * @param base64UrlPath MISSING·SCHEMA-DESCRIPTION-BYTEARRAY.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void base64Url(byte[] base64UrlPath) {
         base64UrlAsync(base64UrlPath).block();
     }
 
+    /**
+     * Get an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
+     * 
+     * @param arrayPath MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> arrayCsvInPathWithResponseAsync(List<String> arrayPath) {
         if (this.client.getHost() == null) {
@@ -697,17 +1228,41 @@ public final class Paths {
         return service.arrayCsvInPath(this.client.getHost(), arrayPathConverted);
     }
 
+    /**
+     * Get an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
+     * 
+     * @param arrayPath MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> arrayCsvInPathAsync(List<String> arrayPath) {
         return arrayCsvInPathWithResponseAsync(arrayPath)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
+     * 
+     * @param arrayPath MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void arrayCsvInPath(List<String> arrayPath) {
         arrayCsvInPathAsync(arrayPath).block();
     }
 
+    /**
+     * Get the date 2016-04-13 encoded value as '1460505600' (Unix time).
+     * 
+     * @param unixTimeUrlPath date in seconds since 1970-01-01T00:00:00Z.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> unixTimeUrlWithResponseAsync(OffsetDateTime unixTimeUrlPath) {
         if (this.client.getHost() == null) {
@@ -720,12 +1275,28 @@ public final class Paths {
         return service.unixTimeUrl(this.client.getHost(), unixTimeUrlPathConverted);
     }
 
+    /**
+     * Get the date 2016-04-13 encoded value as '1460505600' (Unix time).
+     * 
+     * @param unixTimeUrlPath date in seconds since 1970-01-01T00:00:00Z.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> unixTimeUrlAsync(OffsetDateTime unixTimeUrlPath) {
         return unixTimeUrlWithResponseAsync(unixTimeUrlPath)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get the date 2016-04-13 encoded value as '1460505600' (Unix time).
+     * 
+     * @param unixTimeUrlPath date in seconds since 1970-01-01T00:00:00Z.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void unixTimeUrl(OffsetDateTime unixTimeUrlPath) {
         unixTimeUrlAsync(unixTimeUrlPath).block();

--- a/tests/src/main/java/fixtures/url/Queries.java
+++ b/tests/src/main/java/fixtures/url/Queries.java
@@ -225,6 +225,12 @@ public final class Queries {
         Mono<Response<Void>> arrayStringPipesValid(@HostParam("$host") String host, @QueryParam("arrayQuery") String arrayQuery);
     }
 
+    /**
+     * Get true Boolean value on path.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> getBooleanTrueWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -234,17 +240,35 @@ public final class Queries {
         return service.getBooleanTrue(this.client.getHost(), boolQuery);
     }
 
+    /**
+     * Get true Boolean value on path.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> getBooleanTrueAsync() {
         return getBooleanTrueWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get true Boolean value on path.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getBooleanTrue() {
         getBooleanTrueAsync().block();
     }
 
+    /**
+     * Get false Boolean value on path.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> getBooleanFalseWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -254,17 +278,37 @@ public final class Queries {
         return service.getBooleanFalse(this.client.getHost(), boolQuery);
     }
 
+    /**
+     * Get false Boolean value on path.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> getBooleanFalseAsync() {
         return getBooleanFalseWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get false Boolean value on path.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getBooleanFalse() {
         getBooleanFalseAsync().block();
     }
 
+    /**
+     * Get null Boolean value on query (query string should be absent).
+     * 
+     * @param boolQuery MISSING·SCHEMA-DESCRIPTION-BOOLEAN.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> getBooleanNullWithResponseAsync(Boolean boolQuery) {
         if (this.client.getHost() == null) {
@@ -273,17 +317,39 @@ public final class Queries {
         return service.getBooleanNull(this.client.getHost(), boolQuery);
     }
 
+    /**
+     * Get null Boolean value on query (query string should be absent).
+     * 
+     * @param boolQuery MISSING·SCHEMA-DESCRIPTION-BOOLEAN.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> getBooleanNullAsync(Boolean boolQuery) {
         return getBooleanNullWithResponseAsync(boolQuery)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get null Boolean value on query (query string should be absent).
+     * 
+     * @param boolQuery MISSING·SCHEMA-DESCRIPTION-BOOLEAN.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getBooleanNull(Boolean boolQuery) {
         getBooleanNullAsync(boolQuery).block();
     }
 
+    /**
+     * Get '1000000' integer value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> getIntOneMillionWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -293,17 +359,35 @@ public final class Queries {
         return service.getIntOneMillion(this.client.getHost(), intQuery);
     }
 
+    /**
+     * Get '1000000' integer value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> getIntOneMillionAsync() {
         return getIntOneMillionWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get '1000000' integer value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getIntOneMillion() {
         getIntOneMillionAsync().block();
     }
 
+    /**
+     * Get '-1000000' integer value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> getIntNegativeOneMillionWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -313,17 +397,37 @@ public final class Queries {
         return service.getIntNegativeOneMillion(this.client.getHost(), intQuery);
     }
 
+    /**
+     * Get '-1000000' integer value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> getIntNegativeOneMillionAsync() {
         return getIntNegativeOneMillionWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get '-1000000' integer value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getIntNegativeOneMillion() {
         getIntNegativeOneMillionAsync().block();
     }
 
+    /**
+     * Get null integer value (no query parameter).
+     * 
+     * @param intQuery MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> getIntNullWithResponseAsync(Integer intQuery) {
         if (this.client.getHost() == null) {
@@ -332,17 +436,39 @@ public final class Queries {
         return service.getIntNull(this.client.getHost(), intQuery);
     }
 
+    /**
+     * Get null integer value (no query parameter).
+     * 
+     * @param intQuery MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> getIntNullAsync(Integer intQuery) {
         return getIntNullWithResponseAsync(intQuery)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get null integer value (no query parameter).
+     * 
+     * @param intQuery MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getIntNull(Integer intQuery) {
         getIntNullAsync(intQuery).block();
     }
 
+    /**
+     * Get '10000000000' 64 bit integer value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> getTenBillionWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -352,17 +478,35 @@ public final class Queries {
         return service.getTenBillion(this.client.getHost(), longQuery);
     }
 
+    /**
+     * Get '10000000000' 64 bit integer value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> getTenBillionAsync() {
         return getTenBillionWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get '10000000000' 64 bit integer value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getTenBillion() {
         getTenBillionAsync().block();
     }
 
+    /**
+     * Get '-10000000000' 64 bit integer value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> getNegativeTenBillionWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -372,17 +516,37 @@ public final class Queries {
         return service.getNegativeTenBillion(this.client.getHost(), longQuery);
     }
 
+    /**
+     * Get '-10000000000' 64 bit integer value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> getNegativeTenBillionAsync() {
         return getNegativeTenBillionWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get '-10000000000' 64 bit integer value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getNegativeTenBillion() {
         getNegativeTenBillionAsync().block();
     }
 
+    /**
+     * Get 'null 64 bit integer value (no query param in uri).
+     * 
+     * @param longQuery MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> getLongNullWithResponseAsync(Long longQuery) {
         if (this.client.getHost() == null) {
@@ -391,17 +555,39 @@ public final class Queries {
         return service.getLongNull(this.client.getHost(), longQuery);
     }
 
+    /**
+     * Get 'null 64 bit integer value (no query param in uri).
+     * 
+     * @param longQuery MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> getLongNullAsync(Long longQuery) {
         return getLongNullWithResponseAsync(longQuery)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get 'null 64 bit integer value (no query param in uri).
+     * 
+     * @param longQuery MISSING·SCHEMA-DESCRIPTION-INTEGER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getLongNull(Long longQuery) {
         getLongNullAsync(longQuery).block();
     }
 
+    /**
+     * Get '1.034E+20' numeric value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> floatScientificPositiveWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -411,17 +597,35 @@ public final class Queries {
         return service.floatScientificPositive(this.client.getHost(), floatQuery);
     }
 
+    /**
+     * Get '1.034E+20' numeric value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> floatScientificPositiveAsync() {
         return floatScientificPositiveWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get '1.034E+20' numeric value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void floatScientificPositive() {
         floatScientificPositiveAsync().block();
     }
 
+    /**
+     * Get '-1.034E-20' numeric value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> floatScientificNegativeWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -431,17 +635,37 @@ public final class Queries {
         return service.floatScientificNegative(this.client.getHost(), floatQuery);
     }
 
+    /**
+     * Get '-1.034E-20' numeric value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> floatScientificNegativeAsync() {
         return floatScientificNegativeWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get '-1.034E-20' numeric value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void floatScientificNegative() {
         floatScientificNegativeAsync().block();
     }
 
+    /**
+     * Get null numeric value (no query parameter).
+     * 
+     * @param floatQuery MISSING·SCHEMA-DESCRIPTION-NUMBER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> floatNullWithResponseAsync(Float floatQuery) {
         if (this.client.getHost() == null) {
@@ -450,17 +674,39 @@ public final class Queries {
         return service.floatNull(this.client.getHost(), floatQuery);
     }
 
+    /**
+     * Get null numeric value (no query parameter).
+     * 
+     * @param floatQuery MISSING·SCHEMA-DESCRIPTION-NUMBER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> floatNullAsync(Float floatQuery) {
         return floatNullWithResponseAsync(floatQuery)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get null numeric value (no query parameter).
+     * 
+     * @param floatQuery MISSING·SCHEMA-DESCRIPTION-NUMBER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void floatNull(Float floatQuery) {
         floatNullAsync(floatQuery).block();
     }
 
+    /**
+     * Get '9999999.999' numeric value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> doubleDecimalPositiveWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -470,17 +716,35 @@ public final class Queries {
         return service.doubleDecimalPositive(this.client.getHost(), doubleQuery);
     }
 
+    /**
+     * Get '9999999.999' numeric value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> doubleDecimalPositiveAsync() {
         return doubleDecimalPositiveWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get '9999999.999' numeric value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void doubleDecimalPositive() {
         doubleDecimalPositiveAsync().block();
     }
 
+    /**
+     * Get '-9999999.999' numeric value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> doubleDecimalNegativeWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -490,17 +754,37 @@ public final class Queries {
         return service.doubleDecimalNegative(this.client.getHost(), doubleQuery);
     }
 
+    /**
+     * Get '-9999999.999' numeric value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> doubleDecimalNegativeAsync() {
         return doubleDecimalNegativeWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get '-9999999.999' numeric value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void doubleDecimalNegative() {
         doubleDecimalNegativeAsync().block();
     }
 
+    /**
+     * Get null numeric value (no query parameter).
+     * 
+     * @param doubleQuery MISSING·SCHEMA-DESCRIPTION-NUMBER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> doubleNullWithResponseAsync(Double doubleQuery) {
         if (this.client.getHost() == null) {
@@ -509,17 +793,39 @@ public final class Queries {
         return service.doubleNull(this.client.getHost(), doubleQuery);
     }
 
+    /**
+     * Get null numeric value (no query parameter).
+     * 
+     * @param doubleQuery MISSING·SCHEMA-DESCRIPTION-NUMBER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> doubleNullAsync(Double doubleQuery) {
         return doubleNullWithResponseAsync(doubleQuery)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get null numeric value (no query parameter).
+     * 
+     * @param doubleQuery MISSING·SCHEMA-DESCRIPTION-NUMBER.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void doubleNull(Double doubleQuery) {
         doubleNullAsync(doubleQuery).block();
     }
 
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> stringUnicodeWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -529,17 +835,35 @@ public final class Queries {
         return service.stringUnicode(this.client.getHost(), stringQuery);
     }
 
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> stringUnicodeAsync() {
         return stringUnicodeWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void stringUnicode() {
         stringUnicodeAsync().block();
     }
 
+    /**
+     * Get 'begin!*'();:@ &amp;=+$,/?#[]end.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> stringUrlEncodedWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -549,17 +873,35 @@ public final class Queries {
         return service.stringUrlEncoded(this.client.getHost(), stringQuery);
     }
 
+    /**
+     * Get 'begin!*'();:@ &amp;=+$,/?#[]end.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> stringUrlEncodedAsync() {
         return stringUrlEncodedWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get 'begin!*'();:@ &amp;=+$,/?#[]end.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void stringUrlEncoded() {
         stringUrlEncodedAsync().block();
     }
 
+    /**
+     * Get ''.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> stringEmptyWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -569,17 +911,37 @@ public final class Queries {
         return service.stringEmpty(this.client.getHost(), stringQuery);
     }
 
+    /**
+     * Get ''.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> stringEmptyAsync() {
         return stringEmptyWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get ''.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void stringEmpty() {
         stringEmptyAsync().block();
     }
 
+    /**
+     * Get null (no query parameter in url).
+     * 
+     * @param stringQuery MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> stringNullWithResponseAsync(String stringQuery) {
         if (this.client.getHost() == null) {
@@ -588,17 +950,41 @@ public final class Queries {
         return service.stringNull(this.client.getHost(), stringQuery);
     }
 
+    /**
+     * Get null (no query parameter in url).
+     * 
+     * @param stringQuery MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> stringNullAsync(String stringQuery) {
         return stringNullWithResponseAsync(stringQuery)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get null (no query parameter in url).
+     * 
+     * @param stringQuery MISSING·SCHEMA-DESCRIPTION-STRING.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void stringNull(String stringQuery) {
         stringNullAsync(stringQuery).block();
     }
 
+    /**
+     * Get using uri with query parameter 'green color'.
+     * 
+     * @param enumQuery MISSING·SCHEMA-DESCRIPTION-CHOICE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> enumValidWithResponseAsync(UriColor enumQuery) {
         if (this.client.getHost() == null) {
@@ -607,17 +993,41 @@ public final class Queries {
         return service.enumValid(this.client.getHost(), enumQuery);
     }
 
+    /**
+     * Get using uri with query parameter 'green color'.
+     * 
+     * @param enumQuery MISSING·SCHEMA-DESCRIPTION-CHOICE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> enumValidAsync(UriColor enumQuery) {
         return enumValidWithResponseAsync(enumQuery)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get using uri with query parameter 'green color'.
+     * 
+     * @param enumQuery MISSING·SCHEMA-DESCRIPTION-CHOICE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void enumValid(UriColor enumQuery) {
         enumValidAsync(enumQuery).block();
     }
 
+    /**
+     * Get null (no query parameter in url).
+     * 
+     * @param enumQuery MISSING·SCHEMA-DESCRIPTION-CHOICE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> enumNullWithResponseAsync(UriColor enumQuery) {
         if (this.client.getHost() == null) {
@@ -626,17 +1036,41 @@ public final class Queries {
         return service.enumNull(this.client.getHost(), enumQuery);
     }
 
+    /**
+     * Get null (no query parameter in url).
+     * 
+     * @param enumQuery MISSING·SCHEMA-DESCRIPTION-CHOICE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> enumNullAsync(UriColor enumQuery) {
         return enumNullWithResponseAsync(enumQuery)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get null (no query parameter in url).
+     * 
+     * @param enumQuery MISSING·SCHEMA-DESCRIPTION-CHOICE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void enumNull(UriColor enumQuery) {
         enumNullAsync(enumQuery).block();
     }
 
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
+     * 
+     * @param byteQuery MISSING·SCHEMA-DESCRIPTION-BYTEARRAY.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> byteMultiByteWithResponseAsync(byte[] byteQuery) {
         if (this.client.getHost() == null) {
@@ -646,17 +1080,39 @@ public final class Queries {
         return service.byteMultiByte(this.client.getHost(), byteQueryConverted);
     }
 
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
+     * 
+     * @param byteQuery MISSING·SCHEMA-DESCRIPTION-BYTEARRAY.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> byteMultiByteAsync(byte[] byteQuery) {
         return byteMultiByteWithResponseAsync(byteQuery)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
+     * 
+     * @param byteQuery MISSING·SCHEMA-DESCRIPTION-BYTEARRAY.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void byteMultiByte(byte[] byteQuery) {
         byteMultiByteAsync(byteQuery).block();
     }
 
+    /**
+     * Get '' as byte array.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> byteEmptyWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -667,17 +1123,37 @@ public final class Queries {
         return service.byteEmpty(this.client.getHost(), byteQueryConverted);
     }
 
+    /**
+     * Get '' as byte array.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> byteEmptyAsync() {
         return byteEmptyWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get '' as byte array.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void byteEmpty() {
         byteEmptyAsync().block();
     }
 
+    /**
+     * Get null as byte array (no query parameters in uri).
+     * 
+     * @param byteQuery MISSING·SCHEMA-DESCRIPTION-BYTEARRAY.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> byteNullWithResponseAsync(byte[] byteQuery) {
         if (this.client.getHost() == null) {
@@ -687,17 +1163,39 @@ public final class Queries {
         return service.byteNull(this.client.getHost(), byteQueryConverted);
     }
 
+    /**
+     * Get null as byte array (no query parameters in uri).
+     * 
+     * @param byteQuery MISSING·SCHEMA-DESCRIPTION-BYTEARRAY.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> byteNullAsync(byte[] byteQuery) {
         return byteNullWithResponseAsync(byteQuery)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get null as byte array (no query parameters in uri).
+     * 
+     * @param byteQuery MISSING·SCHEMA-DESCRIPTION-BYTEARRAY.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void byteNull(byte[] byteQuery) {
         byteNullAsync(byteQuery).block();
     }
 
+    /**
+     * Get '2012-01-01' as date.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> dateValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -707,17 +1205,37 @@ public final class Queries {
         return service.dateValid(this.client.getHost(), dateQuery);
     }
 
+    /**
+     * Get '2012-01-01' as date.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> dateValidAsync() {
         return dateValidWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get '2012-01-01' as date.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void dateValid() {
         dateValidAsync().block();
     }
 
+    /**
+     * Get null as date - this should result in no query parameters in uri.
+     * 
+     * @param dateQuery MISSING·SCHEMA-DESCRIPTION-DATE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> dateNullWithResponseAsync(LocalDate dateQuery) {
         if (this.client.getHost() == null) {
@@ -726,17 +1244,39 @@ public final class Queries {
         return service.dateNull(this.client.getHost(), dateQuery);
     }
 
+    /**
+     * Get null as date - this should result in no query parameters in uri.
+     * 
+     * @param dateQuery MISSING·SCHEMA-DESCRIPTION-DATE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> dateNullAsync(LocalDate dateQuery) {
         return dateNullWithResponseAsync(dateQuery)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get null as date - this should result in no query parameters in uri.
+     * 
+     * @param dateQuery MISSING·SCHEMA-DESCRIPTION-DATE.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void dateNull(LocalDate dateQuery) {
         dateNullAsync(dateQuery).block();
     }
 
+    /**
+     * Get '2012-01-01T01:01:01Z' as date-time.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> dateTimeValidWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -746,17 +1286,37 @@ public final class Queries {
         return service.dateTimeValid(this.client.getHost(), dateTimeQuery);
     }
 
+    /**
+     * Get '2012-01-01T01:01:01Z' as date-time.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> dateTimeValidAsync() {
         return dateTimeValidWithResponseAsync()
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get '2012-01-01T01:01:01Z' as date-time.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void dateTimeValid() {
         dateTimeValidAsync().block();
     }
 
+    /**
+     * Get null as date-time, should result in no query parameters in uri.
+     * 
+     * @param dateTimeQuery MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> dateTimeNullWithResponseAsync(OffsetDateTime dateTimeQuery) {
         if (this.client.getHost() == null) {
@@ -765,17 +1325,41 @@ public final class Queries {
         return service.dateTimeNull(this.client.getHost(), dateTimeQuery);
     }
 
+    /**
+     * Get null as date-time, should result in no query parameters in uri.
+     * 
+     * @param dateTimeQuery MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> dateTimeNullAsync(OffsetDateTime dateTimeQuery) {
         return dateTimeNullWithResponseAsync(dateTimeQuery)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get null as date-time, should result in no query parameters in uri.
+     * 
+     * @param dateTimeQuery MISSING·SCHEMA-DESCRIPTION-DATETIME.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void dateTimeNull(OffsetDateTime dateTimeQuery) {
         dateTimeNullAsync(dateTimeQuery).block();
     }
 
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
+     * 
+     * @param arrayQuery MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> arrayStringCsvValidWithResponseAsync(List<String> arrayQuery) {
         if (this.client.getHost() == null) {
@@ -785,17 +1369,41 @@ public final class Queries {
         return service.arrayStringCsvValid(this.client.getHost(), arrayQueryConverted);
     }
 
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
+     * 
+     * @param arrayQuery MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> arrayStringCsvValidAsync(List<String> arrayQuery) {
         return arrayStringCsvValidWithResponseAsync(arrayQuery)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array format.
+     * 
+     * @param arrayQuery MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void arrayStringCsvValid(List<String> arrayQuery) {
         arrayStringCsvValidAsync(arrayQuery).block();
     }
 
+    /**
+     * Get a null array of string using the csv-array format.
+     * 
+     * @param arrayQuery MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> arrayStringCsvNullWithResponseAsync(List<String> arrayQuery) {
         if (this.client.getHost() == null) {
@@ -805,17 +1413,41 @@ public final class Queries {
         return service.arrayStringCsvNull(this.client.getHost(), arrayQueryConverted);
     }
 
+    /**
+     * Get a null array of string using the csv-array format.
+     * 
+     * @param arrayQuery MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> arrayStringCsvNullAsync(List<String> arrayQuery) {
         return arrayStringCsvNullWithResponseAsync(arrayQuery)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get a null array of string using the csv-array format.
+     * 
+     * @param arrayQuery MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void arrayStringCsvNull(List<String> arrayQuery) {
         arrayStringCsvNullAsync(arrayQuery).block();
     }
 
+    /**
+     * Get an empty array [] of string using the csv-array format.
+     * 
+     * @param arrayQuery MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> arrayStringCsvEmptyWithResponseAsync(List<String> arrayQuery) {
         if (this.client.getHost() == null) {
@@ -825,17 +1457,41 @@ public final class Queries {
         return service.arrayStringCsvEmpty(this.client.getHost(), arrayQueryConverted);
     }
 
+    /**
+     * Get an empty array [] of string using the csv-array format.
+     * 
+     * @param arrayQuery MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> arrayStringCsvEmptyAsync(List<String> arrayQuery) {
         return arrayStringCsvEmptyWithResponseAsync(arrayQuery)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get an empty array [] of string using the csv-array format.
+     * 
+     * @param arrayQuery MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void arrayStringCsvEmpty(List<String> arrayQuery) {
         arrayStringCsvEmptyAsync(arrayQuery).block();
     }
 
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format.
+     * 
+     * @param arrayQuery MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> arrayStringSsvValidWithResponseAsync(List<String> arrayQuery) {
         if (this.client.getHost() == null) {
@@ -845,17 +1501,41 @@ public final class Queries {
         return service.arrayStringSsvValid(this.client.getHost(), arrayQueryConverted);
     }
 
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format.
+     * 
+     * @param arrayQuery MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> arrayStringSsvValidAsync(List<String> arrayQuery) {
         return arrayStringSsvValidWithResponseAsync(arrayQuery)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array format.
+     * 
+     * @param arrayQuery MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void arrayStringSsvValid(List<String> arrayQuery) {
         arrayStringSsvValidAsync(arrayQuery).block();
     }
 
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format.
+     * 
+     * @param arrayQuery MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> arrayStringTsvValidWithResponseAsync(List<String> arrayQuery) {
         if (this.client.getHost() == null) {
@@ -865,17 +1545,41 @@ public final class Queries {
         return service.arrayStringTsvValid(this.client.getHost(), arrayQueryConverted);
     }
 
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format.
+     * 
+     * @param arrayQuery MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> arrayStringTsvValidAsync(List<String> arrayQuery) {
         return arrayStringTsvValidWithResponseAsync(arrayQuery)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array format.
+     * 
+     * @param arrayQuery MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void arrayStringTsvValid(List<String> arrayQuery) {
         arrayStringTsvValidAsync(arrayQuery).block();
     }
 
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format.
+     * 
+     * @param arrayQuery MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> arrayStringPipesValidWithResponseAsync(List<String> arrayQuery) {
         if (this.client.getHost() == null) {
@@ -885,12 +1589,28 @@ public final class Queries {
         return service.arrayStringPipesValid(this.client.getHost(), arrayQueryConverted);
     }
 
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format.
+     * 
+     * @param arrayQuery MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> arrayStringPipesValidAsync(List<String> arrayQuery) {
         return arrayStringPipesValidWithResponseAsync(arrayQuery)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array format.
+     * 
+     * @param arrayQuery MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void arrayStringPipesValid(List<String> arrayQuery) {
         arrayStringPipesValidAsync(arrayQuery).block();

--- a/tests/src/main/java/fixtures/xmlservice/Xmls.java
+++ b/tests/src/main/java/fixtures/xmlservice/Xmls.java
@@ -212,6 +212,12 @@ public final class Xmls {
         Mono<SimpleResponse<JSONOutput>> jsonOutput(@HostParam("$host") String host);
     }
 
+    /**
+     * Get a complex type that has a ref to a complex type with no XML node.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<RootWithRefAndNoMeta>> getComplexTypeRefNoMetaWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -220,6 +226,12 @@ public final class Xmls {
         return service.getComplexTypeRefNoMeta(this.client.getHost());
     }
 
+    /**
+     * Get a complex type that has a ref to a complex type with no XML node.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<RootWithRefAndNoMeta> getComplexTypeRefNoMetaAsync() {
         return getComplexTypeRefNoMetaWithResponseAsync()
@@ -232,11 +244,25 @@ public final class Xmls {
             });
     }
 
+    /**
+     * Get a complex type that has a ref to a complex type with no XML node.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public RootWithRefAndNoMeta getComplexTypeRefNoMeta() {
         return getComplexTypeRefNoMetaAsync().block();
     }
 
+    /**
+     * Puts a complex type that has a ref to a complex type with no XML node.
+     * 
+     * @param model I am root, and I ref a model with no meta.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putComplexTypeRefNoMetaWithResponseAsync(RootWithRefAndNoMeta model) {
         if (this.client.getHost() == null) {
@@ -250,17 +276,39 @@ public final class Xmls {
         return service.putComplexTypeRefNoMeta(this.client.getHost(), model);
     }
 
+    /**
+     * Puts a complex type that has a ref to a complex type with no XML node.
+     * 
+     * @param model I am root, and I ref a model with no meta.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putComplexTypeRefNoMetaAsync(RootWithRefAndNoMeta model) {
         return putComplexTypeRefNoMetaWithResponseAsync(model)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Puts a complex type that has a ref to a complex type with no XML node.
+     * 
+     * @param model I am root, and I ref a model with no meta.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putComplexTypeRefNoMeta(RootWithRefAndNoMeta model) {
         putComplexTypeRefNoMetaAsync(model).block();
     }
 
+    /**
+     * Get a complex type that has a ref to a complex type with XML node.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<RootWithRefAndMeta>> getComplexTypeRefWithMetaWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -269,6 +317,12 @@ public final class Xmls {
         return service.getComplexTypeRefWithMeta(this.client.getHost());
     }
 
+    /**
+     * Get a complex type that has a ref to a complex type with XML node.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<RootWithRefAndMeta> getComplexTypeRefWithMetaAsync() {
         return getComplexTypeRefWithMetaWithResponseAsync()
@@ -281,11 +335,25 @@ public final class Xmls {
             });
     }
 
+    /**
+     * Get a complex type that has a ref to a complex type with XML node.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public RootWithRefAndMeta getComplexTypeRefWithMeta() {
         return getComplexTypeRefWithMetaAsync().block();
     }
 
+    /**
+     * Puts a complex type that has a ref to a complex type with XML node.
+     * 
+     * @param model I am root, and I ref a model WITH meta.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putComplexTypeRefWithMetaWithResponseAsync(RootWithRefAndMeta model) {
         if (this.client.getHost() == null) {
@@ -299,17 +367,39 @@ public final class Xmls {
         return service.putComplexTypeRefWithMeta(this.client.getHost(), model);
     }
 
+    /**
+     * Puts a complex type that has a ref to a complex type with XML node.
+     * 
+     * @param model I am root, and I ref a model WITH meta.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putComplexTypeRefWithMetaAsync(RootWithRefAndMeta model) {
         return putComplexTypeRefWithMetaWithResponseAsync(model)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Puts a complex type that has a ref to a complex type with XML node.
+     * 
+     * @param model I am root, and I ref a model WITH meta.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putComplexTypeRefWithMeta(RootWithRefAndMeta model) {
         putComplexTypeRefWithMetaAsync(model).block();
     }
 
+    /**
+     * Get a simple XML document.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Slideshow>> getSimpleWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -318,6 +408,12 @@ public final class Xmls {
         return service.getSimple(this.client.getHost());
     }
 
+    /**
+     * Get a simple XML document.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Slideshow> getSimpleAsync() {
         return getSimpleWithResponseAsync()
@@ -330,11 +426,25 @@ public final class Xmls {
             });
     }
 
+    /**
+     * Get a simple XML document.
+     * 
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Slideshow getSimple() {
         return getSimpleAsync().block();
     }
 
+    /**
+     * Put a simple XML document.
+     * 
+     * @param slideshow Data about a slideshow.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putSimpleWithResponseAsync(Slideshow slideshow) {
         if (this.client.getHost() == null) {
@@ -348,17 +458,39 @@ public final class Xmls {
         return service.putSimple(this.client.getHost(), slideshow);
     }
 
+    /**
+     * Put a simple XML document.
+     * 
+     * @param slideshow Data about a slideshow.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putSimpleAsync(Slideshow slideshow) {
         return putSimpleWithResponseAsync(slideshow)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put a simple XML document.
+     * 
+     * @param slideshow Data about a slideshow.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putSimple(Slideshow slideshow) {
         putSimpleAsync(slideshow).block();
     }
 
+    /**
+     * Get an XML document with multiple wrapped lists.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<AppleBarrel>> getWrappedListsWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -367,6 +499,12 @@ public final class Xmls {
         return service.getWrappedLists(this.client.getHost());
     }
 
+    /**
+     * Get an XML document with multiple wrapped lists.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<AppleBarrel> getWrappedListsAsync() {
         return getWrappedListsWithResponseAsync()
@@ -379,11 +517,25 @@ public final class Xmls {
             });
     }
 
+    /**
+     * Get an XML document with multiple wrapped lists.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public AppleBarrel getWrappedLists() {
         return getWrappedListsAsync().block();
     }
 
+    /**
+     * Put an XML document with multiple wrapped lists.
+     * 
+     * @param wrappedLists A barrel of apples.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putWrappedListsWithResponseAsync(AppleBarrel wrappedLists) {
         if (this.client.getHost() == null) {
@@ -397,17 +549,39 @@ public final class Xmls {
         return service.putWrappedLists(this.client.getHost(), wrappedLists);
     }
 
+    /**
+     * Put an XML document with multiple wrapped lists.
+     * 
+     * @param wrappedLists A barrel of apples.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putWrappedListsAsync(AppleBarrel wrappedLists) {
         return putWrappedListsWithResponseAsync(wrappedLists)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Put an XML document with multiple wrapped lists.
+     * 
+     * @param wrappedLists A barrel of apples.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putWrappedLists(AppleBarrel wrappedLists) {
         putWrappedListsAsync(wrappedLists).block();
     }
 
+    /**
+     * Get strongly-typed response headers.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<XmlsGetHeadersResponse> getHeadersWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -416,17 +590,35 @@ public final class Xmls {
         return service.getHeaders(this.client.getHost());
     }
 
+    /**
+     * Get strongly-typed response headers.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> getHeadersAsync() {
         return getHeadersWithResponseAsync()
             .flatMap((XmlsGetHeadersResponse res) -> Mono.empty());
     }
 
+    /**
+     * Get strongly-typed response headers.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void getHeaders() {
         getHeadersAsync().block();
     }
 
+    /**
+     * Get an empty list.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Slideshow>> getEmptyListWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -435,6 +627,12 @@ public final class Xmls {
         return service.getEmptyList(this.client.getHost());
     }
 
+    /**
+     * Get an empty list.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Slideshow> getEmptyListAsync() {
         return getEmptyListWithResponseAsync()
@@ -447,11 +645,25 @@ public final class Xmls {
             });
     }
 
+    /**
+     * Get an empty list.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Slideshow getEmptyList() {
         return getEmptyListAsync().block();
     }
 
+    /**
+     * Puts an empty list.
+     * 
+     * @param slideshow Data about a slideshow.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putEmptyListWithResponseAsync(Slideshow slideshow) {
         if (this.client.getHost() == null) {
@@ -465,17 +677,39 @@ public final class Xmls {
         return service.putEmptyList(this.client.getHost(), slideshow);
     }
 
+    /**
+     * Puts an empty list.
+     * 
+     * @param slideshow Data about a slideshow.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putEmptyListAsync(Slideshow slideshow) {
         return putEmptyListWithResponseAsync(slideshow)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Puts an empty list.
+     * 
+     * @param slideshow Data about a slideshow.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putEmptyList(Slideshow slideshow) {
         putEmptyListAsync(slideshow).block();
     }
 
+    /**
+     * Gets some empty wrapped lists.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<AppleBarrel>> getEmptyWrappedListsWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -484,6 +718,12 @@ public final class Xmls {
         return service.getEmptyWrappedLists(this.client.getHost());
     }
 
+    /**
+     * Gets some empty wrapped lists.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<AppleBarrel> getEmptyWrappedListsAsync() {
         return getEmptyWrappedListsWithResponseAsync()
@@ -496,11 +736,25 @@ public final class Xmls {
             });
     }
 
+    /**
+     * Gets some empty wrapped lists.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public AppleBarrel getEmptyWrappedLists() {
         return getEmptyWrappedListsAsync().block();
     }
 
+    /**
+     * Puts some empty wrapped lists.
+     * 
+     * @param appleBarrel A barrel of apples.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putEmptyWrappedListsWithResponseAsync(AppleBarrel appleBarrel) {
         if (this.client.getHost() == null) {
@@ -514,17 +768,39 @@ public final class Xmls {
         return service.putEmptyWrappedLists(this.client.getHost(), appleBarrel);
     }
 
+    /**
+     * Puts some empty wrapped lists.
+     * 
+     * @param appleBarrel A barrel of apples.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putEmptyWrappedListsAsync(AppleBarrel appleBarrel) {
         return putEmptyWrappedListsWithResponseAsync(appleBarrel)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Puts some empty wrapped lists.
+     * 
+     * @param appleBarrel A barrel of apples.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putEmptyWrappedLists(AppleBarrel appleBarrel) {
         putEmptyWrappedListsAsync(appleBarrel).block();
     }
 
+    /**
+     * Gets a list as the root element.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<List<Banana>>> getRootListWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -533,6 +809,12 @@ public final class Xmls {
         return service.getRootList(this.client.getHost());
     }
 
+    /**
+     * Gets a list as the root element.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<List<Banana>> getRootListAsync() {
         return getRootListWithResponseAsync()
@@ -545,11 +827,25 @@ public final class Xmls {
             });
     }
 
+    /**
+     * Gets a list as the root element.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Banana> getRootList() {
         return getRootListAsync().block();
     }
 
+    /**
+     * Puts a list as the root element.
+     * 
+     * @param bananas MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putRootListWithResponseAsync(List<Banana> bananas) {
         if (this.client.getHost() == null) {
@@ -564,17 +860,39 @@ public final class Xmls {
         return service.putRootList(this.client.getHost(), bananasConverted);
     }
 
+    /**
+     * Puts a list as the root element.
+     * 
+     * @param bananas MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putRootListAsync(List<Banana> bananas) {
         return putRootListWithResponseAsync(bananas)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Puts a list as the root element.
+     * 
+     * @param bananas MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putRootList(List<Banana> bananas) {
         putRootListAsync(bananas).block();
     }
 
+    /**
+     * Gets a list with a single item.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<List<Banana>>> getRootListSingleItemWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -583,6 +901,12 @@ public final class Xmls {
         return service.getRootListSingleItem(this.client.getHost());
     }
 
+    /**
+     * Gets a list with a single item.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<List<Banana>> getRootListSingleItemAsync() {
         return getRootListSingleItemWithResponseAsync()
@@ -595,11 +919,25 @@ public final class Xmls {
             });
     }
 
+    /**
+     * Gets a list with a single item.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Banana> getRootListSingleItem() {
         return getRootListSingleItemAsync().block();
     }
 
+    /**
+     * Puts a list with a single item.
+     * 
+     * @param bananas MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putRootListSingleItemWithResponseAsync(List<Banana> bananas) {
         if (this.client.getHost() == null) {
@@ -614,17 +952,39 @@ public final class Xmls {
         return service.putRootListSingleItem(this.client.getHost(), bananasConverted);
     }
 
+    /**
+     * Puts a list with a single item.
+     * 
+     * @param bananas MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putRootListSingleItemAsync(List<Banana> bananas) {
         return putRootListSingleItemWithResponseAsync(bananas)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Puts a list with a single item.
+     * 
+     * @param bananas MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putRootListSingleItem(List<Banana> bananas) {
         putRootListSingleItemAsync(bananas).block();
     }
 
+    /**
+     * Gets an empty list as the root element.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<List<Banana>>> getEmptyRootListWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -633,6 +993,12 @@ public final class Xmls {
         return service.getEmptyRootList(this.client.getHost());
     }
 
+    /**
+     * Gets an empty list as the root element.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<List<Banana>> getEmptyRootListAsync() {
         return getEmptyRootListWithResponseAsync()
@@ -645,11 +1011,25 @@ public final class Xmls {
             });
     }
 
+    /**
+     * Gets an empty list as the root element.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Banana> getEmptyRootList() {
         return getEmptyRootListAsync().block();
     }
 
+    /**
+     * Puts an empty list as the root element.
+     * 
+     * @param bananas MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putEmptyRootListWithResponseAsync(List<Banana> bananas) {
         if (this.client.getHost() == null) {
@@ -664,17 +1044,39 @@ public final class Xmls {
         return service.putEmptyRootList(this.client.getHost(), bananasConverted);
     }
 
+    /**
+     * Puts an empty list as the root element.
+     * 
+     * @param bananas MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putEmptyRootListAsync(List<Banana> bananas) {
         return putEmptyRootListWithResponseAsync(bananas)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Puts an empty list as the root element.
+     * 
+     * @param bananas MISSING·SCHEMA-DESCRIPTION-ARRAYSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putEmptyRootList(List<Banana> bananas) {
         putEmptyRootListAsync(bananas).block();
     }
 
+    /**
+     * Gets an XML document with an empty child element.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<Banana>> getEmptyChildElementWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -683,6 +1085,12 @@ public final class Xmls {
         return service.getEmptyChildElement(this.client.getHost());
     }
 
+    /**
+     * Gets an XML document with an empty child element.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Banana> getEmptyChildElementAsync() {
         return getEmptyChildElementWithResponseAsync()
@@ -695,11 +1103,25 @@ public final class Xmls {
             });
     }
 
+    /**
+     * Gets an XML document with an empty child element.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Banana getEmptyChildElement() {
         return getEmptyChildElementAsync().block();
     }
 
+    /**
+     * Puts a value with an empty child element.
+     * 
+     * @param banana A banana.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putEmptyChildElementWithResponseAsync(Banana banana) {
         if (this.client.getHost() == null) {
@@ -713,17 +1135,39 @@ public final class Xmls {
         return service.putEmptyChildElement(this.client.getHost(), banana);
     }
 
+    /**
+     * Puts a value with an empty child element.
+     * 
+     * @param banana A banana.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putEmptyChildElementAsync(Banana banana) {
         return putEmptyChildElementWithResponseAsync(banana)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Puts a value with an empty child element.
+     * 
+     * @param banana A banana.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putEmptyChildElement(Banana banana) {
         putEmptyChildElementAsync(banana).block();
     }
 
+    /**
+     * Lists containers in a storage account.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<ListContainersResponse>> listContainersWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -733,6 +1177,12 @@ public final class Xmls {
         return service.listContainers(this.client.getHost(), comp);
     }
 
+    /**
+     * Lists containers in a storage account.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<ListContainersResponse> listContainersAsync() {
         return listContainersWithResponseAsync()
@@ -745,11 +1195,23 @@ public final class Xmls {
             });
     }
 
+    /**
+     * Lists containers in a storage account.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public ListContainersResponse listContainers() {
         return listContainersAsync().block();
     }
 
+    /**
+     * Gets storage service properties.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<StorageServiceProperties>> getServicePropertiesWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -760,6 +1222,12 @@ public final class Xmls {
         return service.getServiceProperties(this.client.getHost(), comp, restype);
     }
 
+    /**
+     * Gets storage service properties.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<StorageServiceProperties> getServicePropertiesAsync() {
         return getServicePropertiesWithResponseAsync()
@@ -772,11 +1240,25 @@ public final class Xmls {
             });
     }
 
+    /**
+     * Gets storage service properties.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public StorageServiceProperties getServiceProperties() {
         return getServicePropertiesAsync().block();
     }
 
+    /**
+     * Puts storage service properties.
+     * 
+     * @param properties Storage Service Properties.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putServicePropertiesWithResponseAsync(StorageServiceProperties properties) {
         if (this.client.getHost() == null) {
@@ -792,17 +1274,39 @@ public final class Xmls {
         return service.putServiceProperties(this.client.getHost(), comp, restype, properties);
     }
 
+    /**
+     * Puts storage service properties.
+     * 
+     * @param properties Storage Service Properties.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putServicePropertiesAsync(StorageServiceProperties properties) {
         return putServicePropertiesWithResponseAsync(properties)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Puts storage service properties.
+     * 
+     * @param properties Storage Service Properties.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putServiceProperties(StorageServiceProperties properties) {
         putServicePropertiesAsync(properties).block();
     }
 
+    /**
+     * Gets storage ACLs for a container.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<List<SignedIdentifier>>> getAclsWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -813,6 +1317,12 @@ public final class Xmls {
         return service.getAcls(this.client.getHost(), comp, restype);
     }
 
+    /**
+     * Gets storage ACLs for a container.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<List<SignedIdentifier>> getAclsAsync() {
         return getAclsWithResponseAsync()
@@ -825,11 +1335,25 @@ public final class Xmls {
             });
     }
 
+    /**
+     * Gets storage ACLs for a container.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<SignedIdentifier> getAcls() {
         return getAclsAsync().block();
     }
 
+    /**
+     * Puts storage ACLs for a container.
+     * 
+     * @param properties a collection of signed identifiers.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> putAclsWithResponseAsync(List<SignedIdentifier> properties) {
         if (this.client.getHost() == null) {
@@ -846,17 +1370,39 @@ public final class Xmls {
         return service.putAcls(this.client.getHost(), comp, restype, propertiesConverted);
     }
 
+    /**
+     * Puts storage ACLs for a container.
+     * 
+     * @param properties a collection of signed identifiers.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putAclsAsync(List<SignedIdentifier> properties) {
         return putAclsWithResponseAsync(properties)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * Puts storage ACLs for a container.
+     * 
+     * @param properties a collection of signed identifiers.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putAcls(List<SignedIdentifier> properties) {
         putAclsAsync(properties).block();
     }
 
+    /**
+     * Lists blobs in a storage container.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<ListBlobsResponse>> listBlobsWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -867,6 +1413,12 @@ public final class Xmls {
         return service.listBlobs(this.client.getHost(), comp, restype);
     }
 
+    /**
+     * Lists blobs in a storage container.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<ListBlobsResponse> listBlobsAsync() {
         return listBlobsWithResponseAsync()
@@ -879,11 +1431,25 @@ public final class Xmls {
             });
     }
 
+    /**
+     * Lists blobs in a storage container.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public ListBlobsResponse listBlobs() {
         return listBlobsAsync().block();
     }
 
+    /**
+     * A Swagger with XML that has one operation that takes JSON as input. You need to send the ID number 42.
+     * 
+     * @param properties MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> jsonInputWithResponseAsync(JSONInput properties) {
         if (this.client.getHost() == null) {
@@ -897,17 +1463,39 @@ public final class Xmls {
         return service.jsonInput(this.client.getHost(), properties);
     }
 
+    /**
+     * A Swagger with XML that has one operation that takes JSON as input. You need to send the ID number 42.
+     * 
+     * @param properties MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> jsonInputAsync(JSONInput properties) {
         return jsonInputWithResponseAsync(properties)
             .flatMap((Response<Void> res) -> Mono.empty());
     }
 
+    /**
+     * A Swagger with XML that has one operation that takes JSON as input. You need to send the ID number 42.
+     * 
+     * @param properties MISSING·SCHEMA-DESCRIPTION-OBJECTSCHEMA.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void jsonInput(JSONInput properties) {
         jsonInputAsync(properties).block();
     }
 
+    /**
+     * A Swagger with XML that has one operation that returns JSON. ID number 42.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<SimpleResponse<JSONOutput>> jsonOutputWithResponseAsync() {
         if (this.client.getHost() == null) {
@@ -916,6 +1504,12 @@ public final class Xmls {
         return service.jsonOutput(this.client.getHost());
     }
 
+    /**
+     * A Swagger with XML that has one operation that returns JSON. ID number 42.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<JSONOutput> jsonOutputAsync() {
         return jsonOutputWithResponseAsync()
@@ -928,6 +1522,12 @@ public final class Xmls {
             });
     }
 
+    /**
+     * A Swagger with XML that has one operation that returns JSON. ID number 42.
+     * 
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public JSONOutput jsonOutput() {
         return jsonOutputAsync().block();


### PR DESCRIPTION
This PR includes changes to generate javadocs for client methods and client method parameters. Also, I cleaned up the javadoc for model setter methods.

There are still some quirks with some client method parameters not having a proper description but it may be an issue in Swagger or modeler.

Fixes #479 