### PR TITLE
Add support for application/x-www-form-urlencoded

### DIFF
--- a/src/azure/Templates/AzureMethodGroupRetrofitTemplate.cshtml
+++ b/src/azure/Templates/AzureMethodGroupRetrofitTemplate.cshtml
@@ -10,9 +10,13 @@
 interface @Model.MethodGroupServiceType {
 @foreach (MethodJva method in Model.Methods)
 {
-if (method.RequestContentType == "multipart/form-data" || method.RequestContentType == "application/x-www-form-urlencoded")
+if (method.RequestContentType == "multipart/form-data")
 {
 @:    @@Multipart
+}
+else if (method.RequestContentType == "application/x-www-form-urlencoded")
+{
+ @:    @@FormUrlEncoded
 }
 else
 {

--- a/src/azure/Templates/AzureServiceClientRetrofitTemplate.cshtml
+++ b/src/azure/Templates/AzureServiceClientRetrofitTemplate.cshtml
@@ -10,9 +10,13 @@
 interface @Model.ServiceClientServiceType {
 @foreach (MethodJva method in Model.RootMethods)
 {
-if (method.RequestContentType == "multipart/form-data" || method.RequestContentType == "application/x-www-form-urlencoded")
+if (method.RequestContentType == "multipart/form-data")
 {
 @:    @@Multipart
+}
+else if (method.RequestContentType == "application/x-www-form-urlencoded")
+{
+ @:    @@FormUrlEncoded
 }
 else
 {

--- a/src/vanilla/Model/MethodJv.cs
+++ b/src/vanilla/Model/MethodJv.cs
@@ -94,9 +94,18 @@ namespace AutoRest.Java.Model
                     }
                     else if (parameter.Location == ParameterLocation.FormData)
                     {
+                        string annotation;
+                        if (parameter.Method.RequestContentType == "multipart/form-data")
+                        {
+                            annotation = "Part";
+                        }
+                        else
+                        {
+                            annotation = "Field";
+                        }
                         declarationBuilder.Append(string.Format(CultureInfo.InvariantCulture,
-                            "@Part(\"{0}\") ",
-                            parameter.SerializedName));
+                            "@{0}(\"{1}\") ",
+                            annotation, parameter.SerializedName));
                     }
                     var declarativeName = parameter.ClientProperty != null ? parameter.ClientProperty.Name : parameter.Name;
                     declarationBuilder.Append(parameter.WireType.Name);
@@ -714,9 +723,13 @@ namespace AutoRest.Java.Model
                 // static imports
                 imports.Add("rx.Observable");
                 imports.Add("rx.functions.Func1");
-                if (RequestContentType == "multipart/form-data" || RequestContentType == "application/x-www-form-urlencoded")
+                if (RequestContentType == "multipart/form-data")
                 {
                     imports.Add("retrofit2.http.Multipart");
+                }
+                else if (RequestContentType == "application/x-www-form-urlencoded")
+                {
+                    imports.Add("retrofit2.http.FormUrlEncoded");
                 }
                 else
                 {

--- a/src/vanilla/Model/ParameterJv.cs
+++ b/src/vanilla/Model/ParameterJv.cs
@@ -291,9 +291,15 @@ namespace AutoRest.Java.Model
 
         private string LocationImport(ParameterLocation parameterLocation)
         {
-            if (parameterLocation == Core.Model.ParameterLocation.FormData)
+            if (parameterLocation == Core.Model.ParameterLocation.FormData
+                && Method.RequestContentType == "multipart/form-data")
             {
                 return "retrofit2.http.Part";
+            }
+            else if (parameterLocation == Core.Model.ParameterLocation.FormData
+                     && Method.RequestContentType == "application/x-www-form-urlencoded")
+            {
+                return "retrofit2.http.Field";
             }
             else if (parameterLocation != Core.Model.ParameterLocation.None)
             {

--- a/src/vanilla/Templates/MethodGroupRetrofitTemplate.cshtml
+++ b/src/vanilla/Templates/MethodGroupRetrofitTemplate.cshtml
@@ -10,9 +10,13 @@
 interface @Model.MethodGroupServiceType {
 @foreach (MethodJv method in Model.Methods)
 {
-if (method.RequestContentType == "multipart/form-data" || method.RequestContentType == "application/x-www-form-urlencoded")
+if (method.RequestContentType == "multipart/form-data"")
 {
 @:    @@Multipart
+}
+else if (method.RequestContentType == "application/x-www-form-urlencoded")
+{
+ @:    @@FormUrlEncoded
 }
 else
 {

--- a/src/vanilla/Templates/ServiceClientRetrofitTemplate.cshtml
+++ b/src/vanilla/Templates/ServiceClientRetrofitTemplate.cshtml
@@ -10,9 +10,13 @@
 interface @Model.ServiceClientServiceType {
 @foreach (MethodJv method in Model.Methods)
 {
-if (method.RequestContentType == "multipart/form-data" || method.RequestContentType == "application/x-www-form-urlencoded")
+if (method.RequestContentType == "multipart/form-data")
 {
 @:    @@Multipart
+}
+else if (method.RequestContentType == "application/x-www-form-urlencoded")
+{
+ @:    @@FormUrlEncoded
 }
 else
 {


### PR DESCRIPTION
Previously, the generator was treating this MIME type the same as the multipart/form-data MIME type. In fact, these are two unique ways of submitting data to a server, and Retrofit has support for both of them.