### PR TITLE
Fix param grouping proxy method call args

### DIFF
--- a/azure-tests/src/main/java/fixtures/paging/Pagings.java
+++ b/azure-tests/src/main/java/fixtures/paging/Pagings.java
@@ -330,6 +330,10 @@ public final class Pagings {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<PagedResponse<Product>> getNullNextLinkNamePagesSinglePageAsync() {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
         return FluxUtil.withContext(context -> service.getNullNextLinkNamePages(this.client.getHost(), context))
                 .map(
                         res ->
@@ -568,6 +572,10 @@ public final class Pagings {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<PagedResponse<Product>> nextOperationWithQueryParamsSinglePageAsync() {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
         final boolean queryConstant = true;
         return FluxUtil.withContext(
                         context -> service.nextOperationWithQueryParams(this.client.getHost(), queryConstant, context))

--- a/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
@@ -479,14 +479,15 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
 
     protected void generatePagedAsyncSinglePage(ClientMethod clientMethod, JavaType typeBlock, ProxyMethod restAPIMethod, JavaSettings settings) {
         typeBlock.annotation("ServiceMethod(returns = ReturnType.SINGLE)");
-        String restAPIMethodArgumentList = String.join(", ", clientMethod.getProxyMethodArguments(settings));
-        String serviceMethodCall = String.format("service.%s(%s)", restAPIMethod.getName(), restAPIMethodArgumentList);
+
         if (clientMethod.getMethodPageDetails().nonNullNextLink()) {
             typeBlock.publicMethod(clientMethod.getDeclaration(), function -> {
                 AddValidations(function, clientMethod.getRequiredNullableParameterExpressions(), clientMethod.getValidateExpressions(), settings);
                 AddOptionalAndConstantVariables(function, clientMethod, restAPIMethod.getParameters(), settings);
                 ApplyParameterTransformations(function, clientMethod, settings);
                 ConvertClientTypesToWireTypes(function, clientMethod, restAPIMethod.getParameters(), clientMethod.getClientReference(), settings);
+                String restAPIMethodArgumentList = String.join(", ", clientMethod.getProxyMethodArguments(settings));
+                String serviceMethodCall = String.format("service.%s(%s)", restAPIMethod.getName(), restAPIMethodArgumentList);
                 if (settings.getAddContextParameter()) {
                     if (settings.isContextClientMethodParameter() && contextInParameters(clientMethod)) {
                         function.line(String.format("return %s", serviceMethodCall));
@@ -517,7 +518,12 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
             });
         } else {
             typeBlock.publicMethod(clientMethod.getDeclaration(), function -> {
+                AddValidations(function, clientMethod.getRequiredNullableParameterExpressions(), clientMethod.getValidateExpressions(), settings);
                 AddOptionalAndConstantVariables(function, clientMethod, restAPIMethod.getParameters(), settings);
+                ApplyParameterTransformations(function, clientMethod, settings);
+                ConvertClientTypesToWireTypes(function, clientMethod, restAPIMethod.getParameters(), clientMethod.getClientReference(), settings);
+                String restAPIMethodArgumentList = String.join(", ", clientMethod.getProxyMethodArguments(settings));
+                String serviceMethodCall = String.format("service.%s(%s)", restAPIMethod.getName(), restAPIMethodArgumentList);
                 if (settings.getAddContextParameter()) {
                     if (settings.isContextClientMethodParameter() && contextInParameters(clientMethod)) {
                         function.line(String.format("return %s", serviceMethodCall));


### PR DESCRIPTION
For single page async calls, the param grouping arguments were not correctly used to call the proxy method call. This PR fixes the bug.