### PR TITLE
Fix content type to be more specific

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
@@ -116,10 +116,12 @@ public class ProxyMethodMapper implements IMapper<Operation, Map<Request, ProxyM
             }
 
             String requestContentType = "application/json";
-            if (request.getProtocol().getHttp().getKnownMediaType() != null) {
-                requestContentType = request.getProtocol().getHttp().getKnownMediaType().getContentType();
-            } else if (request.getProtocol().getHttp().getMediaTypes() != null && !request.getProtocol().getHttp().getMediaTypes().isEmpty()) {
+
+            // check for mediaTypes first as that is more specific than the knownMediaType
+            if (request.getProtocol().getHttp().getMediaTypes() != null && !request.getProtocol().getHttp().getMediaTypes().isEmpty()) {
                 requestContentType = request.getProtocol().getHttp().getMediaTypes().get(0);
+            } else if (request.getProtocol().getHttp().getKnownMediaType() != null) {
+                 requestContentType = request.getProtocol().getHttp().getKnownMediaType().getContentType();
             }
             builder.requestContentType(requestContentType);
 

--- a/preprocessor/readme.md
+++ b/preprocessor/readme.md
@@ -6,7 +6,7 @@ pass-thru:
   - subset-reducer
 
 use-extension:
-  "@autorest/modelerfour": "4.14.362"
+  "@autorest/modelerfour": "4.15.375"
 
 pipeline:
 

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/MyKind.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/MyKind.java
@@ -1,0 +1,27 @@
+package fixtures.bodycomplex.models;
+
+import com.azure.core.util.ExpandableStringEnum;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.Collection;
+
+/** Defines values for MyKind. */
+public final class MyKind extends ExpandableStringEnum<MyKind> {
+    /** Static value Kind1 for MyKind. */
+    public static final MyKind KIND1 = fromString("Kind1");
+
+    /**
+     * Creates or finds a MyKind from its string representation.
+     *
+     * @param name a name to look for.
+     * @return the corresponding MyKind.
+     */
+    @JsonCreator
+    public static MyKind fromString(String name) {
+        return fromString(name, MyKind.class);
+    }
+
+    /** @return known MyKind values. */
+    public static Collection<MyKind> values() {
+        return values(MyKind.class);
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClient.java
+++ b/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClient.java
@@ -88,7 +88,7 @@ public final class MediaTypesClient {
         Mono<Response<String>> analyzeBody(
                 @HostParam("$host") String host,
                 @HeaderParam("Content-Type") ContentType contentType,
-                @BodyParam("application/octet-stream") Flux<ByteBuffer> input,
+                @BodyParam("application/pdf") Flux<ByteBuffer> input,
                 @HeaderParam("Content-Length") long contentLength,
                 Context context);
 


### PR DESCRIPTION
The request level content-type should use the more specific `media-type` than the `known-media-type` parameter.