### PR TITLE
Support timeschema and represent it as String

### DIFF
--- a/azure-tests/src/main/java/fixtures/paging/AutoRestPagingTestService.java
+++ b/azure-tests/src/main/java/fixtures/paging/AutoRestPagingTestService.java
@@ -59,7 +59,7 @@ public final class AutoRestPagingTestService {
      * 
      * @return the Pagings object.
      */
-    public Pagings pagings() {
+    public Pagings getPagings() {
         return this.pagings;
     }
 

--- a/azure-tests/src/test/java/fixtures/paging/PagingTests.java
+++ b/azure-tests/src/test/java/fixtures/paging/PagingTests.java
@@ -27,20 +27,20 @@ public class PagingTests {
 
     @Test
     public void getSinglePages() throws Exception {
-        PagedIterable<Product> response = client.pagings().getSinglePages();
+        PagedIterable<Product> response = client.getPagings().getSinglePages();
         Assert.assertEquals(1, response.stream().count());
     }
 
     @Test
     public void getMultiplePages() throws Exception {
-        List<Product> response = client.pagings().getMultiplePages(null, null)
+        List<Product> response = client.getPagings().getMultiplePages(null, null)
                 .stream().collect(Collectors.toList());
         Assert.assertEquals(10, response.size());
     }
 
     @Test
     public void getOdataMultiplePages() throws Exception {
-        List<Product> response = client.pagings().getOdataMultiplePages(null, null)
+        List<Product> response = client.getPagings().getOdataMultiplePages(null, null)
                 .stream().collect(Collectors.toList());
         Assert.assertEquals(10, response.size());
     }
@@ -49,7 +49,7 @@ public class PagingTests {
     public void getMultiplePagesWithOffset() throws Exception {
         PagingGetMultiplePagesWithOffsetOptions options = new PagingGetMultiplePagesWithOffsetOptions();
         options.setOffset(100);
-        List<Product> response = client.pagings().getMultiplePagesWithOffset(options, "client-id")
+        List<Product> response = client.getPagings().getMultiplePagesWithOffset(options, "client-id")
                 .stream().collect(Collectors.toList());
         Assert.assertEquals(10, response.size());
         Assert.assertEquals(110, (int) response.get(response.size() - 1).getProperties().getId());
@@ -58,7 +58,7 @@ public class PagingTests {
     @Test
     public void getMultiplePagesAsync() throws Exception {
         final CountDownLatch lock = new CountDownLatch(1);
-        client.pagings().getMultiplePagesAsync("client-id", null)
+        client.getPagings().getMultiplePagesAsync("client-id", null)
                 .doOnError(throwable -> fail(throwable.getMessage()))
                 .doOnComplete(lock::countDown)
                 .blockLast();
@@ -68,14 +68,14 @@ public class PagingTests {
 
     @Test
     public void getMultiplePagesRetryFirst() throws Exception {
-        List<Product> response = client.pagings().getMultiplePagesRetryFirst()
+        List<Product> response = client.getPagings().getMultiplePagesRetryFirst()
                 .stream().collect(Collectors.toList());
         Assert.assertEquals(10, response.size());
     }
 
     @Test
     public void getMultiplePagesRetrySecond() throws Exception {
-        List<Product> response = client.pagings().getMultiplePagesRetrySecond()
+        List<Product> response = client.getPagings().getMultiplePagesRetrySecond()
                 .stream().collect(Collectors.toList());
         Assert.assertEquals(10, response.size());
     }
@@ -83,7 +83,7 @@ public class PagingTests {
     @Test
     public void getSinglePagesFailure() throws Exception {
         try {
-            List<Product> response = client.pagings().getSinglePagesFailure()
+            List<Product> response = client.getPagings().getSinglePagesFailure()
                     .stream().collect(Collectors.toList());
             fail();
         } catch (HttpResponseException ex) {
@@ -94,7 +94,7 @@ public class PagingTests {
     @Test
     public void getMultiplePagesFailure() throws Exception {
         try {
-            List<Product> response = client.pagings().getMultiplePagesFailure()
+            List<Product> response = client.getPagings().getMultiplePagesFailure()
                     .stream().collect(Collectors.toList());
             response.size();
             fail();
@@ -106,7 +106,7 @@ public class PagingTests {
     @Test
     public void getMultiplePagesFailureUri() {
         try {
-            client.pagings().getMultiplePagesFailureUri().stream().collect(Collectors.toList());
+            client.getPagings().getMultiplePagesFailureUri().stream().collect(Collectors.toList());
             fail();
         } catch (Exception e) {
             Assert.assertTrue(e.getCause() instanceof MalformedURLException);
@@ -115,13 +115,13 @@ public class PagingTests {
 
     @Test
     public void getMultiplePagesFragmentNextLink() throws Exception {
-        PagedIterable<Product> response = client.pagings().getMultiplePagesFragmentNextLink("1.6", "test_user");
+        PagedIterable<Product> response = client.getPagings().getMultiplePagesFragmentNextLink("1.6", "test_user");
         Assert.assertEquals(10, response.stream().count());
     }
 
     @Test
     public void getMultiplePagesFragmentWithGroupingNextLink() throws Exception {
-        PagedIterable<Product> response = client.pagings().getMultiplePagesFragmentWithGroupingNextLink(
+        PagedIterable<Product> response = client.getPagings().getMultiplePagesFragmentWithGroupingNextLink(
                 new CustomParameterGroup().setApiVersion("1.6").setTenant("test_user"));
         Assert.assertEquals(10, response.stream().count());
     }

--- a/eng/pipelines/ci.yaml
+++ b/eng/pipelines/ci.yaml
@@ -49,6 +49,10 @@ jobs:
           ./generate
         displayName: 'Generate code'
 
+      - script |
+          git diff
+        displayName: 'Git Diff'
+
       - script: |
           [ -z "`git status --porcelain`" ]
         displayName: 'Check no diff in generated files'

--- a/eng/pipelines/ci.yaml
+++ b/eng/pipelines/ci.yaml
@@ -49,7 +49,7 @@ jobs:
           ./generate
         displayName: 'Generate code'
 
-      - script |
+      - script: |
           git diff
         displayName: 'Git Diff'
 

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/CodeModelCustomConstructor.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/CodeModelCustomConstructor.java
@@ -283,6 +283,7 @@ public class CodeModelCustomConstructor extends Constructor {
                     case "parameter-group": return ParameterGroupSchema.class;
                     case "sealed-choice": return SealedChoiceSchema.class;
                     case "string": return StringSchema.class;
+                    case "time": return TimeSchema.class;
                     case "unixtime": return UnixTimeSchema.class;
                     case "uri": return UriSchema.class;
                     case "uuid": return UuidSchema.class;

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Schema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Schema.java
@@ -277,6 +277,7 @@ public class Schema extends Metadata {
         PARAMETER_GROUP("parameter-group"),
         SEALED_CHOICE("sealed-choice"),
         STRING("string"),
+        TIME("time"),
         UNIXTIME("unixtime"),
         URI("uri"),
         UUID("uuid"),

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/TimeSchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/TimeSchema.java
@@ -1,0 +1,4 @@
+package com.azure.autorest.extension.base.model.codemodel;
+
+public class TimeSchema extends PrimitiveSchema {
+}

--- a/fluent-tests/src/test/java/com/azure/mgmttest/RuntimeTests.java
+++ b/fluent-tests/src/test/java/com/azure/mgmttest/RuntimeTests.java
@@ -29,6 +29,6 @@ public class RuntimeTests {
                 .buildClient();
         Assertions.assertNotNull(storageManagementClient.getHttpPipeline());
         Assertions.assertEquals(MOCK_SUBSCRIPTION_ID, storageManagementClient.getSubscriptionId());
-        Assertions.assertNotNull(storageManagementClient.storageAccounts());
+        Assertions.assertNotNull(storageManagementClient.getStorageAccounts());
     }
 }

--- a/javagen/src/main/java/com/azure/autorest/mapper/PrimitiveMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/PrimitiveMapper.java
@@ -4,6 +4,7 @@ import com.azure.autorest.extension.base.model.codemodel.ByteArraySchema;
 import com.azure.autorest.extension.base.model.codemodel.DateTimeSchema;
 import com.azure.autorest.extension.base.model.codemodel.NumberSchema;
 import com.azure.autorest.extension.base.model.codemodel.PrimitiveSchema;
+import com.azure.autorest.extension.base.model.codemodel.TimeSchema;
 import com.azure.autorest.model.clientmodel.ArrayType;
 import com.azure.autorest.model.clientmodel.ClassType;
 import com.azure.autorest.model.clientmodel.IType;
@@ -59,6 +60,10 @@ public class PrimitiveMapper implements IMapper<PrimitiveSchema, IType> {
                 } else {
                     iType = ClassType.DateTime;
                 }
+                break;
+            case TIME:
+                TimeSchema timeSchema = (TimeSchema) primaryType;
+                iType = ClassType.String;
                 break;
 //            case KnownPrimaryType.DateTimeRfc1123:
 //                iType = ClassType.DateTimeRfc1123;

--- a/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
@@ -28,7 +28,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class ProxyMethodMapper implements IMapper<Operation, Map<Request, ProxyMethod>> {
-    private static final List<IType> unixTimeTypes = Arrays.asList(PrimitiveType.UnixTimeLong, ClassType.UnixTimeLong, ClassType.UnixTimeDateTime);
+    private static final List<IType> unixTimeTypes = Arrays.asList(PrimitiveType.UnixTimeLong, ClassType.UnixTimeLong
+        , ClassType.UnixTimeDateTime);
     private static final List<IType> returnValueWireTypeOptions = Stream.concat(Stream.of(ClassType.Base64Url, ClassType.DateTimeRfc1123), unixTimeTypes.stream()).collect(Collectors.toList());
     private static ProxyMethodMapper instance = new ProxyMethodMapper();
 

--- a/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
@@ -155,8 +155,8 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ServiceClient
                         if (serviceClient.getProxy() != null) {
                             function.line("return new %1$s(%2$s());", asyncClassName, buildMethodName);
                         } else {
-                            function.line("return new %1$s(%2$s().%3$s());", asyncClassName, buildMethodName,
-                                CodeNamer.toCamelCase(serviceClient.getMethodGroupClients().get(0).getClassBaseName()));
+                            function.line("return new %1$s(%2$s().get%3$s());", asyncClassName, buildMethodName,
+                                CodeNamer.toPascalCase(serviceClient.getMethodGroupClients().get(0).getClassBaseName()));
                         }
                     });
 
@@ -176,8 +176,8 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ServiceClient
                             if (serviceClient.getProxy() != null) {
                                 function.line("return new %1$s(%2$s());", syncClassName, buildMethodName);
                             } else {
-                                function.line("return new %1$s(%2$s().%3$s());", syncClassName, buildMethodName,
-                                    CodeNamer.toCamelCase(serviceClient.getMethodGroupClients().get(0).getClassBaseName()));
+                                function.line("return new %1$s(%2$s().get%3$s());", syncClassName, buildMethodName,
+                                    CodeNamer.toPascalCase(serviceClient.getMethodGroupClients().get(0).getClassBaseName()));
                             }
                         });
                 }

--- a/javagen/src/main/java/com/azure/autorest/template/ServiceClientTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ServiceClientTemplate.java
@@ -127,7 +127,8 @@ public class ServiceClientTemplate implements IJavaTemplate<ServiceClient, JavaF
                     comment.description(String.format("Gets the %1$s object to access its operations.", methodGroupClient.getVariableType()));
                     comment.methodReturns(String.format("the %1$s object.", methodGroupClient.getVariableType()));
                 });
-                classBlock.publicMethod(String.format("%1$s %2$s()", methodGroupClient.getVariableType(), methodGroupClient.getVariableName()), function ->
+                classBlock.publicMethod(String.format("%1$s get%2$s()", methodGroupClient.getVariableType(),
+                    CodeNamer.toPascalCase(methodGroupClient.getVariableName())), function ->
                 {
                     function.methodReturn(String.format("this.%1$s", methodGroupClient.getVariableName()));
                 });

--- a/vanilla-tests/src/main/java/fixtures/additionalproperties/AdditionalPropertiesClient.java
+++ b/vanilla-tests/src/main/java/fixtures/additionalproperties/AdditionalPropertiesClient.java
@@ -59,7 +59,7 @@ public final class AdditionalPropertiesClient {
      * 
      * @return the Pets object.
      */
-    public Pets pets() {
+    public Pets getPets() {
         return this.pets;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodyarray/AutoRestSwaggerBATArrayService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyarray/AutoRestSwaggerBATArrayService.java
@@ -59,7 +59,7 @@ public final class AutoRestSwaggerBATArrayService {
      * 
      * @return the Arrays object.
      */
-    public Arrays arrays() {
+    public Arrays getArrays() {
         return this.arrays;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodyboolean/AutoRestBoolTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyboolean/AutoRestBoolTestService.java
@@ -59,7 +59,7 @@ public final class AutoRestBoolTestService {
      * 
      * @return the Bools object.
      */
-    public Bools bools() {
+    public Bools getBools() {
         return this.bools;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodyboolean/Bools.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyboolean/Bools.java
@@ -99,6 +99,23 @@ public final class Bools {
     /**
      * Get true Boolean value.
      * 
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return true Boolean value.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<SimpleResponse<Boolean>> getTrueWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return service.getTrue(this.client.getHost(), context);
+    }
+
+    /**
+     * Get true Boolean value.
+     * 
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return true Boolean value.
@@ -146,6 +163,24 @@ public final class Bools {
     /**
      * Set Boolean value true.
      * 
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putTrueWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final boolean boolBody = true;
+        return service.putTrue(this.client.getHost(), boolBody, context);
+    }
+
+    /**
+     * Set Boolean value true.
+     * 
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the completion.
@@ -180,6 +215,23 @@ public final class Bools {
             return Mono.error(new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
         }
         return FluxUtil.withContext(context -> service.getFalse(this.client.getHost(), context));
+    }
+
+    /**
+     * Get false Boolean value.
+     * 
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return false Boolean value.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<SimpleResponse<Boolean>> getFalseWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return service.getFalse(this.client.getHost(), context);
     }
 
     /**
@@ -232,6 +284,24 @@ public final class Bools {
     /**
      * Set Boolean value false.
      * 
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putFalseWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final boolean boolBody = false;
+        return service.putFalse(this.client.getHost(), boolBody, context);
+    }
+
+    /**
+     * Set Boolean value false.
+     * 
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the completion.
@@ -266,6 +336,23 @@ public final class Bools {
             return Mono.error(new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
         }
         return FluxUtil.withContext(context -> service.getNull(this.client.getHost(), context));
+    }
+
+    /**
+     * Get null Boolean value.
+     * 
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null Boolean value.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<SimpleResponse<Boolean>> getNullWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return service.getNull(this.client.getHost(), context);
     }
 
     /**
@@ -312,6 +399,23 @@ public final class Bools {
             return Mono.error(new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
         }
         return FluxUtil.withContext(context -> service.getInvalid(this.client.getHost(), context));
+    }
+
+    /**
+     * Get invalid Boolean value.
+     * 
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return invalid Boolean value.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<SimpleResponse<Boolean>> getInvalidWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return service.getInvalid(this.client.getHost(), context);
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/bodyboolean/quirks/AutoRestBoolTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyboolean/quirks/AutoRestBoolTestService.java
@@ -59,7 +59,7 @@ public final class AutoRestBoolTestService {
      * 
      * @return the Bools object.
      */
-    public Bools bools() {
+    public Bools getBools() {
         return this.bools;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodyboolean/quirks/Bools.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyboolean/quirks/Bools.java
@@ -99,23 +99,6 @@ public final class Bools {
     /**
      * Get true Boolean value.
      * 
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws ErrorException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return true Boolean value.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<SimpleResponse<Boolean>> getTrueWithResponseAsync(Context context) {
-        if (this.client.getHost() == null) {
-            return Mono.error(new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
-        }
-        return service.getTrue(this.client.getHost(), context);
-    }
-
-    /**
-     * Get true Boolean value.
-     * 
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return true Boolean value.
@@ -165,24 +148,6 @@ public final class Bools {
      * Set Boolean value true.
      * 
      * @param boolBody The boolBody parameter.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws ErrorException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the completion.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<Void>> putTrueWithResponseAsync(boolean boolBody, Context context) {
-        if (this.client.getHost() == null) {
-            return Mono.error(new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
-        }
-        return service.putTrue(this.client.getHost(), boolBody, context);
-    }
-
-    /**
-     * Set Boolean value true.
-     * 
-     * @param boolBody The boolBody parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -220,23 +185,6 @@ public final class Bools {
             return Mono.error(new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
         }
         return FluxUtil.withContext(context -> service.getFalse(this.client.getHost(), context));
-    }
-
-    /**
-     * Get false Boolean value.
-     * 
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws ErrorException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return false Boolean value.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<SimpleResponse<Boolean>> getFalseWithResponseAsync(Context context) {
-        if (this.client.getHost() == null) {
-            return Mono.error(new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
-        }
-        return service.getFalse(this.client.getHost(), context);
     }
 
     /**
@@ -291,24 +239,6 @@ public final class Bools {
      * Set Boolean value false.
      * 
      * @param boolBody The boolBody parameter.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws ErrorException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the completion.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<Void>> putFalseWithResponseAsync(boolean boolBody, Context context) {
-        if (this.client.getHost() == null) {
-            return Mono.error(new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
-        }
-        return service.putFalse(this.client.getHost(), boolBody, context);
-    }
-
-    /**
-     * Set Boolean value false.
-     * 
-     * @param boolBody The boolBody parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -346,23 +276,6 @@ public final class Bools {
             return Mono.error(new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
         }
         return FluxUtil.withContext(context -> service.getNull(this.client.getHost(), context));
-    }
-
-    /**
-     * Get null Boolean value.
-     * 
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws ErrorException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return null Boolean value.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<SimpleResponse<Boolean>> getNullWithResponseAsync(Context context) {
-        if (this.client.getHost() == null) {
-            return Mono.error(new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
-        }
-        return service.getNull(this.client.getHost(), context);
     }
 
     /**
@@ -409,23 +322,6 @@ public final class Bools {
             return Mono.error(new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
         }
         return FluxUtil.withContext(context -> service.getInvalid(this.client.getHost(), context));
-    }
-
-    /**
-     * Get invalid Boolean value.
-     * 
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws ErrorException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return invalid Boolean value.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<SimpleResponse<Boolean>> getInvalidWithResponseAsync(Context context) {
-        if (this.client.getHost() == null) {
-            return Mono.error(new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
-        }
-        return service.getInvalid(this.client.getHost(), context);
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/bodybyte/AutoRestSwaggerBATByteService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodybyte/AutoRestSwaggerBATByteService.java
@@ -59,7 +59,7 @@ public final class AutoRestSwaggerBATByteService {
      * 
      * @return the Bytes object.
      */
-    public Bytes bytes() {
+    public Bytes getBytes() {
         return this.bytes;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/AutoRestComplexTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/AutoRestComplexTestService.java
@@ -84,7 +84,7 @@ public final class AutoRestComplexTestService {
      * 
      * @return the Basics object.
      */
-    public Basics basics() {
+    public Basics getBasics() {
         return this.basics;
     }
 
@@ -98,7 +98,7 @@ public final class AutoRestComplexTestService {
      * 
      * @return the Primitives object.
      */
-    public Primitives primitives() {
+    public Primitives getPrimitives() {
         return this.primitives;
     }
 
@@ -112,7 +112,7 @@ public final class AutoRestComplexTestService {
      * 
      * @return the Arrays object.
      */
-    public Arrays arrays() {
+    public Arrays getArrays() {
         return this.arrays;
     }
 
@@ -126,7 +126,7 @@ public final class AutoRestComplexTestService {
      * 
      * @return the Dictionarys object.
      */
-    public Dictionarys dictionarys() {
+    public Dictionarys getDictionarys() {
         return this.dictionarys;
     }
 
@@ -140,7 +140,7 @@ public final class AutoRestComplexTestService {
      * 
      * @return the Inheritances object.
      */
-    public Inheritances inheritances() {
+    public Inheritances getInheritances() {
         return this.inheritances;
     }
 
@@ -154,7 +154,7 @@ public final class AutoRestComplexTestService {
      * 
      * @return the Polymorphisms object.
      */
-    public Polymorphisms polymorphisms() {
+    public Polymorphisms getPolymorphisms() {
         return this.polymorphisms;
     }
 
@@ -168,7 +168,7 @@ public final class AutoRestComplexTestService {
      * 
      * @return the Polymorphicrecursives object.
      */
-    public Polymorphicrecursives polymorphicrecursives() {
+    public Polymorphicrecursives getPolymorphicrecursives() {
         return this.polymorphicrecursives;
     }
 
@@ -182,7 +182,7 @@ public final class AutoRestComplexTestService {
      * 
      * @return the Readonlypropertys object.
      */
-    public Readonlypropertys readonlypropertys() {
+    public Readonlypropertys getReadonlypropertys() {
         return this.readonlypropertys;
     }
 
@@ -196,7 +196,7 @@ public final class AutoRestComplexTestService {
      * 
      * @return the Flattencomplexs object.
      */
-    public Flattencomplexs flattencomplexs() {
+    public Flattencomplexs getFlattencomplexs() {
         return this.flattencomplexs;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodydate/AutoRestDateTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydate/AutoRestDateTestService.java
@@ -59,7 +59,7 @@ public final class AutoRestDateTestService {
      * 
      * @return the Dates object.
      */
-    public Dates dates() {
+    public Dates getDates() {
         return this.dates;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodydatetime/AutoRestDateTimeTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydatetime/AutoRestDateTimeTestService.java
@@ -59,7 +59,7 @@ public final class AutoRestDateTimeTestService {
      * 
      * @return the Datetimes object.
      */
-    public Datetimes datetimes() {
+    public Datetimes getDatetimes() {
         return this.datetimes;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodydatetimerfc1123/AutoRestRFC1123DateTimeTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydatetimerfc1123/AutoRestRFC1123DateTimeTestService.java
@@ -59,7 +59,7 @@ public final class AutoRestRFC1123DateTimeTestService {
      * 
      * @return the Datetimerfc1123s object.
      */
-    public Datetimerfc1123s datetimerfc1123s() {
+    public Datetimerfc1123s getDatetimerfc1123s() {
         return this.datetimerfc1123s;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodydictionary/AutoRestSwaggerBATDictionaryServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydictionary/AutoRestSwaggerBATDictionaryServiceBuilder.java
@@ -68,7 +68,7 @@ public final class AutoRestSwaggerBATDictionaryServiceBuilder {
      * @return an instance of AutoRestSwaggerBATDictionaryServiceAsyncClient.
      */
     public AutoRestSwaggerBATDictionaryServiceAsyncClient buildAsyncClient() {
-        return new AutoRestSwaggerBATDictionaryServiceAsyncClient(buildInnerClient().dictionarys());
+        return new AutoRestSwaggerBATDictionaryServiceAsyncClient(buildInnerClient().getDictionarys());
     }
 
     /**
@@ -77,6 +77,6 @@ public final class AutoRestSwaggerBATDictionaryServiceBuilder {
      * @return an instance of AutoRestSwaggerBATDictionaryServiceClient.
      */
     public AutoRestSwaggerBATDictionaryServiceClient buildClient() {
-        return new AutoRestSwaggerBATDictionaryServiceClient(buildInnerClient().dictionarys());
+        return new AutoRestSwaggerBATDictionaryServiceClient(buildInnerClient().getDictionarys());
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodydictionary/implementation/AutoRestSwaggerBATDictionaryServiceImpl.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydictionary/implementation/AutoRestSwaggerBATDictionaryServiceImpl.java
@@ -59,7 +59,7 @@ public final class AutoRestSwaggerBATDictionaryServiceImpl {
      * 
      * @return the DictionarysImpl object.
      */
-    public DictionarysImpl dictionarys() {
+    public DictionarysImpl getDictionarys() {
         return this.dictionarys;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodyduration/AutoRestDurationTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyduration/AutoRestDurationTestService.java
@@ -59,7 +59,7 @@ public final class AutoRestDurationTestService {
      * 
      * @return the Durations object.
      */
-    public Durations durations() {
+    public Durations getDurations() {
         return this.durations;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodyfile/AutoRestSwaggerBATFileService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyfile/AutoRestSwaggerBATFileService.java
@@ -59,7 +59,7 @@ public final class AutoRestSwaggerBATFileService {
      * 
      * @return the Files object.
      */
-    public Files files() {
+    public Files getFiles() {
         return this.files;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodyinteger/AutoRestIntegerTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyinteger/AutoRestIntegerTestService.java
@@ -59,7 +59,7 @@ public final class AutoRestIntegerTestService {
      * 
      * @return the Ints object.
      */
-    public Ints ints() {
+    public Ints getInts() {
         return this.ints;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodynumber/AutoRestNumberTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodynumber/AutoRestNumberTestService.java
@@ -59,7 +59,7 @@ public final class AutoRestNumberTestService {
      * 
      * @return the Numbers object.
      */
-    public Numbers numbers() {
+    public Numbers getNumbers() {
         return this.numbers;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodystring/AutoRestSwaggerBATService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodystring/AutoRestSwaggerBATService.java
@@ -59,7 +59,7 @@ public final class AutoRestSwaggerBATService {
      * 
      * @return the Strings object.
      */
-    public Strings strings() {
+    public Strings getStrings() {
         return this.strings;
     }
 
@@ -73,7 +73,7 @@ public final class AutoRestSwaggerBATService {
      * 
      * @return the Enums object.
      */
-    public Enums enums() {
+    public Enums getEnums() {
         return this.enums;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/custombaseuri/AutoRestParameterizedHostTestClient.java
+++ b/vanilla-tests/src/main/java/fixtures/custombaseuri/AutoRestParameterizedHostTestClient.java
@@ -59,7 +59,7 @@ public final class AutoRestParameterizedHostTestClient {
      * 
      * @return the Paths object.
      */
-    public Paths paths() {
+    public Paths getPaths() {
         return this.paths;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/custombaseuri/moreoptions/AutoRestParameterizedCustomHostTestClient.java
+++ b/vanilla-tests/src/main/java/fixtures/custombaseuri/moreoptions/AutoRestParameterizedCustomHostTestClient.java
@@ -84,7 +84,7 @@ public final class AutoRestParameterizedCustomHostTestClient {
      * 
      * @return the Paths object.
      */
-    public Paths paths() {
+    public Paths getPaths() {
         return this.paths;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/extensibleenums/PetStoreInc.java
+++ b/vanilla-tests/src/main/java/fixtures/extensibleenums/PetStoreInc.java
@@ -59,7 +59,7 @@ public final class PetStoreInc {
      * 
      * @return the Pets object.
      */
-    public Pets pets() {
+    public Pets getPets() {
         return this.pets;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/head/AutoRestHeadTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/head/AutoRestHeadTestService.java
@@ -59,7 +59,7 @@ public final class AutoRestHeadTestService {
      * 
      * @return the HttpSuccess object.
      */
-    public HttpSuccess httpSuccess() {
+    public HttpSuccess getHttpSuccess() {
         return this.httpSuccess;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/header/AutoRestSwaggerBATHeaderService.java
+++ b/vanilla-tests/src/main/java/fixtures/header/AutoRestSwaggerBATHeaderService.java
@@ -59,7 +59,7 @@ public final class AutoRestSwaggerBATHeaderService {
      * 
      * @return the Headers object.
      */
-    public Headers headers() {
+    public Headers getHeaders() {
         return this.headers;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/headexceptions/AutoRestHeadExceptionTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/headexceptions/AutoRestHeadExceptionTestService.java
@@ -59,7 +59,7 @@ public final class AutoRestHeadExceptionTestService {
      * 
      * @return the HeadExceptions object.
      */
-    public HeadExceptions headExceptions() {
+    public HeadExceptions getHeadExceptions() {
         return this.headExceptions;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/httpinfrastructure/AutoRestHttpInfrastructureTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/httpinfrastructure/AutoRestHttpInfrastructureTestService.java
@@ -59,7 +59,7 @@ public final class AutoRestHttpInfrastructureTestService {
      * 
      * @return the HttpFailures object.
      */
-    public HttpFailures httpFailures() {
+    public HttpFailures getHttpFailures() {
         return this.httpFailures;
     }
 
@@ -73,7 +73,7 @@ public final class AutoRestHttpInfrastructureTestService {
      * 
      * @return the HttpSuccess object.
      */
-    public HttpSuccess httpSuccess() {
+    public HttpSuccess getHttpSuccess() {
         return this.httpSuccess;
     }
 
@@ -87,7 +87,7 @@ public final class AutoRestHttpInfrastructureTestService {
      * 
      * @return the HttpRedirects object.
      */
-    public HttpRedirects httpRedirects() {
+    public HttpRedirects getHttpRedirects() {
         return this.httpRedirects;
     }
 
@@ -101,7 +101,7 @@ public final class AutoRestHttpInfrastructureTestService {
      * 
      * @return the HttpClientFailures object.
      */
-    public HttpClientFailures httpClientFailures() {
+    public HttpClientFailures getHttpClientFailures() {
         return this.httpClientFailures;
     }
 
@@ -115,7 +115,7 @@ public final class AutoRestHttpInfrastructureTestService {
      * 
      * @return the HttpServerFailures object.
      */
-    public HttpServerFailures httpServerFailures() {
+    public HttpServerFailures getHttpServerFailures() {
         return this.httpServerFailures;
     }
 
@@ -129,7 +129,7 @@ public final class AutoRestHttpInfrastructureTestService {
      * 
      * @return the HttpRetrys object.
      */
-    public HttpRetrys httpRetrys() {
+    public HttpRetrys getHttpRetrys() {
         return this.httpRetrys;
     }
 
@@ -143,7 +143,7 @@ public final class AutoRestHttpInfrastructureTestService {
      * 
      * @return the MultipleResponses object.
      */
-    public MultipleResponses multipleResponses() {
+    public MultipleResponses getMultipleResponses() {
         return this.multipleResponses;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClient.java
+++ b/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClient.java
@@ -101,12 +101,12 @@ public final class MediaTypesClient {
         @Post("/mediatypes/analyze")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(HttpResponseException.class)
-        Mono<SimpleResponse<String>> analyzeBody(@HostParam("$host") String host, @BodyParam("application/json") SourcePath input, Context context);
+        Mono<SimpleResponse<String>> analyzeBody(@HostParam("$host") String host, @HeaderParam("Content-Type") ContentType contentType, @BodyParam("application/octet-stream") Flux<ByteBuffer> input, @HeaderParam("Content-Length") long contentLength, Context context);
 
         @Post("/mediatypes/analyze")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(HttpResponseException.class)
-        Mono<SimpleResponse<String>> analyzeBody(@HostParam("$host") String host, @HeaderParam("Content-Type") ContentType contentType, @BodyParam("application/octet-stream") Flux<ByteBuffer> input, @HeaderParam("Content-Length") long contentLength, Context context);
+        Mono<SimpleResponse<String>> analyzeBody(@HostParam("$host") String host, @BodyParam("application/json") SourcePath input, Context context);
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClient.java
+++ b/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClient.java
@@ -101,12 +101,12 @@ public final class MediaTypesClient {
         @Post("/mediatypes/analyze")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(HttpResponseException.class)
-        Mono<SimpleResponse<String>> analyzeBody(@HostParam("$host") String host, @HeaderParam("Content-Type") ContentType contentType, @BodyParam("application/octet-stream") Flux<ByteBuffer> input, @HeaderParam("Content-Length") long contentLength, Context context);
+        Mono<SimpleResponse<String>> analyzeBody(@HostParam("$host") String host, @BodyParam("application/json") SourcePath input, Context context);
 
         @Post("/mediatypes/analyze")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(HttpResponseException.class)
-        Mono<SimpleResponse<String>> analyzeBody(@HostParam("$host") String host, @BodyParam("application/json") SourcePath input, Context context);
+        Mono<SimpleResponse<String>> analyzeBody(@HostParam("$host") String host, @HeaderParam("Content-Type") ContentType contentType, @BodyParam("application/octet-stream") Flux<ByteBuffer> input, @HeaderParam("Content-Length") long contentLength, Context context);
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/parameterflattening/AutoRestParameterFlattening.java
+++ b/vanilla-tests/src/main/java/fixtures/parameterflattening/AutoRestParameterFlattening.java
@@ -59,7 +59,7 @@ public final class AutoRestParameterFlattening {
      * 
      * @return the AvailabilitySets object.
      */
-    public AvailabilitySets availabilitySets() {
+    public AvailabilitySets getAvailabilitySets() {
         return this.availabilitySets;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/requiredoptional/AutoRestRequiredOptionalTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/requiredoptional/AutoRestRequiredOptionalTestService.java
@@ -134,7 +134,7 @@ public final class AutoRestRequiredOptionalTestService {
      * 
      * @return the Implicits object.
      */
-    public Implicits implicits() {
+    public Implicits getImplicits() {
         return this.implicits;
     }
 
@@ -148,7 +148,7 @@ public final class AutoRestRequiredOptionalTestService {
      * 
      * @return the Explicits object.
      */
-    public Explicits explicits() {
+    public Explicits getExplicits() {
         return this.explicits;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/url/AutoRestUrlTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/url/AutoRestUrlTestService.java
@@ -109,7 +109,7 @@ public final class AutoRestUrlTestService {
      * 
      * @return the Paths object.
      */
-    public Paths paths() {
+    public Paths getPaths() {
         return this.paths;
     }
 
@@ -123,7 +123,7 @@ public final class AutoRestUrlTestService {
      * 
      * @return the Queries object.
      */
-    public Queries queries() {
+    public Queries getQueries() {
         return this.queries;
     }
 
@@ -137,7 +137,7 @@ public final class AutoRestUrlTestService {
      * 
      * @return the PathItems object.
      */
-    public PathItems pathItems() {
+    public PathItems getPathItems() {
         return this.pathItems;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/AutoRestSwaggerBATXMLService.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/AutoRestSwaggerBATXMLService.java
@@ -59,7 +59,7 @@ public final class AutoRestSwaggerBATXMLService {
      * 
      * @return the Xmls object.
      */
-    public Xmls xmls() {
+    public Xmls getXmls() {
         return this.xmls;
     }
 

--- a/vanilla-tests/src/test/java/fixtures/additionalproperties/AdditionalPropertiesTests.java
+++ b/vanilla-tests/src/test/java/fixtures/additionalproperties/AdditionalPropertiesTests.java
@@ -32,7 +32,7 @@ public class AdditionalPropertiesTests {
         petAPObject.setAdditionalProperties(new HashMap<>());
         petAPObject.getAdditionalProperties().put("birthdate", OffsetDateTime.parse("2017-12-13T02:29:51Z"));
         petAPObject.getAdditionalProperties().put("complexProperty", Collections.singletonMap("color", "Red"));
-        PetAPTrue response = client.pets().createAPTrue(petAPObject);
+        PetAPTrue response = client.getPets().createAPTrue(petAPObject);
         Assert.assertEquals(1, response.getId());
         Assert.assertEquals("Puppy", response.getName());
         Assert.assertEquals(2, petAPObject.getAdditionalProperties().size());
@@ -52,7 +52,7 @@ public class AdditionalPropertiesTests {
         petAPObject.setAdditionalProperties(new HashMap<>());
         petAPObject.getAdditionalProperties().put("birthdate", OffsetDateTime.parse("2017-12-13T02:29:51Z"));
         petAPObject.getAdditionalProperties().put("complexProperty", Collections.singletonMap("color", "Red"));
-        CatAPTrue response = client.pets().createCatAPTrue(petAPObject);
+        CatAPTrue response = client.getPets().createCatAPTrue(petAPObject);
         Assert.assertEquals(1, response.getId());
         Assert.assertEquals("Lisa", response.getName());
         Assert.assertTrue(response.isFriendly());
@@ -79,7 +79,7 @@ public class AdditionalPropertiesTests {
         petAPObject.setAdditionalProperties(new HashMap<>());
         petAPObject.getAdditionalProperties().put("siblings", Collections.singletonList(puppy));
         petAPObject.getAdditionalProperties().put("picture", new byte[]{(byte) 255, (byte) 255, (byte) 255, (byte) 255, (byte) 254});
-        PetAPObject response = client.pets().createAPObject(petAPObject);
+        PetAPObject response = client.getPets().createAPObject(petAPObject);
 
         Assert.assertEquals(2, response.getId());
         Assert.assertEquals("Hira", response.getName());
@@ -99,7 +99,7 @@ public class AdditionalPropertiesTests {
         petAPObject.getAdditionalProperties().put("color", "red");
         petAPObject.getAdditionalProperties().put("weight", "10 kg");
         petAPObject.getAdditionalProperties().put("city", "Bombay");
-        PetAPString response = client.pets().createAPString(petAPObject);
+        PetAPString response = client.getPets().createAPString(petAPObject);
         Assert.assertEquals(3, response.getId());
         Assert.assertEquals("Tommy", response.getName());
         Assert.assertEquals(3, petAPObject.getAdditionalProperties().size());
@@ -117,7 +117,7 @@ public class AdditionalPropertiesTests {
         petAPObject.getAdditionalProperties().put("height", 5.61f);
         petAPObject.getAdditionalProperties().put("weight", 599f);
         petAPObject.getAdditionalProperties().put("footsize", 11.5f);
-        PetAPInProperties response = client.pets().createAPInProperties(petAPObject);
+        PetAPInProperties response = client.getPets().createAPInProperties(petAPObject);
         Assert.assertEquals(4, response.getId());
         Assert.assertEquals("Bunny", response.getName());
         Assert.assertEquals(3, petAPObject.getAdditionalProperties().size());
@@ -140,6 +140,6 @@ public class AdditionalPropertiesTests {
         petAPObject.getAdditionalProperties().put("color", "red");
         petAPObject.getAdditionalProperties().put("city", "Seattle");
         petAPObject.getAdditionalProperties().put("food", "tikka masala");
-        client.pets().createAPInPropertiesWithAPString(petAPObject);
+        client.getPets().createAPInPropertiesWithAPString(petAPObject);
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/bodyarray/ArrayTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodyarray/ArrayTests.java
@@ -30,13 +30,13 @@ public class ArrayTests {
 
     @Test
     public void getNull() throws Exception {
-        Assert.assertNull(client.arrays().getNull());
+        Assert.assertNull(client.getArrays().getNull());
     }
 
     @Test
     public void getInvalid() throws Exception {
         try {
-            List<Integer> result = client.arrays().getInvalid();
+            List<Integer> result = client.getArrays().getInvalid();
             Assert.assertTrue(false);
         } catch (RuntimeException exception) {
             // expected
@@ -46,31 +46,31 @@ public class ArrayTests {
 
     @Test
     public void getEmpty() throws Exception {
-        List<Integer> result = client.arrays().getEmpty();
+        List<Integer> result = client.getArrays().getEmpty();
         Assert.assertEquals(0, result.size());
     }
 
     @Test
     public void putEmpty() throws Exception {
-        client.arrays().putEmpty(new ArrayList<String>());
+        client.getArrays().putEmpty(new ArrayList<String>());
     }
 
     @Test
     public void getBooleanTfft() throws Exception {
-        List<Boolean> result = client.arrays().getBooleanTfft();
+        List<Boolean> result = client.getArrays().getBooleanTfft();
         Object[] exected = new Boolean[] {true, false, false, true};
         Assert.assertArrayEquals(exected, result.toArray());
     }
 
     @Test
     public void putBooleanTfft() throws Exception {
-        client.arrays().putBooleanTfft(Arrays.asList(true, false, false, true));
+        client.getArrays().putBooleanTfft(Arrays.asList(true, false, false, true));
     }
 
     @Test
     public void getBooleanInvalidNull() throws Exception {
         try {
-            List<Boolean> result = client.arrays().getBooleanInvalidNull();
+            List<Boolean> result = client.getArrays().getBooleanInvalidNull();
         } catch (ErrorException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("JsonMappingException"));
@@ -80,7 +80,7 @@ public class ArrayTests {
     @Test
     public void getBooleanInvalidString() throws Exception {
         try {
-            List<Boolean> result = client.arrays().getBooleanInvalidString();
+            List<Boolean> result = client.getArrays().getBooleanInvalidString();
         } catch (RuntimeException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("Deserialization Failed"));
@@ -89,20 +89,20 @@ public class ArrayTests {
 
     @Test
     public void getIntegerValid() throws Exception {
-        List<Integer> result = client.arrays().getIntegerValid();
+        List<Integer> result = client.getArrays().getIntegerValid();
         Object[] expected = new Integer[] {1, -1, 3, 300};
         Assert.assertArrayEquals(expected, result.toArray());
     }
 
     @Test
     public void putIntegerValid() throws Exception {
-        client.arrays().putIntegerValid(Arrays.asList(1, -1, 3, 300));
+        client.getArrays().putIntegerValid(Arrays.asList(1, -1, 3, 300));
     }
 
     @Test
     public void getIntInvalidNull() throws Exception {
         try {
-            List<Integer> result = client.arrays().getIntInvalidNull();
+            List<Integer> result = client.getArrays().getIntInvalidNull();
         } catch (ErrorException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("JsonMappingException"));
@@ -112,7 +112,7 @@ public class ArrayTests {
     @Test
     public void getIntInvalidString() throws Exception {
         try {
-            List<Integer> result = client.arrays().getIntInvalidString();
+            List<Integer> result = client.getArrays().getIntInvalidString();
         } catch (RuntimeException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("Deserialization Failed"));
@@ -121,20 +121,20 @@ public class ArrayTests {
 
     @Test
     public void getLongValid() throws Exception {
-        List<Long> result = client.arrays().getLongValid();
+        List<Long> result = client.getArrays().getLongValid();
         Object[] expected = new Long[] {1L, -1L, 3L, 300L};
         Assert.assertArrayEquals(expected, result.toArray());
     }
 
     @Test
     public void putLongValid() throws Exception {
-        client.arrays().putLongValid(Arrays.asList(1L, -1L, 3L, 300L));
+        client.getArrays().putLongValid(Arrays.asList(1L, -1L, 3L, 300L));
     }
 
     @Test
     public void getLongInvalidNull() throws Exception {
         try {
-            List<Long> result = client.arrays().getLongInvalidNull();
+            List<Long> result = client.getArrays().getLongInvalidNull();
         } catch (ErrorException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("JsonMappingException"));
@@ -144,7 +144,7 @@ public class ArrayTests {
     @Test
     public void getLongInvalidString() throws Exception {
         try {
-            List<Long> result = client.arrays().getLongInvalidString();
+            List<Long> result = client.getArrays().getLongInvalidString();
         } catch (RuntimeException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("Deserialization Failed"));
@@ -153,20 +153,20 @@ public class ArrayTests {
 
     @Test
     public void getFloatValid() throws Exception {
-        List<Float> result = client.arrays().getFloatValid();
+        List<Float> result = client.getArrays().getFloatValid();
         Object[] expected = new Float[] {0f, -0.01f, -1.2e20f};
         Assert.assertArrayEquals(expected, result.toArray());
     }
 
     @Test
     public void putFloatValid() throws Exception {
-        client.arrays().putFloatValid(Arrays.asList(0f, -0.01f, -1.2e20f));
+        client.getArrays().putFloatValid(Arrays.asList(0f, -0.01f, -1.2e20f));
     }
 
     @Test
     public void getFloatInvalidNull() throws Exception {
         try {
-            List<Float> result = client.arrays().getFloatInvalidNull();
+            List<Float> result = client.getArrays().getFloatInvalidNull();
         } catch (ErrorException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("JsonMappingException"));
@@ -176,7 +176,7 @@ public class ArrayTests {
     @Test
     public void getFloatInvalidString() throws Exception {
         try {
-            List<Float> result = client.arrays().getFloatInvalidString();
+            List<Float> result = client.getArrays().getFloatInvalidString();
         } catch (RuntimeException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("Deserialization Failed"));
@@ -185,20 +185,20 @@ public class ArrayTests {
 
     @Test
     public void getDoubleValid() throws Exception {
-        List<Double> result = client.arrays().getDoubleValid();
+        List<Double> result = client.getArrays().getDoubleValid();
         Object[] expected = new Double[] {0d, -0.01, -1.2e20};
         Assert.assertArrayEquals(expected, result.toArray());
     }
 
     @Test
     public void putDoubleValid() throws Exception {
-        client.arrays().putDoubleValid(Arrays.asList(0d, -0.01d, -1.2e20d));
+        client.getArrays().putDoubleValid(Arrays.asList(0d, -0.01d, -1.2e20d));
     }
 
     @Test
     public void getDoubleInvalidNull() throws Exception {
         try {
-            List<Double> result = client.arrays().getDoubleInvalidNull();
+            List<Double> result = client.getArrays().getDoubleInvalidNull();
         } catch (ErrorException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("JsonMappingException"));
@@ -208,7 +208,7 @@ public class ArrayTests {
     @Test
     public void getDoubleInvalidString() throws Exception {
         try {
-            List<Double> result = client.arrays().getDoubleInvalidString();
+            List<Double> result = client.getArrays().getDoubleInvalidString();
         } catch (RuntimeException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("Deserialization Failed"));
@@ -217,44 +217,44 @@ public class ArrayTests {
 
     @Test
     public void getStringValid() throws Exception {
-        List<String> result = client.arrays().getStringValid();
+        List<String> result = client.getArrays().getStringValid();
         Object[] expected = new String[] {"foo1", "foo2", "foo3"};
         Assert.assertArrayEquals(expected, result.toArray());
     }
 
     @Test
     public void putStringValid() throws Exception {
-        client.arrays().putStringValid(Arrays.asList("foo1", "foo2", "foo3"));
+        client.getArrays().putStringValid(Arrays.asList("foo1", "foo2", "foo3"));
     }
 
     @Test
     public void getEnumValid() throws Exception {
-        List<FooEnum> result = client.arrays().getEnumValid();
+        List<FooEnum> result = client.getArrays().getEnumValid();
         Object[] expected = new FooEnum[] {FooEnum.FOO1, FooEnum.FOO2, FooEnum.FOO3};
         Assert.assertArrayEquals(expected, result.toArray());
     }
 
     @Test
     public void putEnumValid() throws Exception {
-        client.arrays().putEnumValid(Arrays.asList(FooEnum.FOO1, FooEnum.FOO2, FooEnum.FOO3));
+        client.getArrays().putEnumValid(Arrays.asList(FooEnum.FOO1, FooEnum.FOO2, FooEnum.FOO3));
     }
 
     @Test
     public void getStringEnumValid() throws Exception {
-        List<Enum0> result = client.arrays().getStringEnumValid();
+        List<Enum0> result = client.getArrays().getStringEnumValid();
         Object[] expected = new Enum0[] {Enum0.FOO1, Enum0.FOO2, Enum0.FOO3};
         Assert.assertArrayEquals(expected, result.toArray());
     }
 
     @Test
     public void putStringEnumValid() throws Exception {
-        client.arrays().putStringEnumValid(Arrays.asList(Enum1.FOO1, Enum1.FOO2, Enum1.FOO3));
+        client.getArrays().putStringEnumValid(Arrays.asList(Enum1.FOO1, Enum1.FOO2, Enum1.FOO3));
     }
 
     @Test
     public void getStringWithNull() throws Exception {
         try {
-            List<String> result = client.arrays().getStringWithNull();
+            List<String> result = client.getArrays().getStringWithNull();
         } catch (ErrorException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("JsonMappingException"));
@@ -264,7 +264,7 @@ public class ArrayTests {
     @Test
     public void getStringWithInvalid() throws Exception {
         try {
-            List<String> result = client.arrays().getStringWithInvalid();
+            List<String> result = client.getArrays().getStringWithInvalid();
         } catch (ErrorException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("InvalidFormatException"));
@@ -273,7 +273,7 @@ public class ArrayTests {
 
     @Test
     public void getUuidValid() throws Exception {
-        List<UUID> result = client.arrays().getUuidValid();
+        List<UUID> result = client.getArrays().getUuidValid();
         Object[] expected = new UUID[] {UUID.fromString("6dcc7237-45fe-45c4-8a6b-3a8a3f625652"),
                 UUID.fromString("d1399005-30f7-40d6-8da6-dd7c89ad34db"),
                 UUID.fromString("f42f6aa1-a5bc-4ddf-907e-5f915de43205")};
@@ -282,14 +282,14 @@ public class ArrayTests {
 
     @Test
     public void putUuidValid() throws Exception {
-        client.arrays().putUuidValid(Arrays.asList(UUID.fromString("6dcc7237-45fe-45c4-8a6b-3a8a3f625652"),
+        client.getArrays().putUuidValid(Arrays.asList(UUID.fromString("6dcc7237-45fe-45c4-8a6b-3a8a3f625652"),
                 UUID.fromString("d1399005-30f7-40d6-8da6-dd7c89ad34db"), UUID.fromString("f42f6aa1-a5bc-4ddf-907e-5f915de43205")));
     }
 
     @Test
     public void getUuidInvalidChars() throws Exception {
         try {
-            List<UUID> result = client.arrays().getUuidInvalidChars();
+            List<UUID> result = client.getArrays().getUuidInvalidChars();
             Assert.fail();
         } catch (RuntimeException ex) {
             // expected
@@ -298,7 +298,7 @@ public class ArrayTests {
     }
     @Test
     public void getDateValid() throws Exception {
-        List<LocalDate> result = client.arrays().getDateValid();
+        List<LocalDate> result = client.getArrays().getDateValid();
         Object[] expected = new LocalDate[] {
                 LocalDate.of(2000, 12, 1),
                 LocalDate.of(1980, 1, 2),
@@ -309,7 +309,7 @@ public class ArrayTests {
 
     @Test
     public void putDateValid() throws Exception {
-        client.arrays().putDateValid(Arrays.asList(
+        client.getArrays().putDateValid(Arrays.asList(
                 LocalDate.of(2000, 12, 1),
                 LocalDate.of(1980, 1, 2),
                 LocalDate.of(1492, 10, 12)
@@ -319,7 +319,7 @@ public class ArrayTests {
     @Test
     public void getDateInvalidNull() throws Exception {
         try {
-            List<LocalDate> result = client.arrays().getDateInvalidNull();
+            List<LocalDate> result = client.getArrays().getDateInvalidNull();
         } catch (ErrorException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("JsonMappingException"));
@@ -329,7 +329,7 @@ public class ArrayTests {
     @Test
     public void getDateInvalidString() throws Exception {
         try {
-            List<LocalDate> result = client.arrays().getDateInvalidChars();
+            List<LocalDate> result = client.getArrays().getDateInvalidChars();
         } catch (RuntimeException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("Deserialization Failed"));
@@ -338,7 +338,7 @@ public class ArrayTests {
 
     @Test
     public void getDateTimeValid() throws Exception {
-        List<OffsetDateTime> result = client.arrays().getDateTimeValid();
+        List<OffsetDateTime> result = client.getArrays().getDateTimeValid();
         Object[] expected = new OffsetDateTime[] {
                 OffsetDateTime.of(2000, 12, 1, 0, 0, 1, 0, ZoneOffset.UTC),
                 OffsetDateTime.of(1980, 1, 2, 0, 11, 35, 0, ZoneOffset.UTC),
@@ -349,7 +349,7 @@ public class ArrayTests {
 
     @Test
     public void putDateTimeValid() throws Exception {
-        client.arrays().putDateTimeValid(Arrays.asList(
+        client.getArrays().putDateTimeValid(Arrays.asList(
                 OffsetDateTime.of(2000, 12, 1, 0, 0, 1, 0, ZoneOffset.UTC),
                 OffsetDateTime.of(1980, 1, 2, 0, 11, 35, 0, ZoneOffset.UTC),
                 OffsetDateTime.of(1492, 10, 12, 10, 15, 1, 0, ZoneOffset.UTC)
@@ -359,7 +359,7 @@ public class ArrayTests {
     @Test
     public void getDateTimeInvalidNull() throws Exception {
         try {
-            List<OffsetDateTime> result = client.arrays().getDateTimeInvalidNull();
+            List<OffsetDateTime> result = client.getArrays().getDateTimeInvalidNull();
         } catch (ErrorException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("JsonMappingException"));
@@ -369,7 +369,7 @@ public class ArrayTests {
     @Test
     public void getDateTimeInvalidString() throws Exception {
         try {
-            List<OffsetDateTime> result = client.arrays().getDateTimeInvalidChars();
+            List<OffsetDateTime> result = client.getArrays().getDateTimeInvalidChars();
         } catch (RuntimeException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("Deserialization Failed"));
@@ -378,7 +378,7 @@ public class ArrayTests {
 
     @Test
     public void getDateTimeRfc1123Valid() throws Exception {
-        List<OffsetDateTime> result = client.arrays().getDateTimeRfc1123Valid();
+        List<OffsetDateTime> result = client.getArrays().getDateTimeRfc1123Valid();
         Object[] expected = new OffsetDateTime[] {
                 OffsetDateTime.of(2000, 12, 1, 0, 0, 1, 0, ZoneOffset.UTC),
                 OffsetDateTime.of(1980, 1, 2, 0, 11, 35, 0, ZoneOffset.UTC),
@@ -389,7 +389,7 @@ public class ArrayTests {
 
     @Test
     public void putDateTimeRfc1123Valid() throws Exception {
-        client.arrays().putDateTimeRfc1123Valid(Arrays.asList(
+        client.getArrays().putDateTimeRfc1123Valid(Arrays.asList(
                 OffsetDateTime.of(2000, 12, 1, 0, 0, 1, 0, ZoneOffset.UTC),
                 OffsetDateTime.of(1980, 1, 2, 0, 11, 35, 0, ZoneOffset.UTC),
                 OffsetDateTime.of(1492, 10, 12, 10, 15, 1, 0, ZoneOffset.UTC)
@@ -398,7 +398,7 @@ public class ArrayTests {
 
     @Test
     public void getDurationValid() throws Exception {
-        List<Duration> result = client.arrays().getDurationValid();
+        List<Duration> result = client.getArrays().getDurationValid();
         Duration[] expected = new Duration[] {
                 Duration.ofDays(123).plusHours(22).plusMinutes(14).plusSeconds(12).plusMillis(11),
                 Duration.ofDays(5).plusHours(1)
@@ -408,14 +408,14 @@ public class ArrayTests {
 
     @Test
     public void putDurationValid() throws Exception {
-        client.arrays().putDurationValid(Arrays.asList(
+        client.getArrays().putDurationValid(Arrays.asList(
                 Duration.ofDays(123).plusHours(22).plusMinutes(14).plusSeconds(12).plusMillis(11),
                 Duration.ofDays(5).plusHours(1)));
     }
 
     @Test
     public void getByteValid() throws Exception {
-        List<byte[]> result = client.arrays().getByteValid();
+        List<byte[]> result = client.getArrays().getByteValid();
         Object[] expected = new byte[][] {
                 new byte[] {(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFA},
                 new byte[] {(byte) 0x01, (byte) 0x02, (byte) 0x03},
@@ -426,7 +426,7 @@ public class ArrayTests {
 
     @Test
     public void putByteValid() throws Exception {
-        client.arrays().putByteValid(Arrays.asList(
+        client.getArrays().putByteValid(Arrays.asList(
                 new byte[] {(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFA},
                 new byte[] {(byte) 0x01, (byte) 0x02, (byte) 0x03},
                 new byte[] {(byte) 0x25, (byte) 0x29, (byte) 0x43}
@@ -436,7 +436,7 @@ public class ArrayTests {
     @Test
     public void getByteInvalidNull() throws Exception {
         try {
-            List<byte[]> result = client.arrays().getByteInvalidNull();
+            List<byte[]> result = client.getArrays().getByteInvalidNull();
         } catch (ErrorException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("JsonMappingException"));
@@ -445,7 +445,7 @@ public class ArrayTests {
 
     @Test
     public void getBase64Url() throws Exception {
-        List<byte[]> result = client.arrays().getBase64Url();
+        List<byte[]> result = client.getArrays().getBase64Url();
         Assert.assertEquals(3, result.size());
         Assert.assertEquals("a string that gets encoded with base64url", new String(result.get(0)));
         Assert.assertEquals("test string", new String(result.get(1)));
@@ -455,7 +455,7 @@ public class ArrayTests {
     @Test
     public void getComplexNull() throws Exception {
         try {
-            List<Product> result = client.arrays().getComplexNull();
+            List<Product> result = client.getArrays().getComplexNull();
         } catch (ErrorException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("JsonMappingException"));
@@ -464,27 +464,27 @@ public class ArrayTests {
 
     @Test
     public void getComplexEmpty() throws Exception {
-        List<Product> result = client.arrays().getComplexEmpty();
+        List<Product> result = client.getArrays().getComplexEmpty();
         Assert.assertEquals(0, result.size());
     }
 
     @Test
     public void getComplexItemNull() throws Exception {
-        List<Product> result = client.arrays().getComplexItemNull();
+        List<Product> result = client.getArrays().getComplexItemNull();
         Assert.assertEquals(3, result.size());
         Assert.assertNull(result.get(1));
     }
 
     @Test
     public void getComplexItemEmpty() throws Exception {
-        List<Product> result = client.arrays().getComplexItemEmpty();
+        List<Product> result = client.getArrays().getComplexItemEmpty();
         Assert.assertEquals(3, result.size());
         Assert.assertNull(result.get(1).getString());
     }
 
     @Test
     public void getComplexValid() throws Exception {
-        List<Product> result = client.arrays().getComplexValid();
+        List<Product> result = client.getArrays().getComplexValid();
         Assert.assertEquals(3, result.size());
         Assert.assertEquals(5, result.get(2).getInteger().intValue());
         Assert.assertEquals("6", result.get(2).getString());
@@ -505,13 +505,13 @@ public class ArrayTests {
         p3.setInteger(5);
         p3.setString("6");
         body.add(p3);
-        client.arrays().putComplexValid(body);
+        client.getArrays().putComplexValid(body);
     }
 
     @Test
     public void getArrayNull() throws Exception {
         try {
-            List<List<String>> result = client.arrays().getArrayNull();
+            List<List<String>> result = client.getArrays().getArrayNull();
         } catch (ErrorException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("JsonMappingException"));
@@ -520,27 +520,27 @@ public class ArrayTests {
 
     @Test
     public void getArrayEmpty() throws Exception {
-        List<List<String>> result = client.arrays().getArrayEmpty();
+        List<List<String>> result = client.getArrays().getArrayEmpty();
         Assert.assertEquals(0, result.size());
     }
 
     @Test
     public void getArrayItemNull() throws Exception {
-        List<List<String>> result = client.arrays().getArrayItemNull();
+        List<List<String>> result = client.getArrays().getArrayItemNull();
         Assert.assertEquals(3, result.size());
         Assert.assertNull(result.get(1));
     }
 
     @Test
     public void getArrayItemEmpty() throws Exception {
-        List<List<String>> result = client.arrays().getArrayItemEmpty();
+        List<List<String>> result = client.getArrays().getArrayItemEmpty();
         Assert.assertEquals(3, result.size());
         Assert.assertEquals(0, result.get(1).size());
     }
 
     @Test
     public void getArrayValid() throws Exception {
-        List<List<String>> result = client.arrays().getArrayValid();
+        List<List<String>> result = client.getArrays().getArrayValid();
         Assert.assertArrayEquals(new String[]{"1", "2", "3"}, result.get(0).toArray());
         Assert.assertArrayEquals(new String[]{"4", "5", "6"}, result.get(1).toArray());
         Assert.assertArrayEquals(new String[] {"7", "8", "9"}, result.get(2).toArray());
@@ -552,13 +552,13 @@ public class ArrayTests {
         body.add(Arrays.asList("1", "2", "3"));
         body.add(Arrays.asList("4", "5", "6"));
         body.add(Arrays.asList("7", "8", "9"));
-        client.arrays().putArrayValid(body);
+        client.getArrays().putArrayValid(body);
     }
 
     @Test
     public void getDictionaryNull() throws Exception {
         try {
-            List<Map<String, String>> result = client.arrays().getDictionaryNull();
+            List<Map<String, String>> result = client.getArrays().getDictionaryNull();
         } catch (ErrorException ex) {
             // expected
             Assert.assertTrue(ex.getMessage().contains("JsonMappingException"));
@@ -567,27 +567,27 @@ public class ArrayTests {
 
     @Test
     public void getDictionaryEmpty() throws Exception {
-        List<Map<String, String>> result = client.arrays().getDictionaryEmpty();
+        List<Map<String, String>> result = client.getArrays().getDictionaryEmpty();
         Assert.assertEquals(0, result.size());
     }
 
     @Test
     public void getDictionaryItemNull() throws Exception {
-        List<Map<String, String>> result = client.arrays().getDictionaryItemNull();
+        List<Map<String, String>> result = client.getArrays().getDictionaryItemNull();
         Assert.assertEquals(3, result.size());
         Assert.assertNull(result.get(1));
     }
 
     @Test
     public void getDictionaryItemEmpty() throws Exception {
-        List<Map<String, String>> result = client.arrays().getDictionaryItemEmpty();
+        List<Map<String, String>> result = client.getArrays().getDictionaryItemEmpty();
         Assert.assertEquals(3, result.size());
         Assert.assertEquals(0, result.get(1).size());
     }
 
     @Test
     public void getDictionaryValid() throws Exception {
-        List<Map<String, String>> result = client.arrays().getDictionaryValid();
+        List<Map<String, String>> result = client.getArrays().getDictionaryValid();
         Assert.assertEquals("seven", result.get(2).get("7"));
         Assert.assertEquals("five", result.get(1).get("5"));
         Assert.assertEquals("three", result.get(0).get("3"));
@@ -611,6 +611,6 @@ public class ArrayTests {
         m3.put("8", "eight");
         m3.put("9", "nine");
         body.add(m3);
-        client.arrays().putDictionaryValid(body);
+        client.getArrays().putDictionaryValid(body);
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/bodyboolean/BoolTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodyboolean/BoolTests.java
@@ -18,7 +18,7 @@ public class BoolTests {
     @Test
     public void getNull() throws Exception {
         try {
-            boolean b = client.bools().getNull();
+            boolean b = client.getBools().getNull();
             fail();
         } catch (NullPointerException e) {
             // expected
@@ -28,7 +28,7 @@ public class BoolTests {
     @Test
     public void getInvalid() throws Exception {
         try {
-            client.bools().getInvalid();
+            client.getBools().getInvalid();
             Assert.assertTrue(false);
         } catch (Exception exception) {
             // expected
@@ -38,23 +38,23 @@ public class BoolTests {
 
     @Test
     public void getTrue() throws Exception {
-        boolean result = client.bools().getTrue();
+        boolean result = client.getBools().getTrue();
         Assert.assertTrue(result);
     }
 
     @Test
     public void getFalse() throws Exception {
-        boolean result = client.bools().getFalse();
+        boolean result = client.getBools().getFalse();
         Assert.assertFalse(result);
     }
 
     @Test
     public void putTrue() throws Exception {
-        client.bools().putTrueWithResponseAsync().block();
+        client.getBools().putTrueWithResponseAsync().block();
     }
 
     @Test
     public void putFalse() throws Exception {
-        client.bools().putFalseWithResponseAsync().block();
+        client.getBools().putFalseWithResponseAsync().block();
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/bodybyte/ByteOperationsTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodybyte/ByteOperationsTests.java
@@ -17,19 +17,19 @@ public class ByteOperationsTests {
 
     @Test
     public void getNull() throws Exception {
-        byte[] result = client.bytes().getNull();
+        byte[] result = client.getBytes().getNull();
         Assert.assertEquals(0, result.length);
     }
 
     @Test
     public void getEmpty() throws Exception {
-        byte[] result = client.bytes().getEmpty();
+        byte[] result = client.getBytes().getEmpty();
         Assert.assertArrayEquals("\"\"".getBytes(StandardCharsets.UTF_8), result);
     }
 
     @Test
     public void getNonAscii() throws Exception {
-        byte[] result = client.bytes().getNonAscii();
+        byte[] result = client.getBytes().getNonAscii();
         // Previously, byte[] response bodies were automatically base64 decoded by the runtime.
         // This conflicts with the octet-stream  (e.g. file/media download) use case,
         // so we're now passing the byte[] through as-is.
@@ -44,13 +44,13 @@ public class ByteOperationsTests {
                 (byte) 250, (byte) 249, (byte) 248, (byte) 247, (byte) 246
         };
 
-        client.bytes().putNonAscii(body);
+        client.getBytes().putNonAscii(body);
     }
 
     @Test
     public void getInvalid() throws Exception {
         try {
-            byte[] result = client.bytes().getInvalid();
+            byte[] result = client.getBytes().getInvalid();
             Assert.assertArrayEquals("\"::::SWAGGER::::\"".getBytes(StandardCharsets.UTF_8), result);
         } catch (ErrorException e) {
             e.printStackTrace();

--- a/vanilla-tests/src/test/java/fixtures/bodycomplex/ArrayTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodycomplex/ArrayTests.java
@@ -18,7 +18,7 @@ public class ArrayTests {
 
     @Test
     public void getValid() throws Exception {
-        ArrayWrapper result = client.arrays().getValid();
+        ArrayWrapper result = client.getArrays().getValid();
         Assert.assertEquals(5, result.getArray().size());
         Assert.assertEquals("&S#$(*Y", result.getArray().get(3));
     }
@@ -27,12 +27,12 @@ public class ArrayTests {
     public void putValid() throws Exception {
         ArrayWrapper body = new ArrayWrapper();
         body.setArray(Arrays.asList("1, 2, 3, 4", "", null, "&S#$(*Y", "The quick brown fox jumps over the lazy dog"));
-        client.arrays().putValidWithResponseAsync(body).block();
+        client.getArrays().putValidWithResponseAsync(body).block();
     }
 
     @Test
     public void getEmpty() throws Exception {
-        ArrayWrapper result = client.arrays().getEmpty();
+        ArrayWrapper result = client.getArrays().getEmpty();
         Assert.assertEquals(0, result.getArray().size());
     }
 
@@ -40,12 +40,12 @@ public class ArrayTests {
     public void putEmpty() throws Exception {
         ArrayWrapper body = new ArrayWrapper();
         body.setArray(new ArrayList<>());
-        client.arrays().putEmptyWithResponseAsync(body).block();
+        client.getArrays().putEmptyWithResponseAsync(body).block();
     }
 
     @Test
     public void getNotProvided() throws Exception {
-        ArrayWrapper result = client.arrays().getNotProvided();
+        ArrayWrapper result = client.getArrays().getNotProvided();
         Assert.assertNull(result.getArray());
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/bodycomplex/BasicOperationsTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodycomplex/BasicOperationsTests.java
@@ -17,7 +17,7 @@ public class BasicOperationsTests {
 
     @Test
     public void getValid() throws Exception {
-        Basic result = client.basics().getValid();
+        Basic result = client.getBasics().getValid();
         Assert.assertEquals(2, result.getId().intValue());
         Assert.assertEquals("abc", result.getName());
         Assert.assertEquals(CMYKColors.YELLOW, result.getColor());
@@ -29,13 +29,13 @@ public class BasicOperationsTests {
         body.setId(2);
         body.setName("abc");
         body.setColor(CMYKColors.MAGENTA);
-        client.basics().putValidWithResponseAsync(body).block();
+        client.getBasics().putValidWithResponseAsync(body).block();
     }
 
     @Test
     public void getInvalid() throws Exception {
         try {
-            client.basics().getInvalid();
+            client.getBasics().getInvalid();
             Assert.assertTrue(false);
         } catch (Exception exception) {
             // expected
@@ -45,18 +45,18 @@ public class BasicOperationsTests {
 
     @Test
     public void getEmpty() throws Exception {
-        Basic result = client.basics().getEmpty();
+        Basic result = client.getBasics().getEmpty();
         Assert.assertNull(result.getName());
     }
 
     @Test
     public void getNull() throws Exception {
-        Basic result = client.basics().getNull();
+        Basic result = client.getBasics().getNull();
         Assert.assertNull(result.getName());
     }
 
     @Test
     public void getNotProvided() throws Exception {
-        Assert.assertNull(client.basics().getNotProvided());
+        Assert.assertNull(client.getBasics().getNotProvided());
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/bodycomplex/DictionaryTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodycomplex/DictionaryTests.java
@@ -19,7 +19,7 @@ public class DictionaryTests {
 
     @Test
     public void getValid() throws Exception {
-        DictionaryWrapper result = client.dictionarys().getValid();
+        DictionaryWrapper result = client.getDictionarys().getValid();
         Assert.assertEquals(5, result.getDefaultProgram().size());
         Assert.assertEquals("", result.getDefaultProgram().get("exe"));
         Assert.assertNull(result.getDefaultProgram().get(""));
@@ -35,12 +35,12 @@ public class DictionaryTests {
         programs.put("exe", "");
         programs.put("", null);
         body.setDefaultProgram(programs);
-        client.dictionarys().putValidWithResponseAsync(body).block();
+        client.getDictionarys().putValidWithResponseAsync(body).block();
     }
 
     @Test
     public void getEmpty() throws Exception {
-        DictionaryWrapper result = client.dictionarys().getEmpty();
+        DictionaryWrapper result = client.getDictionarys().getEmpty();
         Assert.assertEquals(0, result.getDefaultProgram().size());
     }
 
@@ -48,18 +48,18 @@ public class DictionaryTests {
     public void putEmpty() throws Exception {
         DictionaryWrapper body = new DictionaryWrapper();
         body.setDefaultProgram(new HashMap<String, String>());
-        client.dictionarys().putEmptyWithResponseAsync(body).block();
+        client.getDictionarys().putEmptyWithResponseAsync(body).block();
     }
 
     @Test
     public void getNull() throws Exception {
-        DictionaryWrapper result = client.dictionarys().getNull();
+        DictionaryWrapper result = client.getDictionarys().getNull();
         Assert.assertNull(result.getDefaultProgram());
     }
 
     @Test
     public void getNotProvided() throws Exception {
-        DictionaryWrapper result = client.dictionarys().getNotProvided();
+        DictionaryWrapper result = client.getDictionarys().getNotProvided();
         Assert.assertNull(result.getDefaultProgram());
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/bodycomplex/InheritanceTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodycomplex/InheritanceTests.java
@@ -18,7 +18,7 @@ public class InheritanceTests {
 
     @Test
     public void getValid() throws Exception {
-        Siamese result = client.inheritances().getValid();
+        Siamese result = client.getInheritances().getValid();
         Assert.assertEquals("persian", result.getBreed());
         Assert.assertEquals("green", result.getColor());
         Assert.assertEquals(2, result.getId().intValue());
@@ -44,6 +44,6 @@ public class InheritanceTests {
         dog2.setId(-1);
         dog2.setName("Tomato");
         body.getHates().add(dog2);
-        client.inheritances().putValidWithResponseAsync(body).block();
+        client.getInheritances().putValidWithResponseAsync(body).block();
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/bodycomplex/PolymorphismTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodycomplex/PolymorphismTests.java
@@ -29,7 +29,7 @@ public class PolymorphismTests {
 
     @Test
     public void getValid() {
-        Fish result = client.polymorphisms().getValid();
+        Fish result = client.getPolymorphisms().getValid();
         Assert.assertEquals(Salmon.class, result.getClass());
         Salmon salmon = (Salmon) result;
         Assert.assertEquals("alaska", salmon.getLocation());
@@ -81,7 +81,7 @@ public class PolymorphismTests {
         sib3.setColor(GoblinSharkColor.fromString("pinkish-gray"));
         body.getSiblings().add(sib3);
 
-        client.polymorphisms().putValidWithResponseAsync(body).block();
+        client.getPolymorphisms().putValidWithResponseAsync(body).block();
     }
 
     @Test
@@ -108,7 +108,7 @@ public class PolymorphismTests {
             sib2.setSpecies("dangerous");
             body.getSiblings().add(sib2);
 
-            client.polymorphisms().putValidMissingRequiredWithResponseAsync(body).block();
+            client.getPolymorphisms().putValidMissingRequiredWithResponseAsync(body).block();
         } catch (IllegalArgumentException ex) {
             //expected
             Assert.assertTrue(ex.getMessage().contains("Missing required property birthday in model Shark"));
@@ -118,7 +118,7 @@ public class PolymorphismTests {
 
     @Test
     public void getComplicated() {
-        Salmon result = client.polymorphisms().getComplicated();
+        Salmon result = client.getPolymorphisms().getComplicated();
         Assert.assertEquals(SmartSalmon.class, result.getClass());
         SmartSalmon salmon = (SmartSalmon) result;
         Assert.assertEquals("alaska", salmon.getLocation());
@@ -195,6 +195,6 @@ public class PolymorphismTests {
         sib3.setColor(GoblinSharkColor.fromString("pinkish-gray"));
         body.getSiblings().add(sib3);
 
-        client.polymorphisms().putComplicated(body);
+        client.getPolymorphisms().putComplicated(body);
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/bodycomplex/PolymorphismrecursiveTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodycomplex/PolymorphismrecursiveTests.java
@@ -22,7 +22,7 @@ public class PolymorphismrecursiveTests {
 
     @Test
     public void getValid() throws Exception {
-        Fish result = client.polymorphicrecursives().getValid();
+        Fish result = client.getPolymorphicrecursives().getValid();
         Salmon salmon = (Salmon) result;
         Shark sib1 = (Shark) (salmon.getSiblings().get(0));
         Salmon sib2 = (Salmon) (sib1.getSiblings().get(0));
@@ -82,6 +82,6 @@ public class PolymorphismrecursiveTests {
         sib112.setSpecies("dangerous");
         sib11.getSiblings().add(sib112);
 
-        client.polymorphicrecursives().putValidWithResponseAsync(body).block();
+        client.getPolymorphicrecursives().putValidWithResponseAsync(body).block();
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/bodycomplex/PrimitiveTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodycomplex/PrimitiveTests.java
@@ -30,7 +30,7 @@ public class PrimitiveTests {
 
     @Test
     public void getInt() throws Exception {
-        IntWrapper result = client.primitives().getInt();
+        IntWrapper result = client.getPrimitives().getInt();
         Assert.assertEquals(-1, result.getField1().intValue());
         Assert.assertEquals(2, result.getField2().intValue());
     }
@@ -40,12 +40,12 @@ public class PrimitiveTests {
         IntWrapper body = new IntWrapper();
         body.setField1(-1);
         body.setField2(2);
-        client.primitives().putIntWithResponseAsync(body).block();
+        client.getPrimitives().putIntWithResponseAsync(body).block();
     }
 
     @Test
     public void getLong() throws Exception {
-        LongWrapper result = client.primitives().getLong();
+        LongWrapper result = client.getPrimitives().getLong();
         Assert.assertEquals(1099511627775L, result.getField1().longValue());
         Assert.assertEquals(-999511627788L, result.getField2().longValue());
     }
@@ -55,12 +55,12 @@ public class PrimitiveTests {
         LongWrapper body = new LongWrapper();
         body.setField1(1099511627775L);
         body.setField2(-999511627788L);
-        client.primitives().putLongWithResponseAsync(body).block();
+        client.getPrimitives().putLongWithResponseAsync(body).block();
     }
 
     @Test
     public void getFloat() throws Exception {
-        FloatWrapper result = client.primitives().getFloat();
+        FloatWrapper result = client.getPrimitives().getFloat();
         Assert.assertEquals(1.05f, result.getField1(), 0f);
         Assert.assertEquals(-0.003f, result.getField2(), 0f);
     }
@@ -70,12 +70,12 @@ public class PrimitiveTests {
         FloatWrapper body = new FloatWrapper();
         body.setField1(1.05f);
         body.setField2(-0.003f);
-        client.primitives().putFloatWithResponseAsync(body).block();
+        client.getPrimitives().putFloatWithResponseAsync(body).block();
     }
 
     @Test
     public void getDouble() throws Exception {
-        DoubleWrapper result = client.primitives().getDouble();
+        DoubleWrapper result = client.getPrimitives().getDouble();
         Assert.assertEquals(3e-100, result.getField1(), 0f);
         Assert.assertEquals(-0.000000000000000000000000000000000000000000000000000000005,
                 result.getField56ZerosAfterTheDotAndNegativeZeroBeforeDotAndThisIsALongFieldNameOnPurpose(),
@@ -87,12 +87,12 @@ public class PrimitiveTests {
         DoubleWrapper body = new DoubleWrapper();
         body.setField1(3e-100);
         body.setField56ZerosAfterTheDotAndNegativeZeroBeforeDotAndThisIsALongFieldNameOnPurpose(-5e-57);
-        client.primitives().putDoubleWithResponseAsync(body).block();
+        client.getPrimitives().putDoubleWithResponseAsync(body).block();
     }
 
     @Test
     public void getBool() throws Exception {
-        BooleanWrapper result = client.primitives().getBool();
+        BooleanWrapper result = client.getPrimitives().getBool();
         Assert.assertEquals(true, result.isFieldTrue());
         Assert.assertEquals(false, result.isFieldFalse());
     }
@@ -102,12 +102,12 @@ public class PrimitiveTests {
         BooleanWrapper body = new BooleanWrapper();
         body.setFieldFalse(false);
         body.setFieldTrue(true);
-        client.primitives().putBoolWithResponseAsync(body).block();
+        client.getPrimitives().putBoolWithResponseAsync(body).block();
     }
 
     @Test
     public void getString() throws Exception {
-        StringWrapper result = client.primitives().getString();
+        StringWrapper result = client.getPrimitives().getString();
         Assert.assertEquals("goodrequest", result.getField());
         Assert.assertEquals("", result.getEmpty());
         Assert.assertEquals(null, result.getNullProperty());
@@ -118,12 +118,12 @@ public class PrimitiveTests {
         StringWrapper body = new StringWrapper();
         body.setField("goodrequest");
         body.setEmpty("");
-        client.primitives().putStringWithResponseAsync(body).block();
+        client.getPrimitives().putStringWithResponseAsync(body).block();
     }
 
     @Test
     public void getDate() throws Exception {
-        DateWrapper result = client.primitives().getDate();
+        DateWrapper result = client.getPrimitives().getDate();
         Assert.assertEquals(LocalDate.of(1, 1, 1), result.getField());
         Assert.assertEquals(LocalDate.of(2016, 2, 29), result.getLeap());
     }
@@ -133,12 +133,12 @@ public class PrimitiveTests {
         DateWrapper body = new DateWrapper();
         body.setField(LocalDate.of(1, 1, 1));
         body.setLeap(LocalDate.of(2016, 2, 29));
-        client.primitives().putDateWithResponseAsync(body).block();
+        client.getPrimitives().putDateWithResponseAsync(body).block();
     }
 
     @Test
     public void getDateTime() throws Exception {
-        DatetimeWrapper result = client.primitives().getDateTime();
+        DatetimeWrapper result = client.getPrimitives().getDateTime();
         Assert.assertEquals(OffsetDateTime.of(1, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC), result.getField());
         Assert.assertEquals(OffsetDateTime.of(2015, 5, 18, 18, 38, 0, 0, ZoneOffset.UTC), result.getNow());
     }
@@ -148,12 +148,12 @@ public class PrimitiveTests {
         DatetimeWrapper body = new DatetimeWrapper();
         body.setField(OffsetDateTime.of(1, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC));
         body.setNow(OffsetDateTime.of(2015, 5, 18, 18, 38, 0, 0, ZoneOffset.UTC));
-        client.primitives().putDateTimeWithResponseAsync(body).block();
+        client.getPrimitives().putDateTimeWithResponseAsync(body).block();
     }
 
     @Test
     public void getDateTimeRfc1123() throws Exception {
-        Datetimerfc1123Wrapper result = client.primitives().getDateTimeRfc1123();
+        Datetimerfc1123Wrapper result = client.getPrimitives().getDateTimeRfc1123();
         Assert.assertEquals(OffsetDateTime.of(1, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC), result.getField());
         Assert.assertEquals(OffsetDateTime.of(2015, 5, 18, 11, 38, 0, 0, ZoneOffset.UTC), result.getNow());
     }
@@ -163,12 +163,12 @@ public class PrimitiveTests {
         Datetimerfc1123Wrapper body = new Datetimerfc1123Wrapper();
         body.setField(OffsetDateTime.of(1, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC));
         body.setNow(OffsetDateTime.of(2015, 5, 18, 11, 38, 0, 0, ZoneOffset.UTC));
-        client.primitives().putDateTimeRfc1123WithResponseAsync(body).block();
+        client.getPrimitives().putDateTimeRfc1123WithResponseAsync(body).block();
     }
 
     @Test
     public void getDuration() throws Exception {
-        DurationWrapper result = client.primitives().getDuration();
+        DurationWrapper result = client.getPrimitives().getDuration();
         Assert.assertEquals(Duration.ofDays(123).plusHours(22).plusMinutes(14).plusSeconds(12).plusMillis(11), result.getField());
     }
 
@@ -176,12 +176,12 @@ public class PrimitiveTests {
     public void putDuration() throws Exception {
         DurationWrapper body = new DurationWrapper();
         body.setField(Duration.ofDays(123).plusHours(22).plusMinutes(14).plusSeconds(12).plusMillis(11));
-        client.primitives().putDurationWithResponseAsync(body).block();
+        client.getPrimitives().putDurationWithResponseAsync(body).block();
     }
 
     @Test
     public void getByte() throws Exception {
-        ByteWrapper result = client.primitives().getByte();
+        ByteWrapper result = client.getPrimitives().getByte();
         byte[] expected = new byte[] {
                 (byte) 255, (byte) 254, (byte) 253, (byte) 252, (byte) 0,
                 (byte) 250, (byte) 249, (byte) 248, (byte) 247, (byte) 246
@@ -197,6 +197,6 @@ public class PrimitiveTests {
                 (byte) 250, (byte) 249, (byte) 248, (byte) 247, (byte) 246
         };
         body.setField(byteArray);
-        client.primitives().putByteWithResponseAsync(body).block();
+        client.getPrimitives().putByteWithResponseAsync(body).block();
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/bodycomplex/ReadonlypropertyTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodycomplex/ReadonlypropertyTests.java
@@ -14,7 +14,7 @@ public class ReadonlypropertyTests {
 
     @Test
     public void putReadOnlyPropertyValid() throws Exception {
-        ReadonlyObj o = client.readonlypropertys().getValid();
-        client.readonlypropertys().putValid(o);
+        ReadonlyObj o = client.getReadonlypropertys().getValid();
+        client.getReadonlypropertys().putValid(o);
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/bodydate/DateOperationsTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodydate/DateOperationsTests.java
@@ -18,13 +18,13 @@ public class DateOperationsTests {
 
     @Test
     public void getNull() {
-        assertNull(client.dates().getNull());
+        assertNull(client.getDates().getNull());
     }
 
     @Test
     public void getInvalidDate() {
         try {
-            client.dates().getInvalidDate();
+            client.getDates().getInvalidDate();
             fail();
         } catch (RuntimeException exception) {
             assertEquals(InvalidFormatException.class, exception.getCause().getClass());
@@ -34,7 +34,7 @@ public class DateOperationsTests {
     @Test
     public void getOverflowDate() {
         try {
-            client.dates().getOverflowDate();
+            client.getDates().getOverflowDate();
             fail();
         } catch (RuntimeException exception) {
             assertEquals(InvalidFormatException.class, exception.getCause().getClass());
@@ -44,7 +44,7 @@ public class DateOperationsTests {
     @Test
     public void getUnderflowDate() {
         try {
-            client.dates().getUnderflowDate();
+            client.getDates().getUnderflowDate();
             fail();
         } catch (RuntimeException exception) {
             assertEquals(InvalidFormatException.class, exception.getCause().getClass());
@@ -54,26 +54,26 @@ public class DateOperationsTests {
     @Test
     public void putMaxDate() {
         LocalDate body = LocalDate.of(9999, 12, 31);
-        client.dates().putMaxDate(body);
+        client.getDates().putMaxDate(body);
     }
 
     @Test
     public void getMaxDate() {
         LocalDate expected = LocalDate.of(9999, 12, 31);
-        LocalDate result = client.dates().getMaxDate();
+        LocalDate result = client.getDates().getMaxDate();
         assertEquals(expected, result);
     }
 
     @Test
     public void putMinDate() {
         LocalDate body = LocalDate.of(1, 1, 1);
-        client.dates().putMinDate(body);
+        client.getDates().putMinDate(body);
     }
 
     @Test
     public void getMinDate() {
         LocalDate expected = LocalDate.of(1, 1, 1);
-        LocalDate result = client.dates().getMinDate();
+        LocalDate result = client.getDates().getMinDate();
         assertEquals(expected, result);
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/bodydatetime/DatetimeOperationsTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodydatetime/DatetimeOperationsTests.java
@@ -21,13 +21,13 @@ public class DatetimeOperationsTests {
 
     @Test
     public void getNull() {
-        Assert.assertNull(client.datetimes().getNull());
+        Assert.assertNull(client.getDatetimes().getNull());
     }
 
     @Test
     public void getInvalidDate() {
         try {
-            client.datetimes().getInvalid();
+            client.getDatetimes().getInvalid();
             Assert.fail();
         } catch (RuntimeException exception) {
             Assert.assertEquals(InvalidFormatException.class, exception.getCause().getClass());
@@ -36,7 +36,7 @@ public class DatetimeOperationsTests {
 
     @Test
     public void getOverflowDate() {
-        OffsetDateTime result = client.datetimes().getOverflow();
+        OffsetDateTime result = client.getDatetimes().getOverflow();
         OffsetDateTime expected = OffsetDateTime.of(LocalDate.of(10000, 1, 1), LocalTime.parse("13:59:59.999"), ZoneOffset.UTC);
         Assert.assertEquals(expected, result);
     }
@@ -44,7 +44,7 @@ public class DatetimeOperationsTests {
     @Test
     public void getUnderflowDate() {
         try {
-            client.datetimes().getUnderflow();
+            client.getDatetimes().getUnderflow();
             Assert.fail();
         } catch (RuntimeException exception) {
             // expected
@@ -55,19 +55,19 @@ public class DatetimeOperationsTests {
     @Test
     public void putUtcMaxDateTime() {
         OffsetDateTime body = OffsetDateTime.parse("9999-12-31T23:59:59.999-00:00");
-        client.datetimes().putUtcMaxDateTime(body);
+        client.getDatetimes().putUtcMaxDateTime(body);
     }
 
     @Test
     public void getUtcLowercaseMaxDateTime() {
-        OffsetDateTime result = client.datetimes().getUtcLowercaseMaxDateTime();
+        OffsetDateTime result = client.getDatetimes().getUtcLowercaseMaxDateTime();
         OffsetDateTime expected = OffsetDateTime.parse("9999-12-31T23:59:59.999-00:00");
         Assert.assertEquals(expected, result);
     }
 
     @Test
     public void getUtcUppercaseMaxDateTime() {
-        OffsetDateTime result = client.datetimes().getUtcUppercaseMaxDateTime();
+        OffsetDateTime result = client.getDatetimes().getUtcUppercaseMaxDateTime();
         OffsetDateTime expected = OffsetDateTime.parse("9999-12-31T23:59:59.999+00:00");
         Assert.assertEquals(expected, result);
     }
@@ -75,19 +75,19 @@ public class DatetimeOperationsTests {
     @Test
     public void putLocalPositiveOffsetMaxDateTime() {
         OffsetDateTime body = OffsetDateTime.parse("9999-12-31T09:59:59.999Z");
-        client.datetimes().putLocalPositiveOffsetMaxDateTime(body);
+        client.getDatetimes().putLocalPositiveOffsetMaxDateTime(body);
     }
 
     @Test
     public void getLocalPositiveOffsetLowercaseMaxDateTime() {
-        OffsetDateTime result = client.datetimes().getLocalPositiveOffsetLowercaseMaxDateTime();
+        OffsetDateTime result = client.getDatetimes().getLocalPositiveOffsetLowercaseMaxDateTime();
         OffsetDateTime expected = OffsetDateTime.parse("9999-12-31T09:59:59.999+00:00");
         Assert.assertEquals(expected, result);
     }
 
     @Test
     public void getLocalPositiveOffsetUppercaseMaxDateTime() {
-        OffsetDateTime result = client.datetimes().getLocalPositiveOffsetUppercaseMaxDateTime();
+        OffsetDateTime result = client.getDatetimes().getLocalPositiveOffsetUppercaseMaxDateTime();
         OffsetDateTime expected = OffsetDateTime.parse("9999-12-31T23:59:59.999+00:00").withOffsetSameLocal(ZoneOffset.ofHours(14)).withOffsetSameInstant(ZoneOffset.UTC);
         Assert.assertEquals(expected, result);
     }
@@ -95,19 +95,19 @@ public class DatetimeOperationsTests {
     @Ignore("Test server cannot handle year 10000")
     public void putLocalNegativeOffsetMaxDateTime() {
         OffsetDateTime body = OffsetDateTime.of(LocalDate.of(10000, 1, 1), LocalTime.parse("13:59:59.999"), ZoneOffset.UTC);
-        client.datetimes().putLocalNegativeOffsetMaxDateTime(body);
+        client.getDatetimes().putLocalNegativeOffsetMaxDateTime(body);
     }
 
     @Test
     public void getLocalNegativeOffsetLowercaseMaxDateTime() {
-        OffsetDateTime result = client.datetimes().getLocalNegativeOffsetLowercaseMaxDateTime();
+        OffsetDateTime result = client.getDatetimes().getLocalNegativeOffsetLowercaseMaxDateTime();
         OffsetDateTime expected = OffsetDateTime.parse("9999-12-31T23:59:59.999-00:00").withOffsetSameLocal(ZoneOffset.ofHours(-14)).withOffsetSameInstant(ZoneOffset.UTC);
         Assert.assertEquals(expected, result);
     }
 
     @Test
     public void getLocalNegativeOffsetUppercaseMaxDateTime() {
-        OffsetDateTime result = client.datetimes().getLocalNegativeOffsetUppercaseMaxDateTime();
+        OffsetDateTime result = client.getDatetimes().getLocalNegativeOffsetUppercaseMaxDateTime();
         OffsetDateTime expected = OffsetDateTime.of(LocalDate.of(10000, 1, 1), LocalTime.parse("13:59:59.999"), ZoneOffset.UTC);
         Assert.assertEquals(expected, result);
     }
@@ -115,12 +115,12 @@ public class DatetimeOperationsTests {
     @Test
     public void putUtcMinDateTime() {
         OffsetDateTime body = OffsetDateTime.of(1, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        client.datetimes().putUtcMinDateTime(body);
+        client.getDatetimes().putUtcMinDateTime(body);
     }
 
     @Test
     public void getUtcMinDateTime() {
-        OffsetDateTime result = client.datetimes().getUtcMinDateTime();
+        OffsetDateTime result = client.getDatetimes().getUtcMinDateTime();
         OffsetDateTime expected = OffsetDateTime.of(1, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
         Assert.assertEquals(expected, result);
     }
@@ -128,12 +128,12 @@ public class DatetimeOperationsTests {
     @Test
     public void putLocalPositiveOffsetMinDateTime() {
         OffsetDateTime body = OffsetDateTime.of(1, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(14));
-        client.datetimes().putLocalPositiveOffsetMinDateTime(body);
+        client.getDatetimes().putLocalPositiveOffsetMinDateTime(body);
     }
 
     @Test
     public void getLocalPositiveOffsetMinDateTime() {
-        OffsetDateTime result = client.datetimes().getLocalPositiveOffsetMinDateTime();
+        OffsetDateTime result = client.getDatetimes().getLocalPositiveOffsetMinDateTime();
         OffsetDateTime expected = OffsetDateTime.of(1, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(14)).withOffsetSameInstant(ZoneOffset.UTC);
         Assert.assertEquals(expected, result);
     }
@@ -141,12 +141,12 @@ public class DatetimeOperationsTests {
     @Test
     public void putLocalNegativeOffsetMinDateTime() {
         OffsetDateTime body = OffsetDateTime.of(1, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(-14));
-        client.datetimes().putLocalNegativeOffsetMinDateTime(body);
+        client.getDatetimes().putLocalNegativeOffsetMinDateTime(body);
     }
 
     @Test
     public void getLocalNegativeOffsetMinDateTime() {
-        OffsetDateTime result = client.datetimes().getLocalNegativeOffsetMinDateTime();
+        OffsetDateTime result = client.getDatetimes().getLocalNegativeOffsetMinDateTime();
         OffsetDateTime expected = OffsetDateTime.of(1, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(-14)).withOffsetSameInstant(ZoneOffset.UTC);
         Assert.assertEquals(expected, result);
     }

--- a/vanilla-tests/src/test/java/fixtures/bodydatetimerfc1123/DateTimeRfc1123OperationsTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodydatetimerfc1123/DateTimeRfc1123OperationsTests.java
@@ -22,13 +22,13 @@ public class DateTimeRfc1123OperationsTests {
 
     @Test
     public void getNull() {
-        Assert.assertNull(client.datetimerfc1123s().getNull());
+        Assert.assertNull(client.getDatetimerfc1123s().getNull());
     }
 
     @Test
     public void getInvalidDate() {
         try {
-            client.datetimerfc1123s().getInvalid();
+            client.getDatetimerfc1123s().getInvalid();
             fail();
         } catch (RuntimeException e) {
             assertThat(e.getCause(), instanceOf(JsonMappingException.class));
@@ -37,7 +37,7 @@ public class DateTimeRfc1123OperationsTests {
 
     @Test
     public void getOverflowDate() {
-        OffsetDateTime result = client.datetimerfc1123s().getOverflow();
+        OffsetDateTime result = client.getDatetimerfc1123s().getOverflow();
         OffsetDateTime expected = OffsetDateTime.of(10000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
         Assert.assertEquals(expected, result);
     }
@@ -45,7 +45,7 @@ public class DateTimeRfc1123OperationsTests {
     @Test
     public void getUnderflowDate() {
         try {
-            client.datetimerfc1123s().getUnderflow();
+            client.getDatetimerfc1123s().getUnderflow();
             fail();
         } catch (RuntimeException e) {
             assertThat(e.getCause(), instanceOf(JsonMappingException.class));
@@ -55,19 +55,19 @@ public class DateTimeRfc1123OperationsTests {
     @Test
     public void putUtcMaxDateTime() {
         OffsetDateTime body = OffsetDateTime.of(9999, 12, 31, 23, 59, 59, 0, ZoneOffset.UTC);
-        client.datetimerfc1123s().putUtcMaxDateTime(body);
+        client.getDatetimerfc1123s().putUtcMaxDateTime(body);
     }
 
     @Test
     public void getUtcLowercaseMaxDateTime() {
-        OffsetDateTime result = client.datetimerfc1123s().getUtcLowercaseMaxDateTime();
+        OffsetDateTime result = client.getDatetimerfc1123s().getUtcLowercaseMaxDateTime();
         OffsetDateTime expected = OffsetDateTime.of(9999, 12, 31, 23, 59, 59, 0, ZoneOffset.UTC);
         Assert.assertEquals(expected, result);
     }
 
     @Test
     public void getUtcUppercaseMaxDateTime() {
-        OffsetDateTime result = client.datetimerfc1123s().getUtcUppercaseMaxDateTime();
+        OffsetDateTime result = client.getDatetimerfc1123s().getUtcUppercaseMaxDateTime();
         OffsetDateTime expected = OffsetDateTime.of(9999, 12, 31, 23, 59, 59, 0, ZoneOffset.UTC);
         Assert.assertEquals(expected, result);
     }
@@ -75,12 +75,12 @@ public class DateTimeRfc1123OperationsTests {
     @Test
     public void putUtcMinDateTime() {
         OffsetDateTime body = OffsetDateTime.of(1, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        client.datetimerfc1123s().putUtcMinDateTime(body);
+        client.getDatetimerfc1123s().putUtcMinDateTime(body);
     }
 
     @Test
     public void getUtcMinDateTime() {
-        OffsetDateTime result = client.datetimerfc1123s().getUtcMinDateTime();
+        OffsetDateTime result = client.getDatetimerfc1123s().getUtcMinDateTime();
         OffsetDateTime expected = OffsetDateTime.of(1, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
         Assert.assertEquals(expected, result);
     }

--- a/vanilla-tests/src/test/java/fixtures/bodyduration/DurationOperationsTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodyduration/DurationOperationsTests.java
@@ -19,13 +19,13 @@ public class DurationOperationsTests {
 
     @Test
     public void getNull() {
-        assertNull(client.durations().getNull());
+        assertNull(client.getDurations().getNull());
     }
 
     @Test
     public void getInvalid() {
         try {
-            client.durations().getInvalid();
+            client.getDurations().getInvalid();
             fail();
         }
         catch (RuntimeException e) {
@@ -36,12 +36,12 @@ public class DurationOperationsTests {
     @Test
     @Ignore("The duration sent from the test server includes year and month values, which our durations don't support.")
     public void getPositiveDuration() {
-        client.durations().getPositiveDuration();
+        client.getDurations().getPositiveDuration();
     }
 
     @Test
     @Ignore("The test server expects the duration to have a year and month component, which our durations don't support.")
     public void putPositiveDuration() {
-        client.durations().putPositiveDuration(Duration.ofDays(123).plusHours(22).plusMinutes(14).plusSeconds(12).plusMinutes(11));
+        client.getDurations().putPositiveDuration(Duration.ofDays(123).plusHours(22).plusMinutes(14).plusSeconds(12).plusMinutes(11));
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/bodyfile/FilesTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodyfile/FilesTests.java
@@ -26,7 +26,7 @@ public class FilesTests {
         ClassLoader classLoader = getClass().getClassLoader();
         Path resourcePath = Paths.get(classLoader.getResource("sample.png").toURI());
         byte[] expected = Files.readAllBytes(resourcePath);
-        InputStream in = client.files().getFile();
+        InputStream in = client.getFiles().getFile();
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         byte[] buffer = new byte[1024];
         int length;
@@ -44,7 +44,7 @@ public class FilesTests {
     @Ignore("Uses Transfer-Encoding: chunked which is not currently supported")
     public void getLargeFile() throws Exception {
         final long streamSize = 3000L * 1024L * 1024L;
-        InputStream stream = client.files().getFileLarge();
+        InputStream stream = client.getFiles().getFileLarge();
         byte[] buffer = new byte[4096 * 1024];
         long skipped = 0;
         while (true) {
@@ -61,7 +61,7 @@ public class FilesTests {
 
     @Test
     public void getEmptyFile() throws Exception {
-        InputStream in = client.files().getEmptyFile();
+        InputStream in = client.getFiles().getEmptyFile();
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         byte[] buffer = new byte[1024];
         int length;

--- a/vanilla-tests/src/test/java/fixtures/bodyinteger/IntOperationsTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodyinteger/IntOperationsTests.java
@@ -25,7 +25,7 @@ public class IntOperationsTests {
   @Test
   public void getNull() {
     try {
-      client.ints().getNull();
+      client.getInts().getNull();
       Assert.fail();
     } catch (NullPointerException e) {
       // expected
@@ -34,14 +34,14 @@ public class IntOperationsTests {
 
   @Test
   public void getNullAsync() {
-    Integer i = client.ints().getNullAsync().block();
+    Integer i = client.getInts().getNullAsync().block();
     Assert.assertNull(i);
   }
 
   @Test
   public void getInvalid() {
     try {
-      client.ints().getInvalid();
+      client.getInts().getInvalid();
       Assert.fail();
     } catch (Exception exception) {
       Assert.assertEquals(MalformedValueException.class, exception.getCause().getClass());
@@ -51,7 +51,7 @@ public class IntOperationsTests {
   @Test
   public void getOverflowInt32() {
     try {
-      client.ints().getOverflowInt32();
+      client.getInts().getOverflowInt32();
       Assert.fail();
     } catch (Exception exception) {
       Assert.assertEquals(InputCoercionException.class, exception.getCause().getClass());
@@ -61,7 +61,7 @@ public class IntOperationsTests {
   @Test
   public void getUnderflowInt32() {
     try {
-      client.ints().getUnderflowInt32();
+      client.getInts().getUnderflowInt32();
       Assert.fail();
     } catch (Exception exception) {
       Assert.assertEquals(InputCoercionException.class, exception.getCause().getClass());
@@ -71,7 +71,7 @@ public class IntOperationsTests {
   @Test
   public void getOverflowInt64() {
     try {
-      long value = client.ints().getOverflowInt64();
+      long value = client.getInts().getOverflowInt64();
       Assert.assertEquals(Long.MAX_VALUE, value);
     } catch (Exception exception) {
       Assert.assertEquals(InputCoercionException.class, exception.getCause().getClass());
@@ -81,7 +81,7 @@ public class IntOperationsTests {
   @Test
   public void getUnderflowInt64() {
     try {
-      long value = client.ints().getUnderflowInt64();
+      long value = client.getInts().getUnderflowInt64();
       Assert.assertEquals(Long.MIN_VALUE, value);
     } catch (Exception exception) {
       Assert.assertEquals(InputCoercionException.class, exception.getCause().getClass());
@@ -90,43 +90,43 @@ public class IntOperationsTests {
 
   @Test
   public void putMax32() throws Exception {
-    client.ints().putMax32Async(Integer.MAX_VALUE).subscribe(v -> {}, t -> fail(t.getMessage()), () -> lock.countDown());
+    client.getInts().putMax32Async(Integer.MAX_VALUE).subscribe(v -> {}, t -> fail(t.getMessage()), () -> lock.countDown());
     Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
   }
 
   @Test
   public void putMax64() throws Exception {
-    client.ints().putMax64Async(Long.MAX_VALUE).subscribe(v -> {}, t -> fail(t.getMessage()), () -> lock.countDown());
+    client.getInts().putMax64Async(Long.MAX_VALUE).subscribe(v -> {}, t -> fail(t.getMessage()), () -> lock.countDown());
     Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
   }
 
   @Test
   public void putMin32() throws Exception {
-    client.ints().putMin32Async(Integer.MIN_VALUE).subscribe(v -> {}, t -> fail(t.getMessage()), () -> lock.countDown());
+    client.getInts().putMin32Async(Integer.MIN_VALUE).subscribe(v -> {}, t -> fail(t.getMessage()), () -> lock.countDown());
     Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
   }
 
   @Test
   public void putMin64() throws Exception {
-    client.ints().putMin64Async(Long.MIN_VALUE).subscribe(v -> {}, t -> fail(t.getMessage()), () -> lock.countDown());
+    client.getInts().putMin64Async(Long.MIN_VALUE).subscribe(v -> {}, t -> fail(t.getMessage()), () -> lock.countDown());
     Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
   }
 
   @Test
   public void getUnixTime() {
-    OffsetDateTime result = client.ints().getUnixTime();
+    OffsetDateTime result = client.getInts().getUnixTime();
     Assert.assertEquals(OffsetDateTime.of(2016, 4, 13, 0, 0, 0, 0, ZoneOffset.UTC), result);
   }
 
   @Test
   public void putUnixTimeDate() {
-    client.ints().putUnixTimeDate(OffsetDateTime.of(2016, 4, 13, 0, 0, 0, 0, ZoneOffset.UTC));
+    client.getInts().putUnixTimeDate(OffsetDateTime.of(2016, 4, 13, 0, 0, 0, 0, ZoneOffset.UTC));
   }
 
   @Test
   public void getInvalidUnixTime() {
     try {
-      client.ints().getInvalidUnixTime();
+      client.getInts().getInvalidUnixTime();
       Assert.fail();
     } catch (RuntimeException e) {
       Assert.assertTrue(e.getMessage().contains("HTTP response has a malformed body"));
@@ -135,6 +135,6 @@ public class IntOperationsTests {
 
   @Test
   public void getNullUnixTime() {
-    Assert.assertNull(client.ints().getNullUnixTime());
+    Assert.assertNull(client.getInts().getNullUnixTime());
   }
 }

--- a/vanilla-tests/src/test/java/fixtures/bodynumber/NumberOperationsTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodynumber/NumberOperationsTests.java
@@ -19,7 +19,7 @@ public class NumberOperationsTests {
   @Test
   public void getNull() throws Exception {
     try {
-      double d = client.numbers().getNull();
+      double d = client.getNumbers().getNull();
       fail();
     } catch (NullPointerException e) {
       // expected
@@ -29,7 +29,7 @@ public class NumberOperationsTests {
   @Test
   public void getInvalidFloat() throws Exception {
     try {
-      client.numbers().getInvalidFloat();
+      client.getNumbers().getInvalidFloat();
       Assert.assertTrue(false);
     } catch (Exception exception) {
       // expected
@@ -40,7 +40,7 @@ public class NumberOperationsTests {
   @Test
   public void getInvalidDouble() throws Exception {
     try {
-      client.numbers().getInvalidDouble();
+      client.getNumbers().getInvalidDouble();
       Assert.assertTrue(false);
     } catch (Exception exception) {
       // expected
@@ -50,102 +50,102 @@ public class NumberOperationsTests {
 
   @Test
   public void putBigFloat() throws Exception {
-    client.numbers().putBigFloat(3.402823e+20f);
+    client.getNumbers().putBigFloat(3.402823e+20f);
   }
 
   @Test
   public void putBigDouble() throws Exception {
-    client.numbers().putBigDouble(2.5976931e+101);
+    client.getNumbers().putBigDouble(2.5976931e+101);
   }
 
   @Test
   public void getBigFloat() throws Exception {
-    double result = client.numbers().getBigFloat();
+    double result = client.getNumbers().getBigFloat();
     Assert.assertEquals(3.402823e+20f, result, 0.0f);
   }
 
   @Test
   public void getBigDouble() throws Exception {
-    double result = client.numbers().getBigDouble();
+    double result = client.getNumbers().getBigDouble();
     Assert.assertEquals(2.5976931e+101, result, 0.0f);
   }
 
   @Test
   public void putBigDoublePositiveDecimal() throws Exception {
-    client.numbers().putBigDoublePositiveDecimal();
+    client.getNumbers().putBigDoublePositiveDecimal();
   }
 
   @Test
   public void getBigDoublePositiveDecimal() throws Exception {
-    double result = client.numbers().getBigDoublePositiveDecimal();
+    double result = client.getNumbers().getBigDoublePositiveDecimal();
     Assert.assertEquals(99999999.99, result, 0.0f);
   }
 
   @Test
   public void putBigDoubleNegativeDecimal() throws Exception {
-    client.numbers().putBigDoubleNegativeDecimal();
+    client.getNumbers().putBigDoubleNegativeDecimal();
   }
 
   @Test
   public void getBigDoubleNegativeDecimal() throws Exception {
-    double result = client.numbers().getBigDoubleNegativeDecimal();
+    double result = client.getNumbers().getBigDoubleNegativeDecimal();
     Assert.assertEquals(-99999999.99, result, 0.0f);
   }
 
   @Test
   public void putSmallFloat() throws Exception {
-    client.numbers().putSmallFloat(3.402823e-20f);
+    client.getNumbers().putSmallFloat(3.402823e-20f);
   }
 
   @Test
   public void getSmallFloat() throws Exception {
-    double result = client.numbers().getSmallFloat();
+    double result = client.getNumbers().getSmallFloat();
     Assert.assertEquals(3.402823e-20, result, 0.0f);
   }
 
   @Test
   public void putSmallDouble() throws Exception {
-    client.numbers().putSmallDouble(2.5976931e-101);
+    client.getNumbers().putSmallDouble(2.5976931e-101);
   }
 
   @Test
   public void getSmallDouble() throws Exception {
-    double result = client.numbers().getSmallDouble();
+    double result = client.getNumbers().getSmallDouble();
     Assert.assertEquals(2.5976931e-101, result, 0.0f);
   }
 
   @Test
   public void putBigDecimalPositiveDecimalTest() throws Exception {
-    client.numbers().putBigDecimalPositiveDecimal();
+    client.getNumbers().putBigDecimalPositiveDecimal();
   }
 
   @Test
   public void putBigDecimalNegativeDecimalTest() throws Exception {
-    client.numbers().putBigDecimalNegativeDecimal();
+    client.getNumbers().putBigDecimalNegativeDecimal();
   }
 
   @Test
   public void getBigDecimalTest() throws Exception {
-    BigDecimal result = client.numbers().getBigDecimal();
+    BigDecimal result = client.getNumbers().getBigDecimal();
     Assert.assertEquals(BigDecimal.valueOf(2.5976931E+101), result);
   }
 
   @Test
   public void getBigDecimalPositiveDecimalTest() throws Exception {
-    BigDecimal result = client.numbers().getBigDecimalPositiveDecimal();
+    BigDecimal result = client.getNumbers().getBigDecimalPositiveDecimal();
     Assert.assertEquals(BigDecimal.valueOf(99999999.99), result);
   }
 
   @Test
   public void getBigDecimalNegativeDecimalTest() throws Exception {
-    BigDecimal result = client.numbers().getBigDecimalNegativeDecimal();
+    BigDecimal result = client.getNumbers().getBigDecimalNegativeDecimal();
     Assert.assertEquals(BigDecimal.valueOf(-99999999.99), result);
   }
 
   @Test
   public void putBigDecimalTest() throws Exception {
     BigDecimal request = new BigDecimal("2.5976931e+101");
-    client.numbers().putBigDecimal(request);
+    client.getNumbers().putBigDecimal(request);
   }
 
 }

--- a/vanilla-tests/src/test/java/fixtures/bodystring/EnumOperationsTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodystring/EnumOperationsTests.java
@@ -18,12 +18,12 @@ public class EnumOperationsTests {
 
     @Test
     public void getNotExpandable() throws Exception {
-        Colors result = client.enums().getNotExpandable();
+        Colors result = client.getEnums().getNotExpandable();
         Assert.assertEquals(Colors.RED_COLOR, result);
     }
 
     @Test
     public void putNotExpandable() throws Exception {
-        client.enums().putNotExpandableWithResponseAsync(Colors.RED_COLOR).block();
+        client.getEnums().putNotExpandableWithResponseAsync(Colors.RED_COLOR).block();
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/bodystring/StringOperationsTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodystring/StringOperationsTests.java
@@ -22,13 +22,13 @@ public class StringOperationsTests {
 
     @Test
     public void getNull() throws Exception {
-        Assert.assertNull(client.strings().getNull());
+        Assert.assertNull(client.getStrings().getNull());
     }
 
     @Test
     public void putNull() throws Exception {
         try {
-            client.strings().putNullWithResponseAsync(null).block();
+            client.getStrings().putNullWithResponseAsync(null).block();
         } catch (Exception ex) {
             Assert.assertEquals(IllegalArgumentException.class, ex.getClass());
             assertTrue(ex.getMessage().contains("Argument for @BodyParam parameter must be non-null"));
@@ -37,44 +37,44 @@ public class StringOperationsTests {
 
     @Test
     public void getEmpty() throws Exception {
-        String result = client.strings().getEmpty();
+        String result = client.getStrings().getEmpty();
         Assert.assertEquals("", result);
     }
 
     @Test
     public void putEmpty() throws Exception {
-        client.strings().putEmptyWithResponseAsync().subscribe(v -> {}, t -> fail(t.getMessage()),
+        client.getStrings().putEmptyWithResponseAsync().subscribe(v -> {}, t -> fail(t.getMessage()),
             () -> lock.countDown());
         assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
     }
 
     @Test
     public void getMbcs() throws Exception {
-        String result = client.strings().getMbcs();
+        String result = client.getStrings().getMbcs();
         String expected = "啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑ\uE7C7ɡ〇〾⿻⺁\uE843䜣\uE864€";
         Assert.assertEquals(expected, result);
     }
 
     @Test
     public void putMbcs() throws Exception {
-        client.strings().putMbcsWithResponseAsync().block();
+        client.getStrings().putMbcsWithResponseAsync().block();
     }
 
     @Test
     public void getWhitespace() throws Exception {
-        String result = client.strings().getWhitespace();
+        String result = client.getStrings().getWhitespace();
         Assert.assertEquals("    Now is the time for all good men to come to the aid of their country    ", result);
     }
 
     @Test
     public void putWhitespace() throws Exception {
-        client.strings().putWhitespaceWithResponseAsync().block();
+        client.getStrings().putWhitespaceWithResponseAsync().block();
     }
 
     @Test
     public void getNotProvided() throws Exception {
         try {
-            client.strings().getNotProvided();
+            client.getStrings().getNotProvided();
         } catch (Exception ex) {
             Assert.assertEquals(HttpResponseException.class, ex.getClass());
             assertTrue(ex.getMessage().contains("JsonMappingException"));
@@ -83,24 +83,24 @@ public class StringOperationsTests {
 
     @Test
     public void getBase64Encoded() throws Exception {
-        byte[] result = client.strings().getBase64Encoded();
+        byte[] result = client.getStrings().getBase64Encoded();
         Assert.assertEquals("a string that gets encoded with base64", new String(result));
     }
 
     @Test
     public void getBase64UrlEncoded() throws Exception {
-        byte[] result = client.strings().getBase64UrlEncoded();
+        byte[] result = client.getStrings().getBase64UrlEncoded();
         Assert.assertEquals("a string that gets encoded with base64url", new String(result));
     }
 
     @Test
     public void getNullBase64UrlEncoded() throws Exception {
-        byte[] result = client.strings().getNullBase64UrlEncoded();
+        byte[] result = client.getStrings().getNullBase64UrlEncoded();
         Assert.assertEquals(0, result.length);
     }
 
     @Test
     public void putBase64UrlEncoded() throws Exception {
-        client.strings().putBase64UrlEncodedWithResponseAsync("a string that gets encoded with base64url".getBytes()).block();
+        client.getStrings().putBase64UrlEncodedWithResponseAsync("a string that gets encoded with base64url".getBytes()).block();
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/custombaseuri/CustomBaseUriTests.java
+++ b/vanilla-tests/src/test/java/fixtures/custombaseuri/CustomBaseUriTests.java
@@ -30,13 +30,13 @@ public class CustomBaseUriTests {
     @Test
     public void getEmptyWithValidCustomUri() throws Exception {
         clientBuilder.host("host:3000");
-        clientBuilder.buildClient().paths().getEmpty("local");
+        clientBuilder.buildClient().getPaths().getEmpty("local");
     }
 
     @Test
     public void getEmptyWithInvalidCustomUriAccountName() throws Exception {
         try {
-            clientBuilder.buildClient().paths().getEmpty("bad");
+            clientBuilder.buildClient().getPaths().getEmpty("bad");
             Assert.fail();
         }
         catch (RuntimeException e) {
@@ -47,7 +47,7 @@ public class CustomBaseUriTests {
     public void getEmptyWithInvalidCustomUriHostName() throws Exception {
         try {
             clientBuilder.host("badhost");
-            clientBuilder.buildClient().paths().getEmpty("local");
+            clientBuilder.buildClient().getPaths().getEmpty("local");
             Assert.fail();
         }
         catch (RuntimeException e) {
@@ -60,7 +60,7 @@ public class CustomBaseUriTests {
     @Test
     public void getEmptyWithEmptyCustomUriAccountName() throws Exception {
         try {
-            clientBuilder.buildClient().paths().getEmpty(null);
+            clientBuilder.buildClient().getPaths().getEmpty(null);
             Assert.assertTrue(false);
         }
         catch (IllegalArgumentException e) {
@@ -75,17 +75,17 @@ public class CustomBaseUriTests {
         // to localhost:3000 to be closed.
         // For now, we're working around it by retrying.
         try {
-            clientBuilder.host("host:3000").buildClient().paths().getEmpty("local");
+            clientBuilder.host("host:3000").buildClient().getPaths().getEmpty("local");
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }
         try {
-            clientBuilder.host("badhost").buildClient().paths().getEmpty("local");
+            clientBuilder.host("badhost").buildClient().getPaths().getEmpty("local");
             Assert.fail();
         } catch (Exception ignored){
         }
         try {
-            clientBuilder.host("host:3000").buildClient().paths().getEmpty("local");
+            clientBuilder.host("host:3000").buildClient().getPaths().getEmpty("local");
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }
@@ -101,7 +101,7 @@ public class CustomBaseUriTests {
         client1.host("host:3000");
         Thread t1 = new Thread(() -> {
             try {
-                client1.buildClient().paths().getEmpty("badlocal");
+                client1.buildClient().getPaths().getEmpty("badlocal");
                 fail();
             } catch (RuntimeException e) {
                 latch.countDown();
@@ -111,7 +111,7 @@ public class CustomBaseUriTests {
         });
         Thread t2 = new Thread(() -> {
             try {
-                client1.buildClient().paths().getEmpty("local");
+                client1.buildClient().getPaths().getEmpty("local");
                 latch.countDown();
             } catch (Exception ex) {
                 fail();

--- a/vanilla-tests/src/test/java/fixtures/custombaseuri/moreoptions/CustomBaseUriMoreOptionsTests.java
+++ b/vanilla-tests/src/test/java/fixtures/custombaseuri/moreoptions/CustomBaseUriMoreOptionsTests.java
@@ -15,6 +15,6 @@ public class CustomBaseUriMoreOptionsTests {
     // Positive test case
     @Test
     public void getEmpty() throws Exception {
-        client.dnsSuffix("host:3000").buildClient().paths().getEmpty("http://lo", "cal", "key1", "v1");
+        client.dnsSuffix("host:3000").buildClient().getPaths().getEmpty("http://lo", "cal", "key1", "v1");
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/extensibleenums/PetsTests.java
+++ b/vanilla-tests/src/test/java/fixtures/extensibleenums/PetsTests.java
@@ -17,19 +17,19 @@ public class PetsTests {
 
     @Test
     public void getByPetId() throws Exception {
-        Pet tommy = client.pets().getByPetId("tommy");
+        Pet tommy = client.getPets().getByPetId("tommy");
         Assert.assertNotNull(tommy);
         Assert.assertEquals(DaysOfWeekExtensibleEnum.MONDAY, tommy.getDaysOfWeek());
         Assert.assertEquals(IntEnum.ONE, tommy.getIntEnum());
         Assert.assertEquals("Tommy Tomson", tommy.getName());
 
-        Pet casper = client.pets().getByPetId("casper");
+        Pet casper = client.getPets().getByPetId("casper");
         Assert.assertNotNull(casper);
         Assert.assertEquals(DaysOfWeekExtensibleEnum.fromString("Weekend"), casper.getDaysOfWeek());
         Assert.assertEquals(IntEnum.TWO, casper.getIntEnum());
         Assert.assertEquals("Casper Ghosty", casper.getName());
 
-        Pet scooby = client.pets().getByPetId("scooby");
+        Pet scooby = client.getPets().getByPetId("scooby");
         Assert.assertNotNull(scooby);
         Assert.assertEquals(DaysOfWeekExtensibleEnum.THURSDAY, scooby.getDaysOfWeek());
         Assert.assertEquals(IntEnum.fromString("2.1"), scooby.getIntEnum());
@@ -42,7 +42,7 @@ public class PetsTests {
                 .setName("Retriever")
                 .setIntEnum(IntEnum.ONE)
                 .setDaysOfWeek(DaysOfWeekExtensibleEnum.MONDAY);
-        Pet res = client.pets().addPet(pet);
+        Pet res = client.getPets().addPet(pet);
         Assert.assertEquals(pet.getName(), res.getName());
         Assert.assertEquals(DaysOfWeekExtensibleEnum.MONDAY, res.getDaysOfWeek());
         Assert.assertEquals(IntEnum.ONE, res.getIntEnum());

--- a/vanilla-tests/src/test/java/fixtures/head/HeadOperationsTests.java
+++ b/vanilla-tests/src/test/java/fixtures/head/HeadOperationsTests.java
@@ -15,19 +15,19 @@ public class HeadOperationsTests {
 
     @Test
     public void head200() {
-        Assert.assertEquals(200, client.httpSuccess().head200WithResponseAsync().block().getStatusCode());
+        Assert.assertEquals(200, client.getHttpSuccess().head200WithResponseAsync().block().getStatusCode());
     }
 
     @Test
     public void head204() {
-        Response<Boolean> response =  client.httpSuccess().head204WithResponseAsync().block();
+        Response<Boolean> response =  client.getHttpSuccess().head204WithResponseAsync().block();
         Assert.assertEquals(204, response.getStatusCode());
         Assert.assertTrue(response.getValue()); // 204 means true
     }
 
     @Test
     public void head404() {
-        Response<Boolean> response =  client.httpSuccess().head404WithResponseAsync().block();
+        Response<Boolean> response =  client.getHttpSuccess().head404WithResponseAsync().block();
         // both status code 204 and 404 is not error, 404 means false
         Assert.assertEquals(404, response.getStatusCode());
         Assert.assertFalse(response.getValue());

--- a/vanilla-tests/src/test/java/fixtures/header/HeaderOperationsTests.java
+++ b/vanilla-tests/src/test/java/fixtures/header/HeaderOperationsTests.java
@@ -47,13 +47,13 @@ public class HeaderOperationsTests {
 
     @Ignore("User agent is being overwritten in UserAgentPolicy")
     public void paramExistingKey() {
-        client.headers().paramExistingKeyWithResponseAsync("overwrite").block();
+        client.getHeaders().paramExistingKeyWithResponseAsync("overwrite").block();
     }
 
     @Test
     public void responseExistingKey() throws Exception {
         lock = new CountDownLatch(1);
-        client.headers().responseExistingKeyWithResponseAsync()
+        client.getHeaders().responseExistingKeyWithResponseAsync()
                 .subscribe(response -> {
                     Map<String, String> headers = response.getHeaders().toMap();
                     if (headers.get("User-Agent") != null) {
@@ -67,7 +67,7 @@ public class HeaderOperationsTests {
     @Test
     public void paramProtectedKey() {
         try {
-            client.headers().paramProtectedKeyWithResponseAsync("text/html").block();
+            client.getHeaders().paramProtectedKeyWithResponseAsync("text/html").block();
         } catch (RuntimeException ex) {
             // OkHttp can actually overwrite header "Content-Type"
         }
@@ -76,7 +76,7 @@ public class HeaderOperationsTests {
     @Test
     public void responseProtectedKey() throws Exception {
         lock = new CountDownLatch(1);
-        client.headers().responseProtectedKeyWithResponseAsync()
+        client.getHeaders().responseProtectedKeyWithResponseAsync()
                 .subscribe(response -> {
                     Map<String, String> headers = response.getHeaders().toMap();
                     if (headers.get("Content-Type") != null) {
@@ -89,14 +89,14 @@ public class HeaderOperationsTests {
 
     @Test
     public void paramInteger() {
-        client.headers().paramIntegerWithResponseAsync("positive", 1).block();
-        client.headers().paramIntegerWithResponseAsync("negative", -2).block();
+        client.getHeaders().paramIntegerWithResponseAsync("positive", 1).block();
+        client.getHeaders().paramIntegerWithResponseAsync("negative", -2).block();
     }
 
     @Test
     public void responseInteger() throws Exception {
         lock = new CountDownLatch(1);
-        client.headers().responseIntegerWithResponseAsync("positive")
+        client.getHeaders().responseIntegerWithResponseAsync("positive")
                 .subscribe(response -> {
                     Map<String, String> headers = response.getHeaders().toMap();
                     if (headers.get("value") != null) {
@@ -106,7 +106,7 @@ public class HeaderOperationsTests {
                 }, throwable -> fail());
         Assert.assertTrue(lock.await(10000, TimeUnit.MILLISECONDS));
         lock = new CountDownLatch(1);
-        client.headers().responseIntegerWithResponseAsync("negative")
+        client.getHeaders().responseIntegerWithResponseAsync("negative")
                 .subscribe(response -> {
                     Map<String, String> headers = response.getHeaders().toMap();
                     if (headers.get("value") != null) {
@@ -119,14 +119,14 @@ public class HeaderOperationsTests {
 
     @Test
     public void paramLong() {
-        client.headers().paramLongWithResponseAsync("positive", 105).block();
-        client.headers().paramLongWithResponseAsync("negative", -2).block();
+        client.getHeaders().paramLongWithResponseAsync("positive", 105).block();
+        client.getHeaders().paramLongWithResponseAsync("negative", -2).block();
     }
 
     @Test
     public void responseLong() throws Exception {
         lock = new CountDownLatch(1);
-        client.headers().responseLongWithResponseAsync("positive")
+        client.getHeaders().responseLongWithResponseAsync("positive")
                 .subscribe(response -> {
                     Map<String, String> headers = response.getHeaders().toMap();
                     if (headers.get("value") != null) {
@@ -136,7 +136,7 @@ public class HeaderOperationsTests {
                 }, throwable -> fail());
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
         lock = new CountDownLatch(1);
-        client.headers().responseLongWithResponseAsync("negative")
+        client.getHeaders().responseLongWithResponseAsync("negative")
                 .subscribe(response -> {
                     Map<String, String> headers = response.getHeaders().toMap();
                     if (headers.get("value") != null) {
@@ -149,14 +149,14 @@ public class HeaderOperationsTests {
 
     @Test
     public void paramFloat() {
-        client.headers().paramFloatWithResponseAsync("positive", 0.07f).block();
-        client.headers().paramFloatWithResponseAsync("negative", -3.0f).block();
+        client.getHeaders().paramFloatWithResponseAsync("positive", 0.07f).block();
+        client.getHeaders().paramFloatWithResponseAsync("negative", -3.0f).block();
     }
 
     @Test
     public void responseFloat() throws Exception {
         lock = new CountDownLatch(1);
-        client.headers().responseFloatWithResponseAsync("positive")
+        client.getHeaders().responseFloatWithResponseAsync("positive")
                 .subscribe(response -> {
                     Map<String, String> headers = response.getHeaders().toMap();
                     if (headers.get("value") != null) {
@@ -166,7 +166,7 @@ public class HeaderOperationsTests {
                 }, throwable -> fail());
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
         lock = new CountDownLatch(1);
-        client.headers().responseFloatWithResponseAsync("negative")
+        client.getHeaders().responseFloatWithResponseAsync("negative")
                 .subscribe(response -> {
                     Map<String, String> headers = response.getHeaders().toMap();
                     if (headers.get("value") != null) {
@@ -179,14 +179,14 @@ public class HeaderOperationsTests {
 
     @Test
     public void paramDouble() {
-        client.headers().paramDoubleWithResponseAsync("positive", 7e120).block();
-        client.headers().paramDoubleWithResponseAsync("negative", -3.0).block();
+        client.getHeaders().paramDoubleWithResponseAsync("positive", 7e120).block();
+        client.getHeaders().paramDoubleWithResponseAsync("negative", -3.0).block();
     }
 
     @Test
     public void responseDouble() throws Exception {
         lock = new CountDownLatch(1);
-        client.headers().responseDoubleWithResponseAsync("positive")
+        client.getHeaders().responseDoubleWithResponseAsync("positive")
                 .subscribe(response -> {
                     Map<String, String> headers = response.getHeaders().toMap();
                     if (headers.get("value") != null) {
@@ -196,7 +196,7 @@ public class HeaderOperationsTests {
                 }, throwable -> fail());
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
         lock = new CountDownLatch(1);
-        client.headers().responseDoubleWithResponseAsync("negative")
+        client.getHeaders().responseDoubleWithResponseAsync("negative")
                 .subscribe(response -> {
                     Map<String, String> headers = response.getHeaders().toMap();
                     if (headers.get("value") != null) {
@@ -209,19 +209,19 @@ public class HeaderOperationsTests {
 
     @Test
     public void paramBool() {
-        client.headers().paramBoolWithResponseAsync("true", true).block();
-        client.headers().paramBoolWithResponseAsync("false", false).block();
+        client.getHeaders().paramBoolWithResponseAsync("true", true).block();
+        client.getHeaders().paramBoolWithResponseAsync("false", false).block();
     }
 
     @Test
     public void responseBool() throws Exception {
-        HeadersResponseBoolResponse response = client.headers().responseBoolWithResponseAsync("true").block();
+        HeadersResponseBoolResponse response = client.getHeaders().responseBoolWithResponseAsync("true").block();
         Map<String, String> headers = response.getHeaders().toMap();
         if (headers.get("value") != null) {
             Assert.assertEquals("true", headers.get("value"));
         }
 
-        response = client.headers().responseBoolWithResponseAsync("false").block();
+        response = client.getHeaders().responseBoolWithResponseAsync("false").block();
         headers = response.getHeaders().toMap();
         if (headers.get("value") != null) {
             Assert.assertEquals("false", headers.get("value"));
@@ -230,15 +230,15 @@ public class HeaderOperationsTests {
 
     @Test
     public void paramString() {
-        client.headers().paramStringWithResponseAsync("valid", "The quick brown fox jumps over the lazy dog").block();
-        client.headers().paramStringWithResponseAsync("null", null).block();
-        client.headers().paramStringWithResponseAsync("empty", "").block();
+        client.getHeaders().paramStringWithResponseAsync("valid", "The quick brown fox jumps over the lazy dog").block();
+        client.getHeaders().paramStringWithResponseAsync("null", null).block();
+        client.getHeaders().paramStringWithResponseAsync("empty", "").block();
     }
 
     @Test
     public void responseString() throws Exception {
         lock = new CountDownLatch(1);
-        client.headers().responseStringWithResponseAsync("valid")
+        client.getHeaders().responseStringWithResponseAsync("valid")
                 .subscribe(response -> {
                     Map<String, String> headers = response.getHeaders().toMap();
                     if (headers.get("value") != null) {
@@ -248,7 +248,7 @@ public class HeaderOperationsTests {
                 }, throwable -> fail());
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
         lock = new CountDownLatch(1);
-        client.headers().responseStringWithResponseAsync("null")
+        client.getHeaders().responseStringWithResponseAsync("null")
                 .subscribe(response -> {
                     Map<String, String> headers = response.getHeaders().toMap();
                     if (headers.get("value") != null) {
@@ -258,7 +258,7 @@ public class HeaderOperationsTests {
                 }, throwable -> fail());
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
         lock = new CountDownLatch(1);
-        client.headers().responseStringWithResponseAsync("empty")
+        client.getHeaders().responseStringWithResponseAsync("empty")
                 .subscribe(response -> {
                     Map<String, String> headers = response.getHeaders().toMap();
                     if (headers.get("value") != null) {
@@ -271,14 +271,14 @@ public class HeaderOperationsTests {
 
     @Test
     public void paramDate() {
-        client.headers().paramDateWithResponseAsync("valid", LocalDate.of(2010, 1, 1)).block();
-        client.headers().paramDateWithResponseAsync("min", LocalDate.of(1, 1, 1)).block();
+        client.getHeaders().paramDateWithResponseAsync("valid", LocalDate.of(2010, 1, 1)).block();
+        client.getHeaders().paramDateWithResponseAsync("min", LocalDate.of(1, 1, 1)).block();
     }
 
     @Test
     public void responseDate() throws Exception {
         lock = new CountDownLatch(1);
-        client.headers().responseDateWithResponseAsync("valid")
+        client.getHeaders().responseDateWithResponseAsync("valid")
                 .subscribe(response -> {
                     Map<String, String> headers = response.getHeaders().toMap();
                     if (headers.get("value") != null) {
@@ -288,7 +288,7 @@ public class HeaderOperationsTests {
                 }, throwable -> fail());
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
         lock = new CountDownLatch(1);
-        client.headers().responseDateWithResponseAsync("min")
+        client.getHeaders().responseDateWithResponseAsync("min")
                 .subscribe(response -> {
                     Map<String, String> headers = response.getHeaders().toMap();
                     if (headers.get("value") != null) {
@@ -301,13 +301,13 @@ public class HeaderOperationsTests {
 
     @Test
     public void paramDuration() {
-        client.headers().paramDurationWithResponseAsync("valid", Duration.ofDays(123).plusHours(22).plusMinutes(14).plusSeconds(12).plusMillis(11)).block();
+        client.getHeaders().paramDurationWithResponseAsync("valid", Duration.ofDays(123).plusHours(22).plusMinutes(14).plusSeconds(12).plusMillis(11)).block();
     }
 
     @Test
     public void responseDuration() throws Exception {
         lock = new CountDownLatch(1);
-        client.headers().responseDurationWithResponseAsync("valid")
+        client.getHeaders().responseDurationWithResponseAsync("valid")
                 .subscribe(response -> {
                     Map<String, String> headers = response.getHeaders().toMap();
                     if (headers.get("value") != null) {
@@ -320,19 +320,19 @@ public class HeaderOperationsTests {
 
     @Test
     public void paramDatetimeRfc1123() {
-        client.headers().paramDatetimeRfc1123WithResponseAsync("valid", OffsetDateTime.of(2010, 1, 1, 12, 34, 56, 0, ZoneOffset.UTC)).block();
-        client.headers().paramDatetimeRfc1123WithResponseAsync("min", OffsetDateTime.of(1, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)).block();
+        client.getHeaders().paramDatetimeRfc1123WithResponseAsync("valid", OffsetDateTime.of(2010, 1, 1, 12, 34, 56, 0, ZoneOffset.UTC)).block();
+        client.getHeaders().paramDatetimeRfc1123WithResponseAsync("min", OffsetDateTime.of(1, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)).block();
     }
 
     @Test
     public void responseDatetimeRfc1123() throws Exception {
-        HeadersResponseDatetimeRfc1123Response response = client.headers().responseDatetimeRfc1123WithResponseAsync("valid").block();
+        HeadersResponseDatetimeRfc1123Response response = client.getHeaders().responseDatetimeRfc1123WithResponseAsync("valid").block();
         Map<String, String> headers = response.getHeaders().toMap();
         if (headers.get("value") != null) {
             Assert.assertEquals("Fri, 01 Jan 2010 12:34:56 GMT", headers.get("value"));
         }
 
-        response = client.headers().responseDatetimeRfc1123WithResponseAsync("min").block();
+        response = client.getHeaders().responseDatetimeRfc1123WithResponseAsync("min").block();
         headers = response.getHeaders().toMap();
         if (headers.get("value") != null) {
             Assert.assertEquals("Mon, 01 Jan 0001 00:00:00 GMT", headers.get("value"));
@@ -341,18 +341,18 @@ public class HeaderOperationsTests {
 
     @Test
     public void paramDatetime() {
-        client.headers().paramDatetimeWithResponseAsync("valid", OffsetDateTime.of(2010, 1, 1, 12, 34, 56, 0, ZoneOffset.UTC)).block();
-        client.headers().paramDatetimeWithResponseAsync("min", OffsetDateTime.of(1, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)).block();
+        client.getHeaders().paramDatetimeWithResponseAsync("valid", OffsetDateTime.of(2010, 1, 1, 12, 34, 56, 0, ZoneOffset.UTC)).block();
+        client.getHeaders().paramDatetimeWithResponseAsync("min", OffsetDateTime.of(1, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)).block();
     }
 
     @Test
     public void responseDatetime() throws Exception {
-        HeadersResponseDatetimeResponse response = client.headers().responseDatetimeWithResponseAsync("valid").block();
+        HeadersResponseDatetimeResponse response = client.getHeaders().responseDatetimeWithResponseAsync("valid").block();
         Map<String, String> headers = response.getHeaders().toMap();
         if (headers.get("value") != null) {
             Assert.assertEquals("2010-01-01T12:34:56Z", headers.get("value"));
         }
-        response = client.headers().responseDatetimeWithResponseAsync("min").block();
+        response = client.getHeaders().responseDatetimeWithResponseAsync("min").block();
         headers = response.getHeaders().toMap();
         if (headers.get("value") != null) {
             Assert.assertEquals("0001-01-01T00:00:00Z", headers.get("value"));
@@ -361,13 +361,13 @@ public class HeaderOperationsTests {
 
     @Test
     public void paramByte() {
-        client.headers().paramByteWithResponseAsync("valid", "啊齄丂狛狜隣郎隣兀﨩".getBytes(Charset.forName("UTF-8"))).block();
+        client.getHeaders().paramByteWithResponseAsync("valid", "啊齄丂狛狜隣郎隣兀﨩".getBytes(Charset.forName("UTF-8"))).block();
     }
 
     @Test
     public void responseByte() throws Exception {
         lock = new CountDownLatch(1);
-        client.headers().responseByteWithResponseAsync("valid")
+        client.getHeaders().responseByteWithResponseAsync("valid")
                 .subscribe(response -> {
                     Map<String, String> headers = response.getHeaders().toMap();
                     if (headers.get("value") != null) {
@@ -382,14 +382,14 @@ public class HeaderOperationsTests {
 
     @Test
     public void paramEnum() {
-        client.headers().paramEnumWithResponseAsync("valid", GreyscaleColors.GREY).block();
-        client.headers().paramEnumWithResponseAsync("null", null).block();
+        client.getHeaders().paramEnumWithResponseAsync("valid", GreyscaleColors.GREY).block();
+        client.getHeaders().paramEnumWithResponseAsync("null", null).block();
     }
 
     @Test
     public void responseEnum() throws Exception {
         lock = new CountDownLatch(1);
-        client.headers().responseEnumWithResponseAsync("valid")
+        client.getHeaders().responseEnumWithResponseAsync("valid")
                 .subscribe(response -> {
                     Map<String, String> headers = response.getHeaders().toMap();
                     if (headers.get("value") != null) {
@@ -400,7 +400,7 @@ public class HeaderOperationsTests {
                 }, throwable -> fail());
         Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
         lock = new CountDownLatch(1);
-        client.headers().responseEnumWithResponseAsync("null")
+        client.getHeaders().responseEnumWithResponseAsync("null")
                 .subscribe(response -> {
                     Map<String, String> headers = response.getHeaders().toMap();
                     if (headers.get("value") != null) {
@@ -413,6 +413,6 @@ public class HeaderOperationsTests {
 
     @Test
     public void customRequestId() {
-        client.headers().customRequestId();
+        client.getHeaders().customRequestId();
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/headexceptions/HeadExceptionsOperationsTests.java
+++ b/vanilla-tests/src/test/java/fixtures/headexceptions/HeadExceptionsOperationsTests.java
@@ -15,17 +15,17 @@ public class HeadExceptionsOperationsTests {
 
     @Test
     public void head200() {
-        Assert.assertEquals(200, client.headExceptions().head200WithResponseAsync().block().getStatusCode());
+        Assert.assertEquals(200, client.getHeadExceptions().head200WithResponseAsync().block().getStatusCode());
     }
 
     @Test
     public void head204() {
-        Assert.assertEquals(204, client.headExceptions().head204WithResponseAsync().block().getStatusCode());
+        Assert.assertEquals(204, client.getHeadExceptions().head204WithResponseAsync().block().getStatusCode());
     }
 
     @Test(expected = HttpResponseException.class)
     public void head404() {
-        client.headExceptions().head404();  // status code other than 204 is error
+        client.getHeadExceptions().head404();  // status code other than 204 is error
         Assert.fail();
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/httpinfrastructure/HttpClientFailureTests.java
+++ b/vanilla-tests/src/test/java/fixtures/httpinfrastructure/HttpClientFailureTests.java
@@ -18,7 +18,7 @@ public class HttpClientFailureTests {
   @Test
   public void head400() throws Exception {
     try {
-      client.httpClientFailures().head400();
+      client.getHttpClientFailures().head400();
       fail();
     } catch (ErrorException ex) {
       Assert.assertEquals(400, ex.getResponse().getStatusCode());
@@ -28,7 +28,7 @@ public class HttpClientFailureTests {
   @Test
   public void get400() throws Exception {
     try {
-      client.httpClientFailures().get400();
+      client.getHttpClientFailures().get400();
       fail();
     } catch (ErrorException ex) {
       Assert.assertEquals(400, ex.getResponse().getStatusCode());
@@ -38,7 +38,7 @@ public class HttpClientFailureTests {
   @Test
   public void put400() throws Exception {
     try {
-      client.httpClientFailures().put400();
+      client.getHttpClientFailures().put400();
       fail();
     } catch (ErrorException ex) {
       Assert.assertEquals(400, ex.getResponse().getStatusCode());
@@ -48,7 +48,7 @@ public class HttpClientFailureTests {
   @Test
   public void patch400() throws Exception {
     try {
-      client.httpClientFailures().patch400();
+      client.getHttpClientFailures().patch400();
       fail();
     } catch (ErrorException ex) {
       Assert.assertEquals(400, ex.getResponse().getStatusCode());
@@ -58,7 +58,7 @@ public class HttpClientFailureTests {
   @Test
   public void post400() throws Exception {
     try {
-      client.httpClientFailures().post400();
+      client.getHttpClientFailures().post400();
       fail();
     } catch (ErrorException ex) {
       Assert.assertEquals(400, ex.getResponse().getStatusCode());
@@ -68,7 +68,7 @@ public class HttpClientFailureTests {
   @Test
   public void delete400() throws Exception {
     try {
-      client.httpClientFailures().delete400();
+      client.getHttpClientFailures().delete400();
       fail();
     } catch (ErrorException ex) {
       Assert.assertEquals(400, ex.getResponse().getStatusCode());
@@ -78,7 +78,7 @@ public class HttpClientFailureTests {
   @Test
   public void head401() throws Exception {
     try {
-      client.httpClientFailures().head401();
+      client.getHttpClientFailures().head401();
       fail();
     } catch (ErrorException ex) {
       Assert.assertEquals(401, ex.getResponse().getStatusCode());
@@ -88,7 +88,7 @@ public class HttpClientFailureTests {
   @Test
   public void get402() throws Exception {
     try {
-      client.httpClientFailures().get402();
+      client.getHttpClientFailures().get402();
       fail();
     } catch (ErrorException ex) {
       Assert.assertEquals(402, ex.getResponse().getStatusCode());
@@ -98,7 +98,7 @@ public class HttpClientFailureTests {
   @Test
   public void get403() throws Exception {
     try {
-      client.httpClientFailures().get403();
+      client.getHttpClientFailures().get403();
       fail();
     } catch (ErrorException ex) {
       Assert.assertEquals(403, ex.getResponse().getStatusCode());
@@ -108,7 +108,7 @@ public class HttpClientFailureTests {
   @Test
   public void put404() throws Exception {
     try {
-      client.httpClientFailures().put404();
+      client.getHttpClientFailures().put404();
       fail();
     } catch (ErrorException ex) {
       Assert.assertEquals(404, ex.getResponse().getStatusCode());
@@ -118,7 +118,7 @@ public class HttpClientFailureTests {
   @Test
   public void patch405() throws Exception {
     try {
-      client.httpClientFailures().patch405();
+      client.getHttpClientFailures().patch405();
       fail();
     } catch (ErrorException ex) {
       Assert.assertEquals(405, ex.getResponse().getStatusCode());
@@ -128,7 +128,7 @@ public class HttpClientFailureTests {
   @Test
   public void post406() throws Exception {
     try {
-      client.httpClientFailures().post406();
+      client.getHttpClientFailures().post406();
       fail();
     } catch (ErrorException ex) {
       Assert.assertEquals(406, ex.getResponse().getStatusCode());
@@ -138,7 +138,7 @@ public class HttpClientFailureTests {
   @Test
   public void delete407() throws Exception {
     try {
-      client.httpClientFailures().delete407();
+      client.getHttpClientFailures().delete407();
       fail();
     } catch (RuntimeException ex) {
       Assert.assertTrue(ex.getMessage().contains("Status code 407"));
@@ -148,7 +148,7 @@ public class HttpClientFailureTests {
   @Test
   public void put409() throws Exception {
     try {
-      client.httpClientFailures().put409();
+      client.getHttpClientFailures().put409();
       fail();
     } catch (ErrorException ex) {
       Assert.assertEquals(409, ex.getResponse().getStatusCode());
@@ -158,7 +158,7 @@ public class HttpClientFailureTests {
   @Test
   public void head410() throws Exception {
     try {
-      client.httpClientFailures().head410();
+      client.getHttpClientFailures().head410();
       fail();
     } catch (ErrorException ex) {
       Assert.assertEquals(410, ex.getResponse().getStatusCode());
@@ -168,7 +168,7 @@ public class HttpClientFailureTests {
   @Test
   public void get411() throws Exception {
     try {
-      client.httpClientFailures().get411();
+      client.getHttpClientFailures().get411();
       fail();
     } catch (ErrorException ex) {
       Assert.assertEquals(411, ex.getResponse().getStatusCode());
@@ -178,7 +178,7 @@ public class HttpClientFailureTests {
   @Test
   public void get412() throws Exception {
     try {
-      client.httpClientFailures().get412();
+      client.getHttpClientFailures().get412();
       fail();
     } catch (ErrorException ex) {
       Assert.assertEquals(412, ex.getResponse().getStatusCode());
@@ -188,7 +188,7 @@ public class HttpClientFailureTests {
   @Test
   public void put413() throws Exception {
     try {
-      client.httpClientFailures().put413();
+      client.getHttpClientFailures().put413();
       fail();
     } catch (ErrorException ex) {
       Assert.assertEquals(413, ex.getResponse().getStatusCode());
@@ -198,7 +198,7 @@ public class HttpClientFailureTests {
   @Test
   public void patch414() throws Exception {
     try {
-      client.httpClientFailures().patch414();
+      client.getHttpClientFailures().patch414();
       fail();
     } catch (ErrorException ex) {
       Assert.assertEquals(414, ex.getResponse().getStatusCode());
@@ -208,7 +208,7 @@ public class HttpClientFailureTests {
   @Test
   public void post415() throws Exception {
     try {
-      client.httpClientFailures().post415();
+      client.getHttpClientFailures().post415();
       fail();
     } catch (ErrorException ex) {
       Assert.assertEquals(415, ex.getResponse().getStatusCode());
@@ -218,7 +218,7 @@ public class HttpClientFailureTests {
   @Test
   public void get416() throws Exception {
     try {
-      client.httpClientFailures().get416();
+      client.getHttpClientFailures().get416();
       fail();
     } catch (ErrorException ex) {
       Assert.assertEquals(416, ex.getResponse().getStatusCode());
@@ -228,7 +228,7 @@ public class HttpClientFailureTests {
   @Test
   public void delete417() throws Exception {
     try {
-      client.httpClientFailures().delete417();
+      client.getHttpClientFailures().delete417();
       fail();
     } catch (ErrorException ex) {
       Assert.assertEquals(417, ex.getResponse().getStatusCode());
@@ -238,7 +238,7 @@ public class HttpClientFailureTests {
   @Test
   public void head429() throws Exception {
     try {
-      client.httpClientFailures().head429();
+      client.getHttpClientFailures().head429();
       fail();
     } catch (ErrorException ex) {
       Assert.assertEquals(429, ex.getResponse().getStatusCode());

--- a/vanilla-tests/src/test/java/fixtures/httpinfrastructure/HttpFailureTests.java
+++ b/vanilla-tests/src/test/java/fixtures/httpinfrastructure/HttpFailureTests.java
@@ -19,7 +19,7 @@ public class HttpFailureTests {
   @Test
   public void getEmptyError() throws Exception {
     try {
-      client.httpFailures().getEmptyError();
+      client.getHttpFailures().getEmptyError();
       fail();
     } catch (ErrorException ex) {
       Assert.assertEquals(400, ex.getResponse().getStatusCode());
@@ -29,7 +29,7 @@ public class HttpFailureTests {
   @Test
   public void getNoModelError() throws Exception {
     try {
-      client.httpFailures().getNoModelError();
+      client.getHttpFailures().getNoModelError();
       fail();
     } catch (HttpResponseException ex) {
       Assert.assertEquals(400, ex.getResponse().getStatusCode());

--- a/vanilla-tests/src/test/java/fixtures/httpinfrastructure/HttpRetryTests.java
+++ b/vanilla-tests/src/test/java/fixtures/httpinfrastructure/HttpRetryTests.java
@@ -21,7 +21,7 @@ public class HttpRetryTests {
 
   @Test
   public void head408() throws Exception {
-    client.httpRetrys().head408WithResponseAsync()
+    client.getHttpRetrys().head408WithResponseAsync()
         .subscribe(response -> {
           Assert.assertEquals(200, response.getStatusCode());
           lock.countDown();
@@ -31,7 +31,7 @@ public class HttpRetryTests {
 
   @Test
   public void put500() throws Exception {
-    client.httpRetrys().put500WithResponseAsync()
+    client.getHttpRetrys().put500WithResponseAsync()
         .subscribe(response -> {
           Assert.assertEquals(200, response.getStatusCode());
           lock.countDown();
@@ -41,7 +41,7 @@ public class HttpRetryTests {
 
   @Test
   public void patch500() throws Exception {
-    client.httpRetrys().patch500WithResponseAsync()
+    client.getHttpRetrys().patch500WithResponseAsync()
         .subscribe(response -> {
           Assert.assertEquals(200, response.getStatusCode());
           lock.countDown();
@@ -51,7 +51,7 @@ public class HttpRetryTests {
 
   @Test
   public void get502() throws Exception {
-    client.httpRetrys().get502WithResponseAsync()
+    client.getHttpRetrys().get502WithResponseAsync()
         .subscribe(response -> {
           Assert.assertEquals(200, response.getStatusCode());
           lock.countDown();
@@ -61,7 +61,7 @@ public class HttpRetryTests {
 
   @Test
   public void post503() throws Exception {
-    client.httpRetrys().post503WithResponseAsync()
+    client.getHttpRetrys().post503WithResponseAsync()
         .subscribe(response -> {
           Assert.assertEquals(200, response.getStatusCode());
           lock.countDown();
@@ -71,7 +71,7 @@ public class HttpRetryTests {
 
   @Test
   public void delete503() throws Exception {
-    client.httpRetrys().delete503WithResponseAsync()
+    client.getHttpRetrys().delete503WithResponseAsync()
         .subscribe(response -> {
           Assert.assertEquals(200, response.getStatusCode());
           lock.countDown();
@@ -81,7 +81,7 @@ public class HttpRetryTests {
 
   @Test
   public void put504() throws Exception {
-    client.httpRetrys().put504WithResponseAsync()
+    client.getHttpRetrys().put504WithResponseAsync()
         .subscribe(response -> {
           Assert.assertEquals(200, response.getStatusCode());
           lock.countDown();
@@ -91,7 +91,7 @@ public class HttpRetryTests {
 
   @Test
   public void patch504() throws Exception {
-    client.httpRetrys().patch504WithResponseAsync()
+    client.getHttpRetrys().patch504WithResponseAsync()
         .subscribe(response -> {
           Assert.assertEquals(200, response.getStatusCode());
           lock.countDown();

--- a/vanilla-tests/src/test/java/fixtures/httpinfrastructure/HttpServerFailureTests.java
+++ b/vanilla-tests/src/test/java/fixtures/httpinfrastructure/HttpServerFailureTests.java
@@ -16,7 +16,7 @@ public class HttpServerFailureTests {
   @Test
   public void head501() throws Exception {
     try {
-      client.httpServerFailures().head501();
+      client.getHttpServerFailures().head501();
     } catch (ErrorException ex) {
       Assert.assertEquals(501, ex.getResponse().getStatusCode());
     }
@@ -25,7 +25,7 @@ public class HttpServerFailureTests {
   @Test
   public void get501() throws Exception {
     try {
-      client.httpServerFailures().get501();
+      client.getHttpServerFailures().get501();
     } catch (ErrorException ex) {
       Assert.assertEquals(501, ex.getResponse().getStatusCode());
     }
@@ -34,7 +34,7 @@ public class HttpServerFailureTests {
   @Test
   public void post505() throws Exception {
     try {
-      client.httpServerFailures().post505();
+      client.getHttpServerFailures().post505();
     } catch (ErrorException ex) {
       Assert.assertEquals(505, ex.getResponse().getStatusCode());
     }
@@ -43,7 +43,7 @@ public class HttpServerFailureTests {
   @Test
   public void delete505() throws Exception {
     try {
-      client.httpServerFailures().delete505();
+      client.getHttpServerFailures().delete505();
     } catch (ErrorException ex) {
       Assert.assertEquals(505, ex.getResponse().getStatusCode());
     }

--- a/vanilla-tests/src/test/java/fixtures/httpinfrastructure/HttpSuccessTests.java
+++ b/vanilla-tests/src/test/java/fixtures/httpinfrastructure/HttpSuccessTests.java
@@ -13,91 +13,91 @@ public class HttpSuccessTests {
 
   @Test
   public void head200() throws Exception {
-    client.httpSuccess().head200();
+    client.getHttpSuccess().head200();
   }
 
   @Test
   public void get200() throws Exception {
-    client.httpSuccess().get200();
+    client.getHttpSuccess().get200();
   }
 
   @Test
   public void put200() throws Exception {
-    client.httpSuccess().put200();
+    client.getHttpSuccess().put200();
   }
 
   @Test
   public void patch200() throws Exception {
-    client.httpSuccess().patch200();
+    client.getHttpSuccess().patch200();
   }
 
   @Test
   public void post200() throws Exception {
-    client.httpSuccess().post200();
+    client.getHttpSuccess().post200();
   }
 
   @Test
   public void delete200() throws Exception {
-    client.httpSuccess().delete200();
+    client.getHttpSuccess().delete200();
   }
 
   @Test
   public void put201() throws Exception {
-    client.httpSuccess().put201();
+    client.getHttpSuccess().put201();
   }
 
   @Test
   public void post201() throws Exception {
-    client.httpSuccess().post201();
+    client.getHttpSuccess().post201();
   }
 
   @Test
   public void put202() throws Exception {
-    client.httpSuccess().put202();
+    client.getHttpSuccess().put202();
   }
 
   @Test
   public void patch202() throws Exception {
-    client.httpSuccess().patch202();
+    client.getHttpSuccess().patch202();
   }
 
   @Test
   public void post202() throws Exception {
-    client.httpSuccess().post202();
+    client.getHttpSuccess().post202();
   }
 
   @Test
   public void delete202() throws Exception {
-    client.httpSuccess().delete202();
+    client.getHttpSuccess().delete202();
   }
 
   @Test
   public void head204() throws Exception {
-    client.httpSuccess().head204();
+    client.getHttpSuccess().head204();
   }
 
   @Test
   public void put204() throws Exception {
-    client.httpSuccess().put204();
+    client.getHttpSuccess().put204();
   }
 
   @Test
   public void patch204() throws Exception {
-    client.httpSuccess().patch204();
+    client.getHttpSuccess().patch204();
   }
 
   @Test
   public void post204() throws Exception {
-    client.httpSuccess().post204();
+    client.getHttpSuccess().post204();
   }
 
   @Test
   public void delete204() throws Exception {
-    client.httpSuccess().delete204();
+    client.getHttpSuccess().delete204();
   }
 
   @Test
   public void head404() throws Exception {
-    client.httpSuccess().head404();
+    client.getHttpSuccess().head404();
   }
 }

--- a/vanilla-tests/src/test/java/fixtures/httpinfrastructure/MultipleResponsesTests.java
+++ b/vanilla-tests/src/test/java/fixtures/httpinfrastructure/MultipleResponsesTests.java
@@ -31,21 +31,21 @@ public class MultipleResponsesTests {
 
   @Test
   public void get200Model204NoModelDefaultError200Valid() throws Exception {
-    MyException result = client.multipleResponses().get200Model204NoModelDefaultError200Valid();
+    MyException result = client.getMultipleResponses().get200Model204NoModelDefaultError200Valid();
     Assert.assertEquals(MyException.class, result.getClass());
     Assert.assertEquals("200", result.getStatusCode());
   }
 
   @Test
   public void get200Model204NoModelDefaultError204Valid() throws Exception {
-    MyException result = client.multipleResponses().get200Model204NoModelDefaultError204Valid();
+    MyException result = client.getMultipleResponses().get200Model204NoModelDefaultError204Valid();
     Assert.assertNull(result);
   }
 
   @Test
   public void get200Model204NoModelDefaultError201Invalid() throws Exception {
     try {
-      MyException result = client.multipleResponses().get200Model204NoModelDefaultError201Invalid();
+      MyException result = client.getMultipleResponses().get200Model204NoModelDefaultError201Invalid();
       fail();
     } catch (ErrorException ex) {
       Assert.assertEquals(201, ex.getResponse().getStatusCode());
@@ -55,7 +55,7 @@ public class MultipleResponsesTests {
   @Test
   public void get200Model204NoModelDefaultError202None() throws Exception {
     try {
-      client.multipleResponses().get200Model204NoModelDefaultError202None();
+      client.getMultipleResponses().get200Model204NoModelDefaultError202None();
     } catch (ErrorException ex) {
       Assert.assertEquals(202, ex.getResponse().getStatusCode());
     }
@@ -64,7 +64,7 @@ public class MultipleResponsesTests {
   @Test
   public void get200Model204NoModelDefaultError400Valid() throws Exception {
     try {
-      client.multipleResponses().get200Model204NoModelDefaultError400Valid();
+      client.getMultipleResponses().get200Model204NoModelDefaultError400Valid();
       fail();
     } catch (ErrorException ex) {
       Assert.assertEquals(400, ex.getResponse().getStatusCode());
@@ -73,20 +73,20 @@ public class MultipleResponsesTests {
 
   @Test
   public void get200Model201ModelDefaultError200Valid() throws Exception {
-    MyException result = client.multipleResponses().get200Model201ModelDefaultError200Valid();
+    MyException result = client.getMultipleResponses().get200Model201ModelDefaultError200Valid();
     Assert.assertEquals("200", result.getStatusCode());
   }
 
   @Test
   public void get200Model201ModelDefaultError201Valid() throws Exception {
-    MyException result = client.multipleResponses().get200Model201ModelDefaultError201Valid();
+    MyException result = client.getMultipleResponses().get200Model201ModelDefaultError201Valid();
     Assert.assertEquals("201", result.getStatusCode());
   }
 
   @Test
   public void get200Model201ModelDefaultError400Valid() throws Exception {
     try {
-      client.multipleResponses().get200Model201ModelDefaultError400Valid();
+      client.getMultipleResponses().get200Model201ModelDefaultError400Valid();
       fail();
     } catch (ErrorException ex) {
       Assert.assertEquals(400, ex.getResponse().getStatusCode());
@@ -98,7 +98,7 @@ public class MultipleResponsesTests {
   @Test
   @Ignore("Not currently supported by RestProxy")
   public void get200ModelA201ModelC404ModelDDefaultError200Valid() throws Exception {
-    Object result = client.multipleResponses().get200ModelA201ModelC404ModelDDefaultError200Valid();
+    Object result = client.getMultipleResponses().get200ModelA201ModelC404ModelDDefaultError200Valid();
     MyException actual = (MyException) result;
     Assert.assertEquals("200", actual.getStatusCode());
   }
@@ -106,7 +106,7 @@ public class MultipleResponsesTests {
   @Test
   @Ignore("Not currently supported by RestProxy")
   public void get200ModelA201ModelC404ModelDDefaultError201Valid() throws Exception {
-    Object result = client.multipleResponses().get200ModelA201ModelC404ModelDDefaultError201Valid();
+    Object result = client.getMultipleResponses().get200ModelA201ModelC404ModelDDefaultError201Valid();
     C actual = (C) result;
     Assert.assertEquals("201", actual.getHttpCode());
   }
@@ -114,7 +114,7 @@ public class MultipleResponsesTests {
   @Test
   @Ignore("Not currently supported by RestProxy")
   public void get200ModelA201ModelC404ModelDDefaultError404Valid() throws Exception {
-    Object result = client.multipleResponses().get200ModelA201ModelC404ModelDDefaultError404Valid();
+    Object result = client.getMultipleResponses().get200ModelA201ModelC404ModelDDefaultError404Valid();
     D actual = (D) result;
     Assert.assertEquals("404", actual.getHttpStatusCode());
   }
@@ -122,7 +122,7 @@ public class MultipleResponsesTests {
   @Test
   public void get200ModelA201ModelC404ModelDDefaultError400Valid() throws Exception {
     try {
-      client.multipleResponses().get200ModelA201ModelC404ModelDDefaultError400Valid();
+      client.getMultipleResponses().get200ModelA201ModelC404ModelDDefaultError400Valid();
       fail();
     } catch (ErrorException ex) {
       Assert.assertEquals(400, ex.getResponse().getStatusCode());
@@ -146,7 +146,7 @@ public class MultipleResponsesTests {
 
     AutoRestHttpInfrastructureTestService localClient =
         new AutoRestHttpInfrastructureTestServiceBuilder().pipeline(httpPipeline).buildClient();
-    localClient.multipleResponses().get202None204NoneDefaultError202NoneAsync().subscribe();
+    localClient.getMultipleResponses().get202None204NoneDefaultError202NoneAsync().subscribe();
     Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
   }
 
@@ -164,14 +164,14 @@ public class MultipleResponsesTests {
 
     AutoRestHttpInfrastructureTestService localClient =
         new AutoRestHttpInfrastructureTestServiceBuilder().pipeline(httpPipeline).buildClient();
-    localClient.multipleResponses().get202None204NoneDefaultError204NoneAsync().subscribe();
+    localClient.getMultipleResponses().get202None204NoneDefaultError204NoneAsync().subscribe();
     Assert.assertTrue(lock.await(1000, TimeUnit.MILLISECONDS));
   }
 
   @Test
   public void get202None204NoneDefaultError400Valid() throws Exception {
     try {
-      client.multipleResponses().get202None204NoneDefaultError400Valid();
+      client.getMultipleResponses().get202None204NoneDefaultError400Valid();
       fail();
     } catch (ErrorException ex) {
       Assert.assertEquals(400, ex.getResponse().getStatusCode());
@@ -183,18 +183,18 @@ public class MultipleResponsesTests {
 
   @Test
   public void get202None204NoneDefaultNone202Invalid() throws Exception {
-    client.multipleResponses().get202None204NoneDefaultNone202Invalid();
+    client.getMultipleResponses().get202None204NoneDefaultNone202Invalid();
   }
 
   @Test
   public void get202None204NoneDefaultNone204None() throws Exception {
-    client.multipleResponses().get202None204NoneDefaultNone204None();
+    client.getMultipleResponses().get202None204NoneDefaultNone204None();
   }
 
   @Test
   public void get202None204NoneDefaultNone400None() throws Exception {
     try {
-      client.multipleResponses().get202None204NoneDefaultNone400None();
+      client.getMultipleResponses().get202None204NoneDefaultNone400None();
       fail();
     } catch (HttpResponseException ex) {
       Assert.assertEquals(400, ex.getResponse().getStatusCode());
@@ -204,7 +204,7 @@ public class MultipleResponsesTests {
   @Test
   public void get202None204NoneDefaultNone400Invalid() throws Exception {
     try {
-      client.multipleResponses().get202None204NoneDefaultNone400Invalid();
+      client.getMultipleResponses().get202None204NoneDefaultNone400Invalid();
       fail();
     } catch (HttpResponseException ex) {
       Assert.assertEquals(400, ex.getResponse().getStatusCode());
@@ -213,18 +213,18 @@ public class MultipleResponsesTests {
 
   @Test
   public void getDefaultModelA200Valid() throws Exception {
-    client.multipleResponses().getDefaultModelA200Valid();
+    client.getMultipleResponses().getDefaultModelA200Valid();
   }
 
   @Test
   public void getDefaultModelA200None() throws Exception {
-    client.multipleResponses().getDefaultModelA200None();
+    client.getMultipleResponses().getDefaultModelA200None();
   }
 
   @Test
   public void getDefaultModelA400Valid() throws Exception {
     try {
-      client.multipleResponses().getDefaultModelA400Valid();
+      client.getMultipleResponses().getDefaultModelA400Valid();
       fail();
     } catch (MyExceptionException ex) {
       Assert.assertEquals(400, ex.getResponse().getStatusCode());
@@ -235,7 +235,7 @@ public class MultipleResponsesTests {
   @Test
   public void getDefaultModelA400None() throws Exception {
     try {
-      client.multipleResponses().getDefaultModelA400None();
+      client.getMultipleResponses().getDefaultModelA400None();
       fail();
     } catch (MyExceptionException ex) {
       Assert.assertEquals(400, ex.getResponse().getStatusCode());
@@ -244,18 +244,18 @@ public class MultipleResponsesTests {
 
   @Test
   public void getDefaultNone200Invalid() throws Exception {
-    client.multipleResponses().getDefaultNone200Invalid();
+    client.getMultipleResponses().getDefaultNone200Invalid();
   }
 
   @Test
   public void getDefaultNone200None() throws Exception {
-    client.multipleResponses().getDefaultNone200None();
+    client.getMultipleResponses().getDefaultNone200None();
   }
 
   @Test
   public void getDefaultNone400Invalid() throws Exception {
     try {
-      client.multipleResponses().getDefaultNone400Invalid();
+      client.getMultipleResponses().getDefaultNone400Invalid();
       fail();
     } catch (HttpResponseException ex) {
       Assert.assertEquals(400, ex.getResponse().getStatusCode());
@@ -265,7 +265,7 @@ public class MultipleResponsesTests {
   @Test
   public void getDefaultNone400None() throws Exception {
     try {
-      client.multipleResponses().getDefaultNone400None();
+      client.getMultipleResponses().getDefaultNone400None();
       fail();
     } catch (HttpResponseException ex) {
       Assert.assertEquals(400, ex.getResponse().getStatusCode());
@@ -274,25 +274,25 @@ public class MultipleResponsesTests {
 
   @Test
   public void get200ModelA200None() throws Exception {
-    MyException result = client.multipleResponses().get200ModelA200None();
+    MyException result = client.getMultipleResponses().get200ModelA200None();
     Assert.assertNull(result);
   }
 
   @Test
   public void get200ModelA200Valid() throws Exception {
-    MyException result = client.multipleResponses().get200ModelA200Valid();
+    MyException result = client.getMultipleResponses().get200ModelA200Valid();
     Assert.assertEquals("200", result.getStatusCode());
   }
 
   @Test
   public void get200ModelA200Invalid() throws Exception {
-    Assert.assertEquals(null, client.multipleResponses().get200ModelA200Invalid().getStatusCode());
+    Assert.assertEquals(null, client.getMultipleResponses().get200ModelA200Invalid().getStatusCode());
   }
 
   @Test
   public void get200ModelA400None() throws Exception {
     try {
-      client.multipleResponses().get200ModelA400None();
+      client.getMultipleResponses().get200ModelA400None();
       fail();
     } catch (HttpResponseException ex) {
       Assert.assertEquals(400, ex.getResponse().getStatusCode());
@@ -303,7 +303,7 @@ public class MultipleResponsesTests {
   @Test
   public void get200ModelA400Valid() throws Exception {
     try {
-      client.multipleResponses().get200ModelA400Valid();
+      client.getMultipleResponses().get200ModelA400Valid();
       fail();
     } catch (HttpResponseException ex) {
       Assert.assertEquals(400, ex.getResponse().getStatusCode());
@@ -313,7 +313,7 @@ public class MultipleResponsesTests {
   @Test
   public void get200ModelA400Invalid() throws Exception {
     try {
-      client.multipleResponses().get200ModelA400Invalid();
+      client.getMultipleResponses().get200ModelA400Invalid();
       fail();
     } catch (HttpResponseException ex) {
       Assert.assertEquals(400, ex.getResponse().getStatusCode());
@@ -323,7 +323,7 @@ public class MultipleResponsesTests {
   @Test
   public void get200ModelA202Valid() throws Exception {
     try {
-      client.multipleResponses().get200ModelA202Valid();
+      client.getMultipleResponses().get200ModelA202Valid();
       fail();
     } catch (HttpResponseException ex) {
       Assert.assertEquals(202, ex.getResponse().getStatusCode());

--- a/vanilla-tests/src/test/java/fixtures/requiredoptional/ExplicitTests.java
+++ b/vanilla-tests/src/test/java/fixtures/requiredoptional/ExplicitTests.java
@@ -18,12 +18,12 @@ public class ExplicitTests {
     @Test
     public void postRequiredIntegerParameter() throws Exception {
         // Compile time error
-        //client.explicits().postRequiredIntegerParameter(null);
+        //client.getExplicits().postRequiredIntegerParameter(null);
     }
 
     @Test
     public void postOptionalIntegerParameter() throws Exception {
-        client.explicits().postOptionalIntegerParameter(null);
+        client.getExplicits().postOptionalIntegerParameter(null);
     }
 
     @Test
@@ -37,24 +37,24 @@ public class ExplicitTests {
     public void postOptionalIntegerProperty() throws Exception {
         IntOptionalWrapper body = new IntOptionalWrapper();
         body.setValue(null);
-        client.explicits().postOptionalIntegerProperty(body);
+        client.getExplicits().postOptionalIntegerProperty(body);
     }
 
     @Test
     public void postRequiredIntegerHeader() throws Exception {
         // Compile time error
-        //client.explicits().postRequiredIntegerHeader(null);
+        //client.getExplicits().postRequiredIntegerHeader(null);
     }
 
     @Test
     public void postOptionalIntegerHeader() throws Exception {
-        client.explicits().postOptionalIntegerHeader(null);
+        client.getExplicits().postOptionalIntegerHeader(null);
     }
 
     @Test
     public void postRequiredStringParameter() throws Exception {
         try {
-            client.explicits().postRequiredStringParameter(null);
+            client.getExplicits().postRequiredStringParameter(null);
             fail();
         } catch (IllegalArgumentException ex) {
             Assert.assertTrue(ex.getMessage().contains("Parameter bodyParameter is required"));
@@ -63,7 +63,7 @@ public class ExplicitTests {
 
     @Test
     public void postOptionalStringParameter() throws Exception {
-        client.explicits().postOptionalStringParameter(null);
+        client.getExplicits().postOptionalStringParameter(null);
     }
 
     @Test
@@ -71,7 +71,7 @@ public class ExplicitTests {
         try {
             StringWrapper body = new StringWrapper();
             body.setValue(null);
-            client.explicits().postRequiredStringProperty(body);
+            client.getExplicits().postRequiredStringProperty(body);
             fail();
         } catch (IllegalArgumentException ex) {
             Assert.assertTrue(ex.getMessage().contains("Missing required property value"));
@@ -82,13 +82,13 @@ public class ExplicitTests {
     public void postOptionalStringProperty() throws Exception {
         StringOptionalWrapper body = new StringOptionalWrapper();
         body.setValue(null);
-        client.explicits().postOptionalStringProperty(body);
+        client.getExplicits().postOptionalStringProperty(body);
     }
 
     @Test
     public void postRequiredStringHeader() throws Exception {
         try {
-            client.explicits().postRequiredStringHeader(null);
+            client.getExplicits().postRequiredStringHeader(null);
             fail();
         } catch (IllegalArgumentException ex) {
             Assert.assertTrue(ex.getMessage().contains("Parameter headerParameter is required"));
@@ -97,13 +97,13 @@ public class ExplicitTests {
 
     @Test
     public void postOptionalStringHeader() throws Exception {
-        client.explicits().postOptionalStringHeader(null);
+        client.getExplicits().postOptionalStringHeader(null);
     }
 
     @Test
     public void postRequiredClassParameter() throws Exception {
         try {
-            client.explicits().postRequiredClassParameter(null);
+            client.getExplicits().postRequiredClassParameter(null);
             fail();
         } catch (IllegalArgumentException ex) {
             Assert.assertTrue(ex.getMessage().contains("Parameter bodyParameter is required"));
@@ -112,7 +112,7 @@ public class ExplicitTests {
 
     @Test
     public void postOptionalClassParameter() throws Exception {
-        client.explicits().postOptionalClassParameter(null);
+        client.getExplicits().postOptionalClassParameter(null);
     }
 
     @Test
@@ -120,7 +120,7 @@ public class ExplicitTests {
         try {
             ClassWrapper body = new ClassWrapper();
             body.setValue(null);
-            client.explicits().postRequiredClassProperty(body);
+            client.getExplicits().postRequiredClassProperty(body);
             fail();
         } catch (IllegalArgumentException ex) {
             Assert.assertTrue(ex.getMessage().contains("Missing required property value"));
@@ -131,13 +131,13 @@ public class ExplicitTests {
     public void postOptionalClassProperty() throws Exception {
         ClassOptionalWrapper body = new ClassOptionalWrapper();
         body.setValue(null);
-        client.explicits().postOptionalClassProperty(body);
+        client.getExplicits().postOptionalClassProperty(body);
     }
 
     @Test
     public void postRequiredArrayParameter() throws Exception {
         try {
-            client.explicits().postRequiredArrayParameter(null);
+            client.getExplicits().postRequiredArrayParameter(null);
             fail();
         } catch (IllegalArgumentException ex) {
             Assert.assertTrue(ex.getMessage().contains("Parameter bodyParameter is required"));
@@ -146,7 +146,7 @@ public class ExplicitTests {
 
     @Test
     public void postOptionalArrayParameter() throws Exception {
-        client.explicits().postOptionalArrayParameter(null);
+        client.getExplicits().postOptionalArrayParameter(null);
     }
 
     @Test
@@ -154,7 +154,7 @@ public class ExplicitTests {
         try {
             ArrayWrapper body = new ArrayWrapper();
             body.setValue(null);
-            client.explicits().postRequiredArrayProperty(body);
+            client.getExplicits().postRequiredArrayProperty(body);
             fail();
         } catch (IllegalArgumentException ex) {
             Assert.assertTrue(ex.getMessage().contains("Missing required property value"));
@@ -165,13 +165,13 @@ public class ExplicitTests {
     public void postOptionalArrayProperty() throws Exception {
         ArrayOptionalWrapper body = new ArrayOptionalWrapper();
         body.setValue(null);
-        client.explicits().postOptionalArrayProperty(body);
+        client.getExplicits().postOptionalArrayProperty(body);
     }
 
     @Test
     public void postRequiredArrayHeader() throws Exception {
         try {
-            client.explicits().postRequiredArrayHeader(null);
+            client.getExplicits().postRequiredArrayHeader(null);
             fail();
         } catch (IllegalArgumentException ex) {
             Assert.assertTrue(ex.getMessage().contains("Parameter headerParameter is required"));
@@ -180,6 +180,6 @@ public class ExplicitTests {
 
     @Test
     public void postOptionalArrayHeader() throws Exception {
-        client.explicits().postOptionalArrayHeader(null);
+        client.getExplicits().postOptionalArrayHeader(null);
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/requiredoptional/ImplicitTests.java
+++ b/vanilla-tests/src/test/java/fixtures/requiredoptional/ImplicitTests.java
@@ -17,7 +17,7 @@ public class ImplicitTests {
     @Test
     public void getRequiredPath() throws Exception {
         try {
-            client.implicits().getRequiredPath(null);
+            client.getImplicits().getRequiredPath(null);
             fail();
         } catch (IllegalArgumentException ex) {
             Assert.assertTrue(ex.getMessage().contains("Parameter pathParameter is required"));
@@ -26,23 +26,23 @@ public class ImplicitTests {
 
     @Test
     public void putOptionalQuery() throws Exception {
-        client.implicits().putOptionalQuery(null);
+        client.getImplicits().putOptionalQuery(null);
     }
 
     @Test
     public void putOptionalHeader() throws Exception {
-        client.implicits().putOptionalHeader(null);
+        client.getImplicits().putOptionalHeader(null);
     }
 
     @Test
     public void putOptionalBody() throws Exception {
-        client.implicits().putOptionalBody(null);
+        client.getImplicits().putOptionalBody(null);
     }
 
     @Test
     public void getRequiredGlobalPath() throws Exception {
         try {
-            client.implicits().getRequiredGlobalPath();
+            client.getImplicits().getRequiredGlobalPath();
             fail();
         } catch (IllegalArgumentException ex) {
             Assert.assertTrue(ex.getMessage().contains("this.client.getRequiredGlobalPath() is required"));
@@ -52,7 +52,7 @@ public class ImplicitTests {
     @Test
     public void getRequiredGlobalQuery() throws Exception {
         try {
-            client.implicits().getRequiredGlobalQuery();
+            client.getImplicits().getRequiredGlobalQuery();
             fail();
         } catch (IllegalArgumentException ex) {
             Assert.assertTrue(ex.getMessage().contains("this.client.getRequiredGlobalQuery() is required"));
@@ -61,6 +61,6 @@ public class ImplicitTests {
 
     @Test
     public void getOptionalGlobalQuery() throws Exception {
-        client.implicits().getOptionalGlobalQuery();
+        client.getImplicits().getOptionalGlobalQuery();
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/url/PathItemsTests.java
+++ b/vanilla-tests/src/test/java/fixtures/url/PathItemsTests.java
@@ -15,7 +15,7 @@ public class PathItemsTests {
     public void getAllWithValues() throws Exception {
         client.globalStringPath("globalStringPath");
         client.globalStringQuery("globalStringQuery");
-        client.buildClient().pathItems().getAllWithValues(
+        client.buildClient().getPathItems().getAllWithValues(
                 "pathItemStringPath",
                 "localStringPath",
                 "pathItemStringQuery",
@@ -27,7 +27,7 @@ public class PathItemsTests {
     public void getGlobalQueryNull() throws Exception {
         client.globalStringPath("globalStringPath");
         client.globalStringQuery(null);
-        client.buildClient().pathItems().getGlobalQueryNull(
+        client.buildClient().getPathItems().getGlobalQueryNull(
                 "pathItemStringPath",
                 "localStringPath",
                 "pathItemStringQuery",
@@ -39,7 +39,7 @@ public class PathItemsTests {
     public void getGlobalAndLocalQueryNull() throws Exception {
         client.globalStringPath("globalStringPath");
         client.globalStringQuery(null);
-        client.buildClient().pathItems().getGlobalAndLocalQueryNull(
+        client.buildClient().getPathItems().getGlobalAndLocalQueryNull(
                 "pathItemStringPath",
                 "localStringPath",
                 "pathItemStringQuery",
@@ -51,7 +51,7 @@ public class PathItemsTests {
     public void getLocalPathItemQueryNull() throws Exception {
         client.globalStringPath("globalStringPath");
         client.globalStringQuery("globalStringQuery");
-        client.buildClient().pathItems().getLocalPathItemQueryNull(
+        client.buildClient().getPathItems().getLocalPathItemQueryNull(
                 "pathItemStringPath",
                 "localStringPath",
                 null,

--- a/vanilla-tests/src/test/java/fixtures/url/PathsTests.java
+++ b/vanilla-tests/src/test/java/fixtures/url/PathsTests.java
@@ -18,68 +18,68 @@ public class PathsTests {
 
     @Test
     public void getBooleanTrue() throws Exception {
-        client.paths().getBooleanTrue();
+        client.getPaths().getBooleanTrue();
     }
 
     @Test
     public void getBooleanFalse() throws Exception {
-        client.paths().getBooleanFalse();
+        client.getPaths().getBooleanFalse();
     }
 
     @Test
     public void getIntOneMillion() throws Exception {
-        client.paths().getIntOneMillion();
+        client.getPaths().getIntOneMillion();
     }
 
     @Test
     public void getIntNegativeOneMillion() throws Exception {
-        client.paths().getIntNegativeOneMillion();
+        client.getPaths().getIntNegativeOneMillion();
     }
 
     @Test
     public void getTenBillion() throws Exception {
-        client.paths().getTenBillion();
+        client.getPaths().getTenBillion();
     }
 
     @Test
     public void getNegativeTenBillion() throws Exception {
-        client.paths().getNegativeTenBillion();
+        client.getPaths().getNegativeTenBillion();
     }
 
     @Test
     public void floatScientificPositive() throws Exception {
-        client.paths().floatScientificPositive();
+        client.getPaths().floatScientificPositive();
     }
 
     @Test
     public void floatScientificNegative() throws Exception {
-        client.paths().floatScientificNegative();
+        client.getPaths().floatScientificNegative();
     }
 
     @Test
     public void doubleDecimalPositive() throws Exception {
-        client.paths().doubleDecimalPositive();
+        client.getPaths().doubleDecimalPositive();
     }
 
     @Test
     public void doubleDecimalNegative() throws Exception {
-        client.paths().doubleDecimalNegative();
+        client.getPaths().doubleDecimalNegative();
     }
 
     @Test
     public void stringUrlEncoded() throws Exception {
-        client.paths().stringUrlEncoded();
+        client.getPaths().stringUrlEncoded();
     }
 
     @Test
     public void stringEmpty() throws Exception {
-        client.paths().stringEmpty();
+        client.getPaths().stringEmpty();
     }
 
     @Ignore("Client side validation")
     public void stringNull() throws Exception {
         try {
-            client.paths().stringNull(null);
+            client.getPaths().stringNull(null);
         } catch (IllegalArgumentException ex) {
             Assert.assertTrue(ex.getMessage().contains("Parameter stringPath is required"));
         }
@@ -87,13 +87,13 @@ public class PathsTests {
 
     @Test
     public void enumValid() throws Exception {
-        client.paths().enumValid(UriColor.GREEN_COLOR);
+        client.getPaths().enumValid(UriColor.GREEN_COLOR);
     }
 
     @Test
     public void enumNull() throws Exception {
         try {
-            client.paths().enumNull(null);
+            client.getPaths().enumNull(null);
         } catch (IllegalArgumentException ex) {
             Assert.assertTrue(ex.getMessage().contains("Parameter enumPath is required"));
         }
@@ -101,18 +101,18 @@ public class PathsTests {
 
     @Test
     public void byteMultiByte() throws Exception {
-        client.paths().byteMultiByte("啊齄丂狛狜隣郎隣兀﨩".getBytes("UTF-8"));
+        client.getPaths().byteMultiByte("啊齄丂狛狜隣郎隣兀﨩".getBytes("UTF-8"));
     }
 
     @Test
     public void byteEmpty() throws Exception {
-        client.paths().byteEmpty();
+        client.getPaths().byteEmpty();
     }
 
     @Test
     public void byteNull() throws Exception {
         try {
-            client.paths().byteNull(null);
+            client.getPaths().byteNull(null);
         } catch (IllegalArgumentException ex) {
             Assert.assertTrue(ex.getMessage().contains("Parameter bytePath is required"));
         }
@@ -120,13 +120,13 @@ public class PathsTests {
 
     @Test
     public void dateValid() throws Exception {
-        client.paths().dateValid();
+        client.getPaths().dateValid();
     }
 
     @Test
     public void dateNull() throws Exception {
         try {
-            client.paths().dateNull(null);
+            client.getPaths().dateNull(null);
         } catch (IllegalArgumentException ex) {
             Assert.assertTrue(ex.getMessage().contains("Parameter datePath is required"));
         }
@@ -134,13 +134,13 @@ public class PathsTests {
 
     @Test
     public void dateTimeValid() throws Exception {
-        client.paths().dateTimeValid();
+        client.getPaths().dateTimeValid();
     }
 
     @Test
     public void dateTimeNull() throws Exception {
         try {
-            client.paths().dateTimeNull(null);
+            client.getPaths().dateTimeNull(null);
         } catch (IllegalArgumentException ex) {
             Assert.assertTrue(ex.getMessage().contains("Parameter dateTimePath is required"));
         }
@@ -148,7 +148,7 @@ public class PathsTests {
 
     @Test
     public void base64Url() throws Exception {
-        client.paths().base64Url("lorem".getBytes());
+        client.getPaths().base64Url("lorem".getBytes());
     }
 
     /*
@@ -165,6 +165,6 @@ public class PathsTests {
 
     @Test
     public void unixTimeUrl() throws Exception {
-        client.paths().unixTimeUrl(OffsetDateTime.parse("2016-04-13T00:00:00Z"));
+        client.getPaths().unixTimeUrl(OffsetDateTime.parse("2016-04-13T00:00:00Z"));
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/url/QueriesTests.java
+++ b/vanilla-tests/src/test/java/fixtures/url/QueriesTests.java
@@ -19,93 +19,93 @@ public class QueriesTests {
 
     @Test
     public void getBooleanTrue() throws Exception {
-        client.queries().getBooleanTrue();
+        client.getQueries().getBooleanTrue();
     }
 
     @Test
     public void getBooleanFalse() throws Exception {
-        client.queries().getBooleanFalse();
+        client.getQueries().getBooleanFalse();
     }
 
     @Test
     public void getBooleanNull() throws Exception {
-        client.queries().getBooleanNull(null);
+        client.getQueries().getBooleanNull(null);
     }
 
     @Test
     public void getIntOneMillion() throws Exception {
-        client.queries().getIntOneMillion();
+        client.getQueries().getIntOneMillion();
     }
 
     @Test
     public void getIntNegativeOneMillion() throws Exception {
-        client.queries().getIntNegativeOneMillion();
+        client.getQueries().getIntNegativeOneMillion();
     }
 
     @Test
     public void getIntNull() throws Exception {
-        client.queries().getIntNull(null);
+        client.getQueries().getIntNull(null);
     }
 
     @Test
     public void getTenBillion() throws Exception {
-        client.queries().getTenBillion();
+        client.getQueries().getTenBillion();
     }
 
     @Test
     public void getNegativeTenBillion() throws Exception {
-        client.queries().getNegativeTenBillion();
+        client.getQueries().getNegativeTenBillion();
     }
 
     @Test
     public void getLongNull() throws Exception {
-        client.queries().getLongNull(null);
+        client.getQueries().getLongNull(null);
     }
 
     @Test
     public void floatScientificPositive() throws Exception {
-        client.queries().floatScientificPositive();
+        client.getQueries().floatScientificPositive();
     }
 
     @Test
     public void floatScientificNegative() throws Exception {
-        client.queries().floatScientificNegative();
+        client.getQueries().floatScientificNegative();
     }
 
     @Test
     public void floatNull() throws Exception {
-        client.queries().floatNull(null);
+        client.getQueries().floatNull(null);
     }
 
     @Test
     public void doubleDecimalPositive() throws Exception {
-        client.queries().doubleDecimalPositive();
+        client.getQueries().doubleDecimalPositive();
     }
 
     @Test
     public void doubleDecimalNegative() throws Exception {
-        client.queries().doubleDecimalNegative();
+        client.getQueries().doubleDecimalNegative();
     }
 
     @Test
     public void doubleNull() throws Exception {
-        client.queries().doubleNull(null);
+        client.getQueries().doubleNull(null);
     }
 
     @Test
     public void stringUrlEncoded() throws Exception {
-        client.queries().stringUrlEncoded();
+        client.getQueries().stringUrlEncoded();
     }
 
     @Test
     public void stringEmpty() throws Exception {
-        client.queries().stringEmpty();
+        client.getQueries().stringEmpty();
     }
 
     @Test
     public void stringNull() throws Exception {
         try {
-            client.queries().stringNull(null);
+            client.getQueries().stringNull(null);
         } catch (ErrorException ex) {
             Assert.assertTrue(ex.getMessage().contains("Parameter stringPath is required"));
         }
@@ -113,13 +113,13 @@ public class QueriesTests {
 
     @Test
     public void enumValid() throws Exception {
-        client.queries().enumValid(UriColor.GREEN_COLOR);
+        client.getQueries().enumValid(UriColor.GREEN_COLOR);
     }
 
     @Test
     public void enumNull() throws Exception {
         try {
-            client.queries().enumNull(null);
+            client.getQueries().enumNull(null);
         } catch (ErrorException ex) {
             Assert.assertTrue(ex.getMessage().contains("Parameter enumPath is required"));
         }
@@ -127,18 +127,18 @@ public class QueriesTests {
 
     @Test
     public void byteMultiByte() throws Exception {
-        client.queries().byteMultiByte("啊齄丂狛狜隣郎隣兀﨩".getBytes("UTF-8"));
+        client.getQueries().byteMultiByte("啊齄丂狛狜隣郎隣兀﨩".getBytes("UTF-8"));
     }
 
     @Test
     public void byteEmpty() throws Exception {
-        client.queries().byteEmpty();
+        client.getQueries().byteEmpty();
     }
 
     @Test
     public void byteNull() throws Exception {
         try {
-            client.queries().byteNull(null);
+            client.getQueries().byteNull(null);
         } catch (ErrorException ex) {
             Assert.assertTrue(ex.getMessage().contains("Parameter bytePath is required"));
         }
@@ -146,13 +146,13 @@ public class QueriesTests {
 
     @Test
     public void dateValid() throws Exception {
-        client.queries().dateValid();
+        client.getQueries().dateValid();
     }
 
     @Test
     public void dateNull() throws Exception {
         try {
-            client.queries().dateNull(null);
+            client.getQueries().dateNull(null);
         } catch (ErrorException ex) {
             Assert.assertTrue(ex.getMessage().contains("Parameter datePath is required"));
         }
@@ -160,13 +160,13 @@ public class QueriesTests {
 
     @Test
     public void dateTimeValid() throws Exception {
-        client.queries().dateTimeValid();
+        client.getQueries().dateTimeValid();
     }
 
     @Test
     public void dateTimeNull() throws Exception {
         try {
-            client.queries().dateTimeNull(null);
+            client.getQueries().dateTimeNull(null);
         } catch (ErrorException ex) {
             Assert.assertTrue(ex.getMessage().contains("Parameter dateTimePath is required"));
         }
@@ -179,17 +179,17 @@ public class QueriesTests {
         query.add("begin!*'();:@ &=+$,/?#[]end");
         query.add(null);
         query.add("");
-        client.queries().arrayStringCsvValid(query);
+        client.getQueries().arrayStringCsvValid(query);
     }
 
     @Test
     public void arrayStringCsvNull() throws Exception {
-        client.queries().arrayStringCsvNull(null);
+        client.getQueries().arrayStringCsvNull(null);
     }
 
     @Test
     public void arrayStringCsvEmpty() throws Exception {
-        client.queries().arrayStringCsvEmpty(new ArrayList<String>());
+        client.getQueries().arrayStringCsvEmpty(new ArrayList<String>());
     }
 
     @Test
@@ -199,7 +199,7 @@ public class QueriesTests {
         query.add("begin!*'();:@ &=+$,/?#[]end");
         query.add(null);
         query.add("");
-        client.queries().arrayStringSsvValid(query);
+        client.getQueries().arrayStringSsvValid(query);
     }
 
     @Test
@@ -209,7 +209,7 @@ public class QueriesTests {
         query.add("begin!*'();:@ &=+$,/?#[]end");
         query.add(null);
         query.add("");
-        client.queries().arrayStringTsvValid(query);
+        client.getQueries().arrayStringTsvValid(query);
     }
 
     @Test
@@ -219,6 +219,6 @@ public class QueriesTests {
         query.add("begin!*'();:@ &=+$,/?#[]end");
         query.add(null);
         query.add("");
-        client.queries().arrayStringPipesValid(query);
+        client.getQueries().arrayStringPipesValid(query);
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/xmlservice/XmlServiceTests.java
+++ b/vanilla-tests/src/test/java/fixtures/xmlservice/XmlServiceTests.java
@@ -23,7 +23,7 @@ public class XmlServiceTests {
 
   @Test
   public void getSimpleDocument() {
-    Slideshow slideshow = client.xmls().getSimpleAsync().block();
+    Slideshow slideshow = client.getXmls().getSimpleAsync().block();
     assertNotNull(slideshow);
     assertEquals("Yours Truly", slideshow.getAuthor());
     assertEquals("Date of publication", slideshow.getDate());
@@ -46,7 +46,7 @@ public class XmlServiceTests {
 
   @Test
   public void getEmptyList() {
-    Slideshow slideshow = client.xmls().getEmptyListAsync().block();
+    Slideshow slideshow = client.getXmls().getEmptyListAsync().block();
     assertNotNull(slideshow);
     assertNotNull(slideshow.getSlides());
     assertEquals(null, slideshow.getTitle());
@@ -57,7 +57,7 @@ public class XmlServiceTests {
 
   @Test
   public void getEmptyWrappedLists() {
-    AppleBarrel barrel = client.xmls().getEmptyWrappedListsAsync().block();
+    AppleBarrel barrel = client.getXmls().getEmptyWrappedListsAsync().block();
     assertNotNull(barrel);
     assertNotNull(barrel.getBadApples());
     assertEquals(0, barrel.getBadApples().size());
@@ -68,13 +68,13 @@ public class XmlServiceTests {
 
   @Test
   public void putSimpleDocument() {
-    Slideshow slideshow = client.xmls().getSimpleAsync().block();
-    client.xmls().putSimpleAsync(slideshow).block();
+    Slideshow slideshow = client.getXmls().getSimpleAsync().block();
+    client.getXmls().putSimpleAsync(slideshow).block();
   }
 
   @Test
   public void getWrappedLists() {
-    AppleBarrel barrel = client.xmls().getWrappedListsAsync().block();
+    AppleBarrel barrel = client.getXmls().getWrappedListsAsync().block();
     assertNotNull(barrel);
 
     assertNotNull(barrel.getGoodApples());
@@ -87,13 +87,13 @@ public class XmlServiceTests {
 
   @Test
   public void putWrappedLists() {
-    AppleBarrel barrel = client.xmls().getWrappedListsAsync().block();
-    client.xmls().putWrappedListsAsync(barrel).block();
+    AppleBarrel barrel = client.getXmls().getWrappedListsAsync().block();
+    client.getXmls().putWrappedListsAsync(barrel).block();
   }
 
   @Test
   public void getRootList() {
-    List<Banana> bananas = client.xmls().getRootListAsync().block();
+    List<Banana> bananas = client.getXmls().getRootListAsync().block();
     assertNotNull(bananas);
     assertEquals(2, bananas.size());
 
@@ -108,7 +108,7 @@ public class XmlServiceTests {
 
   @Test
   public void getItemWithEmptyChildElement() {
-    Banana banana = client.xmls().getEmptyChildElementAsync().block();
+    Banana banana = client.getXmls().getEmptyChildElementAsync().block();
     assertNotNull(banana);
 
     assertEquals("Unknown Banana", banana.getName());
@@ -118,32 +118,32 @@ public class XmlServiceTests {
 
   @Test
   public void putItemWithEmptyChildElement() {
-    Banana banana = client.xmls().getEmptyChildElementAsync().block();
-    client.xmls().putEmptyChildElementAsync(banana).block();
+    Banana banana = client.getXmls().getEmptyChildElementAsync().block();
+    client.getXmls().putEmptyChildElementAsync(banana).block();
   }
 
   @Test
   public void putRootList() {
-    List<Banana> bananas = client.xmls().getRootListAsync().block();
-    client.xmls().putRootListAsync(bananas).block();
+    List<Banana> bananas = client.getXmls().getRootListAsync().block();
+    client.getXmls().putRootListAsync(bananas).block();
   }
 
   @Test
   public void getEmptyRootList() {
-    List<Banana> bananas = client.xmls().getEmptyRootListAsync().block();
+    List<Banana> bananas = client.getXmls().getEmptyRootListAsync().block();
     assertNotNull(bananas);
     assertEquals(0, bananas.size());
   }
 
   @Test
   public void putEmptyRootList() {
-    List<Banana> bananas = client.xmls().getEmptyRootListAsync().block();
-    client.xmls().putEmptyRootListAsync(bananas).block();
+    List<Banana> bananas = client.getXmls().getEmptyRootListAsync().block();
+    client.getXmls().putEmptyRootListAsync(bananas).block();
   }
 
   @Test
   public void testResponseHeaders() {
-    XmlsGetHeadersHeaders headers = client.xmls().getHeadersWithResponseAsync().block().getDeserializedHeaders();
+    XmlsGetHeadersHeaders headers = client.getXmls().getHeadersWithResponseAsync().block().getDeserializedHeaders();
     assertEquals("custom-value", headers.getCustomHeader());
   }
 }


### PR DESCRIPTION
This PR adds support for `time` type. A new TimeSchema is added which will use `String` representation. This is because Java's `OffsetTime` requires a zone offset while `LocalTime` doesn't support zone offset. As per ISO 8601, zone offset is optional. Before we make a decision on which type to use, this PR represents time as a string to unblock Form Recognizer.