### PR TITLE
support beginLRO with SyncPoller

### DIFF
--- a/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentClientMethodTemplate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentClientMethodTemplate.java
@@ -155,7 +155,7 @@ public class FluentClientMethodTemplate extends ClientMethodTemplate {
         });
     }
 
-    protected void generateLongRunningBegin(ClientMethod clientMethod, JavaType typeBlock, ProxyMethod restAPIMethod, JavaSettings settings) {
+    protected void generateLongRunningBeginAsync(ClientMethod clientMethod, JavaType typeBlock, ProxyMethod restAPIMethod, JavaSettings settings) {
         typeBlock.annotation("ServiceMethod(returns = ReturnType.SINGLE)");
         typeBlock.publicMethod(clientMethod.getDeclaration(), function -> {
             IType classType = ((GenericType) clientMethod.getReturnValue().getType().getClientType()).getTypeArguments()[1];
@@ -167,6 +167,17 @@ public class FluentClientMethodTemplate extends ClientMethodTemplate {
             } else {
                 function.line("return %s.<%s, %s>getLroResultAsync(mono, %s.getHttpPipeline(), %s.class, %s.class);", clientMethod.getClientReference(), classType.toString(), classType.toString(), clientMethod.getClientReference(), classType.toString(), classType.toString());
             }
+        });
+    }
+
+    protected void generateLongRunningBeginSync(ClientMethod clientMethod, JavaType typeBlock, ProxyMethod restAPIMethod, JavaSettings settings) {
+        typeBlock.annotation("ServiceMethod(returns = ReturnType.SINGLE)");
+        typeBlock.publicMethod(clientMethod.getDeclaration(), function -> {
+            AddOptionalVariables(function, clientMethod, restAPIMethod.getParameters(), settings);
+            function.line("return %s(%s)", "begin" + CodeNamer.toPascalCase(restAPIMethod.getSimpleAsyncMethodName()), clientMethod.getArgumentList());
+            function.indent((() -> {
+                function.text(".getSyncPoller();");
+            }));
         });
     }
 

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -273,18 +273,36 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                     addClientMethodWithContext(methods, builder, parameters);
                 }
 
