### PR TITLE
Add option to create models with ctor args for required params

### DIFF
--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
@@ -19,7 +19,6 @@ public class JavaSettings
     private static NewPlugin host;
 
     private static String _header;
-
     static void setHeader(String value) {
         if ("MICROSOFT_MIT".equals(value))
         {
@@ -87,7 +86,8 @@ public class JavaSettings
                     host.getBooleanValue("context-client-method-parameter", false),
                     host.getBooleanValue("generate-sync-async-clients", false),
                     host.getStringValue("sync-methods", "essential"),
-                    host.getBooleanValue("client-logger", false));
+                    host.getBooleanValue("client-logger", false),
+                    host.getBooleanValue("required-fields-as-ctor-args"));
         }
         return _instance;
     }
@@ -131,7 +131,8 @@ public class JavaSettings
                          boolean contextClientMethodParameter,
                          boolean generateSyncAsyncClients,
                          String syncMethods,
-                         boolean clientLogger)
+                         boolean clientLogger,
+                         boolean requiredFieldsAsConstructorArgs)
     {
         this.azure = azure;
         this.fluent = fluent;
@@ -156,6 +157,7 @@ public class JavaSettings
         this.generateSyncAsyncClients = generateSyncAsyncClients;
         this.syncMethods =  SyncMethodsGeneration.fromValue(syncMethods);
         this.clientLogger = clientLogger;
+        this.requiredFieldsAsConstructorArgs = requiredFieldsAsConstructorArgs;
     }
 
     private boolean azure;
@@ -169,7 +171,6 @@ public class JavaSettings
     {
         return fluent;
     }
