### PR TITLE
Add context to client method

### DIFF
--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
@@ -84,6 +84,7 @@ public class JavaSettings
                     host.getStringValue("custom-types-subpackage", ""),
                     host.getBooleanValue("required-parameter-client-methods", true),
                     host.getBooleanValue("add-context-parameter", false),
+                    host.getBooleanValue("context-client-method-parameter", false),
                     host.getBooleanValue("generate-sync-async-clients", false),
                     host.getStringValue("sync-methods", "essential"));
         }
@@ -126,6 +127,7 @@ public class JavaSettings
                          String customTypesSubpackage,
                          boolean requiredParameterClientMethods,
                          boolean addContextParameter,
+                         boolean contextClientMethodParameter,
                          boolean generateSyncAsyncClients,
                          String syncMethods)
     {
@@ -147,7 +149,8 @@ public class JavaSettings
         this.customTypes = (customTypes == null || customTypes.isEmpty()) ? new ArrayList<>() : Arrays.asList(customTypes.split(","));
         this.customTypesSubpackage = customTypesSubpackage;
         this.requiredParameterClientMethods = requiredParameterClientMethods;
-        this.addContextParameter = addContextParameter;
+        this.addContextParameter = addContextParameter || contextClientMethodParameter;
+        this.contextClientMethodParameter = contextClientMethodParameter;
         this.generateSyncAsyncClients = generateSyncAsyncClients;
         this.syncMethods =  SyncMethodsGeneration.fromValue(syncMethods);
     }
@@ -294,6 +297,11 @@ public class JavaSettings
     private boolean addContextParameter;
     public final boolean getAddContextParameter() {
         return addContextParameter;
+    }
+
+    private boolean contextClientMethodParameter;
+    public final boolean isContextClientMethodParameter() {
+        return contextClientMethodParameter;
     }
 
     private boolean generateSyncAsyncClients;

--- a/generate
+++ b/generate
@@ -11,7 +11,7 @@ autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure
 autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/body-string.json --namespace=fixtures.bodystring
 autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/custom-baseUrl.json --namespace=fixtures.custombaseuri
 autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/custom-baseUrl-more-options.json --namespace=fixtures.custombaseuri.moreoptions
-autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/body-boolean.json --namespace=fixtures.bodyboolean
+autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/body-boolean.json --namespace=fixtures.bodyboolean --context-client-method-parameter=true
 autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/head.json --namespace=fixtures.head
 autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/head-exceptions.json --namespace=fixtures.headexceptions
 autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/header.json --namespace=fixtures.header

