### PR TITLE
[draft] use fluent in readme to pick pipeline

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,7 @@ AutoRest needs the below config to pick this up as a plug-in - see https://githu
 
 #### Javagen
 
-``` yaml
+``` yaml !$(fluent)
 use-extension:
   "@autorest/modelerfour": "4.8.221"
 
@@ -105,5 +105,42 @@ scope-javagen/emitter:
     input-artifact: java-files
     output-uri-expr: $key
 
+output-artifact: java-files
+```
+
+``` yaml $(fluent)
+use-extension:
+  "@autorest/modelerfour": "4.9.236"
+
+pipeline:
+
+# --- extension remodeler ---
+
+  # "Shake the tree", and normalize the model
+  modelerfour:
+    input: openapi-document/multi-api/identity     # the plugin where we get inputs from
+    flatten-models: true
+    flatten-payloads: true
+  
+  # allow developer to do transformations on the code model.
+  modelerfour/new-transform:
+    input: modelerfour
+
+  fluentnamer:
+    input: modelerfour/identity
+
+  fluentgen:
+    scope: java
+    input: fluentnamer
+    output-artifact: java-files
+  
+  fluentgen/emitter:
+    input: fluentgen
+    scope: scope-fluentgen/emitter
+
+scope-fluentgen/emitter:
+    input-artifact: java-files
+    output-uri-expr: $key
+  
 output-artifact: java-files
 ```


### PR DESCRIPTION
@jianghaolu 

We are able to use `$(fluent)` in readme to pick different yaml and hence different pipeline.

However I am not able to start 2 java plugin at same time. (I don't think `--use:./preprocessor --use:./javagen` would be the real use case in published npm pakcage, unless we publish all these separately)

Idealy we need to start preprocessor and javagen (well, plus fluentnamer and fluentgen) in package.json start script. So pipeline can pickup whatever plugin need to finish the flow.

But due to stdin/stdout problem, I am not able to use `concurrently` to do this. Any advice?

Well, if we indeed can use for 4 `--use` to load 4 plugins, we can do same `$(fluent)` in plugin readme to control pipeline.