### PR TITLE
escape dot in discriminator to avoid it get flatten

### DIFF
--- a/fluentnamer/readme.md
+++ b/fluentnamer/readme.md
@@ -6,7 +6,7 @@ pass-thru:
   - subset-reducer
 
 use-extension:
-  "@autorest/modelerfour": "4.13.309"
+  "@autorest/modelerfour": "4.13.351"
 
 pipeline:
 

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMapper.java
@@ -232,7 +232,7 @@ public class ClientMapper implements IMapper<CodeModel, Client> {
         builder.name(classType.getName()).packageName(classType.getPackage());
         builder.description(String.format("Contains all response data for the %s operation.", method.getLanguage().getJava().getName()));
         builder.headersType(Mappers.getSchemaMapper().map(headerSchema));
-        builder.bodyType(SchemaUtil.operationResponseType(method));
+        builder.bodyType(SchemaUtil.getOperationResponseType(method));
         return builder.build();
     }
 

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -82,7 +82,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
             syncReturnType = GenericType.PagedIterable(elementType);
         } else {
             asyncRestResponseReturnType = null;
-            IType responseBodyType = SchemaUtil.operationResponseType(operation);
+            IType responseBodyType = SchemaUtil.getOperationResponseType(operation);
             IType restAPIMethodReturnBodyClientType = responseBodyType.getClientType();
             if (operation.getResponses().stream().anyMatch(r -> Boolean.TRUE.equals(r.getBinary()))) {
                 asyncReturnType = GenericType.Flux(ClassType.ByteBuffer);

--- a/javagen/src/main/java/com/azure/autorest/mapper/ModelMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ModelMapper.java
@@ -14,6 +14,8 @@ import com.azure.autorest.model.clientmodel.ClientModel;
 import com.azure.autorest.model.clientmodel.ClientModelProperty;
 import com.azure.autorest.model.clientmodel.ClientModels;
 import com.azure.autorest.model.clientmodel.IType;
+import com.azure.autorest.util.SchemaUtil;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -146,21 +148,11 @@ public class ModelMapper implements IMapper<ObjectSchema, ClientModel> {
             }
 
             boolean discriminatorNeedEscape = false;
-            if (compositeType.getDiscriminator() != null) {
-                String discriminator = compositeType.getDiscriminator().getProperty().getSerializedName();
-                discriminatorNeedEscape = discriminator.contains(".");
-                discriminator = discriminatorNeedEscape ? discriminator.replace(".", "\\\\.") : discriminator;
-                builder.polymorphicDiscriminator(discriminator);
-            } else if (isPolymorphic) {
-                for (ComplexSchema parent : compositeType.getParents().getAll()) {
-                    if (((ObjectSchema) parent).getDiscriminator() != null) {
-                        String discriminator = ((ObjectSchema) parent).getDiscriminator().getProperty().getSerializedName();
-                        discriminatorNeedEscape = discriminator.contains(".");
-                        discriminator = discriminatorNeedEscape ? discriminator.replace(".", "\\\\.") : discriminator;
-                        builder.polymorphicDiscriminator(discriminator);
-                        break;
-                    }
-                }
+            if (isPolymorphic) {
+                String discriminatorSerializedName = SchemaUtil.getDiscriminatorSerializedName(compositeType);
+                discriminatorNeedEscape = discriminatorSerializedName.contains(".");
+                discriminatorSerializedName = discriminatorNeedEscape ? discriminatorSerializedName.replace(".", "\\\\.") : discriminatorSerializedName;
+                builder.polymorphicDiscriminator(discriminatorSerializedName);
             }
 
             String modelSerializedName = compositeType.getDiscriminatorValue();

--- a/javagen/src/main/java/com/azure/autorest/mapper/ModelMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ModelMapper.java
@@ -149,14 +149,14 @@ public class ModelMapper implements IMapper<ObjectSchema, ClientModel> {
             if (compositeType.getDiscriminator() != null) {
                 String discriminator = compositeType.getDiscriminator().getProperty().getSerializedName();
                 discriminatorNeedEscape = discriminator.contains(".");
-                discriminator = discriminator.replace(".", "\\\\.");
+                discriminator = discriminatorNeedEscape ? discriminator.replace(".", "\\\\.") : discriminator;
                 builder.polymorphicDiscriminator(discriminator);
             } else if (isPolymorphic) {
                 for (ComplexSchema parent : compositeType.getParents().getAll()) {
                     if (((ObjectSchema) parent).getDiscriminator() != null) {
                         String discriminator = ((ObjectSchema) parent).getDiscriminator().getProperty().getSerializedName();
                         discriminatorNeedEscape = discriminator.contains(".");
-                        discriminator = discriminator.replace(".", "\\\\.");
+                        discriminator = discriminatorNeedEscape ? discriminator.replace(".", "\\\\.") : discriminator;
                         builder.polymorphicDiscriminator(discriminator);
                         break;
                     }

--- a/javagen/src/main/java/com/azure/autorest/mapper/ModelPropertyMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ModelPropertyMapper.java
@@ -7,6 +7,8 @@ import com.azure.autorest.extension.base.model.codemodel.Schema;
 import com.azure.autorest.extension.base.model.codemodel.XmlSerlializationFormat;
 import com.azure.autorest.model.clientmodel.ClientModelProperty;
 import com.azure.autorest.model.clientmodel.IType;
+import com.azure.autorest.util.SchemaUtil;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -37,7 +39,10 @@ public class ModelPropertyMapper implements IMapper<Property, ClientModelPropert
         if (property.getParentSchema() != null) {
             flattened = property.getParentSchema().getProperties().stream()
                     .anyMatch(p -> p.getFlattenedNames() != null && !p.getFlattenedNames().isEmpty());
-            flattened = flattened || (property.getParentSchema().getDiscriminator() != null && property.getParentSchema().getDiscriminator().getProperty().getSerializedName().contains("."));
+            if (!flattened) {
+                String discriminatorSerializedName = SchemaUtil.getDiscriminatorSerializedName(property.getParentSchema());
+                flattened = discriminatorSerializedName != null && discriminatorSerializedName.contains(".");
+            }
         }
 
         StringBuilder serializedName = new StringBuilder();

--- a/javagen/src/main/java/com/azure/autorest/mapper/ModelPropertyMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ModelPropertyMapper.java
@@ -37,6 +37,7 @@ public class ModelPropertyMapper implements IMapper<Property, ClientModelPropert
         if (property.getParentSchema() != null) {
             flattened = property.getParentSchema().getProperties().stream()
                     .anyMatch(p -> p.getFlattenedNames() != null && !p.getFlattenedNames().isEmpty());
+            flattened = flattened || (property.getParentSchema().getDiscriminator() != null && property.getParentSchema().getDiscriminator().getProperty().getSerializedName().contains("."));
         }
 
         StringBuilder serializedName = new StringBuilder();

--- a/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
@@ -60,7 +60,7 @@ public class ProxyMethodMapper implements IMapper<Operation, Map<Request, ProxyM
                 .map(s -> HttpResponseStatus.valueOf(Integer.parseInt(s)))
                 .sorted().collect(Collectors.toList()));
 
-        IType responseBodyType = SchemaUtil.operationResponseType(operation);
+        IType responseBodyType = SchemaUtil.getOperationResponseType(operation);
 
         IType returnType;
         if (operation.getExtensions() != null && operation.getExtensions().isXmsLongRunningOperation() && settings.isFluent()) {

--- a/javagen/src/main/java/com/azure/autorest/util/SchemaUtil.java
+++ b/javagen/src/main/java/com/azure/autorest/util/SchemaUtil.java
@@ -1,6 +1,7 @@
 package com.azure.autorest.util;
 
 import com.azure.autorest.extension.base.model.codemodel.AnySchema;
+import com.azure.autorest.extension.base.model.codemodel.ComplexSchema;
 import com.azure.autorest.extension.base.model.codemodel.ObjectSchema;
 import com.azure.autorest.extension.base.model.codemodel.Operation;
 import com.azure.autorest.extension.base.model.codemodel.Response;
@@ -66,7 +67,7 @@ public class SchemaUtil {
         return chain.isEmpty() ? new AnySchema() : chain.getLast();
     }
 
-    public static IType operationResponseType(Operation operation) {
+    public static IType getOperationResponseType(Operation operation) {
         Schema responseBodySchema = SchemaUtil.getLowestCommonParent(
                 operation.getResponses().stream().map(Response::getSchema).filter(Objects::nonNull).collect(Collectors.toList()));
         IType responseBodyType = Mappers.getSchemaMapper().map(responseBodySchema);
@@ -82,5 +83,20 @@ public class SchemaUtil {
         }
 
         return responseBodyType;
+    }
+
+    public static String getDiscriminatorSerializedName(ObjectSchema compositeType) {
+        String discriminator = null;
+        if (compositeType.getDiscriminator() != null) {
+            discriminator = compositeType.getDiscriminator().getProperty().getSerializedName();
+        } else if (compositeType.getDiscriminatorValue() != null) {
+            for (ComplexSchema parent : compositeType.getParents().getAll()) {
+                if (((ObjectSchema) parent).getDiscriminator() != null) {
+                    discriminator = ((ObjectSchema) parent).getDiscriminator().getProperty().getSerializedName();
+                    break;
+                }
+            }
+        }
+        return discriminator;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/DotFish.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/DotFish.java
@@ -1,6 +1,7 @@
 package fixtures.bodycomplex.models;
 
 import com.azure.core.annotation.Fluent;
+import com.azure.core.annotation.JsonFlatten;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -9,11 +10,12 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 /**
  * The DotFish model.
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "fish.type", defaultImpl = DotFish.class)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "fish\\.type", defaultImpl = DotFish.class)
 @JsonTypeName("DotFish")
 @JsonSubTypes({
     @JsonSubTypes.Type(name = "DotSalmon", value = DotSalmon.class)
 })
+@JsonFlatten
 @Fluent
 public class DotFish {
     /*

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/DotSalmon.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/DotSalmon.java
@@ -1,6 +1,7 @@
 package fixtures.bodycomplex.models;
 
 import com.azure.core.annotation.Fluent;
+import com.azure.core.annotation.JsonFlatten;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -8,10 +9,11 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 /**
  * The DotSalmon model.
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "fish.type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "fish\\.type")
 @JsonTypeName("DotSalmon")
+@JsonFlatten
 @Fluent
-public final class DotSalmon extends DotFish {
+public class DotSalmon extends DotFish {
     /*
      * The location property.
      */

--- a/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClient.java
+++ b/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClient.java
@@ -107,6 +107,11 @@ public final class MediaTypesClient {
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Mono<SimpleResponse<String>> analyzeBody(@HostParam("$host") String host, @BodyParam("application/json") SourcePath input, Context context);
+
+        @Post("/mediatypes/contentTypeWithEncoding")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(HttpResponseException.class)
+        Mono<SimpleResponse<String>> contentTypeWithEncoding(@HostParam("$host") String host, @BodyParam("text/plain") String input, Context context);
     }
 
     /**
@@ -229,5 +234,60 @@ public final class MediaTypesClient {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public String analyzeBody(String source) {
         return analyzeBodyAsync(source).block();
+    }
+
+    /**
+     * Pass in contentType 'text/plain; encoding=UTF-8' to pass test. Value for input does not matter.
+     * 
+     * @param input simple string.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<SimpleResponse<String>> contentTypeWithEncodingWithResponseAsync(String input) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        if (input == null) {
+            return Mono.error(new IllegalArgumentException("Parameter input is required and cannot be null."));
+        }
+        return FluxUtil.withContext(context -> service.contentTypeWithEncoding(this.getHost(), input, context));
+    }
+
+    /**
+     * Pass in contentType 'text/plain; encoding=UTF-8' to pass test. Value for input does not matter.
+     * 
+     * @param input simple string.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> contentTypeWithEncodingAsync(String input) {
+        return contentTypeWithEncodingWithResponseAsync(input)
+            .flatMap((SimpleResponse<String> res) -> {
+                if (res.getValue() != null) {
+                    return Mono.just(res.getValue());
+                } else {
+                    return Mono.empty();
+                }
+            });
+    }
+
+    /**
+     * Pass in contentType 'text/plain; encoding=UTF-8' to pass test. Value for input does not matter.
+     * 
+     * @param input simple string.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public String contentTypeWithEncoding(String input) {
+        return contentTypeWithEncodingAsync(input).block();
     }
 }


### PR DESCRIPTION
If the type using these class has @JsonFlatten, the discriminator of "odata.type" will get expanded to "odata: { type: ... }"

azure-core fixed this in https://github.com/Azure/azure-sdk-for-java/issues/10217, though it requires "@JsonFlatten" annotation and escaping of "odata.type".