### PR TITLE
v4 need compare Java name in equals check

### DIFF
--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ChoiceSchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ChoiceSchema.java
@@ -3,6 +3,7 @@ package com.azure.autorest.extension.base.model.codemodel;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 
 /**
@@ -85,6 +86,7 @@ public class ChoiceSchema extends ValueSchema {
         int result = 1;
         result = ((result* 31)+((this.choiceType == null)? 0 :this.choiceType.hashCode()));
         result = ((result* 31)+((this.choices == null)? 0 :this.choices.hashCode()));
+        result = ((result* 31)+((this.getLanguage().getJava().getName() == null)? 0 :this.getLanguage().getJava().getName().hashCode()));
         return result;
     }
 
@@ -97,7 +99,8 @@ public class ChoiceSchema extends ValueSchema {
             return false;
         }
         ChoiceSchema rhs = ((ChoiceSchema) other);
-        return (((this.choiceType == rhs.choiceType)||((this.choiceType!= null)&&this.choiceType.equals(rhs.choiceType)))&&((this.choices == rhs.choices)||((this.choices!= null)&&this.choices.equals(rhs.choices))));
+        return Objects.equals(this.choiceType, rhs.choiceType) && Objects.equals(this.choices, rhs.choices)
+                && Objects.equals(this.getLanguage().getJava().getName(), rhs.getLanguage().getJava().getName());
     }
 
 }

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/SealedChoiceSchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/SealedChoiceSchema.java
@@ -3,6 +3,7 @@ package com.azure.autorest.extension.base.model.codemodel;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 
 /**
@@ -85,6 +86,7 @@ public class SealedChoiceSchema extends ValueSchema {
         int result = 1;
         result = ((result* 31)+((this.choiceType == null)? 0 :this.choiceType.hashCode()));
         result = ((result* 31)+((this.choices == null)? 0 :this.choices.hashCode()));
+        result = ((result* 31)+((this.getLanguage().getJava().getName() == null)? 0 :this.getLanguage().getJava().getName().hashCode()));
         return result;
     }
 
@@ -97,7 +99,8 @@ public class SealedChoiceSchema extends ValueSchema {
             return false;
         }
         SealedChoiceSchema rhs = ((SealedChoiceSchema) other);
-        return (((this.choiceType == rhs.choiceType)||((this.choiceType!= null)&&this.choiceType.equals(rhs.choiceType)))&&((this.choices == rhs.choices)||((this.choices!= null)&&this.choices.equals(rhs.choices))));
+        return Objects.equals(this.choiceType, rhs.choiceType) && Objects.equals(this.choices, rhs.choices)
+                && Objects.equals(this.getLanguage().getJava().getName(), rhs.getLanguage().getJava().getName());
     }
 
 }


### PR DESCRIPTION
The issue is, that there is a few same choices, with different Java name.

https://github.com/Azure/azure-rest-api-specs/blob/master/specification/network/resource-manager/Microsoft.Network/stable/2019-11-01/azureFirewall.json#L1048-L1056
https://github.com/Azure/azure-rest-api-specs/blob/master/specification/network/resource-manager/Microsoft.Network/stable/2019-11-01/natGateway.json#L369-L377
https://github.com/Azure/azure-rest-api-specs/blob/master/specification/network/resource-manager/Microsoft.Network/stable/2019-11-01/publicIpPrefix.json#L366-L374

Apparently they need to be in different classes.

So add compare on Java name to hashCode and equals.