### PR TITLE
v4 mgmt, make client immutable

### DIFF
--- a/azure-tests/src/main/java/fixtures/azurereport/AutoRestReportServiceForAzure.java
+++ b/azure-tests/src/main/java/fixtures/azurereport/AutoRestReportServiceForAzure.java
@@ -28,7 +28,7 @@ public final class AutoRestReportServiceForAzure {
     private final AutoRestReportServiceForAzureService service;
 
     /** server parameter. */
-    private String host;
+    private final String host;
 
     /**
      * Gets server parameter.
@@ -37,17 +37,6 @@ public final class AutoRestReportServiceForAzure {
      */
     public String getHost() {
         return this.host;
-    }
-
-    /**
-     * Sets server parameter.
-     *
-     * @param host the host value.
-     * @return the service client itself.
-     */
-    AutoRestReportServiceForAzure setHost(String host) {
-        this.host = host;
-        return this;
     }
 
     /** The HTTP pipeline to send requests through. */
@@ -63,8 +52,12 @@ public final class AutoRestReportServiceForAzure {
     }
 
     /** Initializes an instance of AutoRestReportServiceForAzure client. */
-    AutoRestReportServiceForAzure() {
-        this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build());
+    AutoRestReportServiceForAzure(String host) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                host);
     }
 
     /**
@@ -72,8 +65,9 @@ public final class AutoRestReportServiceForAzure {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
-    AutoRestReportServiceForAzure(HttpPipeline httpPipeline) {
+    AutoRestReportServiceForAzure(HttpPipeline httpPipeline, String host) {
         this.httpPipeline = httpPipeline;
+        this.host = host;
         this.service = RestProxy.create(AutoRestReportServiceForAzureService.class, this.httpPipeline);
     }
 

--- a/azure-tests/src/main/java/fixtures/azurereport/AutoRestReportServiceForAzureBuilder.java
+++ b/azure-tests/src/main/java/fixtures/azurereport/AutoRestReportServiceForAzureBuilder.java
@@ -57,8 +57,7 @@ public final class AutoRestReportServiceForAzureBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestReportServiceForAzure client = new AutoRestReportServiceForAzure(pipeline);
-        client.setHost(this.host);
+        AutoRestReportServiceForAzure client = new AutoRestReportServiceForAzure(pipeline, host);
         return client;
     }
 }

--- a/azure-tests/src/main/java/fixtures/paging/AutoRestPagingTestService.java
+++ b/azure-tests/src/main/java/fixtures/paging/AutoRestPagingTestService.java
@@ -9,7 +9,7 @@ import com.azure.core.http.policy.UserAgentPolicy;
 /** Initializes a new instance of the AutoRestPagingTestService type. */
 public final class AutoRestPagingTestService {
     /** server parameter. */
-    private String host;
+    private final String host;
 
     /**
      * Gets server parameter.
@@ -18,17 +18,6 @@ public final class AutoRestPagingTestService {
      */
     public String getHost() {
         return this.host;
-    }
-
-    /**
-     * Sets server parameter.
-     *
-     * @param host the host value.
-     * @return the service client itself.
-     */
-    AutoRestPagingTestService setHost(String host) {
-        this.host = host;
-        return this;
     }
 
     /** The HTTP pipeline to send requests through. */
@@ -56,8 +45,12 @@ public final class AutoRestPagingTestService {
     }
 
     /** Initializes an instance of AutoRestPagingTestService client. */
-    AutoRestPagingTestService() {
-        this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build());
+    AutoRestPagingTestService(String host) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                host);
     }
 
     /**
@@ -65,8 +58,9 @@ public final class AutoRestPagingTestService {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
-    AutoRestPagingTestService(HttpPipeline httpPipeline) {
+    AutoRestPagingTestService(HttpPipeline httpPipeline, String host) {
         this.httpPipeline = httpPipeline;
+        this.host = host;
         this.pagings = new Pagings(this);
     }
 }

--- a/azure-tests/src/main/java/fixtures/paging/AutoRestPagingTestServiceBuilder.java
+++ b/azure-tests/src/main/java/fixtures/paging/AutoRestPagingTestServiceBuilder.java
@@ -57,8 +57,7 @@ public final class AutoRestPagingTestServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestPagingTestService client = new AutoRestPagingTestService(pipeline);
-        client.setHost(this.host);
+        AutoRestPagingTestService client = new AutoRestPagingTestService(pipeline, host);
         return client;
     }
 }

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Parameter.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Parameter.java
@@ -19,6 +19,14 @@ public class Parameter extends Value {
     private Property targetProperty;
 
     public String getClientDefaultValue() {
+        if (clientDefaultValue == null) {
+            if (this.getSchema() != null && this.getSchema() instanceof ConstantSchema) {
+                ConstantSchema constantSchema = (ConstantSchema) this.getSchema();
+                if (constantSchema.getValue() != null) {
+                    this.setClientDefaultValue(constantSchema.getValue().getValue().toString());
+                }
+            }
+        }
         return clientDefaultValue;
     }
 

--- a/fluent-tests/src/test/java/com/azure/mgmttest/RuntimeTests.java
+++ b/fluent-tests/src/test/java/com/azure/mgmttest/RuntimeTests.java
@@ -32,7 +32,7 @@ public class RuntimeTests {
     public void testManagementClient() {
         StorageManagementClient storageManagementClient = new StorageManagementClientBuilder()
                 .pipeline(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build())
-                .host(AzureEnvironment.AZURE.getResourceManagerEndpoint())
+                .endpoint(AzureEnvironment.AZURE.getResourceManagerEndpoint())
                 .subscriptionId(MOCK_SUBSCRIPTION_ID)
                 .buildClient();
         Assertions.assertNotNull(storageManagementClient.getHttpPipeline());

--- a/fluentnamer/src/main/java/com/azure/autorest/fluent/transformer/FluentTransformer.java
+++ b/fluentnamer/src/main/java/com/azure/autorest/fluent/transformer/FluentTransformer.java
@@ -35,6 +35,7 @@ public class FluentTransformer {
         codeModel = new SchemaNameNormalization(fluentJavaSettings.getNamingOverride()).process(codeModel);
         codeModel = new ConstantSchemaOptimization().process(codeModel);
         codeModel = new NamingConflictResolver().process(codeModel);
+        codeModel = renameHostParameter(codeModel);
         codeModel = normalizeApiVersionParameter(codeModel);
         codeModel = addStartOperationForLROs(codeModel);
         return codeModel;
@@ -54,6 +55,21 @@ public class FluentTransformer {
         codeModel.getOperationGroups().stream().flatMap(og -> og.getOperations().stream())
                 .filter(o -> hasLongRunningOperationExtension(o) && hasPaging(o))
                 .forEach(o -> o.getExtensions().setXmsPageable(null));
+        return codeModel;
+    }
+
+    /**
+     * Renames $host to endpoint.
+     *
+     * @param codeModel Code model.
+     * @return Processed code model.
+     */
+    protected CodeModel renameHostParameter(CodeModel codeModel) {
+        codeModel.getGlobalParameters().stream()
+                .filter(p -> "$host".equals(p.getLanguage().getDefault().getSerializedName()))
+                .forEach(p -> {
+                    p.getLanguage().getDefault().setName("endpoint");
+                });
         return codeModel;
     }
 

--- a/fluentnamer/src/main/java/com/azure/autorest/fluent/transformer/FluentTransformer.java
+++ b/fluentnamer/src/main/java/com/azure/autorest/fluent/transformer/FluentTransformer.java
@@ -36,7 +36,6 @@ public class FluentTransformer {
         codeModel = new ConstantSchemaOptimization().process(codeModel);
         codeModel = new NamingConflictResolver().process(codeModel);
         codeModel = renameHostParameter(codeModel);
-        codeModel = normalizeApiVersionParameter(codeModel);
         codeModel = addStartOperationForLROs(codeModel);
         return codeModel;
     }
@@ -69,23 +68,6 @@ public class FluentTransformer {
                 .filter(p -> "$host".equals(p.getLanguage().getDefault().getSerializedName()))
                 .forEach(p -> {
                     p.getLanguage().getDefault().setName("endpoint");
-                });
-        return codeModel;
-    }
-
-    /**
-     * Sets proper ClientDefaultValue to api-version parameters.
-     *
-     * @param codeModel Code model.
-     * @return Processed code model.
-     */
-    protected CodeModel normalizeApiVersionParameter(CodeModel codeModel) {
-        codeModel.getGlobalParameters().stream()
-                .filter(p -> "api-version".equals(p.getLanguage().getDefault().getSerializedName()))
-                .forEach(p -> {
-                    if (p.getSchema() instanceof ConstantSchema) {
-                        p.setClientDefaultValue(((ConstantSchema) p.getSchema()).getValue().getValue().toString());
-                    }
                 });
         return codeModel;
     }

--- a/javagen/src/main/java/com/azure/autorest/mapper/ServiceClientMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ServiceClientMapper.java
@@ -108,7 +108,7 @@ public class ServiceClientMapper implements IMapper<CodeModel, ServiceClient> {
                 serviceClientPropertyClientType = serviceClientPropertyClientType.asNullable();
             }
 
-            boolean serviceClientPropertyIsReadOnly = serviceClientPropertyClientType instanceof ConstantSchema;
+            boolean serviceClientPropertyIsReadOnly = p.getSchema() instanceof ConstantSchema;
 
             String serviceClientPropertyDefaultValueExpression = serviceClientPropertyClientType.defaultValueExpression(p.getClientDefaultValue());
 

