### PR TITLE
return type Boolean for HEAD request

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -188,12 +188,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                     null,
                     methodTransformationDetails));
 
-            IType responseBodyType = Mappers.getSchemaMapper().map(SchemaUtil.getLowestCommonParent(
-                    operation.getResponses().stream().map(Response::getSchema).filter(Objects::nonNull).collect(Collectors.toList())));
-
-            if (responseBodyType == null) {
-                responseBodyType = PrimitiveType.Void;
-            }
+            IType responseBodyType = SchemaUtil.operationResponseType(operation);
 
             // Simple Async
             if (settings.getSyncMethods() != JavaSettings.SyncMethodsGeneration.NONE) {

--- a/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
@@ -3,8 +3,6 @@ package com.azure.autorest.mapper;
 import com.azure.autorest.extension.base.model.codemodel.Header;
 import com.azure.autorest.extension.base.model.codemodel.Operation;
 import com.azure.autorest.extension.base.model.codemodel.Parameter;
-import com.azure.autorest.extension.base.model.codemodel.Response;
-import com.azure.autorest.extension.base.model.codemodel.Schema;
 import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.model.clientmodel.ClassType;
 import com.azure.autorest.model.clientmodel.GenericType;
@@ -65,13 +63,7 @@ public class ProxyMethodMapper implements IMapper<Operation, ProxyMethod> {
                 .map(s -> HttpResponseStatus.valueOf(Integer.parseInt(s)))
                 .sorted().collect(Collectors.toList());
 
-        Schema responseBodySchema = SchemaUtil.getLowestCommonParent(
-                operation.getResponses().stream().map(Response::getSchema).filter(Objects::nonNull).collect(Collectors.toList()));
-        IType responseBodyType = Mappers.getSchemaMapper().map(responseBodySchema);
-
-        if (responseBodyType == null) {
-            responseBodyType = PrimitiveType.Void;
-        }
+        IType responseBodyType = SchemaUtil.operationResponseType(operation);
 
         IType returnType;
         if (operation.getResponses().stream().anyMatch(r -> Boolean.TRUE.equals(r.getBinary()))) {

--- a/javagen/src/main/java/com/azure/autorest/util/SchemaUtil.java
+++ b/javagen/src/main/java/com/azure/autorest/util/SchemaUtil.java
@@ -2,11 +2,19 @@ package com.azure.autorest.util;
 
 import com.azure.autorest.extension.base.model.codemodel.AnySchema;
 import com.azure.autorest.extension.base.model.codemodel.ObjectSchema;
+import com.azure.autorest.extension.base.model.codemodel.Operation;
+import com.azure.autorest.extension.base.model.codemodel.Response;
 import com.azure.autorest.extension.base.model.codemodel.Schema;
+import com.azure.autorest.mapper.Mappers;
+import com.azure.autorest.model.clientmodel.IType;
+import com.azure.autorest.model.clientmodel.PrimitiveType;
+import com.azure.core.http.HttpMethod;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Stack;
+import java.util.stream.Collectors;
 
 public class SchemaUtil {
     private SchemaUtil() {
@@ -56,5 +64,23 @@ public class SchemaUtil {
             }
         }
         return chain.isEmpty() ? new AnySchema() : chain.getLast();
+    }
+
+    public static IType operationResponseType(Operation operation) {
+        Schema responseBodySchema = SchemaUtil.getLowestCommonParent(
+                operation.getResponses().stream().map(Response::getSchema).filter(Objects::nonNull).collect(Collectors.toList()));
+        IType responseBodyType = Mappers.getSchemaMapper().map(responseBodySchema);
+
+        if (responseBodyType == null) {
+            if (HttpMethod.HEAD.name().equalsIgnoreCase(operation.getRequest().getProtocol().getHttp().getMethod())
+                    && operation.getResponses().stream().flatMap(r -> r.getProtocol().getHttp().getStatusCodes().stream()).anyMatch(c -> c.equals("404"))) {
+                // Azure core would internally convert the response status code to boolean.
+                responseBodyType = PrimitiveType.Boolean;
+            } else {
+                responseBodyType = PrimitiveType.Void;
+            }
+        }
+
+        return responseBodyType;
     }
 }


### PR DESCRIPTION
Azure core will internal convert HEAD response to boolean, if response type is boolean. https://github.com/Azure/azure-sdk-for-java/blob/master/sdk/core/azure-core/src/main/java/com/azure/core/http/rest/RestProxy.java#L503

So I figure it be safe to just use boolean as response type for HEAD (I also added a condition that 404 is in the status code).

Let me know if data-plane would actually do not want this.

Tested on resources.json, works as expected.