-                // begin method
-                methods.add(builder
-                        .returnValue(new ReturnValue(returnTypeDescription(operation, proxyMethod.getReturnType().getClientType(), syncReturnType),
-                                GenericType.PollerFlux(GenericType.PollResult(syncReturnType.asNullable()), syncReturnType.asNullable())))
-                        .name("begin" + CodeNamer.toPascalCase(proxyMethod.getName()))
-                        .onlyRequiredParameters(false)
-                        .type(ClientMethodType.LongRunningBegin)
-                        .isGroupedParameterRequired(false)
-                        .build());
+                if (settings.getSyncMethods() != JavaSettings.SyncMethodsGeneration.NONE) {
+                    // begin method async
+                    methods.add(builder
+                            .returnValue(new ReturnValue(returnTypeDescription(operation, proxyMethod.getReturnType().getClientType(), syncReturnType),
+                                    GenericType.PollerFlux(GenericType.PollResult(syncReturnType.asNullable()), syncReturnType.asNullable())))
+                            .name("begin" + CodeNamer.toPascalCase(proxyMethod.getSimpleAsyncMethodName()))
+                            .onlyRequiredParameters(false)
+                            .type(ClientMethodType.LongRunningBeginAsync)
+                            .isGroupedParameterRequired(false)
+                            .build());
 
-                if (settings.isContextClientMethodParameter()) {
-                    addClientMethodWithContext(methods, builder, parameters);
+                    if (settings.isContextClientMethodParameter()) {
+                        addClientMethodWithContext(methods, builder, parameters);
+                    }
+                }
+
+                if (settings.getSyncMethods() == JavaSettings.SyncMethodsGeneration.ALL) {
+                    // begin method sync
+                    methods.add(builder
+                            .returnValue(new ReturnValue(returnTypeDescription(operation, proxyMethod.getReturnType().getClientType(), syncReturnType),
+                                    GenericType.SyncPoller(GenericType.PollResult(syncReturnType.asNullable()), syncReturnType.asNullable())))
+                            .name("begin" + CodeNamer.toPascalCase(proxyMethod.getName()))
+                            .onlyRequiredParameters(false)
+                            .type(ClientMethodType.LongRunningBeginSync)
+                            .isGroupedParameterRequired(false)
+                            .build());
+
+                    if (settings.isContextClientMethodParameter()) {
+                        addClientMethodWithContext(methods, builder, parameters);
+                    }
                 }
 
                 if (settings.getSyncMethods() != JavaSettings.SyncMethodsGeneration.NONE) {

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientMethod.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientMethod.java
@@ -290,7 +290,7 @@ public class ClientMethod {
             }
         }
 
-        if (type == ClientMethodType.LongRunningBegin) {
+        if (type == ClientMethodType.LongRunningBeginAsync) {
             if (((GenericType) this.getReturnValue().getType().getClientType()).getTypeArguments()[0] instanceof GenericType) {
                 imports.add("com.fasterxml.jackson.core.type.TypeReference");
             }

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientMethodType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientMethodType.java
@@ -16,13 +16,14 @@ public enum ClientMethodType {
 
     LongRunningSync(5),
     LongRunningAsync(6),
-    LongRunningBegin(7),
+    LongRunningBeginSync(7),
+    LongRunningBeginAsync(8),
 
-    SimpleSync(8),
-    SimpleAsync(9), // will not generate when sync-methods=none, will generate when sync-methods=essential
-    SimpleAsyncRestResponse(10),
+    SimpleSync(9),
+    SimpleAsync(10), // will not generate when sync-methods=none, will generate when sync-methods=essential
+    SimpleAsyncRestResponse(11),
 
-    Resumable(11);
+    Resumable(12);
 
     public static final int SIZE = Integer.SIZE;
     private static java.util.HashMap<Integer, ClientMethodType> mappings;

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/GenericType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/GenericType.java
@@ -85,6 +85,10 @@ public class GenericType implements IType {
         return new GenericType("com.azure.core.util.polling", "PollerFlux", pollResultType, finalResultType);
     }
 
+    public static GenericType SyncPoller(IType pollResultType, IType finalResultType) {
+        return new GenericType("com.azure.core.util.polling", "SyncPoller", pollResultType, finalResultType);
+    }
+
     public static GenericType PollResult(IType pollResultType) {
         return new GenericType("com.azure.core.management.polling", "PollResult", pollResultType);
     }

--- a/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
@@ -351,8 +351,12 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
                 generateLongRunningAsync(clientMethod, typeBlock, restAPIMethod, settings);
                 break;
 
-            case LongRunningBegin:
-                generateLongRunningBegin(clientMethod, typeBlock, restAPIMethod, settings);
+            case LongRunningBeginAsync:
+                generateLongRunningBeginAsync(clientMethod, typeBlock, restAPIMethod, settings);
+                break;
+
+            case LongRunningBeginSync:
+                generateLongRunningBeginSync(clientMethod, typeBlock, restAPIMethod, settings);
                 break;
 
             case Resumable:
@@ -583,7 +587,27 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
 
     }
 
-    protected void generateLongRunningBegin(ClientMethod clientMethod, JavaType typeBlock, ProxyMethod restAPIMethod, JavaSettings settings) {
+    /**
+     * Extension to write LRO begin async client method.
+     *
+     * @param clientMethod client method
+     * @param typeBlock type block
+     * @param restAPIMethod proxy method
+     * @param settings java settings
+     */
+    protected void generateLongRunningBeginAsync(ClientMethod clientMethod, JavaType typeBlock, ProxyMethod restAPIMethod, JavaSettings settings) {
+
+    }
+
+    /**
+     * Extension to write LRO begin sync client method.
+     *
+     * @param clientMethod client method
+     * @param typeBlock type block
+     * @param restAPIMethod proxy method
+     * @param settings java settings
+     */
+    protected void generateLongRunningBeginSync(ClientMethod clientMethod, JavaType typeBlock, ProxyMethod restAPIMethod, JavaSettings settings) {
 
     }
 }

--- a/javagen/src/main/java/com/azure/autorest/template/ServiceAsyncClientTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ServiceAsyncClientTemplate.java
@@ -2,7 +2,6 @@ package com.azure.autorest.template;
 
 import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.model.clientmodel.AsyncSyncClient;
-import com.azure.autorest.model.clientmodel.ClientMethodType;
 import com.azure.autorest.model.clientmodel.MethodGroupClient;
 import com.azure.autorest.model.clientmodel.ServiceClient;
 import com.azure.autorest.model.javamodel.JavaFile;
@@ -81,7 +80,7 @@ public class ServiceAsyncClientTemplate implements IJavaTemplate<AsyncSyncClient
       if (wrapServiceClient) {
         serviceClient.getClientMethods()
             .stream()
-            .filter(clientMethod -> clientMethod.getType().name().contains("Async") || clientMethod.getType() == ClientMethodType.LongRunningBegin)
+            .filter(clientMethod -> clientMethod.getType().name().contains("Async"))
             .forEach(clientMethod -> {
               Templates.getWrapperClientMethodTemplate().write(clientMethod, classBlock);
             });
@@ -89,7 +88,7 @@ public class ServiceAsyncClientTemplate implements IJavaTemplate<AsyncSyncClient
         methodGroupClient
             .getClientMethods()
             .stream()
-            .filter(clientMethod -> clientMethod.getType().name().contains("Async") || clientMethod.getType() == ClientMethodType.LongRunningBegin)
+            .filter(clientMethod -> clientMethod.getType().name().contains("Async"))
             .forEach(clientMethod -> {
               Templates.getWrapperClientMethodTemplate().write(clientMethod, classBlock);
             });


### PR DESCRIPTION
LongRunningBeginSync will generated method with return type `SyncPoller`.

LongRunningBeginAsync will generated method with return type `PollerFlux`.