--- a/javagen/src/main/java/com/azure/autorest/mapper/ServiceClientMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ServiceClientMapper.java
@@ -170,8 +170,8 @@ public class ServiceClientMapper implements IMapper<CodeModel, ServiceClient> {
                             : new ArrayList<>())
                     .build();
 
-            serviceClientConstructors.add(new Constructor(new ArrayList<>()));
-            serviceClientConstructors.add(new Constructor(Arrays.asList(httpPipelineParameter)));
+//            serviceClientConstructors.add(new Constructor(new ArrayList<>()));
+//            serviceClientConstructors.add(new Constructor(Arrays.asList(httpPipelineParameter)));
             serviceClientConstructors.add(new Constructor(Arrays.asList(httpPipelineParameter, azureEnvironmentParameter)));
             builder.tokenCredentialParameter(tokenCredentialParameter)
                     .httpPipelineParameter(httpPipelineParameter)

--- a/vanilla-tests/src/main/java/fixtures/additionalproperties/AdditionalPropertiesClient.java
+++ b/vanilla-tests/src/main/java/fixtures/additionalproperties/AdditionalPropertiesClient.java
@@ -9,7 +9,7 @@ import com.azure.core.http.policy.UserAgentPolicy;
 /** Initializes a new instance of the AdditionalPropertiesClient type. */
 public final class AdditionalPropertiesClient {
     /** server parameter. */
-    private String host;
+    private final String host;
 
     /**
      * Gets server parameter.
@@ -18,17 +18,6 @@ public final class AdditionalPropertiesClient {
      */
     public String getHost() {
         return this.host;
-    }
-
-    /**
-     * Sets server parameter.
-     *
-     * @param host the host value.
-     * @return the service client itself.
-     */
-    AdditionalPropertiesClient setHost(String host) {
-        this.host = host;
-        return this;
     }
 
     /** The HTTP pipeline to send requests through. */
@@ -56,8 +45,12 @@ public final class AdditionalPropertiesClient {
     }
 
     /** Initializes an instance of AdditionalPropertiesClient client. */
-    AdditionalPropertiesClient() {
-        this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build());
+    AdditionalPropertiesClient(String host) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                host);
     }
 
     /**
@@ -65,8 +58,9 @@ public final class AdditionalPropertiesClient {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
-    AdditionalPropertiesClient(HttpPipeline httpPipeline) {
+    AdditionalPropertiesClient(HttpPipeline httpPipeline, String host) {
         this.httpPipeline = httpPipeline;
+        this.host = host;
         this.pets = new Pets(this);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/additionalproperties/AdditionalPropertiesClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/additionalproperties/AdditionalPropertiesClientBuilder.java
@@ -57,8 +57,7 @@ public final class AdditionalPropertiesClientBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AdditionalPropertiesClient client = new AdditionalPropertiesClient(pipeline);
-        client.setHost(this.host);
+        AdditionalPropertiesClient client = new AdditionalPropertiesClient(pipeline, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodyarray/AutoRestSwaggerBATArrayService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyarray/AutoRestSwaggerBATArrayService.java
@@ -9,7 +9,7 @@ import com.azure.core.http.policy.UserAgentPolicy;
 /** Initializes a new instance of the AutoRestSwaggerBATArrayService type. */
 public final class AutoRestSwaggerBATArrayService {
     /** server parameter. */
-    private String host;
+    private final String host;
 
     /**
      * Gets server parameter.
@@ -18,17 +18,6 @@ public final class AutoRestSwaggerBATArrayService {
      */
     public String getHost() {
         return this.host;
-    }
-
-    /**
-     * Sets server parameter.
-     *
-     * @param host the host value.
-     * @return the service client itself.
-     */
-    AutoRestSwaggerBATArrayService setHost(String host) {
-        this.host = host;
-        return this;
     }
 
     /** The HTTP pipeline to send requests through. */
@@ -56,8 +45,12 @@ public final class AutoRestSwaggerBATArrayService {
     }
 
     /** Initializes an instance of AutoRestSwaggerBATArrayService client. */
-    AutoRestSwaggerBATArrayService() {
-        this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build());
+    AutoRestSwaggerBATArrayService(String host) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                host);
     }
 
     /**
@@ -65,8 +58,9 @@ public final class AutoRestSwaggerBATArrayService {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
-    AutoRestSwaggerBATArrayService(HttpPipeline httpPipeline) {
+    AutoRestSwaggerBATArrayService(HttpPipeline httpPipeline, String host) {
         this.httpPipeline = httpPipeline;
+        this.host = host;
         this.arrays = new Arrays(this);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodyarray/AutoRestSwaggerBATArrayServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyarray/AutoRestSwaggerBATArrayServiceBuilder.java
@@ -57,8 +57,7 @@ public final class AutoRestSwaggerBATArrayServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestSwaggerBATArrayService client = new AutoRestSwaggerBATArrayService(pipeline);
-        client.setHost(this.host);
+        AutoRestSwaggerBATArrayService client = new AutoRestSwaggerBATArrayService(pipeline, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodyboolean/AutoRestBoolTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyboolean/AutoRestBoolTestService.java
@@ -9,7 +9,7 @@ import com.azure.core.http.policy.UserAgentPolicy;
 /** Initializes a new instance of the AutoRestBoolTestService type. */
 public final class AutoRestBoolTestService {
     /** server parameter. */
-    private String host;
+    private final String host;
 
     /**
      * Gets server parameter.
@@ -18,17 +18,6 @@ public final class AutoRestBoolTestService {
      */
     public String getHost() {
         return this.host;
-    }
-
-    /**
-     * Sets server parameter.
-     *
-     * @param host the host value.
-     * @return the service client itself.
-     */
-    AutoRestBoolTestService setHost(String host) {
-        this.host = host;
-        return this;
     }
 
     /** The HTTP pipeline to send requests through. */
@@ -56,8 +45,12 @@ public final class AutoRestBoolTestService {
     }
 
     /** Initializes an instance of AutoRestBoolTestService client. */
-    AutoRestBoolTestService() {
-        this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build());
+    AutoRestBoolTestService(String host) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                host);
     }
 
     /**
@@ -65,8 +58,9 @@ public final class AutoRestBoolTestService {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
-    AutoRestBoolTestService(HttpPipeline httpPipeline) {
+    AutoRestBoolTestService(HttpPipeline httpPipeline, String host) {
         this.httpPipeline = httpPipeline;
+        this.host = host;
         this.bools = new Bools(this);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodyboolean/AutoRestBoolTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyboolean/AutoRestBoolTestServiceBuilder.java
@@ -57,8 +57,7 @@ public final class AutoRestBoolTestServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestBoolTestService client = new AutoRestBoolTestService(pipeline);
-        client.setHost(this.host);
+        AutoRestBoolTestService client = new AutoRestBoolTestService(pipeline, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodyboolean/quirks/AutoRestBoolTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyboolean/quirks/AutoRestBoolTestService.java
@@ -9,7 +9,7 @@ import com.azure.core.http.policy.UserAgentPolicy;
 /** Initializes a new instance of the AutoRestBoolTestService type. */
 public final class AutoRestBoolTestService {
     /** server parameter. */
-    private String host;
+    private final String host;
 
     /**
      * Gets server parameter.
@@ -18,17 +18,6 @@ public final class AutoRestBoolTestService {
      */
     public String getHost() {
         return this.host;
-    }
-
-    /**
-     * Sets server parameter.
-     *
-     * @param host the host value.
-     * @return the service client itself.
-     */
-    AutoRestBoolTestService setHost(String host) {
-        this.host = host;
-        return this;
     }
 
     /** The HTTP pipeline to send requests through. */
@@ -56,8 +45,12 @@ public final class AutoRestBoolTestService {
     }
 
     /** Initializes an instance of AutoRestBoolTestService client. */
-    AutoRestBoolTestService() {
-        this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build());
+    AutoRestBoolTestService(String host) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                host);
     }
 
     /**
@@ -65,8 +58,9 @@ public final class AutoRestBoolTestService {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
-    AutoRestBoolTestService(HttpPipeline httpPipeline) {
+    AutoRestBoolTestService(HttpPipeline httpPipeline, String host) {
         this.httpPipeline = httpPipeline;
+        this.host = host;
         this.bools = new Bools(this);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodyboolean/quirks/AutoRestBoolTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyboolean/quirks/AutoRestBoolTestServiceBuilder.java
@@ -57,8 +57,7 @@ public final class AutoRestBoolTestServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestBoolTestService client = new AutoRestBoolTestService(pipeline);
-        client.setHost(this.host);
+        AutoRestBoolTestService client = new AutoRestBoolTestService(pipeline, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodybyte/AutoRestSwaggerBATByteService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodybyte/AutoRestSwaggerBATByteService.java
@@ -9,7 +9,7 @@ import com.azure.core.http.policy.UserAgentPolicy;
 /** Initializes a new instance of the AutoRestSwaggerBATByteService type. */
 public final class AutoRestSwaggerBATByteService {
     /** server parameter. */
-    private String host;
+    private final String host;
 
     /**
      * Gets server parameter.
@@ -18,17 +18,6 @@ public final class AutoRestSwaggerBATByteService {
      */
     public String getHost() {
         return this.host;
-    }
-
-    /**
-     * Sets server parameter.
-     *
-     * @param host the host value.
-     * @return the service client itself.
-     */
-    AutoRestSwaggerBATByteService setHost(String host) {
-        this.host = host;
-        return this;
     }
 
     /** The HTTP pipeline to send requests through. */
@@ -56,8 +45,12 @@ public final class AutoRestSwaggerBATByteService {
     }
 
     /** Initializes an instance of AutoRestSwaggerBATByteService client. */
-    AutoRestSwaggerBATByteService() {
-        this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build());
+    AutoRestSwaggerBATByteService(String host) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                host);
     }
 
     /**
@@ -65,8 +58,9 @@ public final class AutoRestSwaggerBATByteService {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
-    AutoRestSwaggerBATByteService(HttpPipeline httpPipeline) {
+    AutoRestSwaggerBATByteService(HttpPipeline httpPipeline, String host) {
         this.httpPipeline = httpPipeline;
+        this.host = host;
         this.byteOperations = new ByteOperations(this);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodybyte/AutoRestSwaggerBATByteServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodybyte/AutoRestSwaggerBATByteServiceBuilder.java
@@ -57,8 +57,7 @@ public final class AutoRestSwaggerBATByteServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestSwaggerBATByteService client = new AutoRestSwaggerBATByteService(pipeline);
-        client.setHost(this.host);
+        AutoRestSwaggerBATByteService client = new AutoRestSwaggerBATByteService(pipeline, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/AutoRestComplexTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/AutoRestComplexTestService.java
@@ -9,7 +9,7 @@ import com.azure.core.http.policy.UserAgentPolicy;
 /** Initializes a new instance of the AutoRestComplexTestService type. */
 public final class AutoRestComplexTestService {
     /** server parameter. */
-    private String host;
+    private final String host;
 
     /**
      * Gets server parameter.
@@ -20,19 +20,8 @@ public final class AutoRestComplexTestService {
         return this.host;
     }
 
-    /**
-     * Sets server parameter.
-     *
-     * @param host the host value.
-     * @return the service client itself.
-     */
-    AutoRestComplexTestService setHost(String host) {
-        this.host = host;
-        return this;
-    }
-
     /** Api Version. */
-    private String apiVersion;
+    private final String apiVersion;
 
     /**
      * Gets Api Version.
@@ -41,17 +30,6 @@ public final class AutoRestComplexTestService {
      */
     public String getApiVersion() {
         return this.apiVersion;
-    }
-
-    /**
-     * Sets Api Version.
-     *
-     * @param apiVersion the apiVersion value.
-     * @return the service client itself.
-     */
-    AutoRestComplexTestService setApiVersion(String apiVersion) {
-        this.apiVersion = apiVersion;
-        return this;
     }
 
     /** The HTTP pipeline to send requests through. */
@@ -175,8 +153,12 @@ public final class AutoRestComplexTestService {
     }
 
     /** Initializes an instance of AutoRestComplexTestService client. */
-    AutoRestComplexTestService() {
-        this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build());
+    AutoRestComplexTestService(String host) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                host);
     }
 
     /**
@@ -184,8 +166,9 @@ public final class AutoRestComplexTestService {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
-    AutoRestComplexTestService(HttpPipeline httpPipeline) {
+    AutoRestComplexTestService(HttpPipeline httpPipeline, String host) {
         this.httpPipeline = httpPipeline;
+        this.host = host;
         this.basics = new Basics(this);
         this.primitives = new Primitives(this);
         this.arrays = new Arrays(this);

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/AutoRestComplexTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/AutoRestComplexTestService.java
@@ -169,6 +169,7 @@ public final class AutoRestComplexTestService {
     AutoRestComplexTestService(HttpPipeline httpPipeline, String host) {
         this.httpPipeline = httpPipeline;
         this.host = host;
+        this.apiVersion = "2016-02-29";
         this.basics = new Basics(this);
         this.primitives = new Primitives(this);
         this.arrays = new Arrays(this);

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/AutoRestComplexTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/AutoRestComplexTestServiceBuilder.java
@@ -27,22 +27,6 @@ public final class AutoRestComplexTestServiceBuilder {
     }
 
     /*
-     * Api Version
-     */
-    private String apiVersion;
-
-    /**
-     * Sets Api Version.
-     *
-     * @param apiVersion the apiVersion value.
-     * @return the AutoRestComplexTestServiceBuilder.
-     */
-    public AutoRestComplexTestServiceBuilder apiVersion(String apiVersion) {
-        this.apiVersion = apiVersion;
-        return this;
-    }
-
-    /*
      * The HTTP pipeline to send requests through
      */
     private HttpPipeline pipeline;