--- a/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
@@ -446,8 +446,13 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
                 ApplyParameterTransformations(function, clientMethod, settings);
                 ConvertClientTypesToWireTypes(function, clientMethod, restAPIMethod.getParameters(), clientMethod.getClientReference(), settings);
                 if (settings.getAddContextParameter()) {
-                    function.line(String.format("return FluxUtil.withContext(context -> %s)",
+                    if (settings.isContextClientMethodParameter() && clientMethod.getParameters().stream()
+                        .anyMatch(param -> ClassType.Context.equals(param.getClientType()))) {
+                        function.line(String.format("return %s", serviceMethodCall));
+                    } else {
+                        function.line(String.format("return FluxUtil.withContext(context -> %s)",
                             serviceMethodCall));
+                    }
                 } else {
                     function.line(String.format("return %s",
                             serviceMethodCall));
@@ -473,8 +478,13 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
             typeBlock.publicMethod(clientMethod.getDeclaration(), function -> {
                 AddOptionalAndConstantVariables(function, clientMethod, restAPIMethod.getParameters(), settings);
                 if (settings.getAddContextParameter()) {
-                    function.line(String.format("return FluxUtil.withContext(context -> %s)",
+                    if (settings.isContextClientMethodParameter() && clientMethod.getParameters().stream()
+                        .anyMatch(param -> ClassType.Context.equals(param.getClientType()))) {
+                        function.line(String.format("return %s", serviceMethodCall));
+                    } else {
+                        function.line(String.format("return FluxUtil.withContext(context -> %s)",
                             serviceMethodCall));
+                    }
                 } else {
                     function.line(String.format("return %s",
                             serviceMethodCall));
@@ -509,8 +519,13 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
             String restAPIMethodArgumentList = String.join(", ", clientMethod.getProxyMethodArguments(settings));
             String serviceMethodCall = String.format("service.%s(%s)", restAPIMethod.getName(), restAPIMethodArgumentList);
             if (settings.getAddContextParameter()) {
-                function.methodReturn(String.format("FluxUtil.withContext(context -> %s)",
+                if (settings.isContextClientMethodParameter() && clientMethod.getParameters().stream()
+                    .anyMatch(param -> ClassType.Context.equals(param.getClientType()))) {
+                    function.methodReturn(serviceMethodCall);
+                } else {
+                    function.methodReturn(String.format("FluxUtil.withContext(context -> %s)",
                         serviceMethodCall));
+                }
             } else {
                 function.methodReturn(serviceMethodCall);
             }

--- a/vanilla-tests/src/main/java/fixtures/bodyboolean/AutoRestBoolTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyboolean/AutoRestBoolTestService.java
@@ -30,7 +30,7 @@ public final class AutoRestBoolTestService {
      * @param host the host value.
      * @return the service client itself.
      */
-    AutoRestBoolTestService setHost(String host) {
+    public AutoRestBoolTestService setHost(String host) {
         this.host = host;
         return this;
     }
@@ -67,7 +67,7 @@ public final class AutoRestBoolTestService {
      * Initializes an instance of AutoRestBoolTestService client.
      */
     public AutoRestBoolTestService() {
-        new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build();
+        this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build());
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/bodyboolean/AutoRestBoolTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyboolean/AutoRestBoolTestServiceBuilder.java
@@ -10,7 +10,7 @@ import com.azure.core.http.policy.UserAgentPolicy;
 /**
  * A builder for creating a new instance of the AutoRestBoolTestService type.
  */
-@ServiceClientBuilder(serviceClients = AutoRestBoolTestService.class)
+@ServiceClientBuilder(serviceClients = {AutoRestBoolTestService.class})
 public final class AutoRestBoolTestServiceBuilder {
     /*
      * server parameter

--- a/vanilla-tests/src/main/java/fixtures/bodyboolean/Bools.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyboolean/Bools.java
@@ -98,6 +98,22 @@ public final class Bools {
     /**
      * Get true Boolean value.
      * 
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<SimpleResponse<Boolean>> getTrueWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return service.getTrue(this.client.getHost(), context);
+    }
+
+    /**
+     * Get true Boolean value.
+     * 
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
@@ -142,6 +158,23 @@ public final class Bools {
     /**
      * Set Boolean value true.
      * 
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putTrueWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final boolean boolBody = true;
+        return service.putTrue(this.client.getHost(), boolBody, context);
+    }
+
+    /**
+     * Set Boolean value true.
+     * 
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
@@ -174,6 +207,22 @@ public final class Bools {
             return Mono.error(new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
         }
         return FluxUtil.withContext(context -> service.getFalse(this.client.getHost(), context));
+    }
+
+    /**
+     * Get false Boolean value.
+     * 
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<SimpleResponse<Boolean>> getFalseWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return service.getFalse(this.client.getHost(), context);
     }
 
     /**
@@ -223,6 +272,23 @@ public final class Bools {
     /**
      * Set Boolean value false.
      * 
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putFalseWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final boolean boolBody = false;
+        return service.putFalse(this.client.getHost(), boolBody, context);
+    }
+
+    /**
+     * Set Boolean value false.
+     * 
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
@@ -255,6 +321,22 @@ public final class Bools {
             return Mono.error(new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
         }
         return FluxUtil.withContext(context -> service.getNull(this.client.getHost(), context));
+    }
+
+    /**
+     * Get null Boolean value.
+     * 
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<SimpleResponse<Boolean>> getNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return service.getNull(this.client.getHost(), context);
     }
 
     /**
@@ -298,6 +380,22 @@ public final class Bools {
             return Mono.error(new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
         }
         return FluxUtil.withContext(context -> service.getInvalid(this.client.getHost(), context));
+    }
+
+    /**
+     * Get invalid Boolean value.
+     * 
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<SimpleResponse<Boolean>> getInvalidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return service.getInvalid(this.client.getHost(), context);
     }
 
     /**


### PR DESCRIPTION
Provide an option to generate async client methods that return `withResponse` to include `Context` as input parameter. This is required for convenience layer to pass in user provided context from sync clients and also add additional context properties like tracing before calling autorest methods..

Fixes #560 

