### PR TITLE
Make apiversion settable on the builder

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/mapper/ServiceClientMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ServiceClientMapper.java
@@ -1,7 +1,6 @@
 package com.azure.autorest.mapper;
 
 import com.azure.autorest.extension.base.model.codemodel.CodeModel;
-import com.azure.autorest.extension.base.model.codemodel.ConstantSchema;
 import com.azure.autorest.extension.base.model.codemodel.Operation;
 import com.azure.autorest.extension.base.model.codemodel.OperationGroup;
 import com.azure.autorest.extension.base.model.codemodel.Parameter;
@@ -17,7 +16,6 @@ import com.azure.autorest.model.clientmodel.ServiceClient;
 import com.azure.autorest.model.clientmodel.ServiceClientProperty;
 import com.azure.autorest.util.ClientModelUtil;
 import com.azure.autorest.util.CodeNamer;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -108,14 +106,14 @@ public class ServiceClientMapper implements IMapper<CodeModel, ServiceClient> {
                 serviceClientPropertyClientType = serviceClientPropertyClientType.asNullable();
             }
 
-            boolean serviceClientPropertyIsReadOnly = p.getSchema() instanceof ConstantSchema;
-
             String serviceClientPropertyDefaultValueExpression = serviceClientPropertyClientType.defaultValueExpression(p.getClientDefaultValue());
 
             if (serviceClientPropertyClientType == ClassType.TokenCredential) {
                 usesCredentials = true;
             } else {
-                ServiceClientProperty serviceClientProperty = new ServiceClientProperty(serviceClientPropertyDescription, serviceClientPropertyClientType, serviceClientPropertyName, serviceClientPropertyIsReadOnly, serviceClientPropertyDefaultValueExpression);
+                ServiceClientProperty serviceClientProperty =
+                    new ServiceClientProperty(serviceClientPropertyDescription, serviceClientPropertyClientType,
+                        serviceClientPropertyName, false, serviceClientPropertyDefaultValueExpression);
                 if (!serviceClientProperties.contains(serviceClientProperty)) {
                     // Ignore duplicate client property.
                     serviceClientProperties.add(serviceClientProperty);

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/AutoRestComplexTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/AutoRestComplexTestService.java
@@ -153,12 +153,13 @@ public final class AutoRestComplexTestService {
     }
 
     /** Initializes an instance of AutoRestComplexTestService client. */
-    AutoRestComplexTestService(String host) {
+    AutoRestComplexTestService(String host, String apiVersion) {
         this(
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
-                host);
+                host,
+                apiVersion);
     }
 
     /**
@@ -166,10 +167,10 @@ public final class AutoRestComplexTestService {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
-    AutoRestComplexTestService(HttpPipeline httpPipeline, String host) {
+    AutoRestComplexTestService(HttpPipeline httpPipeline, String host, String apiVersion) {
         this.httpPipeline = httpPipeline;
         this.host = host;
-        this.apiVersion = "2016-02-29";
+        this.apiVersion = apiVersion;
         this.basics = new Basics(this);
         this.primitives = new Primitives(this);
         this.arrays = new Arrays(this);

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/AutoRestComplexTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/AutoRestComplexTestServiceBuilder.java
@@ -27,6 +27,22 @@ public final class AutoRestComplexTestServiceBuilder {
     }
 
     /*
+     * Api Version
+     */
+    private String apiVersion;
+
+    /**
+     * Sets Api Version.
+     *
+     * @param apiVersion the apiVersion value.
+     * @return the AutoRestComplexTestServiceBuilder.
+     */
+    public AutoRestComplexTestServiceBuilder apiVersion(String apiVersion) {
+        this.apiVersion = apiVersion;
+        return this;
+    }
+
+    /*
      * The HTTP pipeline to send requests through
      */
     private HttpPipeline pipeline;
@@ -51,13 +67,16 @@ public final class AutoRestComplexTestServiceBuilder {
         if (host == null) {
             this.host = "http://localhost:3000";
         }
+        if (apiVersion == null) {
+            this.apiVersion = "2016-02-29";
+        }
         if (pipeline == null) {
             this.pipeline =
                     new HttpPipelineBuilder()
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestComplexTestService client = new AutoRestComplexTestService(pipeline, host);
+        AutoRestComplexTestService client = new AutoRestComplexTestService(pipeline, host, apiVersion);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/validation/AutoRestValidationTest.java
+++ b/vanilla-tests/src/main/java/fixtures/validation/AutoRestValidationTest.java
@@ -81,13 +81,14 @@ public final class AutoRestValidationTest {
     }
 
     /** Initializes an instance of AutoRestValidationTest client. */
-    AutoRestValidationTest(String subscriptionId, String host) {
+    AutoRestValidationTest(String subscriptionId, String host, String apiVersion) {
         this(
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
                 subscriptionId,
-                host);
+                host,
+                apiVersion);
     }
 
     /**
@@ -95,11 +96,11 @@ public final class AutoRestValidationTest {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
-    AutoRestValidationTest(HttpPipeline httpPipeline, String subscriptionId, String host) {
+    AutoRestValidationTest(HttpPipeline httpPipeline, String subscriptionId, String host, String apiVersion) {
         this.httpPipeline = httpPipeline;
         this.subscriptionId = subscriptionId;
         this.host = host;
-        this.apiVersion = "1.0.0";
+        this.apiVersion = apiVersion;
         this.service = RestProxy.create(AutoRestValidationTestService.class, this.httpPipeline);
     }
 

--- a/vanilla-tests/src/main/java/fixtures/validation/AutoRestValidationTestBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/validation/AutoRestValidationTestBuilder.java
@@ -43,6 +43,22 @@ public final class AutoRestValidationTestBuilder {
     }
 
     /*
+     * Api Version
+     */
+    private String apiVersion;
+
+    /**
+     * Sets Api Version.
+     *
+     * @param apiVersion the apiVersion value.
+     * @return the AutoRestValidationTestBuilder.
+     */
+    public AutoRestValidationTestBuilder apiVersion(String apiVersion) {
+        this.apiVersion = apiVersion;
+        return this;
+    }
+
+    /*
      * The HTTP pipeline to send requests through
      */
     private HttpPipeline pipeline;
@@ -67,13 +83,16 @@ public final class AutoRestValidationTestBuilder {
         if (host == null) {
             this.host = "http://localhost:3000";
         }
+        if (apiVersion == null) {
+            this.apiVersion = "1.0.0";
+        }
         if (pipeline == null) {
             this.pipeline =
                     new HttpPipelineBuilder()
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestValidationTest client = new AutoRestValidationTest(pipeline, subscriptionId, host);
+        AutoRestValidationTest client = new AutoRestValidationTest(pipeline, subscriptionId, host, apiVersion);
         return client;
     }
 }


### PR DESCRIPTION
`apiversion` has a default value in the swagger but it's a settable property for data-plane APIs. So, this PR changes the behavior of global parameters to be settable in the builder and if it's not set, the buildClient() method will set it to default value.