@@ -73,9 +57,7 @@ public final class AutoRestComplexTestServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestComplexTestService client = new AutoRestComplexTestService(pipeline);
-        client.setHost(this.host);
-        client.setApiVersion(this.apiVersion);
+        AutoRestComplexTestService client = new AutoRestComplexTestService(pipeline, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodydate/AutoRestDateTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydate/AutoRestDateTestService.java
@@ -9,7 +9,7 @@ import com.azure.core.http.policy.UserAgentPolicy;
 /** Initializes a new instance of the AutoRestDateTestService type. */
 public final class AutoRestDateTestService {
     /** server parameter. */
-    private String host;
+    private final String host;
 
     /**
      * Gets server parameter.
@@ -18,17 +18,6 @@ public final class AutoRestDateTestService {
      */
     public String getHost() {
         return this.host;
-    }
-
-    /**
-     * Sets server parameter.
-     *
-     * @param host the host value.
-     * @return the service client itself.
-     */
-    AutoRestDateTestService setHost(String host) {
-        this.host = host;
-        return this;
     }
 
     /** The HTTP pipeline to send requests through. */
@@ -56,8 +45,12 @@ public final class AutoRestDateTestService {
     }
 
     /** Initializes an instance of AutoRestDateTestService client. */
-    AutoRestDateTestService() {
-        this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build());
+    AutoRestDateTestService(String host) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                host);
     }
 
     /**
@@ -65,8 +58,9 @@ public final class AutoRestDateTestService {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
-    AutoRestDateTestService(HttpPipeline httpPipeline) {
+    AutoRestDateTestService(HttpPipeline httpPipeline, String host) {
         this.httpPipeline = httpPipeline;
+        this.host = host;
         this.dateOperations = new DateOperations(this);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodydate/AutoRestDateTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydate/AutoRestDateTestServiceBuilder.java
@@ -57,8 +57,7 @@ public final class AutoRestDateTestServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestDateTestService client = new AutoRestDateTestService(pipeline);
-        client.setHost(this.host);
+        AutoRestDateTestService client = new AutoRestDateTestService(pipeline, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodydatetime/AutoRestDateTimeTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydatetime/AutoRestDateTimeTestService.java
@@ -9,7 +9,7 @@ import com.azure.core.http.policy.UserAgentPolicy;
 /** Initializes a new instance of the AutoRestDateTimeTestService type. */
 public final class AutoRestDateTimeTestService {
     /** server parameter. */
-    private String host;
+    private final String host;
 
     /**
      * Gets server parameter.
@@ -18,17 +18,6 @@ public final class AutoRestDateTimeTestService {
      */
     public String getHost() {
         return this.host;
-    }
-
-    /**
-     * Sets server parameter.
-     *
-     * @param host the host value.
-     * @return the service client itself.
-     */
-    AutoRestDateTimeTestService setHost(String host) {
-        this.host = host;
-        return this;
     }
 
     /** The HTTP pipeline to send requests through. */
@@ -56,8 +45,12 @@ public final class AutoRestDateTimeTestService {
     }
 
     /** Initializes an instance of AutoRestDateTimeTestService client. */
-    AutoRestDateTimeTestService() {
-        this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build());
+    AutoRestDateTimeTestService(String host) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                host);
     }
 
     /**
@@ -65,8 +58,9 @@ public final class AutoRestDateTimeTestService {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
-    AutoRestDateTimeTestService(HttpPipeline httpPipeline) {
+    AutoRestDateTimeTestService(HttpPipeline httpPipeline, String host) {
         this.httpPipeline = httpPipeline;
+        this.host = host;
         this.datetimeOperations = new DatetimeOperations(this);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodydatetime/AutoRestDateTimeTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydatetime/AutoRestDateTimeTestServiceBuilder.java
@@ -57,8 +57,7 @@ public final class AutoRestDateTimeTestServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestDateTimeTestService client = new AutoRestDateTimeTestService(pipeline);
-        client.setHost(this.host);
+        AutoRestDateTimeTestService client = new AutoRestDateTimeTestService(pipeline, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodydatetimerfc1123/AutoRestRFC1123DateTimeTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydatetimerfc1123/AutoRestRFC1123DateTimeTestService.java
@@ -9,7 +9,7 @@ import com.azure.core.http.policy.UserAgentPolicy;
 /** Initializes a new instance of the AutoRestRFC1123DateTimeTestService type. */
 public final class AutoRestRFC1123DateTimeTestService {
     /** server parameter. */
-    private String host;
+    private final String host;
 
     /**
      * Gets server parameter.
@@ -18,17 +18,6 @@ public final class AutoRestRFC1123DateTimeTestService {
      */
     public String getHost() {
         return this.host;
-    }
-
-    /**
-     * Sets server parameter.
-     *
-     * @param host the host value.
-     * @return the service client itself.
-     */
-    AutoRestRFC1123DateTimeTestService setHost(String host) {
-        this.host = host;
-        return this;
     }
 
     /** The HTTP pipeline to send requests through. */
@@ -56,8 +45,12 @@ public final class AutoRestRFC1123DateTimeTestService {
     }
 
     /** Initializes an instance of AutoRestRFC1123DateTimeTestService client. */
-    AutoRestRFC1123DateTimeTestService() {
-        this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build());
+    AutoRestRFC1123DateTimeTestService(String host) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                host);
     }
 
     /**
@@ -65,8 +58,9 @@ public final class AutoRestRFC1123DateTimeTestService {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
-    AutoRestRFC1123DateTimeTestService(HttpPipeline httpPipeline) {
+    AutoRestRFC1123DateTimeTestService(HttpPipeline httpPipeline, String host) {
         this.httpPipeline = httpPipeline;
+        this.host = host;
         this.datetimerfc1123s = new Datetimerfc1123s(this);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodydatetimerfc1123/AutoRestRFC1123DateTimeTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydatetimerfc1123/AutoRestRFC1123DateTimeTestServiceBuilder.java
@@ -57,8 +57,7 @@ public final class AutoRestRFC1123DateTimeTestServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestRFC1123DateTimeTestService client = new AutoRestRFC1123DateTimeTestService(pipeline);
-        client.setHost(this.host);
+        AutoRestRFC1123DateTimeTestService client = new AutoRestRFC1123DateTimeTestService(pipeline, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodydictionary/AutoRestSwaggerBATDictionaryServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydictionary/AutoRestSwaggerBATDictionaryServiceBuilder.java
@@ -62,8 +62,7 @@ public final class AutoRestSwaggerBATDictionaryServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestSwaggerBATDictionaryServiceImpl client = new AutoRestSwaggerBATDictionaryServiceImpl(pipeline);
-        client.setHost(this.host);
+        AutoRestSwaggerBATDictionaryServiceImpl client = new AutoRestSwaggerBATDictionaryServiceImpl(pipeline, host);
         return client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodydictionary/implementation/AutoRestSwaggerBATDictionaryServiceImpl.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydictionary/implementation/AutoRestSwaggerBATDictionaryServiceImpl.java
@@ -9,7 +9,7 @@ import com.azure.core.http.policy.UserAgentPolicy;
 /** Initializes a new instance of the AutoRestSwaggerBATDictionaryService type. */
 public final class AutoRestSwaggerBATDictionaryServiceImpl {
     /** server parameter. */
-    private String host;
+    private final String host;
 
     /**
      * Gets server parameter.
@@ -18,17 +18,6 @@ public final class AutoRestSwaggerBATDictionaryServiceImpl {
      */
     public String getHost() {
         return this.host;
-    }
-
-    /**
-     * Sets server parameter.
-     *
-     * @param host the host value.
-     * @return the service client itself.
-     */
-    public AutoRestSwaggerBATDictionaryServiceImpl setHost(String host) {
-        this.host = host;
-        return this;
     }
 
     /** The HTTP pipeline to send requests through. */
@@ -56,8 +45,12 @@ public final class AutoRestSwaggerBATDictionaryServiceImpl {
     }
 
     /** Initializes an instance of AutoRestSwaggerBATDictionaryService client. */
-    public AutoRestSwaggerBATDictionaryServiceImpl() {
-        this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build());
+    public AutoRestSwaggerBATDictionaryServiceImpl(String host) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                host);
     }
 
     /**
@@ -65,8 +58,9 @@ public final class AutoRestSwaggerBATDictionaryServiceImpl {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
-    public AutoRestSwaggerBATDictionaryServiceImpl(HttpPipeline httpPipeline) {
+    public AutoRestSwaggerBATDictionaryServiceImpl(HttpPipeline httpPipeline, String host) {
         this.httpPipeline = httpPipeline;
+        this.host = host;
         this.dictionarys = new DictionarysImpl(this);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodyduration/AutoRestDurationTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyduration/AutoRestDurationTestService.java
@@ -9,7 +9,7 @@ import com.azure.core.http.policy.UserAgentPolicy;
 /** Initializes a new instance of the AutoRestDurationTestService type. */
 public final class AutoRestDurationTestService {
     /** server parameter. */
-    private String host;
+    private final String host;
 
     /**
      * Gets server parameter.
@@ -18,17 +18,6 @@ public final class AutoRestDurationTestService {
      */
     public String getHost() {
         return this.host;
-    }
-
-    /**
-     * Sets server parameter.
-     *
-     * @param host the host value.
-     * @return the service client itself.
-     */
-    AutoRestDurationTestService setHost(String host) {
-        this.host = host;
-        return this;
     }
 
     /** The HTTP pipeline to send requests through. */
@@ -56,8 +45,12 @@ public final class AutoRestDurationTestService {
     }
 
     /** Initializes an instance of AutoRestDurationTestService client. */
-    AutoRestDurationTestService() {
-        this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build());
+    AutoRestDurationTestService(String host) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                host);
     }
 
     /**
@@ -65,8 +58,9 @@ public final class AutoRestDurationTestService {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
-    AutoRestDurationTestService(HttpPipeline httpPipeline) {
+    AutoRestDurationTestService(HttpPipeline httpPipeline, String host) {
         this.httpPipeline = httpPipeline;
+        this.host = host;
         this.durationOperations = new DurationOperations(this);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodyduration/AutoRestDurationTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyduration/AutoRestDurationTestServiceBuilder.java
@@ -57,8 +57,7 @@ public final class AutoRestDurationTestServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestDurationTestService client = new AutoRestDurationTestService(pipeline);
-        client.setHost(this.host);
+        AutoRestDurationTestService client = new AutoRestDurationTestService(pipeline, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodyfile/AutoRestSwaggerBATFileService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyfile/AutoRestSwaggerBATFileService.java
@@ -9,7 +9,7 @@ import com.azure.core.http.policy.UserAgentPolicy;
 /** Initializes a new instance of the AutoRestSwaggerBATFileService type. */
 public final class AutoRestSwaggerBATFileService {
     /** server parameter. */
-    private String host;
+    private final String host;
 
     /**
      * Gets server parameter.
@@ -18,17 +18,6 @@ public final class AutoRestSwaggerBATFileService {
      */
     public String getHost() {
         return this.host;
-    }
-
-    /**
-     * Sets server parameter.
-     *
-     * @param host the host value.
-     * @return the service client itself.
-     */
-    AutoRestSwaggerBATFileService setHost(String host) {
-        this.host = host;
-        return this;
     }
 
     /** The HTTP pipeline to send requests through. */
@@ -56,8 +45,12 @@ public final class AutoRestSwaggerBATFileService {
     }
 
     /** Initializes an instance of AutoRestSwaggerBATFileService client. */
-    AutoRestSwaggerBATFileService() {
-        this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build());
+    AutoRestSwaggerBATFileService(String host) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                host);
     }
 
     /**
@@ -65,8 +58,9 @@ public final class AutoRestSwaggerBATFileService {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
-    AutoRestSwaggerBATFileService(HttpPipeline httpPipeline) {
+    AutoRestSwaggerBATFileService(HttpPipeline httpPipeline, String host) {
         this.httpPipeline = httpPipeline;
+        this.host = host;
         this.files = new Files(this);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodyfile/AutoRestSwaggerBATFileServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyfile/AutoRestSwaggerBATFileServiceBuilder.java
@@ -57,8 +57,7 @@ public final class AutoRestSwaggerBATFileServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestSwaggerBATFileService client = new AutoRestSwaggerBATFileService(pipeline);
-        client.setHost(this.host);
+        AutoRestSwaggerBATFileService client = new AutoRestSwaggerBATFileService(pipeline, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodyinteger/AutoRestIntegerTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyinteger/AutoRestIntegerTestService.java
@@ -9,7 +9,7 @@ import com.azure.core.http.policy.UserAgentPolicy;
 /** Initializes a new instance of the AutoRestIntegerTestService type. */
 public final class AutoRestIntegerTestService {
     /** server parameter. */
-    private String host;
+    private final String host;
 
     /**
      * Gets server parameter.
@@ -18,17 +18,6 @@ public final class AutoRestIntegerTestService {
      */
     public String getHost() {
         return this.host;
-    }
-
-    /**
-     * Sets server parameter.
-     *
-     * @param host the host value.
-     * @return the service client itself.
-     */
-    AutoRestIntegerTestService setHost(String host) {
-        this.host = host;
-        return this;
     }
 
     /** The HTTP pipeline to send requests through. */
@@ -56,8 +45,12 @@ public final class AutoRestIntegerTestService {
     }
 
     /** Initializes an instance of AutoRestIntegerTestService client. */
-    AutoRestIntegerTestService() {
-        this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build());
+    AutoRestIntegerTestService(String host) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                host);
     }
 
     /**
@@ -65,8 +58,9 @@ public final class AutoRestIntegerTestService {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
-    AutoRestIntegerTestService(HttpPipeline httpPipeline) {
+    AutoRestIntegerTestService(HttpPipeline httpPipeline, String host) {
         this.httpPipeline = httpPipeline;
+        this.host = host;
         this.ints = new Ints(this);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodyinteger/AutoRestIntegerTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyinteger/AutoRestIntegerTestServiceBuilder.java
@@ -57,8 +57,7 @@ public final class AutoRestIntegerTestServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestIntegerTestService client = new AutoRestIntegerTestService(pipeline);
-        client.setHost(this.host);
+        AutoRestIntegerTestService client = new AutoRestIntegerTestService(pipeline, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodynumber/AutoRestNumberTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodynumber/AutoRestNumberTestService.java
@@ -9,7 +9,7 @@ import com.azure.core.http.policy.UserAgentPolicy;
 /** Initializes a new instance of the AutoRestNumberTestService type. */
 public final class AutoRestNumberTestService {
     /** server parameter. */
-    private String host;
+    private final String host;
 
     /**
      * Gets server parameter.
@@ -18,17 +18,6 @@ public final class AutoRestNumberTestService {
      */
     public String getHost() {
         return this.host;
-    }
-
-    /**
-     * Sets server parameter.
-     *
-     * @param host the host value.
-     * @return the service client itself.
-     */
-    AutoRestNumberTestService setHost(String host) {
-        this.host = host;
-        return this;
     }
 
     /** The HTTP pipeline to send requests through. */
@@ -56,8 +45,12 @@ public final class AutoRestNumberTestService {
     }
 
     /** Initializes an instance of AutoRestNumberTestService client. */
-    AutoRestNumberTestService() {
-        this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build());
+    AutoRestNumberTestService(String host) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                host);
     }
 
     /**
@@ -65,8 +58,9 @@ public final class AutoRestNumberTestService {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
-    AutoRestNumberTestService(HttpPipeline httpPipeline) {
+    AutoRestNumberTestService(HttpPipeline httpPipeline, String host) {
         this.httpPipeline = httpPipeline;
+        this.host = host;
         this.numbers = new Numbers(this);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodynumber/AutoRestNumberTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodynumber/AutoRestNumberTestServiceBuilder.java
@@ -57,8 +57,7 @@ public final class AutoRestNumberTestServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestNumberTestService client = new AutoRestNumberTestService(pipeline);
-        client.setHost(this.host);
+        AutoRestNumberTestService client = new AutoRestNumberTestService(pipeline, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodystring/AutoRestSwaggerBATService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodystring/AutoRestSwaggerBATService.java
@@ -9,7 +9,7 @@ import com.azure.core.http.policy.UserAgentPolicy;
 /** Initializes a new instance of the AutoRestSwaggerBATService type. */
 public final class AutoRestSwaggerBATService {
     /** server parameter. */
-    private String host;
+    private final String host;
 
     /**
      * Gets server parameter.
@@ -18,17 +18,6 @@ public final class AutoRestSwaggerBATService {
      */
     public String getHost() {
         return this.host;
-    }
-
-    /**
-     * Sets server parameter.
-     *
-     * @param host the host value.
-     * @return the service client itself.
-     */
-    AutoRestSwaggerBATService setHost(String host) {
-        this.host = host;
-        return this;
     }
 
     /** The HTTP pipeline to send requests through. */
@@ -68,8 +57,12 @@ public final class AutoRestSwaggerBATService {
     }
 
     /** Initializes an instance of AutoRestSwaggerBATService client. */
-    AutoRestSwaggerBATService() {
-        this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build());
+    AutoRestSwaggerBATService(String host) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                host);
     }
 
     /**
@@ -77,8 +70,9 @@ public final class AutoRestSwaggerBATService {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
-    AutoRestSwaggerBATService(HttpPipeline httpPipeline) {
+    AutoRestSwaggerBATService(HttpPipeline httpPipeline, String host) {
         this.httpPipeline = httpPipeline;
+        this.host = host;
         this.stringOperations = new StringOperations(this);
         this.enums = new Enums(this);
     }

--- a/vanilla-tests/src/main/java/fixtures/bodystring/AutoRestSwaggerBATServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodystring/AutoRestSwaggerBATServiceBuilder.java
@@ -57,8 +57,7 @@ public final class AutoRestSwaggerBATServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestSwaggerBATService client = new AutoRestSwaggerBATService(pipeline);
-        client.setHost(this.host);
+        AutoRestSwaggerBATService client = new AutoRestSwaggerBATService(pipeline, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/custombaseuri/AutoRestParameterizedHostTestClient.java
+++ b/vanilla-tests/src/main/java/fixtures/custombaseuri/AutoRestParameterizedHostTestClient.java
@@ -9,7 +9,7 @@ import com.azure.core.http.policy.UserAgentPolicy;
 /** Initializes a new instance of the AutoRestParameterizedHostTestClient type. */
 public final class AutoRestParameterizedHostTestClient {
     /** A string value that is used as a global part of the parameterized host. */
-    private String host;
+    private final String host;
 
     /**
      * Gets A string value that is used as a global part of the parameterized host.
@@ -18,17 +18,6 @@ public final class AutoRestParameterizedHostTestClient {
      */
     public String getHost() {
         return this.host;
-    }
-
-    /**
-     * Sets A string value that is used as a global part of the parameterized host.
-     *
-     * @param host the host value.
-     * @return the service client itself.
-     */
-    AutoRestParameterizedHostTestClient setHost(String host) {
-        this.host = host;
-        return this;
     }
 
     /** The HTTP pipeline to send requests through. */
@@ -56,8 +45,12 @@ public final class AutoRestParameterizedHostTestClient {
     }
 
     /** Initializes an instance of AutoRestParameterizedHostTestClient client. */
-    AutoRestParameterizedHostTestClient() {
-        this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build());
+    AutoRestParameterizedHostTestClient(String host) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                host);
     }
 
     /**
@@ -65,8 +58,9 @@ public final class AutoRestParameterizedHostTestClient {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
-    AutoRestParameterizedHostTestClient(HttpPipeline httpPipeline) {
+    AutoRestParameterizedHostTestClient(HttpPipeline httpPipeline, String host) {
         this.httpPipeline = httpPipeline;
+        this.host = host;
         this.paths = new Paths(this);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/custombaseuri/AutoRestParameterizedHostTestClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/custombaseuri/AutoRestParameterizedHostTestClientBuilder.java
@@ -57,8 +57,7 @@ public final class AutoRestParameterizedHostTestClientBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestParameterizedHostTestClient client = new AutoRestParameterizedHostTestClient(pipeline);
-        client.setHost(this.host);
+        AutoRestParameterizedHostTestClient client = new AutoRestParameterizedHostTestClient(pipeline, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/custombaseuri/moreoptions/AutoRestParameterizedCustomHostTestClient.java
+++ b/vanilla-tests/src/main/java/fixtures/custombaseuri/moreoptions/AutoRestParameterizedCustomHostTestClient.java
@@ -9,7 +9,7 @@ import com.azure.core.http.policy.UserAgentPolicy;
 /** Initializes a new instance of the AutoRestParameterizedCustomHostTestClient type. */
 public final class AutoRestParameterizedCustomHostTestClient {
     /** The subscription id with value 'test12'. */
-    private String subscriptionId;
+    private final String subscriptionId;
 
     /**
      * Gets The subscription id with value 'test12'.
@@ -20,19 +20,8 @@ public final class AutoRestParameterizedCustomHostTestClient {
         return this.subscriptionId;
     }
 
-    /**
-     * Sets The subscription id with value 'test12'.
-     *
-     * @param subscriptionId the subscriptionId value.
-     * @return the service client itself.
-     */
-    AutoRestParameterizedCustomHostTestClient setSubscriptionId(String subscriptionId) {
-        this.subscriptionId = subscriptionId;
-        return this;
-    }
-
     /** A string value that is used as a global part of the parameterized host. Default value 'host'. */
-    private String dnsSuffix;
+    private final String dnsSuffix;
 
     /**
      * Gets A string value that is used as a global part of the parameterized host. Default value 'host'.
@@ -41,17 +30,6 @@ public final class AutoRestParameterizedCustomHostTestClient {
      */
     public String getDnsSuffix() {
         return this.dnsSuffix;
-    }
-
-    /**
-     * Sets A string value that is used as a global part of the parameterized host. Default value 'host'.
-     *
-     * @param dnsSuffix the dnsSuffix value.
-     * @return the service client itself.
-     */
-    AutoRestParameterizedCustomHostTestClient setDnsSuffix(String dnsSuffix) {
-        this.dnsSuffix = dnsSuffix;
-        return this;
     }
 
     /** The HTTP pipeline to send requests through. */
@@ -79,8 +57,13 @@ public final class AutoRestParameterizedCustomHostTestClient {
     }
 
     /** Initializes an instance of AutoRestParameterizedCustomHostTestClient client. */
-    AutoRestParameterizedCustomHostTestClient() {
-        this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build());
+    AutoRestParameterizedCustomHostTestClient(String subscriptionId, String dnsSuffix) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                subscriptionId,
+                dnsSuffix);
     }
 
     /**
@@ -88,8 +71,10 @@ public final class AutoRestParameterizedCustomHostTestClient {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
-    AutoRestParameterizedCustomHostTestClient(HttpPipeline httpPipeline) {
+    AutoRestParameterizedCustomHostTestClient(HttpPipeline httpPipeline, String subscriptionId, String dnsSuffix) {
         this.httpPipeline = httpPipeline;
+        this.subscriptionId = subscriptionId;
+        this.dnsSuffix = dnsSuffix;
         this.paths = new Paths(this);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/custombaseuri/moreoptions/AutoRestParameterizedCustomHostTestClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/custombaseuri/moreoptions/AutoRestParameterizedCustomHostTestClientBuilder.java
@@ -74,9 +74,8 @@ public final class AutoRestParameterizedCustomHostTestClientBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestParameterizedCustomHostTestClient client = new AutoRestParameterizedCustomHostTestClient(pipeline);
-        client.setSubscriptionId(this.subscriptionId);
-        client.setDnsSuffix(this.dnsSuffix);
+        AutoRestParameterizedCustomHostTestClient client =
+                new AutoRestParameterizedCustomHostTestClient(pipeline, subscriptionId, dnsSuffix);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/extensibleenums/PetStoreInc.java
+++ b/vanilla-tests/src/main/java/fixtures/extensibleenums/PetStoreInc.java
@@ -9,7 +9,7 @@ import com.azure.core.http.policy.UserAgentPolicy;
 /** Initializes a new instance of the PetStoreInc type. */
 public final class PetStoreInc {
     /** server parameter. */
-    private String host;
+    private final String host;
 
     /**
      * Gets server parameter.
@@ -18,17 +18,6 @@ public final class PetStoreInc {
      */
     public String getHost() {
         return this.host;
-    }
-
-    /**
-     * Sets server parameter.
-     *
-     * @param host the host value.
-     * @return the service client itself.
-     */
-    PetStoreInc setHost(String host) {
-        this.host = host;
-        return this;
     }
 
     /** The HTTP pipeline to send requests through. */
@@ -56,8 +45,12 @@ public final class PetStoreInc {
     }
 
     /** Initializes an instance of PetStoreInc client. */
-    PetStoreInc() {
-        this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build());
+    PetStoreInc(String host) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                host);
     }
 
     /**
@@ -65,8 +58,9 @@ public final class PetStoreInc {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
-    PetStoreInc(HttpPipeline httpPipeline) {
+    PetStoreInc(HttpPipeline httpPipeline, String host) {
         this.httpPipeline = httpPipeline;
+        this.host = host;
         this.pets = new Pets(this);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/extensibleenums/PetStoreIncBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/extensibleenums/PetStoreIncBuilder.java
@@ -57,8 +57,7 @@ public final class PetStoreIncBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        PetStoreInc client = new PetStoreInc(pipeline);
-        client.setHost(this.host);
+        PetStoreInc client = new PetStoreInc(pipeline, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/head/AutoRestHeadTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/head/AutoRestHeadTestService.java
@@ -9,7 +9,7 @@ import com.azure.core.http.policy.UserAgentPolicy;
 /** Initializes a new instance of the AutoRestHeadTestService type. */
 public final class AutoRestHeadTestService {
     /** server parameter. */
-    private String host;
+    private final String host;
 
     /**
      * Gets server parameter.
@@ -18,17 +18,6 @@ public final class AutoRestHeadTestService {
      */
     public String getHost() {
         return this.host;
-    }
-
-    /**
-     * Sets server parameter.
-     *
-     * @param host the host value.
-     * @return the service client itself.
-     */
-    AutoRestHeadTestService setHost(String host) {
-        this.host = host;
-        return this;
     }
 
     /** The HTTP pipeline to send requests through. */
@@ -56,8 +45,12 @@ public final class AutoRestHeadTestService {
     }
 
     /** Initializes an instance of AutoRestHeadTestService client. */
-    AutoRestHeadTestService() {
-        this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build());
+    AutoRestHeadTestService(String host) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                host);
     }
 
     /**
@@ -65,8 +58,9 @@ public final class AutoRestHeadTestService {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
-    AutoRestHeadTestService(HttpPipeline httpPipeline) {
+    AutoRestHeadTestService(HttpPipeline httpPipeline, String host) {
         this.httpPipeline = httpPipeline;
+        this.host = host;
         this.httpSuccess = new HttpSuccess(this);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/head/AutoRestHeadTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/head/AutoRestHeadTestServiceBuilder.java
@@ -57,8 +57,7 @@ public final class AutoRestHeadTestServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestHeadTestService client = new AutoRestHeadTestService(pipeline);
-        client.setHost(this.host);
+        AutoRestHeadTestService client = new AutoRestHeadTestService(pipeline, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/header/AutoRestSwaggerBATHeaderService.java
+++ b/vanilla-tests/src/main/java/fixtures/header/AutoRestSwaggerBATHeaderService.java
@@ -9,7 +9,7 @@ import com.azure.core.http.policy.UserAgentPolicy;
 /** Initializes a new instance of the AutoRestSwaggerBATHeaderService type. */
 public final class AutoRestSwaggerBATHeaderService {
     /** server parameter. */
-    private String host;
+    private final String host;
 
     /**
      * Gets server parameter.
@@ -18,17 +18,6 @@ public final class AutoRestSwaggerBATHeaderService {
      */
     public String getHost() {
         return this.host;
-    }
-
-    /**
-     * Sets server parameter.
-     *
-     * @param host the host value.
-     * @return the service client itself.
-     */
-    AutoRestSwaggerBATHeaderService setHost(String host) {
-        this.host = host;
-        return this;
     }
 
     /** The HTTP pipeline to send requests through. */
@@ -56,8 +45,12 @@ public final class AutoRestSwaggerBATHeaderService {
     }
 
     /** Initializes an instance of AutoRestSwaggerBATHeaderService client. */
-    AutoRestSwaggerBATHeaderService() {
-        this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build());
+    AutoRestSwaggerBATHeaderService(String host) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                host);
     }
 
     /**
@@ -65,8 +58,9 @@ public final class AutoRestSwaggerBATHeaderService {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
-    AutoRestSwaggerBATHeaderService(HttpPipeline httpPipeline) {
+    AutoRestSwaggerBATHeaderService(HttpPipeline httpPipeline, String host) {
         this.httpPipeline = httpPipeline;
+        this.host = host;
         this.headers = new Headers(this);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/header/AutoRestSwaggerBATHeaderServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/header/AutoRestSwaggerBATHeaderServiceBuilder.java
@@ -57,8 +57,7 @@ public final class AutoRestSwaggerBATHeaderServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestSwaggerBATHeaderService client = new AutoRestSwaggerBATHeaderService(pipeline);
-        client.setHost(this.host);
+        AutoRestSwaggerBATHeaderService client = new AutoRestSwaggerBATHeaderService(pipeline, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/headexceptions/AutoRestHeadExceptionTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/headexceptions/AutoRestHeadExceptionTestService.java
@@ -9,7 +9,7 @@ import com.azure.core.http.policy.UserAgentPolicy;
 /** Initializes a new instance of the AutoRestHeadExceptionTestService type. */
 public final class AutoRestHeadExceptionTestService {
     /** server parameter. */
-    private String host;
+    private final String host;
 
     /**
      * Gets server parameter.
@@ -18,17 +18,6 @@ public final class AutoRestHeadExceptionTestService {
      */
     public String getHost() {
         return this.host;
-    }
-
-    /**
-     * Sets server parameter.
-     *
-     * @param host the host value.
-     * @return the service client itself.
-     */
-    AutoRestHeadExceptionTestService setHost(String host) {
-        this.host = host;
-        return this;
     }
 
     /** The HTTP pipeline to send requests through. */
@@ -56,8 +45,12 @@ public final class AutoRestHeadExceptionTestService {
     }
 
     /** Initializes an instance of AutoRestHeadExceptionTestService client. */
-    AutoRestHeadExceptionTestService() {
-        this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build());
+    AutoRestHeadExceptionTestService(String host) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                host);
     }
 
     /**
@@ -65,8 +58,9 @@ public final class AutoRestHeadExceptionTestService {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
-    AutoRestHeadExceptionTestService(HttpPipeline httpPipeline) {
+    AutoRestHeadExceptionTestService(HttpPipeline httpPipeline, String host) {
         this.httpPipeline = httpPipeline;
+        this.host = host;
         this.headExceptions = new HeadExceptions(this);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/headexceptions/AutoRestHeadExceptionTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/headexceptions/AutoRestHeadExceptionTestServiceBuilder.java
@@ -57,8 +57,7 @@ public final class AutoRestHeadExceptionTestServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestHeadExceptionTestService client = new AutoRestHeadExceptionTestService(pipeline);
-        client.setHost(this.host);
+        AutoRestHeadExceptionTestService client = new AutoRestHeadExceptionTestService(pipeline, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/httpinfrastructure/AutoRestHttpInfrastructureTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/httpinfrastructure/AutoRestHttpInfrastructureTestService.java
@@ -9,7 +9,7 @@ import com.azure.core.http.policy.UserAgentPolicy;
 /** Initializes a new instance of the AutoRestHttpInfrastructureTestService type. */
 public final class AutoRestHttpInfrastructureTestService {
     /** server parameter. */
-    private String host;
+    private final String host;
 
     /**
      * Gets server parameter.
@@ -18,17 +18,6 @@ public final class AutoRestHttpInfrastructureTestService {
      */
     public String getHost() {
         return this.host;
-    }
-
-    /**
-     * Sets server parameter.
-     *
-     * @param host the host value.
-     * @return the service client itself.
-     */
-    AutoRestHttpInfrastructureTestService setHost(String host) {
-        this.host = host;
-        return this;
     }
 
     /** The HTTP pipeline to send requests through. */
@@ -128,8 +117,12 @@ public final class AutoRestHttpInfrastructureTestService {
     }
 
     /** Initializes an instance of AutoRestHttpInfrastructureTestService client. */
-    AutoRestHttpInfrastructureTestService() {
-        this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build());
+    AutoRestHttpInfrastructureTestService(String host) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                host);
     }
 
     /**
@@ -137,8 +130,9 @@ public final class AutoRestHttpInfrastructureTestService {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
-    AutoRestHttpInfrastructureTestService(HttpPipeline httpPipeline) {
+    AutoRestHttpInfrastructureTestService(HttpPipeline httpPipeline, String host) {
         this.httpPipeline = httpPipeline;
+        this.host = host;
         this.httpFailures = new HttpFailures(this);
         this.httpSuccess = new HttpSuccess(this);
         this.httpRedirects = new HttpRedirects(this);

--- a/vanilla-tests/src/main/java/fixtures/httpinfrastructure/AutoRestHttpInfrastructureTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/httpinfrastructure/AutoRestHttpInfrastructureTestServiceBuilder.java
@@ -57,8 +57,7 @@ public final class AutoRestHttpInfrastructureTestServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestHttpInfrastructureTestService client = new AutoRestHttpInfrastructureTestService(pipeline);
-        client.setHost(this.host);
+        AutoRestHttpInfrastructureTestService client = new AutoRestHttpInfrastructureTestService(pipeline, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClient.java
+++ b/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClient.java
@@ -32,7 +32,7 @@ public final class MediaTypesClient {
     private final MediaTypesClientService service;
 
     /** server parameter. */