-
     public final boolean isAzureOrFluent()
     {
         return isAzure() || isFluent();
@@ -204,7 +205,6 @@ public class JavaSettings
     {
         return packageName;
     }
-
     public final String getPackage(String... packageSuffixes) {
         StringBuilder packageBuilder = new StringBuilder(packageName);
         if (packageSuffixes != null) {
@@ -317,7 +317,12 @@ public class JavaSettings
         return syncMethods;
     }
 
-    public enum SyncMethodsGeneration {
+    private boolean requiredFieldsAsConstructorArgs;
+    public boolean isRequiredFieldsAsConstructorArgs() {
+        return requiredFieldsAsConstructorArgs;
+    }
+
+  public enum SyncMethodsGeneration {
         ALL,
         ESSENTIAL,
         NONE;

--- a/generate
+++ b/generate
@@ -8,7 +8,7 @@ autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure
 autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/body-array.json --namespace=fixtures.bodyarray
 autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/body-boolean.json --namespace=fixtures.bodyboolean --context-client-method-parameter
 autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/body-boolean.quirks.json --namespace=fixtures.bodyboolean.quirks
-autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/body-complex.json --namespace=fixtures.bodycomplex
+autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/body-complex.json --namespace=fixtures.bodycomplex --required-fields-as-ctor-args=true
 autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/body-file.json --namespace=fixtures.bodyfile
 autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/body-string.json --namespace=fixtures.bodystring
 autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/custom-baseUrl.json --namespace=fixtures.custombaseuri

--- a/javagen/src/main/java/com/azure/autorest/Javagen.java
+++ b/javagen/src/main/java/com/azure/autorest/Javagen.java
@@ -142,7 +142,6 @@ public class Javagen extends NewPlugin {
             //Step 4: Print to files
             Formatter formatter = new Formatter();
             for (JavaFile javaFile : javaPackage.getJavaFiles()) {
-                LOGGER.error("Writing java file \n" + javaFile.getContents());
                 String formattedSource = formatter.formatSourceAndFixImports(javaFile.getContents().toString());
                 writeFile(javaFile.getFilePath(), formattedSource, null);
             }

--- a/javagen/src/main/java/com/azure/autorest/Javagen.java
+++ b/javagen/src/main/java/com/azure/autorest/Javagen.java
@@ -142,6 +142,7 @@ public class Javagen extends NewPlugin {
             //Step 4: Print to files
             Formatter formatter = new Formatter();
             for (JavaFile javaFile : javaPackage.getJavaFiles()) {
+                LOGGER.error("Writing java file \n" + javaFile.getContents());
                 String formattedSource = formatter.formatSourceAndFixImports(javaFile.getContents().toString());
                 writeFile(javaFile.getFilePath(), formattedSource, null);
             }

--- a/javagen/src/main/java/com/azure/autorest/mapper/ModelMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ModelMapper.java
@@ -51,7 +51,7 @@ public class ModelMapper implements IMapper<ObjectSchema, ClientModel> {
 
             HashSet<String> modelImports = new HashSet<>();
 
-            String parentModel = null;
+            String parentModelName = null;
             boolean hasAdditionalProperties = false;
             List<ObjectSchema> parentsNeedFlatten = new ArrayList<>();
             if (compositeType.getParents() != null && compositeType.getParents().getImmediate() != null) {
@@ -71,11 +71,11 @@ public class ModelMapper implements IMapper<ObjectSchema, ClientModel> {
 
                 if (firstParentComplexSchema != null) {
                     ClassType parentType = objectMapper.map(firstParentComplexSchema);
-                    parentModel = parentType.getName();
-                    modelImports.add(parentType.getPackage() + "." + parentModel);
+                    parentModelName = parentType.getName();
+                    modelImports.add(parentType.getPackage() + "." + parentModelName);
                 }
             }
-            builder.parentModelName(parentModel);
+            builder.parentModelName(parentModelName);
 
             List<Property> compositeTypeProperties = compositeType.getProperties()
                     .stream().filter(p -> !p.isIsDiscriminator()).collect(Collectors.toList());

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientModel.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientModel.java
@@ -1,12 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 package com.azure.autorest.model.clientmodel;
 
 import com.azure.autorest.extension.base.plugin.JavaSettings;
 import java.util.List;
 import java.util.Set;
-
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
-
 
 /**
  * A model that is defined by the client.

--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -3,21 +3,22 @@
 
 package com.azure.autorest.template;
 
-import com.azure.autorest.model.clientmodel.ClassType;
-import com.azure.autorest.model.clientmodel.MapType;
-import com.azure.autorest.model.javamodel.JavaModifier;
 import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.model.clientmodel.ArrayType;
+import com.azure.autorest.model.clientmodel.ClassType;
 import com.azure.autorest.model.clientmodel.ClientModel;
 import com.azure.autorest.model.clientmodel.ClientModelProperty;
+import com.azure.autorest.model.clientmodel.ClientModels;
 import com.azure.autorest.model.clientmodel.IType;
 import com.azure.autorest.model.clientmodel.ListType;
+import com.azure.autorest.model.clientmodel.MapType;
 import com.azure.autorest.model.clientmodel.PrimitiveType;
 import com.azure.autorest.model.javamodel.JavaClass;
 import com.azure.autorest.model.javamodel.JavaFile;
 import com.azure.autorest.model.javamodel.JavaIfBlock;
-
+import com.azure.autorest.model.javamodel.JavaModifier;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -45,6 +46,12 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
         if (settings.shouldClientSideValidations() && settings.shouldClientLogger()) {
             imports.add("com.fasterxml.jackson.annotation.JsonIgnore");
             ClassType.ClientLogger.addImportsTo(imports, false);
+        }
+
+        ClientModel parentModel = ClientModels.Instance.getModel(model.getParentModelName());
+        while (parentModel != null) {
+            imports.addAll(parentModel.getImports());
+            parentModel = ClientModels.Instance.getModel(parentModel.getParentModelName());
         }
 
         model.addImportsTo(imports, settings);
@@ -163,18 +170,10 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
             }
 
             List<ClientModelProperty> constantProperties = model.getProperties().stream().filter(ClientModelProperty::getIsConstant).collect(Collectors.toList());
-            if (!constantProperties.isEmpty()) {
-                classBlock.javadocComment(settings.getMaximumJavadocCommentWidth(), (comment) ->
-                {
-                    comment.description(String.format("Creates an instance of %1$s class.", model.getName()));
-                });
-                classBlock.publicConstructor(String.format("%1$s()", model.getName()), (constructor) ->
-                {
-                    for (ClientModelProperty constantProperty : constantProperties) {
-                        constructor.line(String.format("%1$s = %2$s;", constantProperty.getName(), constantProperty.getDefaultValue()));
-                    }
-                });
-            }
+            List<ClientModelProperty> requiredProperties =
+                model.getProperties().stream().filter(ClientModelProperty::isRequired).collect(Collectors.toList());
+
+            addModelConstructor(model, settings, classBlock, constantProperties, requiredProperties);
 
             for (ClientModelProperty property : model.getProperties()) {
                 IType propertyType = property.getWireType();
@@ -227,31 +226,37 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                         comment.param(property.getName(), String.format("the %s value to set", property.getName()));
                         comment.methodReturns(String.format("the %s object itself.", model.getName()));
                     });
-                    classBlock.publicMethod(String.format("%s %s(%s %s)",
-                            model.getName(), property.getSetterName(), propertyClientType, property.getName()), (methodBlock) -> {
-                        String expression;
-                        if (propertyClientType.equals(ArrayType.ByteArray)) {
-                            expression = String.format("CoreUtils.clone(%s)", property.getName());
-                        } else {
-                            expression = property.getName();
-                        }
-                        if (propertyClientType != propertyType) {
-                            methodBlock.ifBlock(String.format("%s == null", property.getName()), (ifBlock) -> ifBlock.line("this.%s = null;", property.getName()))
-                                    .elseBlock((elseBlock) -> {
-                                        String sourceTypeName = propertyClientType.toString();
-                                        String targetTypeName = propertyType.toString();
-                                        String propertyConversion = propertyType.convertFromClientType(expression);
-                                        elseBlock.line("this.%s = %s;", property.getName(), propertyConversion);
-                                    });
-                        } else {
-                            if (settings.shouldGenerateXmlSerialization() && property.getIsXmlWrapper()) {
-                                methodBlock.line("this.%s = new %s(%s);", property.getName(), propertyXmlWrapperClassName.apply(property), expression);
-                            } else {
-                                methodBlock.line("this.%s = %s;", property.getName(), expression);
-                            }
-                        }
-                        methodBlock.methodReturn("this");
-                    });
+
+                    if(!(settings.isRequiredFieldsAsConstructorArgs() && property.isRequired())) {
+                        classBlock.publicMethod(String.format("%s %s(%s %s)",
+                            model.getName(), property.getSetterName(), propertyClientType, property.getName()),
+                            (methodBlock) -> {
+                                String expression;
+                                if (propertyClientType.equals(ArrayType.ByteArray)) {
+                                    expression = String.format("CoreUtils.clone(%s)", property.getName());
+                                } else {
+                                    expression = property.getName();
+                                }
+                                if (propertyClientType != propertyType) {
+                                    methodBlock.ifBlock(String.format("%s == null", property.getName()),
+                                        (ifBlock) -> ifBlock.line("this.%s = null;", property.getName()))
+                                        .elseBlock((elseBlock) -> {
+                                            String sourceTypeName = propertyClientType.toString();
+                                            String targetTypeName = propertyType.toString();
+                                            String propertyConversion = propertyType.convertFromClientType(expression);
+                                            elseBlock.line("this.%s = %s;", property.getName(), propertyConversion);
+                                        });
+                                } else {
+                                    if (settings.shouldGenerateXmlSerialization() && property.getIsXmlWrapper()) {
+                                        methodBlock.line("this.%s = new %s(%s);", property.getName(),
+                                            propertyXmlWrapperClassName.apply(property), expression);
+                                    } else {
+                                        methodBlock.line("this.%s = %s;", property.getName(), expression);
+                                    }
+                                }
+                                methodBlock.methodReturn("this");
+                            });
+                    }
                 }
 
                 if (property.isAdditionalProperties()) {
@@ -268,6 +273,78 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
 
             addPropertyValidations(classBlock, model, settings);
         });
+    }
+
+    private void addModelConstructor(ClientModel model, JavaSettings settings, JavaClass classBlock,
+        List<ClientModelProperty> constantProperties, List<ClientModelProperty> requiredProperties) {
+
+        ClientModel parentModel = ClientModels.Instance.getModel(model.getParentModelName());
+        List<ClientModelProperty> requiredParentProperties = new ArrayList<>();
+        while (parentModel != null) {
+            requiredParentProperties.addAll(
+                parentModel.getProperties().stream().filter(ClientModelProperty::isRequired)
+                    .collect(Collectors.toList()));
+            parentModel = ClientModels.Instance.getModel(parentModel.getParentModelName());
+        }
+
+        if (settings.isRequiredFieldsAsConstructorArgs() && (!requiredProperties.isEmpty() || !requiredParentProperties
+            .isEmpty())) {
+
+            classBlock.javadocComment(settings.getMaximumJavadocCommentWidth(), (comment) ->
+            {
+                comment.description(String.format("Creates an instance of %1$s class.", model.getName()));
+            });
+
+            String requiredCtorArgs = requiredProperties.stream().map(property -> String.format("%1$s %2$s",
+                property.getClientType().toString(), property.getName())).collect(Collectors.joining(", "));
+            String requiredParentCtorArgs = "";
+
+            if (!requiredParentProperties.isEmpty()) {
+                Collections.reverse(requiredParentProperties);
+                requiredParentCtorArgs = requiredParentProperties.stream().map(property -> String.format("%1$s %2$s",
+                    property.getClientType().toString(), property.getName())).collect(Collectors.joining(", "));
+            }
+
+            StringBuilder ctorArgs = new StringBuilder();
+            ctorArgs.append(requiredParentCtorArgs);
+            if (!(requiredParentProperties.isEmpty() || requiredProperties.isEmpty())) {
+                ctorArgs.append(", ");
+            }
+            ctorArgs.append(requiredCtorArgs);
+
+            classBlock.publicConstructor(String.format("%1$s(%2$s)", model.getName(), ctorArgs.toString()), (constructor) ->
+            {
+                if (!requiredParentProperties.isEmpty()) {
+                    constructor.line(String.format("super(%1$s);",
+                        requiredParentProperties.stream().map(ClientModelProperty::getName)
+                            .collect(Collectors.joining(", "))));
+                }
+
+                if (!constantProperties.isEmpty()) {
+                    for (ClientModelProperty constantProperty : constantProperties) {
+                        constructor.line(String
+                            .format("%1$s = %2$s;", constantProperty.getName(), constantProperty.getDefaultValue()));
+                    }
+                }
+                for (ClientModelProperty requiredProperty : requiredProperties) {
+                    constructor.line(String
+                        .format("this.%1$s = %2$s;", requiredProperty.getName(), requiredProperty.getName()));
+                }
+            });
+
+        } else if (!constantProperties.isEmpty()) {
+            classBlock.javadocComment(settings.getMaximumJavadocCommentWidth(), (comment) ->
+            {
+                comment.description(String.format("Creates an instance of %1$s class.", model.getName()));
+            });
+            classBlock.publicConstructor(String.format("%1$s()", model.getName()), (constructor) ->
+            {
+                for (ClientModelProperty constantProperty : constantProperties) {
+                    constructor.line(
+                        String.format("%1$s = %2$s;", constantProperty.getName(), constantProperty.getDefaultValue()));
+                }
+            });
+        }
     }
 
     private void addPropertyValidations(JavaClass classBlock, ClientModel model, JavaSettings settings) {

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Cookiecuttershark.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Cookiecuttershark.java
@@ -1,6 +1,8 @@
 package fixtures.bodycomplex.models;
 
 import com.azure.core.annotation.Immutable;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.time.OffsetDateTime;
@@ -11,7 +13,10 @@ import java.time.OffsetDateTime;
 @Immutable
 public final class Cookiecuttershark extends Shark {
     /** Creates an instance of Cookiecuttershark class. */
-    public Cookiecuttershark(float length, OffsetDateTime birthday) {
+    @JsonCreator
+    public Cookiecuttershark(
+            @JsonProperty(value = "length", required = true) float length,
+            @JsonProperty(value = "birthday", required = true) OffsetDateTime birthday) {
         super(length, birthday);
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Cookiecuttershark.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Cookiecuttershark.java
@@ -3,12 +3,18 @@ package fixtures.bodycomplex.models;
 import com.azure.core.annotation.Immutable;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import java.time.OffsetDateTime;
 
 /** The Cookiecuttershark model. */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "fishtype")
 @JsonTypeName("cookiecuttershark")
 @Immutable
 public final class Cookiecuttershark extends Shark {
+    /** Creates an instance of Cookiecuttershark class. */
+    public Cookiecuttershark(float length, OffsetDateTime birthday) {
+        super(length, birthday);
+    }
+
     /**
      * Validates the instance.
      *

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Fish.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Fish.java
@@ -38,6 +38,11 @@ public class Fish {
     @JsonProperty(value = "siblings")
     private List<Fish> siblings;
 
+    /** Creates an instance of Fish class. */
+    public Fish(float length) {
+        this.length = length;
+    }
+
     /**
      * Get the species property: The species property.
      *
@@ -73,11 +78,6 @@ public class Fish {
      * @param length the length value to set.
      * @return the Fish object itself.
      */
-    public Fish setLength(float length) {
-        this.length = length;
-        return this;
-    }
-
     /**
      * Get the siblings property: The siblings property.
      *

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Fish.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Fish.java
@@ -1,6 +1,7 @@
 package fixtures.bodycomplex.models;
 
 import com.azure.core.annotation.Fluent;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -39,7 +40,8 @@ public class Fish {
     private List<Fish> siblings;
 
     /** Creates an instance of Fish class. */
-    public Fish(float length) {
+    @JsonCreator
+    public Fish(@JsonProperty(value = "length", required = true) float length) {
         this.length = length;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Goblinshark.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Goblinshark.java
@@ -4,6 +4,7 @@ import com.azure.core.annotation.Fluent;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import java.time.OffsetDateTime;
 
 /** The Goblinshark model. */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "fishtype")
@@ -21,6 +22,11 @@ public final class Goblinshark extends Shark {
      */
     @JsonProperty(value = "color")
     private GoblinSharkColor color;
+
+    /** Creates an instance of Goblinshark class. */
+    public Goblinshark(float length, OffsetDateTime birthday) {
+        super(length, birthday);
+    }
 
     /**
      * Get the jawsize property: The jawsize property.

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Goblinshark.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Goblinshark.java
@@ -1,6 +1,7 @@
 package fixtures.bodycomplex.models;
 
 import com.azure.core.annotation.Fluent;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -24,7 +25,10 @@ public final class Goblinshark extends Shark {
     private GoblinSharkColor color;
 
     /** Creates an instance of Goblinshark class. */
-    public Goblinshark(float length, OffsetDateTime birthday) {
+    @JsonCreator
+    public Goblinshark(
+            @JsonProperty(value = "length", required = true) float length,
+            @JsonProperty(value = "birthday", required = true) OffsetDateTime birthday) {
         super(length, birthday);
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Salmon.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Salmon.java
@@ -1,6 +1,7 @@
 package fixtures.bodycomplex.models;
 
 import com.azure.core.annotation.Fluent;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -29,7 +30,8 @@ public class Salmon extends Fish {
     private Boolean iswild;
 
     /** Creates an instance of Salmon class. */
-    public Salmon(float length) {
+    @JsonCreator
+    public Salmon(@JsonProperty(value = "length", required = true) float length) {
         super(length);
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Salmon.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Salmon.java
@@ -28,6 +28,11 @@ public class Salmon extends Fish {
     @JsonProperty(value = "iswild")
     private Boolean iswild;
 
+    /** Creates an instance of Salmon class. */
+    public Salmon(float length) {
+        super(length);
+    }
+
     /**
      * Get the location property: The location property.
      *

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Sawshark.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Sawshark.java
@@ -2,6 +2,7 @@ package fixtures.bodycomplex.models;
 
 import com.azure.core.annotation.Fluent;
 import com.azure.core.util.CoreUtils;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -19,7 +20,10 @@ public final class Sawshark extends Shark {
     private byte[] picture;
 
     /** Creates an instance of Sawshark class. */
-    public Sawshark(float length, OffsetDateTime birthday) {
+    @JsonCreator
+    public Sawshark(
+            @JsonProperty(value = "length", required = true) float length,
+            @JsonProperty(value = "birthday", required = true) OffsetDateTime birthday) {
         super(length, birthday);
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Sawshark.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Sawshark.java
@@ -5,6 +5,7 @@ import com.azure.core.util.CoreUtils;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import java.time.OffsetDateTime;
 
 /** The Sawshark model. */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "fishtype")
@@ -16,6 +17,11 @@ public final class Sawshark extends Shark {
      */
     @JsonProperty(value = "picture")
     private byte[] picture;
+
+    /** Creates an instance of Sawshark class. */
+    public Sawshark(float length, OffsetDateTime birthday) {
+        super(length, birthday);
+    }
 
     /**
      * Get the picture property: The picture property.

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Shark.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Shark.java
@@ -1,6 +1,7 @@
 package fixtures.bodycomplex.models;
 
 import com.azure.core.annotation.Fluent;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -34,7 +35,10 @@ public class Shark extends Fish {
     private OffsetDateTime birthday;
 
     /** Creates an instance of Shark class. */
-    public Shark(float length, OffsetDateTime birthday) {
+    @JsonCreator
+    public Shark(
+            @JsonProperty(value = "length", required = true) float length,
+            @JsonProperty(value = "birthday", required = true) OffsetDateTime birthday) {
         super(length);
         this.birthday = birthday;
     }

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Shark.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Shark.java
@@ -33,6 +33,12 @@ public class Shark extends Fish {
     @JsonProperty(value = "birthday", required = true)
     private OffsetDateTime birthday;
 
+    /** Creates an instance of Shark class. */
+    public Shark(float length, OffsetDateTime birthday) {
+        super(length);
+        this.birthday = birthday;
+    }
+
     /**
      * Get the age property: The age property.
      *
@@ -68,11 +74,6 @@ public class Shark extends Fish {
      * @param birthday the birthday value to set.
      * @return the Shark object itself.
      */
-    public Shark setBirthday(OffsetDateTime birthday) {
-        this.birthday = birthday;
-        return this;
-    }
-
     /**
      * Validates the instance.
      *

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/SmartSalmon.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/SmartSalmon.java
@@ -3,6 +3,7 @@ package fixtures.bodycomplex.models;
 import com.azure.core.annotation.Fluent;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -27,7 +28,8 @@ public final class SmartSalmon extends Salmon {
     @JsonIgnore private Map<String, Object> additionalProperties;
 
     /** Creates an instance of SmartSalmon class. */
-    public SmartSalmon(float length) {
+    @JsonCreator
+    public SmartSalmon(@JsonProperty(value = "length", required = true) float length) {
         super(length);
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/SmartSalmon.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/SmartSalmon.java
@@ -26,6 +26,11 @@ public final class SmartSalmon extends Salmon {
      */
     @JsonIgnore private Map<String, Object> additionalProperties;
 
+    /** Creates an instance of SmartSalmon class. */
+    public SmartSalmon(float length) {
+        super(length);
+    }
+
     /**
      * Get the collegeDegree property: The college_degree property.
      *

--- a/vanilla-tests/src/test/java/fixtures/bodycomplex/PolymorphismTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodycomplex/PolymorphismTests.java
@@ -50,32 +50,25 @@ public class PolymorphismTests {
 
     @Test
     public void putValid() {
-        Salmon body = new Salmon();
+        Salmon body = new Salmon(1.0f);
         body.setLocation("alaska");
         body.setIswild(true);
         body.setSpecies("king");
-        body.setLength(1.0f);
         body.setSiblings(new ArrayList<>());
 
-        Shark sib1 = new Shark();
+        Shark sib1 = new Shark(20.0f, OffsetDateTime.of(2012, 1, 5, 1, 0, 0, 0, ZoneOffset.UTC));
         sib1.setAge(6);
-        sib1.setBirthday(OffsetDateTime.of(2012, 1, 5, 1, 0, 0, 0, ZoneOffset.UTC));
-        sib1.setLength(20.0f);
         sib1.setSpecies("predator");
         body.getSiblings().add(sib1);
 
-        Sawshark sib2 = new Sawshark();
+        Sawshark sib2 = new Sawshark(10.0f, OffsetDateTime.of(1900, 1, 5, 1, 0, 0, 0, ZoneOffset.UTC));
         sib2.setAge(105);
-        sib2.setBirthday(OffsetDateTime.of(1900, 1, 5, 1, 0, 0, 0, ZoneOffset.UTC));
-        sib2.setLength(10.0f);
         sib2.setPicture(new byte[] {(byte) 255, (byte) 255, (byte) 255, (byte) 255, (byte) 254});
         sib2.setSpecies("dangerous");
         body.getSiblings().add(sib2);
 
-        Goblinshark sib3 = new Goblinshark();
+        Goblinshark sib3 = new Goblinshark(30.0f, OffsetDateTime.of(2015, 8, 8, 0, 0, 0, 0, ZoneOffset.UTC));
         sib3.setAge(1);
-        sib3.setBirthday(OffsetDateTime.of(2015, 8, 8, 0, 0, 0, 0, ZoneOffset.UTC));
-        sib3.setLength(30.0f);
         sib3.setSpecies("scary");
         sib3.setJawsize(5);
         sib3.setColor(GoblinSharkColor.fromString("pinkish-gray"));
@@ -87,23 +80,19 @@ public class PolymorphismTests {
     @Test
     public void putValidMissingRequired() {
         try {
-            Salmon body = new Salmon();
+            Salmon body = new Salmon(1.0f);
             body.setLocation("alaska");
             body.setIswild(true);
             body.setSpecies("king");
-            body.setLength(1.0f);
             body.setSiblings(new ArrayList<>());
 
-            Shark sib1 = new Shark();
+            Shark sib1 = new Shark(20.0f, OffsetDateTime.of(2012, 1, 5, 1, 0, 0, 0, ZoneOffset.UTC));
             sib1.setAge(6);
-            sib1.setBirthday(OffsetDateTime.of(2012, 1, 5, 1, 0, 0, 0, ZoneOffset.UTC));
-            sib1.setLength(20.0f);
             sib1.setSpecies("predator");
             body.getSiblings().add(sib1);
 
-            Sawshark sib2 = new Sawshark();
+            Sawshark sib2 = new Sawshark(10.0f, null);
             sib2.setAge(105);
-            sib2.setLength(10.0f);
             sib2.setPicture(new byte[] {(byte) 255, (byte) 255, (byte) 255, (byte) 255, (byte) 254});
             sib2.setSpecies("dangerous");
             body.getSiblings().add(sib2);
@@ -155,11 +144,10 @@ public class PolymorphismTests {
 
     @Test
     public void putComplicated() {
-        SmartSalmon body = new SmartSalmon();
+        SmartSalmon body = new SmartSalmon(1.0f);
         body.setLocation("alaska");
         body.setIswild(true);
         body.setSpecies("king");
-        body.setLength(1.0f);
         body.setSiblings(new ArrayList<>());
         body.setAdditionalProperties(new HashMap<>());
         body.getAdditionalProperties().put("additionalProperty1", 1);
@@ -171,25 +159,19 @@ public class PolymorphismTests {
         body.getAdditionalProperties().put("additionalProperty4", additionalProperty4);
         body.getAdditionalProperties().put("additionalProperty5", Arrays.asList(1, 3));
 
-        Shark sib1 = new Shark();
+        Shark sib1 = new Shark(20.0f, OffsetDateTime.of(2012, 1, 5, 1, 0, 0, 0, ZoneOffset.UTC));
         sib1.setAge(6);
-        sib1.setBirthday(OffsetDateTime.of(2012, 1, 5, 1, 0, 0, 0, ZoneOffset.UTC));
-        sib1.setLength(20.0f);
         sib1.setSpecies("predator");
         body.getSiblings().add(sib1);
 
-        Sawshark sib2 = new Sawshark();
+        Sawshark sib2 = new Sawshark(10.0f, OffsetDateTime.of(1900, 1, 5, 1, 0, 0, 0, ZoneOffset.UTC));
         sib2.setAge(105);
-        sib2.setBirthday(OffsetDateTime.of(1900, 1, 5, 1, 0, 0, 0, ZoneOffset.UTC));
-        sib2.setLength(10.0f);
         sib2.setPicture(new byte[] {(byte) 255, (byte) 255, (byte) 255, (byte) 255, (byte) 254});
         sib2.setSpecies("dangerous");
         body.getSiblings().add(sib2);
 
-        Goblinshark sib3 = new Goblinshark();
+        Goblinshark sib3 = new Goblinshark(30.0f, OffsetDateTime.of(2015, 8, 8, 0, 0, 0, 0, ZoneOffset.UTC));
         sib3.setAge(1);
-        sib3.setBirthday(OffsetDateTime.of(2015, 8, 8, 0, 0, 0, 0, ZoneOffset.UTC));
-        sib3.setLength(30.0f);
         sib3.setSpecies("scary");
         sib3.setJawsize(5);
         sib3.setColor(GoblinSharkColor.fromString("pinkish-gray"));

--- a/vanilla-tests/src/test/java/fixtures/bodycomplex/PolymorphismrecursiveTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodycomplex/PolymorphismrecursiveTests.java
@@ -34,50 +34,40 @@ public class PolymorphismrecursiveTests {
 
     @Test
     public void putValid() throws Exception {
-        Salmon body = new Salmon();
+        Salmon body = new Salmon(1.0f);
         body.setLocation("alaska");
         body.setIswild(true);
         body.setSpecies("king");
-        body.setLength(1.0f);
         body.setSiblings(new ArrayList<Fish>());
 
-        Shark sib1 = new Shark();
+        Shark sib1 = new Shark(20.0f, OffsetDateTime.of(2012, 1, 5, 1, 0, 0, 0, ZoneOffset.UTC));
         sib1.setAge(6);
-        sib1.setBirthday(OffsetDateTime.of(2012, 1, 5, 1, 0, 0, 0, ZoneOffset.UTC));
-        sib1.setLength(20.0f);
         sib1.setSpecies("predator");
         sib1.setSiblings(new ArrayList<Fish>());
         body.getSiblings().add(sib1);
 
-        Sawshark sib2 = new Sawshark();
+        Sawshark sib2 = new Sawshark(10.0f, OffsetDateTime.of(1900, 1, 5, 1, 0, 0, 0, ZoneOffset.UTC));
         sib2.setAge(105);
-        sib2.setBirthday(OffsetDateTime.of(1900, 1, 5, 1, 0, 0, 0, ZoneOffset.UTC));
-        sib2.setLength(10.0f);
         sib2.setPicture(new byte[] {(byte) 255, (byte) 255, (byte) 255, (byte) 255, (byte) 254});
         sib2.setSpecies("dangerous");
         sib2.setSiblings(new ArrayList<Fish>());
         body.getSiblings().add(sib2);
 
-        Salmon sib11 = new Salmon();
+        Salmon sib11 = new Salmon(2);
         sib11.setIswild(true);
         sib11.setLocation("atlantic");
         sib11.setSpecies("coho");
-        sib11.setLength(2);
         sib11.setSiblings(new ArrayList<Fish>());
         sib1.getSiblings().add(sib11);
         sib1.getSiblings().add(sib2);
 
-        Shark sib111 = new Shark();
+        Shark sib111 = new Shark(20, OffsetDateTime.of(2012, 1, 5, 1, 0, 0, 0, ZoneOffset.UTC));
         sib111.setAge(6);
-        sib111.setBirthday(OffsetDateTime.of(2012, 1, 5, 1, 0, 0, 0, ZoneOffset.UTC));
         sib111.setSpecies("predator");
-        sib111.setLength(20);
         sib11.getSiblings().add(sib111);
 
-        Sawshark sib112 = new Sawshark();
+        Sawshark sib112 = new Sawshark(10.0f, OffsetDateTime.of(1900, 1, 5, 1, 0, 0, 0, ZoneOffset.UTC));
         sib112.setAge(105);
-        sib112.setBirthday(OffsetDateTime.of(1900, 1, 5, 1, 0, 0, 0, ZoneOffset.UTC));
-        sib112.setLength(10.0f);
         sib112.setPicture(new byte[] {(byte) 255, (byte) 255, (byte) 255, (byte) 255, (byte) 254});
         sib112.setSpecies("dangerous");
         sib11.getSiblings().add(sib112);


### PR DESCRIPTION
This PR adds a new option `required-field-as-ctor-args` that when set to `true` will generate models with constructors that have required fields as args. There will be no setters for required fields when this option is enabled.