### PR TITLE
v4 sync client method context

### DIFF
--- a/fluent-tests/prepare-tests.bat
+++ b/fluent-tests/prepare-tests.bat
@@ -12,7 +12,7 @@ REM re-generate code
 RMDIR /S /Q "src/main/java/com/azure/mgmttest"
 
 SET AUTOREST_CORE_VERSION=3.0.6274
-SET COMMON_ARGUMENTS=--java --use:../ --output-folder=./ --sync-methods=all --azure-arm=true --fluent=true --generate-client-as-impl=true --required-parameter-client-methods=true --track1-naming=true --implementation-subpackage=models --client-side-validations=true --client-logger=true
+SET COMMON_ARGUMENTS=--java --use:../ --output-folder=./ --sync-methods=all --azure-arm=true --fluent=true --generate-client-as-impl=true --required-parameter-client-methods=true --add-context-parameter=true --context-client-method-parameter=true --track1-naming=true --implementation-subpackage=models --client-side-validations=true --client-logger=true
 
 CALL autorest --version=%AUTOREST_CORE_VERSION% %COMMON_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/resources/resource-manager/Microsoft.Resources/stable/2019-08-01/resources.json --namespace=com.azure.mgmttest.resources
 

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -330,6 +330,10 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                             .isGroupedParameterRequired(false)
                             .build());
 