-    private String host;
+    private final String host;
 
     /**
      * Gets server parameter.
@@ -41,17 +41,6 @@ public final class MediaTypesClient {
      */
     public String getHost() {
         return this.host;
-    }
-
-    /**
-     * Sets server parameter.
-     *
-     * @param host the host value.
-     * @return the service client itself.
-     */
-    MediaTypesClient setHost(String host) {
-        this.host = host;
-        return this;
     }
 
     /** The HTTP pipeline to send requests through. */
@@ -67,8 +56,12 @@ public final class MediaTypesClient {
     }
 
     /** Initializes an instance of MediaTypesClient client. */
-    MediaTypesClient() {
-        this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build());
+    MediaTypesClient(String host) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                host);
     }
 
     /**
@@ -76,8 +69,9 @@ public final class MediaTypesClient {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
-    MediaTypesClient(HttpPipeline httpPipeline) {
+    MediaTypesClient(HttpPipeline httpPipeline, String host) {
         this.httpPipeline = httpPipeline;
+        this.host = host;
         this.service = RestProxy.create(MediaTypesClientService.class, this.httpPipeline);
     }
 

--- a/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClientBuilder.java
@@ -57,8 +57,7 @@ public final class MediaTypesClientBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        MediaTypesClient client = new MediaTypesClient(pipeline);
-        client.setHost(this.host);
+        MediaTypesClient client = new MediaTypesClient(pipeline, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/modelflattening/AutoRestResourceFlatteningTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/modelflattening/AutoRestResourceFlatteningTestService.java
@@ -39,7 +39,7 @@ public final class AutoRestResourceFlatteningTestService {
     private final AutoRestResourceFlatteningTestServiceService service;
 
     /** server parameter. */
