### PR TITLE
v4 fix optional paramter of wiretype

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
@@ -87,7 +87,10 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
                     (parameterClientType instanceof ArrayType || parameterClientType instanceof ListType)) {
                 parameterWireType = ClassType.String;
             }
-            boolean alwaysNull = parameterWireType != parameterClientType && clientMethod.getOnlyRequiredParameters() && !parameter.getIsRequired();
+            // "addConstant" clause is a hack here.
+            // For SimpleAsyncRestResponse and PagingAsyncSinglePage, "alwaysNull" is set to true, to let "ConvertClientTypesToWireTypes" method set the optional parameter.
+            // For other ClientMethodType (which would have addConstant=false), optional parameter need to be initialized for calling method with full parameters.
+            boolean alwaysNull = addConstant && parameterWireType != parameterClientType && clientMethod.getOnlyRequiredParameters() && !parameter.getIsRequired();
 
             if (!parameter.getFromClient() && !alwaysNull && ((addOptional && clientMethod.getOnlyRequiredParameters() && !parameter.getIsRequired()) || (addConstant && parameter.getIsConstant()))) {
                 String defaultValue = parameterClientType.defaultValueExpression(parameter.getDefaultValue());
@@ -181,7 +184,7 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
     protected static void ConvertClientTypesToWireTypes(JavaBlock function, ClientMethod clientMethod, List<ProxyMethodParameter> autoRestMethodRetrofitParameters, String methodClientReference, JavaSettings settings) {
         for (ProxyMethodParameter parameter : autoRestMethodRetrofitParameters) {
             IType parameterWireType = parameter.getWireType();
-            ;
+
             if (parameter.getIsNullable()) {
                 parameterWireType = parameterWireType.asNullable();
             }

--- a/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
@@ -377,7 +377,7 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
                 typeBlock.publicMethod(clientMethod.getDeclaration(), function -> {
                     AddOptionalVariables(function, clientMethod, restAPIMethod.getParameters(), settings);
                     if (clientMethod.getReturnValue().getType() == ClassType.InputStream) {
-                        function.line("Iterator<ByteBufferBackedInputStream> iterator = %s(%S).map(ByteBufferBackedInputStream::new).toStream().iterator()",
+                        function.line("Iterator<ByteBufferBackedInputStream> iterator = %s(%S).map(ByteBufferBackedInputStream::new).toStream().iterator();",
                                 clientMethod.getSimpleAsyncMethodName(), clientMethod.getArgumentList());
                         function.anonymousClass("Enumeration<InputStream>", "enumeration", javaBlock -> {
                             javaBlock.annotation("Override");

--- a/vanilla-tests/src/main/java/fixtures/bodyfile/Files.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyfile/Files.java
@@ -14,15 +14,13 @@ import com.azure.core.util.Context;
 import com.azure.core.util.FluxUtil;
 import com.fasterxml.jackson.databind.util.ByteBufferBackedInputStream;
 import fixtures.bodyfile.models.ErrorException;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-
 import java.io.InputStream;
 import java.io.SequenceInputStream;
 import java.nio.ByteBuffer;
-import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Iterator;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 /** An instance of this class provides access to all the operations defined in Files. */
 public final class Files {
@@ -102,11 +100,21 @@ public final class Files {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public InputStream getFile() {
-        return getFileAsync()
-                .map(ByteBufferBackedInputStream::new)
-                .collectList()
-                .map(list -> new SequenceInputStream(Collections.enumeration(list)))
-                .block();
+        Iterator<ByteBufferBackedInputStream> iterator =
+                getFileAsync().map(ByteBufferBackedInputStream::new).toStream().iterator();
+        Enumeration<InputStream> enumeration =
+                new Enumeration<InputStream>() {
+                    @Override
+                    public boolean hasMoreElements() {
+                        return iterator.hasNext();
+                    }
+
+                    @Override
+                    public InputStream nextElement() {
+                        return iterator.next();
+                    }
+                };
+        return new SequenceInputStream(enumeration);
     }
 
     /**
@@ -146,19 +154,20 @@ public final class Files {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public InputStream getFileLarge() {
-        Iterator<ByteBufferBackedInputStream> iterator = getFileLargeAsync()
-                .map(ByteBufferBackedInputStream::new).toStream().iterator();
-        Enumeration<InputStream> enumeration = new Enumeration<InputStream>() {
-            @Override
-            public boolean hasMoreElements() {
-                return iterator.hasNext();
-            }
+        Iterator<ByteBufferBackedInputStream> iterator =
+                getFileLargeAsync().map(ByteBufferBackedInputStream::new).toStream().iterator();
+        Enumeration<InputStream> enumeration =
+                new Enumeration<InputStream>() {
+                    @Override
+                    public boolean hasMoreElements() {
+                        return iterator.hasNext();
+                    }
 
-            @Override
-            public InputStream nextElement() {
-                return iterator.next();
-            }
-        };
+                    @Override
+                    public InputStream nextElement() {
+                        return iterator.next();
+                    }
+                };
         return new SequenceInputStream(enumeration);
     }
 
@@ -199,10 +208,20 @@ public final class Files {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public InputStream getEmptyFile() {
-        return getEmptyFileAsync()
-                .map(ByteBufferBackedInputStream::new)
-                .collectList()
-                .map(list -> new SequenceInputStream(Collections.enumeration(list)))
-                .block();
+        Iterator<ByteBufferBackedInputStream> iterator =
+                getEmptyFileAsync().map(ByteBufferBackedInputStream::new).toStream().iterator();
+        Enumeration<InputStream> enumeration =
+                new Enumeration<InputStream>() {
+                    @Override
+                    public boolean hasMoreElements() {
+                        return iterator.hasNext();
+                    }
+
+                    @Override
+                    public InputStream nextElement() {
+                        return iterator.next();
+                    }
+                };
+        return new SequenceInputStream(enumeration);
     }
 }


### PR DESCRIPTION
FIx bug that optional parameter in client method is not inited.

Before fix,
```
    @ServiceMethod(returns = ReturnType.COLLECTION)
    public PagedFlux<DeploymentResourceInner> listAsync(String resourceGroupName, String serviceName, String appName) {
        final Context context = null;
        return new PagedFlux<>(
            () -> listSinglePageAsync(resourceGroupName, serviceName, appName, version),
            nextLink -> listNextSinglePageAsync(nextLink));
    }
```

After fix,
```
    @ServiceMethod(returns = ReturnType.COLLECTION)
    public PagedFlux<DeploymentResourceInner> listAsync(String resourceGroupName, String serviceName, String appName) {
        final List<String> version = null;
        final Context context = null;
        return new PagedFlux<>(
            () -> listSinglePageAsync(resourceGroupName, serviceName, appName, version),
            nextLink -> listNextSinglePageAsync(nextLink));
    }
```