### PR TITLE
v4 namer factory + fix exception package for fluent

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/mapper/ExceptionMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ExceptionMapper.java
@@ -46,13 +46,9 @@ public class ExceptionMapper implements IMapper<ObjectSchema, ClientException> {
             boolean isCustomType = settings.isCustomType(methodOperationExceptionTypeName);
             if (isCustomType) {
                 exceptionSubPackage = settings.getCustomTypesSubpackage();
-            }
-            // TODO: Fluent
-//            else if (settings.isFluent())
-//            {
-//                exceptionSubPackage = compositeType.IsInnerModel ? settings.ImplementationSubpackage : "";
-//            }
-            else {
+            } else if (settings.isFluent()) {
+                exceptionSubPackage = "";
+            } else {
                 exceptionSubPackage = settings.getModelsSubpackage();
             }
             String packageName = settings.getPackage(exceptionSubPackage);

--- a/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
@@ -113,15 +113,9 @@ public class ProxyMethodMapper implements IMapper<Operation, ProxyMethod> {
             String exceptionPackage = settings.getPackage();
             if (settings.isCustomType(exceptionName)) {
                 exceptionPackage = settings.getPackage(settings.getCustomTypesSubpackage());
-            }
-//            else if (settings.isFluent())
-//            {
-//                if (((CompositeTypeJv) autoRestExceptionType).IsInnerModel)
-//                {
-//                    exceptionPackage = settings.GetPackage(settings.ImplementationSubpackage);
-//                }
-//            }
-            else {
+            } else if (settings.isFluent()) {
+                exceptionPackage = settings.getPackage();
+            } else {
                 exceptionPackage = settings.getPackage(settings.getModelsSubpackage());
             }
 

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientModelProperty.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientModelProperty.java
@@ -111,18 +111,11 @@ public class ClientModelProperty {
     }
 
     public final String getGetterName() {
-        String prefix = "get";
-        if (clientType == PrimitiveType.Boolean || clientType == ClassType.Boolean) {
-            prefix = "is";
-            if (CodeNamer.toCamelCase(getName()).startsWith(prefix)) {
-                return CodeNamer.toCamelCase(getName());
-            }
-        }
-        return prefix + CodeNamer.toPascalCase(getName());
+        return CodeNamer.getModelNamer().modelPropertyGetterName(this);
     }
 
     public final String getSetterName() {
-        return "set" + CodeNamer.toPascalCase(getName());
+        return CodeNamer.getModelNamer().modelPropertySetterName(this);
     }
 
     public final String getDescription() {

--- a/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
@@ -292,6 +292,7 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
                 typeBlock.annotation("ServiceMethod(returns = ReturnType.SINGLE)");
                 if (clientMethod.getMethodPageDetails().nonNullNextLink()) {
                     typeBlock.publicMethod(clientMethod.getDeclaration(), function -> {
+                        AddOptionalAndConstantVariables(function, clientMethod, restAPIMethod.getParameters(), settings);
                         function.line("return service.%s(%s).map(res -> new PagedResponseBase<>(",
                                 clientMethod.getProxyMethod().getName(),
                                 String.join(", ", clientMethod.getProxyMethodArguments(settings)));
@@ -311,6 +312,7 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
                     });
                 } else {
                     typeBlock.publicMethod(clientMethod.getDeclaration(), function -> {
+                        AddOptionalAndConstantVariables(function, clientMethod, restAPIMethod.getParameters(), settings);
                         function.line("return service.%s(%s).map(res -> new PagedResponseBase<>(",
                                 clientMethod.getProxyMethod().getName(),
                                 String.join(", ", clientMethod.getProxyMethodArguments(settings)));

--- a/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
@@ -139,7 +139,7 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
 
                 String getMapping;
                 if (mapping.getOutputParameterProperty() != null) {
-                    getMapping = String.format(".set%s(%s)", CodeNamer.toPascalCase(mapping.getOutputParameterProperty()), inputPath);
+                    getMapping = String.format(".%s(%s)", CodeNamer.getModelNamer().modelPropertySetterName(mapping.getOutputParameterProperty()), inputPath);
                 } else {
                     getMapping = String.format(" = %s", inputPath);
                 }

--- a/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
@@ -300,8 +300,8 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
                             function.line("res.getRequest(),");
                             function.line("res.getStatusCode(),");
                             function.line("res.getHeaders(),");
-                            function.line("res.getValue().get%s(),", CodeNamer.toPascalCase(clientMethod.getMethodPageDetails().getItemName()));
-                            function.line("res.getValue().get%s(),", CodeNamer.toPascalCase(clientMethod.getMethodPageDetails().getNextLinkName()));
+                            function.line("res.getValue().%s(),", CodeNamer.getModelNamer().modelPropertyGetterName(clientMethod.getMethodPageDetails().getItemName()));
+                            function.line("res.getValue().%s(),", CodeNamer.getModelNamer().modelPropertyGetterName(clientMethod.getMethodPageDetails().getNextLinkName()));
                             IType responseType = ((GenericType) clientMethod.getProxyMethod().getReturnType()).getTypeArguments()[0];
                             if (responseType instanceof ClassType) {
                                 function.line("res.getDeserializedHeaders()));");
@@ -320,7 +320,7 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
                             function.line("res.getRequest(),");
                             function.line("res.getStatusCode(),");
                             function.line("res.getHeaders(),");
-                            function.line("res.getValue().get%s(),", CodeNamer.toPascalCase(clientMethod.getMethodPageDetails().getItemName()));
+                            function.line("res.getValue().%s(),", CodeNamer.getModelNamer().modelPropertyGetterName(clientMethod.getMethodPageDetails().getItemName()));
                             function.line("null,");
                             IType responseType = ((GenericType) clientMethod.getProxyMethod().getReturnType()).getTypeArguments()[0];
                             if (responseType instanceof ClassType) {

--- a/javagen/src/main/java/com/azure/autorest/util/CodeNamer.java
+++ b/javagen/src/main/java/com/azure/autorest/util/CodeNamer.java
@@ -72,6 +72,16 @@ public class CodeNamer {
             "String", "Object", "header"
     );
 
+    private static NamerFactory factory = new DefaultNamerFactory();
+
+    public static void setFactory(NamerFactory templateFactory) {
+        factory = templateFactory;
+    }
+
+    public static ModelNamer getModelNamer() {
+        return factory.getModelNamer();
+    }
+
     private CodeNamer() {
     }
 

--- a/javagen/src/main/java/com/azure/autorest/util/DefaultNamerFactory.java
+++ b/javagen/src/main/java/com/azure/autorest/util/DefaultNamerFactory.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ *
+ */
+
+package com.azure.autorest.util;
+
+public class DefaultNamerFactory implements NamerFactory {
+
+    protected static final ModelNamer modelNamer = new ModelNamer();
+
+    @Override
+    public ModelNamer getModelNamer() {
+        return modelNamer;
+    }
+}

--- a/javagen/src/main/java/com/azure/autorest/util/DefaultNamerFactory.java
+++ b/javagen/src/main/java/com/azure/autorest/util/DefaultNamerFactory.java
@@ -8,7 +8,7 @@ package com.azure.autorest.util;
 
 public class DefaultNamerFactory implements NamerFactory {
 
-    protected static final ModelNamer modelNamer = new ModelNamer();
+    private static final ModelNamer modelNamer = new ModelNamer();
 
     @Override
     public ModelNamer getModelNamer() {

--- a/javagen/src/main/java/com/azure/autorest/util/ModelNamer.java
+++ b/javagen/src/main/java/com/azure/autorest/util/ModelNamer.java
@@ -30,4 +30,8 @@ public class ModelNamer {
     public String modelPropertySetterName(ClientModelProperty property) {
         return "set" + CodeNamer.toPascalCase(property.getName());
     }
+
+    public String modelPropertySetterName(String propertyName) {
+        return "set" + CodeNamer.toPascalCase(propertyName);
+    }
 }

--- a/javagen/src/main/java/com/azure/autorest/util/ModelNamer.java
+++ b/javagen/src/main/java/com/azure/autorest/util/ModelNamer.java
@@ -23,6 +23,10 @@ public class ModelNamer {
         return prefix + CodeNamer.toPascalCase(property.getName());
     }
 
+    public String modelPropertyGetterName(String propertyName) {
+        return "get" + CodeNamer.toPascalCase(propertyName);
+    }
+
     public String modelPropertySetterName(ClientModelProperty property) {
         return "set" + CodeNamer.toPascalCase(property.getName());
     }

--- a/javagen/src/main/java/com/azure/autorest/util/ModelNamer.java
+++ b/javagen/src/main/java/com/azure/autorest/util/ModelNamer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ *
+ */
+
+package com.azure.autorest.util;
+
+import com.azure.autorest.model.clientmodel.ClassType;
+import com.azure.autorest.model.clientmodel.ClientModelProperty;
+import com.azure.autorest.model.clientmodel.PrimitiveType;
+
+public class ModelNamer {
+
+    public String modelPropertyGetterName(ClientModelProperty property) {
+        String prefix = "get";
+        if (property.getClientType() == PrimitiveType.Boolean || property.getClientType() == ClassType.Boolean) {
+            prefix = "is";
+            if (CodeNamer.toCamelCase(property.getName()).startsWith(prefix)) {
+                return CodeNamer.toCamelCase(property.getName());
+            }
+        }
+        return prefix + CodeNamer.toPascalCase(property.getName());
+    }
+
+    public String modelPropertySetterName(ClientModelProperty property) {
+        return "set" + CodeNamer.toPascalCase(property.getName());
+    }
+}

--- a/javagen/src/main/java/com/azure/autorest/util/NamerFactory.java
+++ b/javagen/src/main/java/com/azure/autorest/util/NamerFactory.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ *
+ */
+
+package com.azure.autorest.util;
+
+public interface NamerFactory {
+
+    ModelNamer getModelNamer();
+}

--- a/tests/src/test/java/fixtures/head/HeadOperationsTests.java
+++ b/tests/src/test/java/fixtures/head/HeadOperationsTests.java
@@ -1,5 +1,6 @@
 package fixtures.head;
 
+import com.azure.core.http.rest.Response;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -19,11 +20,16 @@ public class HeadOperationsTests {
 
     @Test
     public void head204() {
-        Assert.assertEquals(204, client.httpSuccess().head204WithResponseAsync().block().getStatusCode());
+        Response<Boolean> response =  client.httpSuccess().head204WithResponseAsync().block();
+        Assert.assertEquals(204, response.getStatusCode());
+        Assert.assertTrue(response.getValue()); // 204 means true
     }
 
     @Test
     public void head404() {
-        Assert.assertEquals(404, client.httpSuccess().head404WithResponseAsync().block().getStatusCode());  // both status code 204 and 404 is not error
+        Response<Boolean> response =  client.httpSuccess().head404WithResponseAsync().block();
+        // both status code 204 and 404 is not error, 404 means false
+        Assert.assertEquals(404, response.getStatusCode());
+        Assert.assertFalse(response.getValue());
     }
 }


### PR DESCRIPTION
At present, fluent would continue track1 naming for a while, until we can decide whether to make this break.