-    private String host;
+    private final String host;
 
     /**
      * Gets server parameter.
@@ -48,17 +48,6 @@ public final class AutoRestResourceFlatteningTestService {
      */
     public String getHost() {
         return this.host;
-    }
-
-    /**
-     * Sets server parameter.
-     *
-     * @param host the host value.
-     * @return the service client itself.
-     */
-    AutoRestResourceFlatteningTestService setHost(String host) {
-        this.host = host;
-        return this;
     }
 
     /** The HTTP pipeline to send requests through. */
@@ -74,8 +63,12 @@ public final class AutoRestResourceFlatteningTestService {
     }
 
     /** Initializes an instance of AutoRestResourceFlatteningTestService client. */
-    AutoRestResourceFlatteningTestService() {
-        this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build());
+    AutoRestResourceFlatteningTestService(String host) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                host);
     }
 
     /**
@@ -83,8 +76,9 @@ public final class AutoRestResourceFlatteningTestService {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
-    AutoRestResourceFlatteningTestService(HttpPipeline httpPipeline) {
+    AutoRestResourceFlatteningTestService(HttpPipeline httpPipeline, String host) {
         this.httpPipeline = httpPipeline;
+        this.host = host;
         this.service = RestProxy.create(AutoRestResourceFlatteningTestServiceService.class, this.httpPipeline);
     }
 

--- a/vanilla-tests/src/main/java/fixtures/modelflattening/AutoRestResourceFlatteningTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/modelflattening/AutoRestResourceFlatteningTestServiceBuilder.java
@@ -57,8 +57,7 @@ public final class AutoRestResourceFlatteningTestServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestResourceFlatteningTestService client = new AutoRestResourceFlatteningTestService(pipeline);
-        client.setHost(this.host);
+        AutoRestResourceFlatteningTestService client = new AutoRestResourceFlatteningTestService(pipeline, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/parameterflattening/AutoRestParameterFlattening.java
+++ b/vanilla-tests/src/main/java/fixtures/parameterflattening/AutoRestParameterFlattening.java
@@ -9,7 +9,7 @@ import com.azure.core.http.policy.UserAgentPolicy;
 /** Initializes a new instance of the AutoRestParameterFlattening type. */
 public final class AutoRestParameterFlattening {
     /** server parameter. */
-    private String host;
+    private final String host;
 
     /**
      * Gets server parameter.
@@ -18,17 +18,6 @@ public final class AutoRestParameterFlattening {
      */
     public String getHost() {
         return this.host;
-    }
-
-    /**
-     * Sets server parameter.
-     *
-     * @param host the host value.
-     * @return the service client itself.
-     */
-    AutoRestParameterFlattening setHost(String host) {
-        this.host = host;
-        return this;
     }
 
     /** The HTTP pipeline to send requests through. */
@@ -56,8 +45,12 @@ public final class AutoRestParameterFlattening {
     }
 
     /** Initializes an instance of AutoRestParameterFlattening client. */
-    AutoRestParameterFlattening() {
-        this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build());
+    AutoRestParameterFlattening(String host) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                host);
     }
 
     /**
@@ -65,8 +58,9 @@ public final class AutoRestParameterFlattening {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
-    AutoRestParameterFlattening(HttpPipeline httpPipeline) {
+    AutoRestParameterFlattening(HttpPipeline httpPipeline, String host) {
         this.httpPipeline = httpPipeline;
+        this.host = host;
         this.availabilitySets = new AvailabilitySets(this);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/parameterflattening/AutoRestParameterFlatteningBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/parameterflattening/AutoRestParameterFlatteningBuilder.java
@@ -57,8 +57,7 @@ public final class AutoRestParameterFlatteningBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestParameterFlattening client = new AutoRestParameterFlattening(pipeline);
-        client.setHost(this.host);
+        AutoRestParameterFlattening client = new AutoRestParameterFlattening(pipeline, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/report/AutoRestReportService.java
+++ b/vanilla-tests/src/main/java/fixtures/report/AutoRestReportService.java
@@ -28,7 +28,7 @@ public final class AutoRestReportService {
     private final AutoRestReportServiceService service;
 
     /** server parameter. */
