### PR TITLE
v4 fluentlite service client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ package-lock.json
 
 # Generated code for tests #
 fluent-tests/src/main/java/com/azure/mgmttest/**
+fluent-tests/src/main/java/com/azure/mgmtlitetest/**

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/jsonrpc/Connection.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/jsonrpc/Connection.java
@@ -285,6 +285,9 @@ public class Connection {
                                 if (f.type.getRawClass().equals(Boolean.class)
                                         && (jobject.get("result") != null) && jobject.get("result").toString().equals("{}")) {
                                     f.complete(Boolean.TRUE);
+                                } else if (f.type.getRawClass().equals(String.class)
+                                    && (jobject.get("result") != null) && jobject.get("result").toString().equals("{}")) {
+                                    f.complete("");
                                 } else {
                                     f.complete(mapper.convertValue(jobject.get("result"), f.type));
                                 }

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
@@ -87,7 +87,8 @@ public class JavaSettings
                     host.getBooleanValue("generate-sync-async-clients", false),
                     host.getStringValue("sync-methods", "essential"),
                     host.getBooleanValue("client-logger", false),
-                    host.getBooleanValue("required-fields-as-ctor-args"));
+                    host.getBooleanValue("required-fields-as-ctor-args", false),
+                    host.getBooleanValue("service-interface-as-public", false));
         }
         return _instance;
     }
@@ -108,6 +109,7 @@ public class JavaSettings
      @param implementationSubpackage The sub-package that the Service and Method Group client implementation classes will be put into.
      @param modelsSubpackage The sub-package that Enums, Exceptions, and Model types will be put into.
      @param requiredParameterClientMethods Whether or not Service and Method Group client method overloads that omit optional parameters will be created.
+     @param serviceInterfaceAsPublic If set to true, proxy method service interface will be marked as public.
      */
     private JavaSettings(boolean azure,
                          boolean fluent,
@@ -132,7 +134,8 @@ public class JavaSettings
                          boolean generateSyncAsyncClients,
                          String syncMethods,
                          boolean clientLogger,
-                         boolean requiredFieldsAsConstructorArgs)
+                         boolean requiredFieldsAsConstructorArgs,
+                         boolean serviceInterfaceAsPublic)
     {
         this.azure = azure;
         this.fluent = fluent;
@@ -158,7 +161,9 @@ public class JavaSettings
         this.syncMethods =  SyncMethodsGeneration.fromValue(syncMethods);
         this.clientLogger = clientLogger;
         this.requiredFieldsAsConstructorArgs = requiredFieldsAsConstructorArgs;
+        this.serviceInterfaceAsPublic = serviceInterfaceAsPublic;
     }
+
 
     private boolean azure;
     public final boolean isAzure()
@@ -322,7 +327,11 @@ public class JavaSettings
         return requiredFieldsAsConstructorArgs;
     }
 