+                    if (settings.isContextClientMethodParameter()) {
+                        addClientMethodWithContext(methods, builder, parameters);
+                    }
+
                     if (generateClientMethodWithOnlyRequiredParameters) {
                         methods.add(builder
                                 .onlyRequiredParameters(true)
@@ -347,6 +351,10 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                             .isGroupedParameterRequired(false)
                             .build());
 
+                    if (settings.isContextClientMethodParameter()) {
+                        addClientMethodWithContext(methods, builder, parameters);
+                    }
+
                     if (generateClientMethodWithOnlyRequiredParameters) {
                         methods.add(builder
                                 .onlyRequiredParameters(true)
@@ -359,10 +367,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
         return methods;
     }
 
-    private void addClientMethodWithContext(List<ClientMethod> methods, Builder builder, ProxyMethod proxyMethod,
-        List<ClientMethodParameter> parameters, ClientMethodType clientMethodType, String proxyMethodName,
-        ReturnValue returnValue) {
-        ClientMethodParameter contextParam = new ClientMethodParameter.Builder()
+    private static final ClientMethodParameter CONTEXT_PARAM = new ClientMethodParameter.Builder()
             .description("The context to associate with this operation.")
             .wireType(ClassType.Context)
             .name("context")
@@ -374,9 +379,11 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
             .isRequired(false)
             .build();
 
-        List<ClientMethodParameter> withContextParameters = new ArrayList<>();
-        withContextParameters.addAll(parameters);
-        withContextParameters.add(contextParam);
+    private void addClientMethodWithContext(List<ClientMethod> methods, Builder builder, ProxyMethod proxyMethod,
+        List<ClientMethodParameter> parameters, ClientMethodType clientMethodType, String proxyMethodName,
+        ReturnValue returnValue) {
+        List<ClientMethodParameter> withContextParameters = new ArrayList<>(parameters);
+        withContextParameters.add(CONTEXT_PARAM);
 
         methods.add(builder
             .parameters(withContextParameters) // update builder parameters to include context
@@ -386,6 +393,18 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
             .type(clientMethodType)
             .isGroupedParameterRequired(false)
             .build());
+        // reset the parameters to original params
+        builder.parameters(parameters);
+    }
+
+    private void addClientMethodWithContext(List<ClientMethod> methods, Builder builder,
+                                            List<ClientMethodParameter> parameters) {
+        List<ClientMethodParameter> withContextParameters = new ArrayList<>(parameters);
+        withContextParameters.add(CONTEXT_PARAM);
+
+        methods.add(builder
+                .parameters(withContextParameters) // update builder parameters to include context
+                .build());
         // reset the parameters to original params
         builder.parameters(parameters);
     }

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -244,6 +244,10 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                                 .isGroupedParameterRequired(false)
                                 .build());
 
+                        if (settings.isContextClientMethodParameter()) {
+                            addClientMethodWithContext(methods, builder, parameters);
+                        }
+
                         if (generateClientMethodWithOnlyRequiredParameters) {
                             methods.add(builder
                                     .onlyRequiredParameters(true)
@@ -262,6 +266,10 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                         .isGroupedParameterRequired(false)
                         .build());
 
+                if (settings.isContextClientMethodParameter()) {
+                    addClientMethodWithContext(methods, builder, parameters);
+                }
+
                 if (settings.getSyncMethods() != JavaSettings.SyncMethodsGeneration.NONE) {
                     methods.add(builder
                             .returnValue(new ReturnValue(returnTypeDescription(operation, asyncReturnType, syncReturnType),
@@ -271,6 +279,10 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                             .type(ClientMethodType.LongRunningAsync)
                             .isGroupedParameterRequired(false)
                             .build());
+
+                    if (settings.isContextClientMethodParameter()) {
+                        addClientMethodWithContext(methods, builder, parameters);
+                    }
 
                     if (generateClientMethodWithOnlyRequiredParameters) {
                         methods.add(builder
@@ -288,6 +300,10 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                             .type(ClientMethodType.LongRunningSync)
                             .isGroupedParameterRequired(false)
                             .build());
+
+                    if (settings.isContextClientMethodParameter()) {
+                        addClientMethodWithContext(methods, builder, parameters);
+                    }
 
                     if (generateClientMethodWithOnlyRequiredParameters) {
                         methods.add(builder

--- a/vanilla-tests/src/main/java/fixtures/bodyboolean/Bools.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyboolean/Bools.java
@@ -135,6 +135,27 @@ public final class Bools {
     /**
      * Get true Boolean value.
      * 
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return true Boolean value.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Boolean> getTrueAsync(Context context) {
+        return getTrueWithResponseAsync(context)
+            .flatMap((SimpleResponse<Boolean> res) -> {
+                if (res.getValue() != null) {
+                    return Mono.just(res.getValue());
+                } else {
+                    return Mono.empty();
+                }
+            });
+    }
+
+    /**
+     * Get true Boolean value.
+     * 
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return true Boolean value.
@@ -142,6 +163,25 @@ public final class Bools {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public boolean getTrue() {
         Boolean value = getTrueAsync().block();
+        if (value != null) {
+            return value;
+        } else {
+            throw new NullPointerException();
+        }
+    }
+
+    /**
+     * Get true Boolean value.
+     * 
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return true Boolean value.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public boolean getTrue(Context context) {
+        Boolean value = getTrueAsync(context).block();
         if (value != null) {
             return value;
         } else {
@@ -199,12 +239,40 @@ public final class Bools {
     /**
      * Set Boolean value true.
      * 
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putTrueAsync(Context context) {
+        return putTrueWithResponseAsync(context)
+            .flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Set Boolean value true.
+     * 
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putTrue() {
         putTrueAsync().block();
+    }
+
+    /**
+     * Set Boolean value true.
+     * 
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void putTrue(Context context) {
+        putTrueAsync(context).block();
     }
 
     /**
@@ -261,6 +329,27 @@ public final class Bools {
     /**
      * Get false Boolean value.
      * 
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return false Boolean value.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Boolean> getFalseAsync(Context context) {
+        return getFalseWithResponseAsync(context)
+            .flatMap((SimpleResponse<Boolean> res) -> {
+                if (res.getValue() != null) {
+                    return Mono.just(res.getValue());
+                } else {
+                    return Mono.empty();
+                }
+            });
+    }
+
+    /**
+     * Get false Boolean value.
+     * 
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return false Boolean value.
@@ -268,6 +357,25 @@ public final class Bools {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public boolean getFalse() {
         Boolean value = getFalseAsync().block();
+        if (value != null) {
+            return value;
+        } else {
+            throw new NullPointerException();
+        }
+    }
+
+    /**
+     * Get false Boolean value.
+     * 
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return false Boolean value.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public boolean getFalse(Context context) {
+        Boolean value = getFalseAsync(context).block();
         if (value != null) {
             return value;
         } else {
@@ -325,12 +433,40 @@ public final class Bools {
     /**
      * Set Boolean value false.
      * 
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putFalseAsync(Context context) {
+        return putFalseWithResponseAsync(context)
+            .flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Set Boolean value false.
+     * 
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putFalse() {
         putFalseAsync().block();
+    }
+
+    /**
+     * Set Boolean value false.
+     * 
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void putFalse(Context context) {
+        putFalseAsync(context).block();
     }
 
     /**
@@ -387,6 +523,27 @@ public final class Bools {
     /**
      * Get null Boolean value.
      * 
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null Boolean value.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Boolean> getNullAsync(Context context) {
+        return getNullWithResponseAsync(context)
+            .flatMap((SimpleResponse<Boolean> res) -> {
+                if (res.getValue() != null) {
+                    return Mono.just(res.getValue());
+                } else {
+                    return Mono.empty();
+                }
+            });
+    }
+
+    /**
+     * Get null Boolean value.
+     * 
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null Boolean value.
@@ -394,6 +551,25 @@ public final class Bools {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public boolean getNull() {
         Boolean value = getNullAsync().block();
+        if (value != null) {
+            return value;
+        } else {
+            throw new NullPointerException();
+        }
+    }
+
+    /**
+     * Get null Boolean value.
+     * 
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null Boolean value.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public boolean getNull(Context context) {
+        Boolean value = getNullAsync(context).block();
         if (value != null) {
             return value;
         } else {
@@ -455,6 +631,27 @@ public final class Bools {
     /**
      * Get invalid Boolean value.
      * 
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return invalid Boolean value.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Boolean> getInvalidAsync(Context context) {
+        return getInvalidWithResponseAsync(context)
+            .flatMap((SimpleResponse<Boolean> res) -> {
+                if (res.getValue() != null) {
+                    return Mono.just(res.getValue());
+                } else {
+                    return Mono.empty();
+                }
+            });
+    }
+
+    /**
+     * Get invalid Boolean value.
+     * 
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return invalid Boolean value.
@@ -462,6 +659,25 @@ public final class Bools {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public boolean getInvalid() {
         Boolean value = getInvalidAsync().block();
+        if (value != null) {
+            return value;
+        } else {
+            throw new NullPointerException();
+        }
+    }
+
+    /**
+     * Get invalid Boolean value.
+     * 
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return invalid Boolean value.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public boolean getInvalid(Context context) {
+        Boolean value = getInvalidAsync(context).block();
         if (value != null) {
             return value;
         } else {


### PR DESCRIPTION
As requested in guideline, sync method need to take `Context` as optional parameter.