### PR TITLE
v4 support client method with only required parameters

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -105,7 +105,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
             }
         }
 
-        final boolean generateClientMethodWithOnlyRequiredParameters = hasNonRequiredParameters(operation);
+        final boolean generateClientMethodWithOnlyRequiredParameters = settings.getRequiredParameterClientMethods() && hasNonRequiredParameters(operation);
 
         if (operation.getExtensions() != null && operation.getExtensions().getXmsPageable() != null) {
             boolean isNextMethod = operation.getExtensions().getXmsPageable().getNextOperation() == operation;

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -105,6 +105,8 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
             }
         }
 
+        final boolean generateClientMethodWithOnlyRequiredParameters = hasNonRequiredParameters(operation);
+
         if (operation.getExtensions() != null && operation.getExtensions().getXmsPageable() != null) {
             boolean isNextMethod = operation.getExtensions().getXmsPageable().getNextOperation() == operation;
 
@@ -142,35 +144,73 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                     methodTransformationDetails));
 
             if (!isNextMethod) {
-                methods.add(new ClientMethod(
-                        operation.getLanguage().getJava().getDescription(),
-                        new ReturnValue(null, asyncReturnType),
-                        proxyMethod.getSimpleAsyncMethodName(),
-                        parameters,
-                        false,
-                        ClientMethodType.PagingAsync,
-                        proxyMethod,
-                        validateExpressions,
-                        requiredParameterExpressions,
-                        false,
-                        null,
-                        details,
-                        methodTransformationDetails));
+                if (settings.getSyncMethods() != JavaSettings.SyncMethodsGeneration.NONE) {
+                    methods.add(new ClientMethod(
+                            operation.getLanguage().getJava().getDescription(),
+                            new ReturnValue(null, asyncReturnType),
+                            proxyMethod.getSimpleAsyncMethodName(),
+                            parameters,
+                            false,
+                            ClientMethodType.PagingAsync,
+                            proxyMethod,
+                            validateExpressions,
+                            requiredParameterExpressions,
+                            false,
+                            null,
+                            details,
+                            methodTransformationDetails));
 
-                methods.add(new ClientMethod(
-                        operation.getLanguage().getJava().getDescription(),
-                        new ReturnValue(null, syncReturnType),
-                        proxyMethod.getName(),
-                        parameters,
-                        false,
-                        ClientMethodType.PagingSync,
-                        proxyMethod,
-                        validateExpressions,
-                        requiredParameterExpressions,
-                        false,
-                        null,
-                        details,
-                        methodTransformationDetails));
+                    if (generateClientMethodWithOnlyRequiredParameters) {
+                        methods.add(new ClientMethod(
+                                operation.getLanguage().getJava().getDescription(),
+                                new ReturnValue(null, asyncReturnType),
+                                proxyMethod.getSimpleAsyncMethodName(),
+                                parameters,
+                                true,
+                                ClientMethodType.PagingAsync,
+                                proxyMethod,
+                                validateExpressions,
+                                requiredParameterExpressions,
+                                false,
+                                null,
+                                details,
+                                methodTransformationDetails));
+                    }
+                }
+
+                if (settings.getSyncMethods() == JavaSettings.SyncMethodsGeneration.ALL) {
+                    methods.add(new ClientMethod(
+                            operation.getLanguage().getJava().getDescription(),
+                            new ReturnValue(null, syncReturnType),
+                            proxyMethod.getName(),
+                            parameters,
+                            false,
+                            ClientMethodType.PagingSync,
+                            proxyMethod,
+                            validateExpressions,
+                            requiredParameterExpressions,
+                            false,
+                            null,
+                            details,
+                            methodTransformationDetails));
+
+                    if (generateClientMethodWithOnlyRequiredParameters) {
+                        methods.add(new ClientMethod(
+                                operation.getLanguage().getJava().getDescription(),
+                                new ReturnValue(null, syncReturnType),
+                                proxyMethod.getName(),
+                                parameters,
+                                true,
+                                ClientMethodType.PagingSync,
+                                proxyMethod,
+                                validateExpressions,
+                                requiredParameterExpressions,
+                                false,
+                                null,
+                                details,
+                                methodTransformationDetails));
+                    }
+                }
             }
         } else {
 
@@ -194,8 +234,6 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
 
             // Simple Async
             if (settings.getSyncMethods() != JavaSettings.SyncMethodsGeneration.NONE) {
-
-
                 IType restAPIMethodReturnBodyClientType = responseBodyType.getClientType();
                 IType asyncMethodReturnType;
                 if (operation.getResponses().stream().anyMatch(r -> Boolean.TRUE.equals(r.getBinary()))) {
@@ -220,6 +258,23 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                         null,
                         null,
                         methodTransformationDetails));
+
+                if (generateClientMethodWithOnlyRequiredParameters) {
+                    methods.add(new ClientMethod(
+                            operation.getLanguage().getJava().getDescription(),
+                            new ReturnValue(null, asyncMethodReturnType),
+                            proxyMethod.getSimpleAsyncMethodName(),
+                            parameters,
+                            true,
+                            ClientMethodType.SimpleAsync,
+                            proxyMethod,
+                            validateExpressions,
+                            requiredParameterExpressions,
+                            false,
+                            null,
+                            null,
+                            methodTransformationDetails));
+                }
             }
 
             // Sync
