### PR TITLE
mgmt fluent improve

### DIFF
--- a/fluentnamer/readme.md
+++ b/fluentnamer/readme.md
@@ -1,3 +1,11 @@
+# Settings
+
+| Option      | Description |
+| ----------- | ----------- |
+| `--track1-naming` | Boolean. Use track1 naming style (`withFoo` / `foo` as setter / getter) |
+| `--add-inner` | CSV. Treat as inner class (append `Inner` to class name) |
+| `--resource-property-as-subresource` | Boolean, experimental. Automatically correct input-only resource type as `SubResource` |
+
 #### Fluentnamer
 
 ``` yaml

--- a/fluentnamer/readme.md
+++ b/fluentnamer/readme.md
@@ -4,6 +4,7 @@
 | ----------- | ----------- |
 | `--track1-naming` | Boolean. Use track1 naming style (`withFoo` / `foo` as setter / getter) |
 | `--add-inner` | CSV. Treat as inner class (append `Inner` to class name) |
+| `--name-for-ungrouped-operations` | String. Name for ungrouped operation group |
 | `--resource-property-as-subresource` | Boolean, experimental. Automatically correct input-only resource type as `SubResource` |
 
 #### Fluentnamer

--- a/fluentnamer/src/main/java/com/azure/autorest/fluent/util/FluentJavaSettings.java
+++ b/fluentnamer/src/main/java/com/azure/autorest/fluent/util/FluentJavaSettings.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
@@ -39,6 +40,11 @@ public class FluentJavaSettings {
     private boolean resourcePropertyAsSubResource = false;
 
     /**
+     * Operation group name for ungrouped operations.
+     */
+    private Optional<String> nameForUngroupedOperations = Optional.empty();
+
+    /**
      * Naming override.
      */
     private final Map<String, String> namingOverride = new HashMap<>();
@@ -62,6 +68,10 @@ public class FluentJavaSettings {
         return resourcePropertyAsSubResource;
     }
 
+    public Optional<String> getNameForUngroupedOperations() {
+        return nameForUngroupedOperations;
+    }
+
     public Map<String, String> getNamingOverride() {
         return namingOverride;
     }
@@ -80,6 +90,8 @@ public class FluentJavaSettings {
         loadBooleanSetting("track1-naming", b -> track1Naming = b);
         loadBooleanSetting("resource-property-as-subresource", b -> resourcePropertyAsSubResource = b);
 
+        loadStringSetting("name-for-ungrouped-operations", s -> nameForUngroupedOperations = Optional.of(s) );
+
         Map<String, String> namingOverride = host.getValue(new TypeReference<Map<String, String>>() {}.getType(), "pipeline.fluentnamer.naming.override");
         if (namingOverride != null) {
             this.namingOverride.putAll(namingOverride);
@@ -88,6 +100,13 @@ public class FluentJavaSettings {
 
     private void loadBooleanSetting(String settingName, Consumer<Boolean> action) {
         Boolean settingValue = host.getBooleanValue(settingName);
+        if (settingValue != null) {
+            action.accept(settingValue);
+        }
+    }
+
+    private void loadStringSetting(String settingName, Consumer<String> action) {
+        String settingValue = host.getStringValue(settingName);
         if (settingValue != null) {
             action.accept(settingValue);
         }


### PR DESCRIPTION
support "name-for-ungrouped-operations"

@ChenTanyi 
Pushed to `v4_fluentgen` branch.
Try add `--name-for-ungrouped-operations=ResourceProvider`.