-  public enum SyncMethodsGeneration {
+    private boolean serviceInterfaceAsPublic;
+    public boolean isServiceInterfaceAsPublic() {
+        return serviceInterfaceAsPublic;
+    }
+    public enum SyncMethodsGeneration {
         ALL,
         ESSENTIAL,
         NONE;

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
@@ -184,6 +184,10 @@ public class JavaSettings
     {
         return fluent == Fluent.LITE;
     }
+    public final boolean isFluentPremium()
+    {
+        return fluent == Fluent.PREMIUM;
+    }
     public final boolean isAzureOrFluent()
     {
         return isAzure() || isFluent();

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
@@ -6,6 +6,7 @@ package com.azure.autorest.extension.base.plugin;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 /**
  Settings that are used by the Java AutoRest Generator.
@@ -65,7 +66,7 @@ public class JavaSettings
             setHeader(host.getStringValue("license-header"));
             _instance = new JavaSettings(
                     host.getBooleanValue("azure-arm"),
-                    host.getBooleanValue("fluent"),
+                    host.getStringValue("fluent"),
                     host.getBooleanValue("regenerate-pom"),
                     _header,
                     80,
@@ -112,7 +113,7 @@ public class JavaSettings
      @param serviceInterfaceAsPublic If set to true, proxy method service interface will be marked as public.
      */
     private JavaSettings(boolean azure,
-                         boolean fluent,
+                         String fluent,
                          boolean regeneratePom,
                          String fileHeaderText,
                          int maximumJavadocCommentWidth,
@@ -138,7 +139,7 @@ public class JavaSettings
                          boolean serviceInterfaceAsPublic)
     {
         this.azure = azure;
-        this.fluent = fluent;
+        this.fluent = fluent == null ? Fluent.NONE : (fluent.isEmpty() ? Fluent.PREMIUM : Fluent.valueOf(fluent.toUpperCase(Locale.ROOT)));
         this.regeneratePom = regeneratePom;
         this.fileHeaderText = fileHeaderText;
         this.maximumJavadocCommentWidth = maximumJavadocCommentWidth;
@@ -171,10 +172,17 @@ public class JavaSettings
         return azure;
     }
 
-    private boolean fluent;
+    public enum Fluent {
+        NONE, LITE, PREMIUM
+    }
+    private Fluent fluent;
     public final boolean isFluent()
     {
-        return fluent;
+        return fluent != Fluent.NONE;
+    }
+    public final boolean isFluentLite()
+    {
+        return fluent == Fluent.LITE;
     }
     public final boolean isAzureOrFluent()
     {

--- a/fluent-tests/prepare-tests.bat
+++ b/fluent-tests/prepare-tests.bat
@@ -28,3 +28,8 @@ CALL autorest --version=%AUTOREST_CORE_VERSION% %COMMON_ARGUMENTS% --payload-fla
 CALL autorest --version=%AUTOREST_CORE_VERSION% %COMMON_ARGUMENTS% --payload-flattening-threshold=1 --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2020-01-01/managedClusters.json --namespace=com.azure.mgmttest.conainterservice
 
 CALL autorest --version=%AUTOREST_CORE_VERSION% %COMMON_ARGUMENTS% --payload-flattening-threshold=1 --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/graphrbac/data-plane/Microsoft.GraphRbac/stable/1.6/graphrbac.json --namespace=com.azure.mgmttest.authorization
+
+
+SET AUTOREST_CORE_VERSION=3.0.6282
+SET FLUENTLITE_ARGUMENTS=--java --use:../ --output-folder=./ --sync-methods=all --azure-arm --fluent=lite --required-parameter-client-methods --add-context-parameter --context-client-method-parameter --track1-naming --implementation-subpackage=implementation --client-side-validations --client-logger --generate-sync-async-clients
+CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENTLITE_ARGUMENTS% --payload-flattening-threshold=1 https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/storage/resource-manager/readme.md --java.namespace=com.azure.mgmtlitetest.storage

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
@@ -112,8 +112,11 @@ public class FluentGen extends NewPlugin {
                 List<AsyncSyncClient> syncClients = new ArrayList<>();
                 ClientModelUtil.getAsyncSyncClients(client.getServiceClient(), asyncClients, syncClients);
 
-                for (AsyncSyncClient asyncClient : asyncClients) {
-                    javaPackage.addAsyncServiceClient(builderPackage, asyncClient);
+                if (!JavaSettings.getInstance().isFluentLite()) {
+                    // fluent lite only expose sync client
+                    for (AsyncSyncClient asyncClient : asyncClients) {
+                        javaPackage.addAsyncServiceClient(builderPackage, asyncClient);
+                    }
                 }
 
                 for (AsyncSyncClient syncClient : syncClients) {

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentMethodGroupMapper.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentMethodGroupMapper.java
@@ -35,21 +35,22 @@ public class FluentMethodGroupMapper extends MethodGroupMapper {
 
     @Override
     protected List<IType> supportedInterfaces(OperationGroup operationGroup, List<ClientMethod> clientMethods) {
-        Optional<IType> classTypeForGet = supportGetMethod(clientMethods);
-        Optional<IType> classTypeForList = supportListMethod(clientMethods);
-        Optional<IType> classTypeForDelete = supportDeleteMethod(clientMethods);
-
         List<IType> interfaces = new ArrayList<>();
-        classTypeForGet.ifPresent(iType -> interfaces.add(FluentType.InnerSupportsGet(iType)));
-        classTypeForList.ifPresent(iType -> interfaces.add(FluentType.InnerSupportsList(iType)));
-        classTypeForDelete.ifPresent(iType -> interfaces.add(FluentType.InnerSupportsDelete(iType)));
+        if (!JavaSettings.getInstance().isFluentLite()) {
+            Optional<IType> classTypeForGet = supportGetMethod(clientMethods);
+            Optional<IType> classTypeForList = supportListMethod(clientMethods);
+            Optional<IType> classTypeForDelete = supportDeleteMethod(clientMethods);
 
-        if (!interfaces.isEmpty()) {
-            logger.info("Method group {} support interfaces {}",
-                    Utils.getJavaName(operationGroup),
-                    interfaces.stream().map(IType::toString).collect(Collectors.toList()));
+            classTypeForGet.ifPresent(iType -> interfaces.add(FluentType.InnerSupportsGet(iType)));
+            classTypeForList.ifPresent(iType -> interfaces.add(FluentType.InnerSupportsList(iType)));
+            classTypeForDelete.ifPresent(iType -> interfaces.add(FluentType.InnerSupportsDelete(iType)));
+
+            if (!interfaces.isEmpty()) {
+                logger.info("Method group {} support interfaces {}",
+                        Utils.getJavaName(operationGroup),
+                        interfaces.stream().map(IType::toString).collect(Collectors.toList()));
+            }
         }
-
         return interfaces;
     }
 

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentServiceClientTemplate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentServiceClientTemplate.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.azure.autorest.fluent.template;
+
+import com.azure.autorest.template.ServiceClientTemplate;
+import com.azure.autorest.template.prototype.MethodTemplate;
+
+public class FluentServiceClientTemplate extends ServiceClientTemplate {
+
+    private static FluentServiceClientTemplate _instance = new FluentServiceClientTemplate();
+    static {
+//        _instance.additionalMethods.add(MethodTemplate.builder()
+//                .methodSignature("abc")
+//                .build());
+    }
+
+    public static FluentServiceClientTemplate getInstance() {
+        return _instance;
+    }
+}

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentServiceClientTemplate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentServiceClientTemplate.java
@@ -7,14 +7,46 @@ package com.azure.autorest.fluent.template;
 
 import com.azure.autorest.template.ServiceClientTemplate;
 import com.azure.autorest.template.prototype.MethodTemplate;
+import com.azure.core.util.Context;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
 
 public class FluentServiceClientTemplate extends ServiceClientTemplate {
 
     private static FluentServiceClientTemplate _instance = new FluentServiceClientTemplate();
     static {
-//        _instance.additionalMethods.add(MethodTemplate.builder()
-//                .methodSignature("abc")
-//                .build());
+        MethodTemplate getContextMethod = MethodTemplate.builder()
+                .imports(Collections.singleton(Context.class.getName()))
+                .methodSignature("Context getContext()")
+                .comment(comment -> {
+                    comment.description("Gets default client context.");
+                    comment.methodReturns("the default client context.");
+                })
+                .method(method -> {
+                    method.methodReturn("Context.NONE");
+                })
+                .build();
+
+        MethodTemplate mergeContextMethod = MethodTemplate.builder()
+                .imports(Arrays.asList(Context.class.getName(), Map.class.getName()))
+                .methodSignature("Context mergeContext(Context context)")
+                .comment(comment -> {
+                    comment.description("Merges default client context with provided context.");
+                    comment.param("context", "the context to be merged with default client context.");
+                    comment.methodReturns("the merged context.");
+                })
+                .method(method -> {
+                    method.block("for (Map.Entry<Object, Object> entry : this.getContext().getValues().entrySet())", block -> {
+                        block.line("context = context.addData(entry.getKey(), entry.getValue());");
+                    });
+                    method.methodReturn("context");
+                })
+                .build();
+
+        _instance.additionalMethods.add(getContextMethod);
+        _instance.additionalMethods.add(mergeContextMethod);
     }
 
     public static FluentServiceClientTemplate getInstance() {

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentTemplateFactory.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentTemplateFactory.java
@@ -10,6 +10,7 @@ import com.azure.autorest.template.DefaultTemplateFactory;
 import com.azure.autorest.template.ModelTemplate;
 import com.azure.autorest.template.ProxyTemplate;
 import com.azure.autorest.template.ServiceClientBuilderTemplate;
+import com.azure.autorest.template.ServiceClientTemplate;
 
 public class FluentTemplateFactory extends DefaultTemplateFactory {
 
@@ -31,5 +32,10 @@ public class FluentTemplateFactory extends DefaultTemplateFactory {
     @Override
     public ModelTemplate getModelTemplate() {
         return FluentModelTemplate.getInstance();
+    }
+
+    @Override
+    public ServiceClientTemplate getServiceClientTemplate() {
+        return FluentServiceClientTemplate.getInstance();
     }
 }

--- a/fluentnamer/pom.xml
+++ b/fluentnamer/pom.xml
@@ -40,6 +40,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-core-management</artifactId>
+      <version>1.0.0-beta.2</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.9</version>

--- a/fluentnamer/src/main/java/com/azure/autorest/fluent/model/FluentType.java
+++ b/fluentnamer/src/main/java/com/azure/autorest/fluent/model/FluentType.java
@@ -13,15 +13,12 @@ import com.azure.autorest.model.clientmodel.IType;
 
 public class FluentType {
 
-    public static final String AZURE_CORE_MANAGEMENT_PACKAGE_NAME = "com.azure.core.management";
-    public static final String AZURE_CORE_MANAGEMENT_EXCEPTION_PACKAGE_NAME = "com.azure.core.management.exception";
+    public static final ClassType Resource = new ClassType.Builder().knownClass(com.azure.core.management.Resource.class).build();
+    public static final ClassType ProxyResource = new ClassType.Builder().knownClass(com.azure.core.management.ProxyResource.class).build();
+    public static final ClassType SubResource = new ClassType.Builder().knownClass(com.azure.core.management.SubResource.class).build();
 
-    public static final ClassType Resource = new ClassType.Builder().packageName(AZURE_CORE_MANAGEMENT_PACKAGE_NAME).name(ResourceTypeName.RESOURCE).build();
-    public static final ClassType ProxyResource = new ClassType.Builder().packageName(AZURE_CORE_MANAGEMENT_PACKAGE_NAME).name(ResourceTypeName.PROXY_RESOURCE).build();
-    public static final ClassType SubResource = new ClassType.Builder().packageName(AZURE_CORE_MANAGEMENT_PACKAGE_NAME).name(ResourceTypeName.SUB_RESOURCE).build();
-
-    public static final ClassType ManagementException = new ClassType.Builder().packageName(AZURE_CORE_MANAGEMENT_EXCEPTION_PACKAGE_NAME).name("ManagementException").build();
-    public static final ClassType ManagementError = new ClassType.Builder().packageName(AZURE_CORE_MANAGEMENT_EXCEPTION_PACKAGE_NAME).name("ManagementError").build();
+    public static final ClassType ManagementException = new ClassType.Builder().knownClass(com.azure.core.management.exception.ManagementException.class).build();
+    public static final ClassType ManagementError = new ClassType.Builder().knownClass(com.azure.core.management.exception.ManagementError.class).build();
 
     private FluentType() {
     }

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMapper.java
@@ -107,7 +107,8 @@ public class ClientMapper implements IMapper<CodeModel, Client> {
 
         Map<String, PackageInfo> packageInfos = new HashMap<>();
         if (settings.shouldGenerateClientInterfaces() || !settings.shouldGenerateClientAsImpl()
-            || settings.getImplementationSubpackage() == null || settings.getImplementationSubpackage().isEmpty()) {
+                || settings.getImplementationSubpackage() == null || settings.getImplementationSubpackage().isEmpty()
+                || settings.isFluent()) {
             packageInfos.put(settings.getPackage(), new PackageInfo(
                 settings.getPackage(),
                 String.format("Package containing the classes for %s.\n%s", serviceClientName,
@@ -122,7 +123,9 @@ public class ClientMapper implements IMapper<CodeModel, Client> {
                         String.format("Package containing the client classes for %s.\n%s",
                             serviceClientName, serviceClientDescription)));
                 }
-                String implementationInnerPackage = settings.getPackage(settings.getImplementationSubpackage(), "inner");
+                String implementationInnerPackage = settings.isFluentLite()
+                        ? settings.getPackage(settings.getModelsSubpackage(), "inner")
+                        : settings.getPackage(settings.getImplementationSubpackage(), "inner");
                 if (!packageInfos.containsKey(implementationInnerPackage)) {
                     packageInfos.put(implementationInnerPackage, new PackageInfo(
                         implementationInnerPackage,

--- a/javagen/src/main/java/com/azure/autorest/mapper/ObjectMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ObjectMapper.java
@@ -41,9 +41,13 @@ public class ObjectMapper implements IMapper<ObjectSchema, IType> {
                 String className = compositeType.getLanguage().getJava().getName();
                 if (settings.isCustomType(compositeType.getLanguage().getJava().getName())) {
                     classPackage = settings.getPackage(settings.getCustomTypesSubpackage());
-                } else if (isInnerModel(compositeType)) {
+                } else if (settings.isFluent() && isInnerModel(compositeType)) {
                     className += "Inner";
-                    classPackage = settings.getPackage(settings.getImplementationSubpackage(), "inner");
+                    if (settings.isFluentLite()) {
+                        classPackage = settings.getPackage(settings.getModelsSubpackage(), "inner");
+                    } else {
+                        classPackage = settings.getPackage(settings.getImplementationSubpackage(), "inner");
+                    }
                 } else {
                     classPackage = settings.getPackage(settings.getModelsSubpackage());
                 }

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ServiceClient.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ServiceClient.java
@@ -153,7 +153,7 @@ public class ServiceClient {
         }
 
         if (includeImplementationImports) {
-            if (settings.isAzureOrFluent()) {
+            if (settings.isFluentPremium()) {
                 imports.add("com.azure.resourcemanager.resources.fluentcore.AzureServiceClient");
             }
             if (!getClientMethods().isEmpty()) {

--- a/javagen/src/main/java/com/azure/autorest/template/ProxyTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ProxyTemplate.java
@@ -44,7 +44,13 @@ public class ProxyTemplate implements IJavaTemplate<Proxy, JavaClass> {
             });
             classBlock.annotation(String.format("Host(\"%1$s\")", restAPI.getBaseURL()));
             classBlock.annotation(String.format("ServiceInterface(name = \"%1$s\")", serviceInterfaceWithLengthLimit(restAPI.getClientTypeName())));
-            classBlock.interfaceBlock(JavaVisibility.Private, restAPI.getName(), interfaceBlock ->
+
+            JavaVisibility visibility = JavaVisibility.Private;
+            if (settings.isServiceInterfaceAsPublic()) {
+                visibility = JavaVisibility.Public;
+            }
+
+            classBlock.interfaceBlock(visibility, restAPI.getName(), interfaceBlock ->
             {
                 for (ProxyMethod restAPIMethod : restAPI.getMethods()) {
                     if (restAPIMethod.getRequestContentType().equals("multipart/form-data") || restAPIMethod.getRequestContentType().equals("application/x-www-form-urlencoded")) {

--- a/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
@@ -56,8 +56,7 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ServiceClient
 
         Set<String> imports = new HashSet<String>();
         serviceClient.addImportsTo(imports, false, true, settings);
-        commonProperties.stream().forEach(p -> p.addImportsTo(imports, false));
-        imports.remove("com.azure.resourcemanager.resources.fluentcore.AzureServiceClient");
+        commonProperties.forEach(p -> p.addImportsTo(imports, false));
         imports.add("com.azure.core.annotation.ServiceClientBuilder");
 
         List<AsyncSyncClient> asyncClients = new ArrayList<>();

--- a/javagen/src/main/java/com/azure/autorest/template/ServiceClientTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ServiceClientTemplate.java
@@ -38,6 +38,7 @@ import java.util.stream.Stream;
 public class ServiceClientTemplate implements IJavaTemplate<ServiceClient, JavaFile> {
     private static ServiceClientTemplate _instance = new ServiceClientTemplate();
 
+    // Extension for additional class methods
     protected List<MethodTemplate> additionalMethods = new ArrayList<>();
 
     protected ServiceClientTemplate() {

--- a/javagen/src/main/java/com/azure/autorest/template/prototype/MethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/prototype/MethodTemplate.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.azure.autorest.template.prototype;
+
+import com.azure.autorest.model.javamodel.JavaBlock;
+import com.azure.autorest.model.javamodel.JavaClass;
+import com.azure.autorest.model.javamodel.JavaJavadocComment;
+import com.azure.autorest.model.javamodel.JavaModifier;
+import com.azure.autorest.model.javamodel.JavaVisibility;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+
+public class MethodTemplate {
+
+    private final Set<String> imports;
+
+    private final JavaVisibility visibility;
+    private final List<JavaModifier> modifiers;
+    private final String methodSignature;
+
+    private final Consumer<JavaJavadocComment> comment;
+    private final Consumer<JavaBlock> method;
+
+    private MethodTemplate(Set<String> imports,
+                           JavaVisibility visibility, List<JavaModifier> modifiers, String methodSignature,
+                           Consumer<JavaJavadocComment> comment, Consumer<JavaBlock> method) {
+        this.imports = imports;
+        this.visibility = visibility;
+        this.modifiers = modifiers;
+        this.methodSignature = methodSignature;
+        this.comment = comment;
+        this.method = method;
+    }
+
+    public final void addImportsTo(Set<String> imports) {
+        imports.addAll(this.imports);
+    }
+
+    public final void writeMethod(JavaClass javaClass) {
+        javaClass.javadocComment(comment);
+        javaClass.method(visibility, modifiers, methodSignature, method);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private Set<String> imports = Collections.emptySet();
+        private JavaVisibility visibility = JavaVisibility.Public;
+        private List<JavaModifier> modifiers = Collections.emptyList();
+        private String methodSignature;
+        private Consumer<JavaJavadocComment> comment = c -> {};
+        private Consumer<JavaBlock> method = m -> {};
+
+        private Builder() {
+        }
+
+        public Builder imports(Set<String> imports) {
+            this.imports = imports;
+            return this;
+        }
+
+        public Builder visibility(JavaVisibility visibility) {
+            this.visibility = visibility;
+            return this;
+        }
+
+        public Builder modifiers(List<JavaModifier> modifiers) {
+            this.modifiers = modifiers;
+            return this;
+        }
+
+        public Builder methodSignature(String methodSignature) {
+            this.methodSignature = methodSignature;
+            return this;
+        }
+
+        public Builder comment(Consumer<JavaJavadocComment> comment) {
+            this.comment = comment;
+            return this;
+        }
+
+        public Builder method(Consumer<JavaBlock> method) {
+            this.method = method;
+            return this;
+        }
+
+        public MethodTemplate build() {
+            Objects.requireNonNull(methodSignature);
+            return new MethodTemplate(imports, visibility, modifiers, methodSignature, comment, method);
+        }
+    }
+}

--- a/javagen/src/main/java/com/azure/autorest/template/prototype/MethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/prototype/MethodTemplate.java
@@ -11,7 +11,10 @@ import com.azure.autorest.model.javamodel.JavaJavadocComment;
 import com.azure.autorest.model.javamodel.JavaModifier;
 import com.azure.autorest.model.javamodel.JavaVisibility;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -53,9 +56,9 @@ public class MethodTemplate {
     }
 
     public static final class Builder {
-        private Set<String> imports = Collections.emptySet();
+        private final Set<String> imports = new HashSet<>();
         private JavaVisibility visibility = JavaVisibility.Public;
-        private List<JavaModifier> modifiers = Collections.emptyList();
+        private final List<JavaModifier> modifiers = new ArrayList<>();
         private String methodSignature;
         private Consumer<JavaJavadocComment> comment = c -> {};
         private Consumer<JavaBlock> method = m -> {};
@@ -63,8 +66,8 @@ public class MethodTemplate {
         private Builder() {
         }
 
-        public Builder imports(Set<String> imports) {
-            this.imports = imports;
+        public Builder imports(Collection<String> imports) {
+            this.imports.addAll(imports);
             return this;
         }
 
@@ -73,8 +76,8 @@ public class MethodTemplate {
             return this;
         }
 
-        public Builder modifiers(List<JavaModifier> modifiers) {
-            this.modifiers = modifiers;
+        public Builder modifiers(Collection<JavaModifier> modifiers) {
+            this.modifiers.addAll(modifiers);
             return this;
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/java",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "The Java extension for classic generators in AutoRest.",
   "scripts": {
     "autorest": "autorest",

--- a/vanilla-tests/src/main/java/fixtures/bodydictionary/AutoRestSwaggerBATDictionaryServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydictionary/AutoRestSwaggerBATDictionaryServiceBuilder.java
@@ -11,8 +11,8 @@ import fixtures.bodydictionary.implementation.AutoRestSwaggerBATDictionaryServic
 /** A builder for creating a new instance of the AutoRestSwaggerBATDictionaryService type. */
 @ServiceClientBuilder(
         serviceClients = {
-            AutoRestSwaggerBATDictionaryServiceAsyncClient.class,
-            AutoRestSwaggerBATDictionaryServiceClient.class
+            AutoRestSwaggerBATDictionaryServiceClient.class,
+            AutoRestSwaggerBATDictionaryServiceAsyncClient.class
         })
 public final class AutoRestSwaggerBATDictionaryServiceBuilder {
     /*


### PR DESCRIPTION
1. add init test framework for fluent lite
2. add `defaultPollInterval` to client/builder
3. for fluent lite, generate a complete client class (no longer need base `AzureServiceClient`)
4. support try-catch-finally block