### PR TITLE
v4 fluent still need client builder at same package as client

### DIFF
--- a/fluent-tests/prepare-tests.bat
+++ b/fluent-tests/prepare-tests.bat
@@ -1,7 +1,7 @@
 RMDIR /S /Q "src/main/java/com/azure/mgmttest"
 
 SET AUTOREST_CORE_VERSION=3.0.6246
-SET COMMON_ARGUMENTS=--java --use:../fluentnamer --use:../fluentgen --output-folder=./ --sync-methods=all --azure-arm=true --fluent=true --generate-client-as-impl=true --required-parameter-client-methods=true --track1-naming=true --implementation-subpackage=models
+SET COMMON_ARGUMENTS=--java --use:../ --output-folder=./ --sync-methods=all --azure-arm=true --fluent=true --generate-client-as-impl=true --required-parameter-client-methods=true --track1-naming=true --implementation-subpackage=models
 
 CALL autorest --version=%AUTOREST_CORE_VERSION% %COMMON_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/resources/resource-manager/Microsoft.Resources/stable/2019-08-01/resources.json --namespace=com.azure.mgmttest.resources
 

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
@@ -99,7 +99,7 @@ public class FluentGen extends NewPlugin {
             }
 
             // Service client builder
-            javaPackage.addServiceClientBuilder(client.getServiceClient().getInterfaceName() + "Builder",
+            javaPackage.addServiceClientBuilder(client.getServiceClient().getPackage(), client.getServiceClient().getInterfaceName() + "Builder",
                     client.getServiceClient());
 
             // Method group

--- a/javagen/src/main/java/com/azure/autorest/model/javamodel/JavaPackage.java
+++ b/javagen/src/main/java/com/azure/autorest/model/javamodel/JavaPackage.java
@@ -52,6 +52,12 @@ public class JavaPackage {
         javaFiles.add(javaFile);
     }
 
+    public final void addServiceClientBuilder(String package_Keyword, String name, ServiceClient model) {
+        JavaFile javaFile = javaFileFactory.createSourceFile(package_Keyword, name);
+        Templates.getServiceClientBuilderTemplate().write(model, javaFile);
+        javaFiles.add(javaFile);
+    }
+
     public final void addMethodGroup(String package_Keyword, String name, MethodGroupClient model) {
         JavaFile javaFile = javaFileFactory.createSourceFile(package_Keyword, name);
         Templates.getMethodGroupTemplate().write(model, javaFile);

--- a/readme.md
+++ b/readme.md
@@ -71,78 +71,10 @@ AutoRest needs the below config to pick this up as a plug-in - see https://githu
 
 #### Javagen
 
-``` yaml !$(fluent)
-use-extension:
-  "@autorest/modelerfour": "4.8.221"
-use: $(this-folder)//javagen
-
-pipeline:
-
-# --- extension remodeler ---
-
-  # "Shake the tree", and normalize the model
-  modelerfour:
-    input: openapi-document/multi-api/identity     # the plugin where we get inputs from
-    flatten-models: true
-    flatten-payloads: true
-    group-parameters: true
-  
-  # allow developer to do transformations on the code model.
-  modelerfour/new-transform:
-    input: modelerfour
-
-  preprocessor:
-    input: modelerfour/identity
-
-  javagen:
-    input: preprocessor
-    output-artifact: java-files
-  
-  javagen/emitter:
-    input: javagen
-    scope: scope-javagen/emitter
-
-scope-javagen/emitter:
-    input-artifact: java-files
-    output-uri-expr: $key
-
-output-artifact: java-files
+``` yaml $(java) && !$(fluent)
+use: $(this-folder)/javagen
 ```
 
-``` yaml $(fluent)
-use-extension:
-  "@autorest/modelerfour": "4.9.236"
+``` yaml $(java) && $(fluent)
 use: $(this-folder)/fluentgen
-
-pipeline:
-
-# --- extension remodeler ---
-
-  # "Shake the tree", and normalize the model
-  modelerfour:
-    input: openapi-document/multi-api/identity     # the plugin where we get inputs from
-    flatten-models: true
-    flatten-payloads: true
-  
-  # allow developer to do transformations on the code model.
-  modelerfour/new-transform:
-    input: modelerfour
-
-  fluentnamer:
-    input: modelerfour/identity
-
-  fluentgen:
-    scope: java
-    input: fluentnamer
-    output-artifact: java-files
-  
-  fluentgen/emitter:
-    input: fluentgen
-    scope: scope-fluentgen/emitter
-
-scope-fluentgen/emitter:
-    input-artifact: java-files
-    output-uri-expr: $key
-  
-output-artifact: java-files
 ```


### PR DESCRIPTION
Since method in client is package scope, client and builder must be in same package, else `setHost` will not resolve.

Let me know if you prefer fluent got a separate JavaPackage (maybe when we do lite we really do need to extend it).