### PR TITLE
fix multiple flattened parameter with same origin

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -67,8 +67,11 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
 
                 // Transformations
                 if (parameter.getOriginalParameter() != null) {// TODO: Need better way to determine transformed parameters
-                    MethodTransformationDetail detail = new MethodTransformationDetail(
-                            Mappers.getClientParameterMapper().map(parameter.getOriginalParameter()), new ArrayList<>());
+                    ClientMethodParameter originalParameter = Mappers.getClientParameterMapper().map(parameter.getOriginalParameter());
+                    MethodTransformationDetail detail = methodTransformationDetails.stream()
+                            .filter(d -> originalParameter.getName().equals(d.getOutParameter().getName()))
+                            .findAny()
+                            .orElse(new MethodTransformationDetail(originalParameter, new ArrayList<>()));
                     ParameterMapping mapping = new ParameterMapping();
                     mapping.setInputParameter(clientMethodParameter);
                     mapping.setOutputParameterProperty(parameter.getTargetProperty().getLanguage().getJava().getName());

--- a/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
@@ -115,9 +115,9 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
             }
             if (generatedCompositeType && transformation.getParameterMappings().stream().anyMatch(m -> m.getOutputParameterProperty() != null && !m.getOutputParameterProperty().isEmpty())) {
                 String transformationOutputParameterModelCompositeTypeName = transformationOutputParameterModelClassType.toString();
-                if (settings.isFluent() && transformationOutputParameterModelCompositeTypeName != null && !transformationOutputParameterModelCompositeTypeName.isEmpty() && transformationOutputParameterModelClassType.getIsInnerModelType()) {
-                    transformationOutputParameterModelCompositeTypeName += "Inner";
-                }
+//                if (settings.isFluent() && transformationOutputParameterModelCompositeTypeName != null && !transformationOutputParameterModelCompositeTypeName.isEmpty() && transformationOutputParameterModelClassType.getIsInnerModelType()) {
+//                    transformationOutputParameterModelCompositeTypeName += "Inner";
+//                }
 
                 function.line("%s%s = new %s();",
                         !conditionalAssignment ? transformation.getOutParameter().getClientType() + " " : "",


### PR DESCRIPTION
1. multiple flattened parameter with same origin need to be put in same detail
2. naming in fluent (should be no need to do this in template)