### PR TITLE
Add option to make proxy service interface public

### DIFF
--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
@@ -87,7 +87,8 @@ public class JavaSettings
                     host.getBooleanValue("generate-sync-async-clients", false),
                     host.getStringValue("sync-methods", "essential"),
                     host.getBooleanValue("client-logger", false),
-                    host.getBooleanValue("required-fields-as-ctor-args"));
+                    host.getBooleanValue("required-fields-as-ctor-args", false),
+                    host.getBooleanValue("service-interface-as-public", false));
         }
         return _instance;
     }
@@ -108,6 +109,7 @@ public class JavaSettings
      @param implementationSubpackage The sub-package that the Service and Method Group client implementation classes will be put into.
      @param modelsSubpackage The sub-package that Enums, Exceptions, and Model types will be put into.
      @param requiredParameterClientMethods Whether or not Service and Method Group client method overloads that omit optional parameters will be created.
+     @param serviceInterfaceAsPublic If set to true, proxy method service interface will be marked as public.
      */
     private JavaSettings(boolean azure,
                          boolean fluent,
@@ -132,7 +134,8 @@ public class JavaSettings
                          boolean generateSyncAsyncClients,
                          String syncMethods,
                          boolean clientLogger,
-                         boolean requiredFieldsAsConstructorArgs)
+                         boolean requiredFieldsAsConstructorArgs,
+                         boolean serviceInterfaceAsPublic)
     {
         this.azure = azure;
         this.fluent = fluent;
@@ -158,7 +161,9 @@ public class JavaSettings
         this.syncMethods =  SyncMethodsGeneration.fromValue(syncMethods);
         this.clientLogger = clientLogger;
         this.requiredFieldsAsConstructorArgs = requiredFieldsAsConstructorArgs;
+        this.serviceInterfaceAsPublic = serviceInterfaceAsPublic;
     }
+
 
     private boolean azure;
     public final boolean isAzure()
@@ -322,7 +327,11 @@ public class JavaSettings
         return requiredFieldsAsConstructorArgs;
     }
 
-  public enum SyncMethodsGeneration {
+    private boolean serviceInterfaceAsPublic;
+    public boolean isServiceInterfaceAsPublic() {
+        return serviceInterfaceAsPublic;
+    }
+    public enum SyncMethodsGeneration {
         ALL,
         ESSENTIAL,
         NONE;

--- a/javagen/src/main/java/com/azure/autorest/template/ProxyTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ProxyTemplate.java
@@ -44,7 +44,13 @@ public class ProxyTemplate implements IJavaTemplate<Proxy, JavaClass> {
             });
             classBlock.annotation(String.format("Host(\"%1$s\")", restAPI.getBaseURL()));
             classBlock.annotation(String.format("ServiceInterface(name = \"%1$s\")", serviceInterfaceWithLengthLimit(restAPI.getClientTypeName())));
-            classBlock.interfaceBlock(JavaVisibility.Private, restAPI.getName(), interfaceBlock ->
+
+            JavaVisibility visibility = JavaVisibility.Private;
+            if (settings.isServiceInterfaceAsPublic()) {
+                visibility = JavaVisibility.Public;
+            }
+
+            classBlock.interfaceBlock(visibility, restAPI.getName(), interfaceBlock ->
             {
                 for (ProxyMethod restAPIMethod : restAPI.getMethods()) {
                     if (restAPIMethod.getRequestContentType().equals("multipart/form-data") || restAPIMethod.getRequestContentType().equals("application/x-www-form-urlencoded")) {


### PR DESCRIPTION
This PR address a customer issue that was reported where the proxy methods that are reflectively accessed are being flagged as security issue because the interface is private. This PR provides options to generate the proxy service interface as public.

This also moves us a step closer in extracting the interface into its own Java file.

Fixes https://github.com/Azure/azure-sdk-for-java/issues/12829
Related - https://github.com/Azure/autorest.java/issues/635
