### PR TITLE
Builder prototype for client models

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientMethod.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientMethod.java
@@ -16,9 +16,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
-
 /**
  * A ClientMethod that exists on a ServiceClient or MethodGroupClient that eventually will call a ProxyMethod.
  */
@@ -55,11 +52,29 @@ public class ClientMethod {
      * The expressions (parameters and service client properties) that need to be validated in this ClientMethod.
      */
     private Map<String, String> validateExpressions;
+    /**
+     * The reference to the service client.
+     */
     private String clientReference;
+    /**
+     * The parameter expressions which are required.
+     */
     private List<String> requiredNullableParameterExpressions;
+    /**
+     * The parameter that needs to transformed before pagination.
+     */
     private boolean isGroupedParameterRequired;
+    /**
+     * The type name of groupedParameter.
+     */
     private String groupedParameterTypeName;
+    /**
+     * The pagination information if this is a paged method.
+     */
     private MethodPageDetails methodPageDetails;
+    /**
+     * The parameter transformations before calling ProxyMethod.
+     */
     private List<MethodTransformationDetail> methodTransformationDetails;
 
     /**
@@ -72,13 +87,14 @@ public class ClientMethod {
      * @param type The type of this ClientMethod.
      * @param proxyMethod The ProxyMethod that this ClientMethod eventually calls.
      * @param validateExpressions The expressions (parameters and service client properties) that need to be validated in this ClientMethod.
+     * @param clientReference The reference to the service client.
      * @param requiredNullableParameterExpressions The parameter expressions which are required.
      * @param isGroupedParameterRequired The parameter that needs to transformed before pagination.
      * @param groupedParameterTypeName The type name of groupedParameter.
      * @param methodPageDetails The pagination information if this is a paged method.
      * @param methodTransformationDetails The parameter transformations before calling ProxyMethod.
      */
-    public ClientMethod(String description, ReturnValue returnValue, String name, List<ClientMethodParameter> parameters, boolean onlyRequiredParameters, ClientMethodType type, ProxyMethod proxyMethod, Map<String, String> validateExpressions, List<String> requiredNullableParameterExpressions, boolean isGroupedParameterRequired, String groupedParameterTypeName, MethodPageDetails methodPageDetails, List<MethodTransformationDetail> methodTransformationDetails) {
+    private ClientMethod(String description, ReturnValue returnValue, String name, List<ClientMethodParameter> parameters, boolean onlyRequiredParameters, ClientMethodType type, ProxyMethod proxyMethod, Map<String, String> validateExpressions, String clientReference, List<String> requiredNullableParameterExpressions, boolean isGroupedParameterRequired, String groupedParameterTypeName, MethodPageDetails methodPageDetails, List<MethodTransformationDetail> methodTransformationDetails) {
         this.description = description;
         this.returnValue = returnValue;
         this.name = name;
@@ -87,6 +103,7 @@ public class ClientMethod {
         this.type = type;
         this.proxyMethod = proxyMethod;
         this.validateExpressions = validateExpressions;
+        this.clientReference = clientReference;
         this.requiredNullableParameterExpressions = requiredNullableParameterExpressions;
         this.isGroupedParameterRequired = isGroupedParameterRequired;
         this.groupedParameterTypeName = groupedParameterTypeName;
@@ -252,6 +269,184 @@ public class ClientMethod {
                 imports.add("java.io.SequenceInputStream");
                 imports.add("java.util.Collections");
             }
+        }
+    }
+
+    public static class Builder {
+        private String description;
+        private ReturnValue returnValue;
+        private String name;
+        private List<ClientMethodParameter> parameters;
+        private boolean onlyRequiredParameters;
+        private ClientMethodType type = ClientMethodType.values()[0];
+        private ProxyMethod proxyMethod;
+        private Map<String, String> validateExpressions;
+        private String clientReference;
+        private List<String> requiredNullableParameterExpressions;
+        private boolean isGroupedParameterRequired;
+        private String groupedParameterTypeName;
+        private MethodPageDetails methodPageDetails;
+        private List<MethodTransformationDetail> methodTransformationDetails;
+
+        /**
+         * Sets the description of this ClientMethod.
+         * @param description the description of this ClientMethod
+         * @return the Builder itself
+         */
+        public Builder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        /**
+         * Sets the return value of this ClientMethod.
+         * @param returnValue the return value of this ClientMethod
+         * @return the Builder itself
+         */
+        public Builder returnValue(ReturnValue returnValue) {
+            this.returnValue = returnValue;
+            return this;
+        }
+
+        /**
+         * Sets the name of this ClientMethod.
+         * @param name the name of this ClientMethod
+         * @return the Builder itself
+         */
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        /**
+         * Sets the parameters of this ClientMethod.
+         * @param parameters the parameters of this ClientMethod
+         * @return the Builder itself
+         */
+        public Builder parameters(List<ClientMethodParameter> parameters) {
+            this.parameters = parameters;
+            return this;
+        }
+
+        /**
+         * Sets whether or not this ClientMethod has omitted optional parameters.
+         * @param onlyRequiredParameters whether or not this ClientMethod has omitted optional parameters
+         * @return the Builder itself
+         */
+        public Builder onlyRequiredParameters(boolean onlyRequiredParameters) {
+            this.onlyRequiredParameters = onlyRequiredParameters;
+            return this;
+        }
+
+        /**
+         * Sets the type of this ClientMethod.
+         * @param type the type of this ClientMethod
+         * @return the Builder itself
+         */
+        public Builder type(ClientMethodType type) {
+            this.type = type;
+            return this;
+        }
+
+        /**
+         * Sets the RestAPIMethod that this ClientMethod eventually calls.
+         * @param proxyMethod the RestAPIMethod that this ClientMethod eventually calls
+         * @return the Builder itself
+         */
+        public Builder proxyMethod(ProxyMethod proxyMethod) {
+            this.proxyMethod = proxyMethod;
+            return this;
+        }
+
+        /**
+         * Sets the expressions ( (parameters and service client properties) that need to be validated in this ClientMethod.
+         * @param validateExpressions the expressions (parameters and service client properties) that need to be validated in this ClientMethod
+         * @return the Builder itself
+         */
+        public Builder validateExpressions(Map<String, String> validateExpressions) {
+            this.validateExpressions = validateExpressions;
+            return this;
+        }
+
+        /**
+         * Sets the reference to the service client.
+         * @param clientReference the reference to the service client
+         * @return the Builder itself
+         */
+        public Builder clientReference(String clientReference) {
+            this.clientReference = clientReference;
+            return this;
+        }
+
+        /**
+         * Sets the parameter expressions which are required.
+         * @param requiredNullableParameterExpressions the parameter expressions which are required
+         * @return the Builder itself
+         */
+        public Builder requiredNullableParameterExpressions(List<String> requiredNullableParameterExpressions) {
+            this.requiredNullableParameterExpressions = requiredNullableParameterExpressions;
+            return this;
+        }
+
+        /**
+         * Sets the parameter that needs to transformed before pagination.
+         * @param isGroupedParameterRequired the parameter that needs to transformed before pagination
+         * @return the Builder itself
+         */
+        public Builder isGroupedParameterRequired(boolean isGroupedParameterRequired) {
+            this.isGroupedParameterRequired = isGroupedParameterRequired;
+            return this;
+        }
+
+        /**
+         * Sets the type name of groupedParameter.
+         * @param groupedParameterTypeName the type name of groupedParameter
+         * @return the Builder itself
+         */
+        public Builder groupedParameterTypeName(String groupedParameterTypeName) {
+            this.groupedParameterTypeName = groupedParameterTypeName;
+            return this;
+        }
+
+        /**
+         * Sets the pagination information if this is a paged method.
+         * @param methodPageDetails the pagination information if this is a paged method
+         * @return the Builder itself
+         */
+        public Builder methodPageDetails(MethodPageDetails methodPageDetails) {
+            this.methodPageDetails = methodPageDetails;
+            return this;
+        }
+
+        /**
+         * Sets the parameter transformations before calling ProxyMethod.
+         * @param methodTransformationDetails the parameter transformations before calling ProxyMethod
+         * @return the Builder itself
+         */
+        public Builder methodTransformationDetails(List<MethodTransformationDetail> methodTransformationDetails) {
+            this.methodTransformationDetails = methodTransformationDetails;
+            return this;
+        }
+
+        /**
+         * @return an immutable ClientMethod instance with the configurations on this builder.
+         */
+        public ClientMethod build() {
+            return new ClientMethod(
+                    description,
+                    returnValue,
+                    name,
+                    parameters,
+                    onlyRequiredParameters,
+                    type,
+                    proxyMethod,
+                    validateExpressions,
+                    clientReference,
+                    requiredNullableParameterExpressions,
+                    isGroupedParameterRequired,
+                    groupedParameterTypeName,
+                    methodPageDetails,
+                    methodTransformationDetails);
         }
     }
 }

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethod.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethod.java
@@ -15,11 +15,6 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import java.util.List;
 import java.util.Set;
 
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
-//C# TO JAVA CONVERTER NOTE: There is no Java equivalent to C# namespace aliases:
-//using AutoRestMethod = AutoRest.Core.Model.Method;
-
 /**
  * A method within a Proxy.
  */
@@ -32,10 +27,6 @@ public class ProxyMethod {
      * The value that is returned from this method.
      */
     private IType returnType;
-    /**
-     * Get whether or not this method is a request to get the next page of a sequence of pages.
-     */
-    private boolean isPagingNextOperation;
     /**
      * Get the HTTP method that will be used for this method.
      */
@@ -77,7 +68,6 @@ public class ProxyMethod {
      * Create a new RestAPIMethod with the provided properties.
      * @param requestContentType The Content-Type of the request.
      * @param returnType The type of value that is returned from this method.
-     * @param isPagingNextOperation Whether or not this method is a request to get the next page of a sequence of pages.
      * @param httpMethod The HTTP method that will be used for this method.
      * @param urlPath The path of this method's request URL.
      * @param responseExpectedStatusCodes The status codes that are expected in the response.
@@ -88,10 +78,9 @@ public class ProxyMethod {
      * @param description The description of this method.
      * @param isResumable Whether or not this method is resumable.
      */
-    public ProxyMethod(String requestContentType, IType returnType, boolean isPagingNextOperation, HttpMethod httpMethod, String urlPath, List<HttpResponseStatus> responseExpectedStatusCodes, ClassType unexpectedResponseExceptionType, String name, List<ProxyMethodParameter> parameters, String description, IType returnValueWireType, boolean isResumable) {
+    private ProxyMethod(String requestContentType, IType returnType, HttpMethod httpMethod, String urlPath, List<HttpResponseStatus> responseExpectedStatusCodes, ClassType unexpectedResponseExceptionType, String name, List<ProxyMethodParameter> parameters, String description, IType returnValueWireType, boolean isResumable) {
         this.requestContentType = requestContentType;
         this.returnType = returnType;
-        this.isPagingNextOperation = isPagingNextOperation;
         this.httpMethod = httpMethod;
         this.urlPath = urlPath;
         this.responseExpectedStatusCodes = responseExpectedStatusCodes;
@@ -109,10 +98,6 @@ public class ProxyMethod {
 
     public final IType getReturnType() {
         return returnType;
-    }
-
-    public final boolean getIsPagingNextOperation() {
-        return isPagingNextOperation;
     }
 
     public final HttpMethod getHttpMethod() {
@@ -242,6 +227,147 @@ public class ProxyMethod {
             for (ProxyMethodParameter parameter : parameters) {
                 parameter.addImportsTo(imports, includeImplementationImports, settings);
             }
+        }
+    }
+
+    public static class Builder {
+        private String requestContentType;
+        private IType returnType;
+        private HttpMethod httpMethod;
+        private String urlPath;
+        private List<HttpResponseStatus> responseExpectedStatusCodes;
+        private ClassType unexpectedResponseExceptionType;
+        private String name;
+        private List<ProxyMethodParameter> parameters;
+        private String description;
+        private IType returnValueWireType;
+        private boolean isResumable;
+
+        /*
+         * Sets the Content-Type of the request.
+         * @param requestContentType the Content-Type of the request
+         * @return the Builder itself
+         */
+        public Builder requestContentType(String requestContentType) {
+            this.requestContentType = requestContentType;
+            return this;
+        }
+
+        /**
+         * Sets the value that is returned from this method.
+         * @param returnType the value that is returned from this method
+         * @return the Builder itself
+         */
+        public Builder returnType(IType returnType) {
+            this.returnType = returnType;
+            return this;
+        }
+
+        /**
+         * Sets the HTTP method that will be used for this method.
+         * @param httpMethod the HTTP method that will be used for this method
+         * @return the Builder itself
+         */
+        public Builder httpMethod(HttpMethod httpMethod) {
+            this.httpMethod = httpMethod;
+            return this;
+        }
+
+        /**
+         * Sets the path of this method's request URL.
+         * @param urlPath the path of this method's request URL
+         * @return the Builder itself
+         */
+        public Builder urlPath(String urlPath) {
+            this.urlPath = urlPath;
+            return this;
+        }
+
+        /**
+         * Sets the status codes that are expected in the response.
+         * @param responseExpectedStatusCodes the status codes that are expected in the response
+         * @return the Builder itself
+         */
+        public Builder responseExpectedStatusCodes(List<HttpResponseStatus> responseExpectedStatusCodes) {
+            this.responseExpectedStatusCodes = responseExpectedStatusCodes;
+            return this;
+        }
+
+        /**
+         * Sets the exception type to throw if this method receives and unexpected response status code.
+         * @param unexpectedResponseExceptionType the exception type to throw if this method receives and unexpected response status code
+         * @return the Builder itself
+         */
+        public Builder unexpectedResponseExceptionType(ClassType unexpectedResponseExceptionType) {
+            this.unexpectedResponseExceptionType = unexpectedResponseExceptionType;
+            return this;
+        }
+
+        /**
+         * Sets the name of this Rest API method.
+         * @param name the name of this Rest API method
+         * @return the Builder itself
+         */
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        /**
+         * Sets the parameters that are provided to this method.
+         * @param parameters the parameters that are provided to this method
+         * @return the Builder itself
+         */
+        public Builder parameters(List<ProxyMethodParameter> parameters) {
+            this.parameters = parameters;
+            return this;
+        }
+
+        /**
+         * Sets the description of this method.
+         * @param description the description of this method
+         * @return the Builder itself
+         */
+        public Builder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        /**
+         * Sets the value of the ReturnValueWireType annotation for this method.
+         * @param returnValueWireType the value of the ReturnValueWireType annotation for this method
+         * @return the Builder itself
+         */
+        public Builder returnValueWireType(IType returnValueWireType) {
+            this.returnValueWireType = returnValueWireType;
+            return this;
+        }
+
+        /**
+         * Sets whether or not this method resumes polling of an LRO.
+         * @param isResumable whether or not this method resumes polling of an LRO
+         * @return the Builder itself
+         */
+        public Builder isResumable(boolean isResumable) {
+            this.isResumable = isResumable;
+            return this;
+        }
+
+        /**
+         * @return an immutable ProxyMethod instance with the configurations on this builder.
+         */
+        public ProxyMethod build() {
+            return new ProxyMethod(requestContentType,
+                    returnType,
+                    httpMethod,
+                    urlPath,
+                    responseExpectedStatusCodes,
+                    unexpectedResponseExceptionType,
+                    name,
+                    parameters,
+                    description,
+                    returnValueWireType,
+                    isResumable);
         }
     }
 }

--- a/javagen/src/main/java/com/azure/autorest/template/ProxyTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ProxyTemplate.java
@@ -47,11 +47,7 @@ public class ProxyTemplate implements IJavaTemplate<Proxy, JavaClass> {
                         interfaceBlock.lineComment(String.format("@Multipart not supported by %1$s", ClassType.RestProxy.getName()));
                     }
 
-                    if (restAPIMethod.getIsPagingNextOperation()) {
-                        interfaceBlock.annotation("Get(\"{nextUrl}\")");
-                    } else {
-                        interfaceBlock.annotation(String.format("%1$s(\"%2$s\")", CodeNamer.toPascalCase(restAPIMethod.getHttpMethod().toString().toLowerCase()), restAPIMethod.getUrlPath()));
-                    }
+                    interfaceBlock.annotation(String.format("%1$s(\"%2$s\")", CodeNamer.toPascalCase(restAPIMethod.getHttpMethod().toString().toLowerCase()), restAPIMethod.getUrlPath()));
 
                     if (!restAPIMethod.getResponseExpectedStatusCodes().isEmpty()) {
                         interfaceBlock.annotation(String.format("ExpectedResponses({%1$s})", restAPIMethod.getResponseExpectedStatusCodes().stream().map(statusCode -> String.format("%s", statusCode.code())).collect(Collectors.joining(", "))));


### PR DESCRIPTION
This is a just a prototype of builders in client models with only ProxyMethod and ClientMethod converted. The benefits include:

1) Allow populating properties step-by-step
2) Reduce duplicate code
3) Avoid breaking changes in client models
4) Avoid passing in constructor parameters in the wrong order since many parameters are of type String

Improvements in ProxyMethodMapper are more obvious due to its 1-to-1 mapping, same as almost all client models. ClientMethod is the exception, where there's a 1-to-many mapping in ClientMethodMapper. Thus I'm re-using the builder here but I'm happy to discuss this design.