-    private String host;
+    private final String host;
 
     /**
      * Gets server parameter.
@@ -37,17 +37,6 @@ public final class AutoRestReportService {
      */
     public String getHost() {
         return this.host;
-    }
-
-    /**
-     * Sets server parameter.
-     *
-     * @param host the host value.
-     * @return the service client itself.
-     */
-    AutoRestReportService setHost(String host) {
-        this.host = host;
-        return this;
     }
 
     /** The HTTP pipeline to send requests through. */
@@ -63,8 +52,12 @@ public final class AutoRestReportService {
     }
 
     /** Initializes an instance of AutoRestReportService client. */
-    AutoRestReportService() {
-        this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build());
+    AutoRestReportService(String host) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                host);
     }
 
     /**
@@ -72,8 +65,9 @@ public final class AutoRestReportService {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
-    AutoRestReportService(HttpPipeline httpPipeline) {
+    AutoRestReportService(HttpPipeline httpPipeline, String host) {
         this.httpPipeline = httpPipeline;
+        this.host = host;
         this.service = RestProxy.create(AutoRestReportServiceService.class, this.httpPipeline);
     }
 

--- a/vanilla-tests/src/main/java/fixtures/report/AutoRestReportServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/report/AutoRestReportServiceBuilder.java
@@ -57,8 +57,7 @@ public final class AutoRestReportServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestReportService client = new AutoRestReportService(pipeline);
-        client.setHost(this.host);
+        AutoRestReportService client = new AutoRestReportService(pipeline, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/requiredoptional/AutoRestRequiredOptionalTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/requiredoptional/AutoRestRequiredOptionalTestService.java
@@ -9,7 +9,7 @@ import com.azure.core.http.policy.UserAgentPolicy;
 /** Initializes a new instance of the AutoRestRequiredOptionalTestService type. */
 public final class AutoRestRequiredOptionalTestService {
     /** number of items to skip. */
-    private String requiredGlobalPath;
+    private final String requiredGlobalPath;
 
     /**
      * Gets number of items to skip.
@@ -20,19 +20,8 @@ public final class AutoRestRequiredOptionalTestService {
         return this.requiredGlobalPath;
     }
 
-    /**
-     * Sets number of items to skip.
-     *
-     * @param requiredGlobalPath the requiredGlobalPath value.
-     * @return the service client itself.
-     */
-    AutoRestRequiredOptionalTestService setRequiredGlobalPath(String requiredGlobalPath) {
-        this.requiredGlobalPath = requiredGlobalPath;
-        return this;
-    }
-
     /** number of items to skip. */
-    private String requiredGlobalQuery;
+    private final String requiredGlobalQuery;
 
     /**
      * Gets number of items to skip.
@@ -43,19 +32,8 @@ public final class AutoRestRequiredOptionalTestService {
         return this.requiredGlobalQuery;
     }
 
-    /**
-     * Sets number of items to skip.
-     *
-     * @param requiredGlobalQuery the requiredGlobalQuery value.
-     * @return the service client itself.
-     */
-    AutoRestRequiredOptionalTestService setRequiredGlobalQuery(String requiredGlobalQuery) {
-        this.requiredGlobalQuery = requiredGlobalQuery;
-        return this;
-    }
-
     /** number of items to skip. */
-    private int optionalGlobalQuery;
+    private final int optionalGlobalQuery;
 
     /**
      * Gets number of items to skip.
@@ -66,19 +44,8 @@ public final class AutoRestRequiredOptionalTestService {
         return this.optionalGlobalQuery;
     }
 
-    /**
-     * Sets number of items to skip.
-     *
-     * @param optionalGlobalQuery the optionalGlobalQuery value.
-     * @return the service client itself.
-     */
-    AutoRestRequiredOptionalTestService setOptionalGlobalQuery(int optionalGlobalQuery) {
-        this.optionalGlobalQuery = optionalGlobalQuery;
-        return this;
-    }
-
     /** server parameter. */
-    private String host;
+    private final String host;
 
     /**
      * Gets server parameter.
@@ -87,17 +54,6 @@ public final class AutoRestRequiredOptionalTestService {
      */
     public String getHost() {
         return this.host;
-    }
-
-    /**
-     * Sets server parameter.
-     *
-     * @param host the host value.
-     * @return the service client itself.
-     */
-    AutoRestRequiredOptionalTestService setHost(String host) {
-        this.host = host;
-        return this;
     }
 
     /** The HTTP pipeline to send requests through. */
@@ -137,8 +93,16 @@ public final class AutoRestRequiredOptionalTestService {
     }
 
     /** Initializes an instance of AutoRestRequiredOptionalTestService client. */
-    AutoRestRequiredOptionalTestService() {
-        this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build());
+    AutoRestRequiredOptionalTestService(
+            String requiredGlobalPath, String requiredGlobalQuery, int optionalGlobalQuery, String host) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                requiredGlobalPath,
+                requiredGlobalQuery,
+                optionalGlobalQuery,
+                host);
     }
 
     /**
@@ -146,8 +110,17 @@ public final class AutoRestRequiredOptionalTestService {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
-    AutoRestRequiredOptionalTestService(HttpPipeline httpPipeline) {
+    AutoRestRequiredOptionalTestService(
+            HttpPipeline httpPipeline,
+            String requiredGlobalPath,
+            String requiredGlobalQuery,
+            int optionalGlobalQuery,
+            String host) {
         this.httpPipeline = httpPipeline;
+        this.requiredGlobalPath = requiredGlobalPath;
+        this.requiredGlobalQuery = requiredGlobalQuery;
+        this.optionalGlobalQuery = optionalGlobalQuery;
+        this.host = host;
         this.implicits = new Implicits(this);
         this.explicits = new Explicits(this);
     }

--- a/vanilla-tests/src/main/java/fixtures/requiredoptional/AutoRestRequiredOptionalTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/requiredoptional/AutoRestRequiredOptionalTestServiceBuilder.java
@@ -105,11 +105,9 @@ public final class AutoRestRequiredOptionalTestServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestRequiredOptionalTestService client = new AutoRestRequiredOptionalTestService(pipeline);
-        client.setRequiredGlobalPath(this.requiredGlobalPath);
-        client.setRequiredGlobalQuery(this.requiredGlobalQuery);
-        client.setOptionalGlobalQuery(this.optionalGlobalQuery);
-        client.setHost(this.host);
+        AutoRestRequiredOptionalTestService client =
+                new AutoRestRequiredOptionalTestService(
+                        pipeline, requiredGlobalPath, requiredGlobalQuery, optionalGlobalQuery, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/url/AutoRestUrlTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/url/AutoRestUrlTestService.java
@@ -9,7 +9,7 @@ import com.azure.core.http.policy.UserAgentPolicy;
 /** Initializes a new instance of the AutoRestUrlTestService type. */
 public final class AutoRestUrlTestService {
     /** A string value 'globalItemStringPath' that appears in the path. */
-    private String globalStringPath;
+    private final String globalStringPath;
 
     /**
      * Gets A string value 'globalItemStringPath' that appears in the path.
@@ -20,19 +20,8 @@ public final class AutoRestUrlTestService {
         return this.globalStringPath;
     }
 
-    /**
-     * Sets A string value 'globalItemStringPath' that appears in the path.
-     *
-     * @param globalStringPath the globalStringPath value.
-     * @return the service client itself.
-     */
-    AutoRestUrlTestService setGlobalStringPath(String globalStringPath) {
-        this.globalStringPath = globalStringPath;
-        return this;
-    }
-
     /** should contain value null. */
-    private String globalStringQuery;
+    private final String globalStringQuery;
 
     /**
      * Gets should contain value null.
@@ -43,19 +32,8 @@ public final class AutoRestUrlTestService {
         return this.globalStringQuery;
     }
 
-    /**
-     * Sets should contain value null.
-     *
-     * @param globalStringQuery the globalStringQuery value.
-     * @return the service client itself.
-     */
-    AutoRestUrlTestService setGlobalStringQuery(String globalStringQuery) {
-        this.globalStringQuery = globalStringQuery;
-        return this;
-    }
-
     /** server parameter. */
-    private String host;
+    private final String host;
 
     /**
      * Gets server parameter.
@@ -64,17 +42,6 @@ public final class AutoRestUrlTestService {
      */
     public String getHost() {
         return this.host;
-    }
-
-    /**
-     * Sets server parameter.
-     *
-     * @param host the host value.
-     * @return the service client itself.
-     */
-    AutoRestUrlTestService setHost(String host) {
-        this.host = host;
-        return this;
     }
 
     /** The HTTP pipeline to send requests through. */
@@ -126,8 +93,14 @@ public final class AutoRestUrlTestService {
     }
 
     /** Initializes an instance of AutoRestUrlTestService client. */
-    AutoRestUrlTestService() {
-        this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build());
+    AutoRestUrlTestService(String globalStringPath, String globalStringQuery, String host) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                globalStringPath,
+                globalStringQuery,
+                host);
     }
 
     /**
@@ -135,8 +108,11 @@ public final class AutoRestUrlTestService {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
-    AutoRestUrlTestService(HttpPipeline httpPipeline) {
+    AutoRestUrlTestService(HttpPipeline httpPipeline, String globalStringPath, String globalStringQuery, String host) {
         this.httpPipeline = httpPipeline;
+        this.globalStringPath = globalStringPath;
+        this.globalStringQuery = globalStringQuery;
+        this.host = host;
         this.paths = new Paths(this);
         this.queries = new Queries(this);
         this.pathItems = new PathItems(this);

--- a/vanilla-tests/src/main/java/fixtures/url/AutoRestUrlTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/url/AutoRestUrlTestServiceBuilder.java
@@ -89,10 +89,7 @@ public final class AutoRestUrlTestServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestUrlTestService client = new AutoRestUrlTestService(pipeline);
-        client.setGlobalStringPath(this.globalStringPath);
-        client.setGlobalStringQuery(this.globalStringQuery);
-        client.setHost(this.host);
+        AutoRestUrlTestService client = new AutoRestUrlTestService(pipeline, globalStringPath, globalStringQuery, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/AutoRestSwaggerBATXMLService.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/AutoRestSwaggerBATXMLService.java
@@ -9,7 +9,7 @@ import com.azure.core.http.policy.UserAgentPolicy;
 /** Initializes a new instance of the AutoRestSwaggerBATXMLService type. */
 public final class AutoRestSwaggerBATXMLService {
     /** server parameter. */
-    private String host;
+    private final String host;
 
     /**
      * Gets server parameter.
@@ -18,17 +18,6 @@ public final class AutoRestSwaggerBATXMLService {
      */
     public String getHost() {
         return this.host;
-    }
-
-    /**
-     * Sets server parameter.
-     *
-     * @param host the host value.
-     * @return the service client itself.
-     */
-    AutoRestSwaggerBATXMLService setHost(String host) {
-        this.host = host;
-        return this;
     }
 
     /** The HTTP pipeline to send requests through. */
@@ -56,8 +45,12 @@ public final class AutoRestSwaggerBATXMLService {
     }
 
     /** Initializes an instance of AutoRestSwaggerBATXMLService client. */
-    AutoRestSwaggerBATXMLService() {
-        this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build());
+    AutoRestSwaggerBATXMLService(String host) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                host);
     }
 
     /**
@@ -65,8 +58,9 @@ public final class AutoRestSwaggerBATXMLService {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
-    AutoRestSwaggerBATXMLService(HttpPipeline httpPipeline) {
+    AutoRestSwaggerBATXMLService(HttpPipeline httpPipeline, String host) {
         this.httpPipeline = httpPipeline;
+        this.host = host;
         this.xmls = new Xmls(this);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/AutoRestSwaggerBATXMLServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/AutoRestSwaggerBATXMLServiceBuilder.java
@@ -57,8 +57,7 @@ public final class AutoRestSwaggerBATXMLServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestSwaggerBATXMLService client = new AutoRestSwaggerBATXMLService(pipeline);
-        client.setHost(this.host);
+        AutoRestSwaggerBATXMLService client = new AutoRestSwaggerBATXMLService(pipeline, host);
         return client;
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/bodycomplex/BasicOperationsTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodycomplex/BasicOperationsTests.java
@@ -12,7 +12,7 @@ public class BasicOperationsTests {
 
     @BeforeClass
     public static void setup() {
-        client = new AutoRestComplexTestServiceBuilder().apiVersion("2015-05-01").buildClient();
+        client = new AutoRestComplexTestServiceBuilder().buildClient();
     }
 
     @Test


### PR DESCRIPTION
As Jonathan's request. make client immutable.

Currently I do it for both data and mgmt. Let me know if data-plane does not need it.