@@ -244,6 +299,23 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                         null,
                         null,
                         methodTransformationDetails));
+
+                if (generateClientMethodWithOnlyRequiredParameters) {
+                    methods.add(new ClientMethod(
+                            operation.getLanguage().getJava().getDescription(),
+                            new ReturnValue(null, syncReturnType),
+                            proxyMethod.getName(),
+                            parameters,
+                            true,
+                            ClientMethodType.SimpleSync,
+                            proxyMethod,
+                            validateExpressions,
+                            requiredParameterExpressions,
+                            false,
+                            null,
+                            null,
+                            methodTransformationDetails));
+                }
             }
         }
 
@@ -253,6 +325,11 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
 
     public static boolean nonNullNextLink(Operation operation) {
         return operation.getExtensions().getXmsPageable().getNextLinkName() != null && !operation.getExtensions().getXmsPageable().getNextLinkName().isEmpty();
+    }
+
+    private static boolean hasNonRequiredParameters(Operation operation) {
+        return operation.getRequest().getParameters().stream().anyMatch(p -> p.getImplementation() == Parameter.ImplementationLocation.METHOD && !p.isRequired() && !(p.getSchema() instanceof ConstantSchema))
+                && operation.getRequest().getParameters().stream().noneMatch(Parameter::isFlattened);   // for now, ignore operation with flattened parameters
     }
 
 //

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientMethod.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientMethod.java
@@ -134,14 +134,15 @@ public class ClientMethod {
      * Get the comma-separated list of parameter declarations for this ClientMethod.
      */
     public final String getParametersDeclaration() {
-        return getParameters().stream().map(ClientMethodParameter::getDeclaration).collect(Collectors.joining(", "));
+        List<ClientMethodParameter> methodParameters = onlyRequiredParameters ? getMethodRequiredParameters() : getMethodParameters();
+        return methodParameters.stream().map(ClientMethodParameter::getDeclaration).collect(Collectors.joining(", "));
     }
 
     /**
      * Get the comma-separated list of parameter names for this ClientMethod.
      */
     public final String getArgumentList() {
-        return getParameters().stream().map(ClientMethodParameter::getName).collect(Collectors.joining(", "));
+        return getMethodParameters().stream().map(ClientMethodParameter::getName).collect(Collectors.joining(", "));
     }
 
     /**
@@ -161,7 +162,7 @@ public class ClientMethod {
 
     public final List<ClientMethodParameter> getMethodParameters() {
         return getParameters().stream().filter(parameter -> parameter != null && !parameter.getFromClient() &&
-                parameter.getName() != null && parameter.getName().trim().isEmpty())
+                parameter.getName() != null && !parameter.getName().trim().isEmpty())
                 .sorted((p1, p2) -> Boolean.compare(!p1.getIsRequired(), !p2.getIsRequired()))
                 .collect(Collectors.toList());
     }

--- a/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
@@ -60,10 +60,20 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
         }
     }
 
+    private static void AddOptionalVariables(JavaBlock function, ClientMethod clientMethod, List<ProxyMethodParameter> proxyMethodAndConstantParameters, JavaSettings settings) {
+        if (clientMethod.getOnlyRequiredParameters()) {
+            AddOptionalAndConstantVariables(function, clientMethod, proxyMethodAndConstantParameters, settings, true, false);
+        }
+    }
+
     private static void AddOptionalAndConstantVariables(JavaBlock function, ClientMethod clientMethod, List<ProxyMethodParameter> proxyMethodAndConstantParameters, JavaSettings settings) {
+        AddOptionalAndConstantVariables(function, clientMethod, proxyMethodAndConstantParameters, settings, true, true);
+    }
+
+    private static void AddOptionalAndConstantVariables(JavaBlock function, ClientMethod clientMethod, List<ProxyMethodParameter> proxyMethodAndConstantParameters, JavaSettings settings,
+                                                        boolean addOptional, boolean addConstant) {
         for (ProxyMethodParameter parameter : proxyMethodAndConstantParameters) {
             IType parameterWireType = parameter.getWireType();
-            ;
             if (parameter.getIsNullable()) {
                 parameterWireType = parameterWireType.asNullable();
             }
@@ -77,7 +87,7 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
             }
             boolean alwaysNull = parameterWireType != parameterClientType && clientMethod.getOnlyRequiredParameters() && !parameter.getIsRequired();
 
-            if (!parameter.getFromClient() && !alwaysNull && ((clientMethod.getOnlyRequiredParameters() && !parameter.getIsRequired()) || parameter.getIsConstant())) {
+            if (!parameter.getFromClient() && !alwaysNull && ((addOptional && clientMethod.getOnlyRequiredParameters() && !parameter.getIsRequired()) || (addConstant && parameter.getIsConstant()))) {
                 String defaultValue = parameterClientType.defaultValueExpression(parameter.getDefaultValue());
                 function.line("final %s %s = %s;", parameterClientType, parameter.getParameterReference(), defaultValue == null ? "null" : defaultValue);
             }
@@ -245,19 +255,18 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
         JavaSettings settings = JavaSettings.getInstance();
 
         ProxyMethod restAPIMethod = clientMethod.getProxyMethod();
-        IType restAPIMethodReturnBodyClientType = restAPIMethod.getReturnType().getClientType();
+        //IType restAPIMethodReturnBodyClientType = restAPIMethod.getReturnType().getClientType();
 
-        MethodPageDetails pageDetails = clientMethod.getMethodPageDetails();
+        //MethodPageDetails pageDetails = clientMethod.getMethodPageDetails();
 
-
-        boolean isFluentDelete = settings.isFluent() && restAPIMethod.getName().equalsIgnoreCase("Delete") && clientMethod.getMethodRequiredParameters().size() == 2;
+        //boolean isFluentDelete = settings.isFluent() && restAPIMethod.getName().equalsIgnoreCase("Delete") && clientMethod.getMethodRequiredParameters().size() == 2;
         generateJavadoc(clientMethod, typeBlock, restAPIMethod);
 
         switch (clientMethod.getType()) {
             case PagingSync:
-
                 typeBlock.annotation("ServiceMethod(returns = ReturnType.COLLECTION)");
                 typeBlock.publicMethod(clientMethod.getDeclaration(), function -> {
+                    AddOptionalVariables(function, clientMethod, restAPIMethod.getParameters(), settings);
                     function.methodReturn(String.format("new PagedIterable<>(%s(%s))", clientMethod.getSimpleAsyncMethodName(), clientMethod.getArgumentList()));
                 });
                 break;
@@ -267,6 +276,7 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
                 typeBlock.annotation("ServiceMethod(returns = ReturnType.COLLECTION)");
                 if (clientMethod.getMethodPageDetails().nonNullNextLink()) {
                     typeBlock.publicMethod(clientMethod.getDeclaration(), function -> {
+                        AddOptionalVariables(function, clientMethod, restAPIMethod.getParameters(), settings);
                         function.line("return new PagedFlux<>(");
                         function.indent(() -> {
                             function.line("() -> %s(%s),",
@@ -279,6 +289,7 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
                     });
                 } else {
                     typeBlock.publicMethod(clientMethod.getDeclaration(), function -> {
+                        AddOptionalVariables(function, clientMethod, restAPIMethod.getParameters(), settings);
                         function.line("return new PagedFlux<>(");
                         function.indent(() -> {
                             function.line("() -> %s(%s));",
@@ -404,6 +415,7 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
             case SimpleSync:
                 typeBlock.annotation("ServiceMethod(returns = ReturnType.SINGLE)");
                 typeBlock.publicMethod(clientMethod.getDeclaration(), function -> {
+                    AddOptionalVariables(function, clientMethod, restAPIMethod.getParameters(), settings);
                     if (clientMethod.getReturnValue().getType() == ClassType.InputStream) {
                         function.line("return %s(%s)", clientMethod.getSimpleAsyncMethodName(), clientMethod.getArgumentList());
                         function.indent(() -> {
@@ -435,6 +447,7 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
             case SimpleAsync:
                 typeBlock.annotation("ServiceMethod(returns = ReturnType.SINGLE)");
                 typeBlock.publicMethod(clientMethod.getDeclaration(), (function -> {
+                    AddOptionalVariables(function, clientMethod, restAPIMethod.getParameters(), settings);
                     function.line("return %s(%s)", clientMethod.getProxyMethod().getSimpleAsyncRestResponseMethodName(), clientMethod.getArgumentList());
                     function.indent((() -> {
                         GenericType restAPIMethodClientReturnType = (GenericType) restAPIMethod.getReturnType().getClientType();
@@ -466,7 +479,10 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
     protected void generateJavadoc(ClientMethod clientMethod, JavaType typeBlock, ProxyMethod restAPIMethod) {
         typeBlock.javadocComment(comment -> {
             comment.description(clientMethod.getDescription());
-            for (ClientMethodParameter parameter : clientMethod.getParameters()) {
+            List<ClientMethodParameter> methodParameters = clientMethod.getOnlyRequiredParameters()
+                    ? clientMethod.getMethodRequiredParameters()
+                    : clientMethod.getMethodParameters();
+            for (ClientMethodParameter parameter : methodParameters) {
                 comment.param(parameter.getName(), parameter.getDescription());
             }
             if (clientMethod.getParametersDeclaration() != null && !clientMethod.getParametersDeclaration().isEmpty()) {


### PR DESCRIPTION
Overload client method with only required parameters.

I choose not to overload XXXWithResponseAsync method. This overload is not useful for fluent. Let me know if you prefer to overload this as well.

Please take a look whether it is OK for you.

If it is OK, I will need to update test cases, since some parameter sequence got updated.