### PR TITLE
Fix media types

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
@@ -119,10 +119,13 @@ public class ProxyMethodMapper implements IMapper<Operation, Map<Request, ProxyM
             String requestContentType = "application/json";
 
             // check for mediaTypes first as that is more specific than the knownMediaType
-            if (request.getProtocol().getHttp().getMediaTypes() != null && !request.getProtocol().getHttp().getMediaTypes().isEmpty()) {
+            // if there are multiple, we'll use the generic type
+            if (request.getProtocol().getHttp().getMediaTypes() != null
+                && !request.getProtocol().getHttp().getMediaTypes().isEmpty()
+                && request.getProtocol().getHttp().getMediaTypes().size() == 1) {
                 requestContentType = request.getProtocol().getHttp().getMediaTypes().get(0);
             } else if (request.getProtocol().getHttp().getKnownMediaType() != null) {
-                 requestContentType = request.getProtocol().getHttp().getKnownMediaType().getContentType();
+                requestContentType = request.getProtocol().getHttp().getKnownMediaType().getContentType();
             }
             builder.requestContentType(requestContentType);
 

--- a/vanilla-tests/src/main/java/fixtures/bodydate/DateOperations.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydate/DateOperations.java
@@ -281,7 +281,7 @@ public final class DateOperations {
     /**
      * Put max date value 9999-12-31.
      *
-     * @param dateBody The dateBody parameter.
+     * @param dateBody date body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -302,7 +302,7 @@ public final class DateOperations {
     /**
      * Put max date value 9999-12-31.
      *
-     * @param dateBody The dateBody parameter.
+     * @param dateBody date body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -316,7 +316,7 @@ public final class DateOperations {
     /**
      * Put max date value 9999-12-31.
      *
-     * @param dateBody The dateBody parameter.
+     * @param dateBody date body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -377,7 +377,7 @@ public final class DateOperations {
     /**
      * Put min date value 0000-01-01.
      *
-     * @param dateBody The dateBody parameter.
+     * @param dateBody date body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -398,7 +398,7 @@ public final class DateOperations {
     /**
      * Put min date value 0000-01-01.
      *
-     * @param dateBody The dateBody parameter.
+     * @param dateBody date body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -412,7 +412,7 @@ public final class DateOperations {
     /**
      * Put min date value 0000-01-01.
      *
-     * @param dateBody The dateBody parameter.
+     * @param dateBody date body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.

--- a/vanilla-tests/src/main/java/fixtures/bodydatetime/DatetimeOperations.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydatetime/DatetimeOperations.java
@@ -393,7 +393,7 @@ public final class DatetimeOperations {
     /**
      * Put max datetime value 9999-12-31T23:59:59.999Z.
      *
-     * @param datetimeBody The datetimeBody parameter.
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -414,7 +414,7 @@ public final class DatetimeOperations {
     /**
      * Put max datetime value 9999-12-31T23:59:59.999Z.
      *
-     * @param datetimeBody The datetimeBody parameter.
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -428,7 +428,7 @@ public final class DatetimeOperations {
     /**
      * Put max datetime value 9999-12-31T23:59:59.999Z.
      *
-     * @param datetimeBody The datetimeBody parameter.
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -441,7 +441,7 @@ public final class DatetimeOperations {
     /**
      * This is against the recommendation that asks for 3 digits, but allow to test what happens in that scenario.
      *
-     * @param datetimeBody The datetimeBody parameter.
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -463,7 +463,7 @@ public final class DatetimeOperations {
     /**
      * This is against the recommendation that asks for 3 digits, but allow to test what happens in that scenario.
      *
-     * @param datetimeBody The datetimeBody parameter.
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -477,7 +477,7 @@ public final class DatetimeOperations {
     /**
      * This is against the recommendation that asks for 3 digits, but allow to test what happens in that scenario.
      *
-     * @param datetimeBody The datetimeBody parameter.
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -635,7 +635,7 @@ public final class DatetimeOperations {
     /**
      * Put max datetime value with positive numoffset 9999-12-31t23:59:59.999+14:00.
      *
-     * @param datetimeBody The datetimeBody parameter.
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -657,7 +657,7 @@ public final class DatetimeOperations {
     /**
      * Put max datetime value with positive numoffset 9999-12-31t23:59:59.999+14:00.
      *
-     * @param datetimeBody The datetimeBody parameter.
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -672,7 +672,7 @@ public final class DatetimeOperations {
     /**
      * Put max datetime value with positive numoffset 9999-12-31t23:59:59.999+14:00.
      *
-     * @param datetimeBody The datetimeBody parameter.
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -783,7 +783,7 @@ public final class DatetimeOperations {
     /**
      * Put max datetime value with positive numoffset 9999-12-31t23:59:59.999-14:00.
      *
-     * @param datetimeBody The datetimeBody parameter.
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -805,7 +805,7 @@ public final class DatetimeOperations {
     /**
      * Put max datetime value with positive numoffset 9999-12-31t23:59:59.999-14:00.
      *
-     * @param datetimeBody The datetimeBody parameter.
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -820,7 +820,7 @@ public final class DatetimeOperations {
     /**
      * Put max datetime value with positive numoffset 9999-12-31t23:59:59.999-14:00.
      *
-     * @param datetimeBody The datetimeBody parameter.
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -931,7 +931,7 @@ public final class DatetimeOperations {
     /**
      * Put min datetime value 0001-01-01T00:00:00Z.
      *
-     * @param datetimeBody The datetimeBody parameter.
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -952,7 +952,7 @@ public final class DatetimeOperations {
     /**
      * Put min datetime value 0001-01-01T00:00:00Z.
      *
-     * @param datetimeBody The datetimeBody parameter.
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -966,7 +966,7 @@ public final class DatetimeOperations {
     /**
      * Put min datetime value 0001-01-01T00:00:00Z.
      *
-     * @param datetimeBody The datetimeBody parameter.
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1027,7 +1027,7 @@ public final class DatetimeOperations {
     /**
      * Put min datetime value 0001-01-01T00:00:00+14:00.
      *
-     * @param datetimeBody The datetimeBody parameter.
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1049,7 +1049,7 @@ public final class DatetimeOperations {
     /**
      * Put min datetime value 0001-01-01T00:00:00+14:00.
      *
-     * @param datetimeBody The datetimeBody parameter.
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1064,7 +1064,7 @@ public final class DatetimeOperations {
     /**
      * Put min datetime value 0001-01-01T00:00:00+14:00.
      *
-     * @param datetimeBody The datetimeBody parameter.
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1126,7 +1126,7 @@ public final class DatetimeOperations {
     /**
      * Put min datetime value 0001-01-01T00:00:00-14:00.
      *
-     * @param datetimeBody The datetimeBody parameter.
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1148,7 +1148,7 @@ public final class DatetimeOperations {
     /**
      * Put min datetime value 0001-01-01T00:00:00-14:00.
      *
-     * @param datetimeBody The datetimeBody parameter.
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1163,7 +1163,7 @@ public final class DatetimeOperations {
     /**
      * Put min datetime value 0001-01-01T00:00:00-14:00.
      *
-     * @param datetimeBody The datetimeBody parameter.
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.

--- a/vanilla-tests/src/main/java/fixtures/bodydatetimerfc1123/Datetimerfc1123s.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydatetimerfc1123/Datetimerfc1123s.java
@@ -299,7 +299,7 @@ public final class Datetimerfc1123s {
     /**
      * Put max datetime value Fri, 31 Dec 9999 23:59:59 GMT.
      *
-     * @param datetimeBody The datetimeBody parameter.
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -322,7 +322,7 @@ public final class Datetimerfc1123s {
     /**
      * Put max datetime value Fri, 31 Dec 9999 23:59:59 GMT.
      *
-     * @param datetimeBody The datetimeBody parameter.
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -336,7 +336,7 @@ public final class Datetimerfc1123s {
     /**
      * Put max datetime value Fri, 31 Dec 9999 23:59:59 GMT.
      *
-     * @param datetimeBody The datetimeBody parameter.
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -445,7 +445,7 @@ public final class Datetimerfc1123s {
     /**
      * Put min datetime value Mon, 1 Jan 0001 00:00:00 GMT.
      *
-     * @param datetimeBody The datetimeBody parameter.
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -468,7 +468,7 @@ public final class Datetimerfc1123s {
     /**
      * Put min datetime value Mon, 1 Jan 0001 00:00:00 GMT.
      *
-     * @param datetimeBody The datetimeBody parameter.
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -482,7 +482,7 @@ public final class Datetimerfc1123s {
     /**
      * Put min datetime value Mon, 1 Jan 0001 00:00:00 GMT.
      *
-     * @param datetimeBody The datetimeBody parameter.
+     * @param datetimeBody datetime body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.

--- a/vanilla-tests/src/main/java/fixtures/bodyduration/DurationOperations.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyduration/DurationOperations.java
@@ -116,7 +116,7 @@ public final class DurationOperations {
     /**
      * Put a positive duration value.
      *
-     * @param durationBody The durationBody parameter.
+     * @param durationBody duration body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -138,7 +138,7 @@ public final class DurationOperations {
     /**
      * Put a positive duration value.
      *
-     * @param durationBody The durationBody parameter.
+     * @param durationBody duration body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -152,7 +152,7 @@ public final class DurationOperations {
     /**
      * Put a positive duration value.
      *
-     * @param durationBody The durationBody parameter.
+     * @param durationBody duration body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.

--- a/vanilla-tests/src/main/java/fixtures/bodyinteger/Ints.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyinteger/Ints.java
@@ -444,7 +444,7 @@ public final class Ints {
     /**
      * Put max int32 value.
      *
-     * @param intBody The intBody parameter.
+     * @param intBody int body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -462,7 +462,7 @@ public final class Ints {
     /**
      * Put max int32 value.
      *
-     * @param intBody The intBody parameter.
+     * @param intBody int body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -476,7 +476,7 @@ public final class Ints {
     /**
      * Put max int32 value.
      *
-     * @param intBody The intBody parameter.
+     * @param intBody int body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -489,7 +489,7 @@ public final class Ints {
     /**
      * Put max int64 value.
      *
-     * @param intBody The intBody parameter.
+     * @param intBody int body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -507,7 +507,7 @@ public final class Ints {
     /**
      * Put max int64 value.
      *
-     * @param intBody The intBody parameter.
+     * @param intBody int body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -521,7 +521,7 @@ public final class Ints {
     /**
      * Put max int64 value.
      *
-     * @param intBody The intBody parameter.
+     * @param intBody int body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -534,7 +534,7 @@ public final class Ints {
     /**
      * Put min int32 value.
      *
-     * @param intBody The intBody parameter.
+     * @param intBody int body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -552,7 +552,7 @@ public final class Ints {
     /**
      * Put min int32 value.
      *
-     * @param intBody The intBody parameter.
+     * @param intBody int body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -566,7 +566,7 @@ public final class Ints {
     /**
      * Put min int32 value.
      *
-     * @param intBody The intBody parameter.
+     * @param intBody int body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -579,7 +579,7 @@ public final class Ints {
     /**
      * Put min int64 value.
      *
-     * @param intBody The intBody parameter.
+     * @param intBody int body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -597,7 +597,7 @@ public final class Ints {
     /**
      * Put min int64 value.
      *
-     * @param intBody The intBody parameter.
+     * @param intBody int body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -611,7 +611,7 @@ public final class Ints {
     /**
      * Put min int64 value.
      *
-     * @param intBody The intBody parameter.
+     * @param intBody int body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.

--- a/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClient.java
+++ b/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClient.java
@@ -88,7 +88,7 @@ public final class MediaTypesClient {
         Mono<Response<String>> analyzeBody(
                 @HostParam("$host") String host,
                 @HeaderParam("Content-Type") ContentType contentType,
-                @BodyParam("application/pdf") Flux<ByteBuffer> input,
+                @BodyParam("application/octet-stream") Flux<ByteBuffer> input,
                 @HeaderParam("Content-Length") long contentLength,
                 Context context);
 


### PR DESCRIPTION
This PR changes how the media type body-param annotations are generated. If the swagger defines multiple media types, then the body param annotation uses the generic known media type value. If the swagger defines a single media type value, then that will be used for body param annotation.