### PR TITLE
v4 fluent naming config, fix javadoc in non-string enum

### DIFF
--- a/fluentnamer/readme.md
+++ b/fluentnamer/readme.md
@@ -19,7 +19,12 @@ pipeline:
     flatten-models: true
     flatten-payloads: true
     naming:
-      preserve-uppercase-max-length: 4
+      override:
+        api: Api
+        cpk: Cpk
+        sas: Sas
+        url: Url
+        xml: Xml
   
   # allow developer to do transformations on the code model.
   modelerfour/new-transform:

--- a/javagen/src/main/java/com/azure/autorest/template/EnumTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/EnumTemplate.java
@@ -134,6 +134,11 @@ public class EnumTemplate implements IJavaTemplate<EnumType, JavaFile> {
                 if (enumType.getElementType() == ClassType.String) {
                     enumBlock.annotation("JsonValue", "Override");
                 } else {
+                    enumBlock.javadocComment(comment ->
+                    {
+                        comment.description(String.format("De-serializes the instance to %1$s value.", enumType.getElementType().toString()));
+                        comment.methodReturns(String.format("the %1$s value", enumType.getElementType().toString()));
+                    });
                     enumBlock.annotation("JsonValue");
                 }
                 enumBlock.PublicMethod(String.format("%1$s to%2$s()", typeName, converterName), (function) ->

--- a/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
@@ -89,7 +89,7 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ServiceClient
             // Add ServiceClient client property variables, getters, and setters
             for (ServiceClientProperty serviceClientProperty : Stream
                     .concat(serviceClient.getProperties().stream().filter(p -> !p.isReadOnly()), commonProperties.stream()).collect(Collectors.toList())) {
-                classBlock.blockComment(comment ->
+                classBlock.blockComment(settings.getMaximumJavadocCommentWidth(), comment ->
                 {
                     comment.line(serviceClientProperty.getDescription());
                 });

--- a/javagen/src/test/java/com/azure/autorest/model/JavaFileContentsTests.java
+++ b/javagen/src/test/java/com/azure/autorest/model/JavaFileContentsTests.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.azure.autorest.model;
+
+import com.azure.autorest.model.javamodel.JavaFileContents;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+public class JavaFileContentsTests {
+
+    private static final int WIDTH = 80;
+
+    @Test
+    public void canWordwrapInComments() {
+        final String commentString = "Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call.";
+
+        JavaFileContents javaFileContents = new JavaFileContents();
+        javaFileContents.blockComment(WIDTH, comment -> comment.line(commentString));
+        String code = javaFileContents.toString();
+        Assert.assertTrue(
+                Arrays.stream(code.split(System.lineSeparator()))
+                        .noneMatch(line -> line.length() > WIDTH)
+        );
+    }
+}


### PR DESCRIPTION
@yungezz @ChenTanyi @xccc-msft 

Note this will force it for all places, regardless what casing used in spec.