### PR TITLE
Support Serializer Adapter for data plane

### DIFF
--- a/azure-tests/src/main/java/fixtures/azurereport/AutoRestReportServiceForAzure.java
+++ b/azure-tests/src/main/java/fixtures/azurereport/AutoRestReportServiceForAzure.java
@@ -18,6 +18,8 @@ import com.azure.core.http.rest.Response;
 import com.azure.core.http.rest.RestProxy;
 import com.azure.core.util.Context;
 import com.azure.core.util.FluxUtil;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 import fixtures.azurereport.models.ErrorException;
 import java.util.Map;
 import reactor.core.publisher.Mono;
@@ -51,12 +53,25 @@ public final class AutoRestReportServiceForAzure {
         return this.httpPipeline;
     }
 
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
     /** Initializes an instance of AutoRestReportServiceForAzure client. */
     AutoRestReportServiceForAzure(String host) {
         this(
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
                 host);
     }
 
@@ -66,9 +81,22 @@ public final class AutoRestReportServiceForAzure {
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
     AutoRestReportServiceForAzure(HttpPipeline httpPipeline, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    }
+
+    /**
+     * Initializes an instance of AutoRestReportServiceForAzure client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    AutoRestReportServiceForAzure(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
         this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
         this.host = host;
-        this.service = RestProxy.create(AutoRestReportServiceForAzureService.class, this.httpPipeline);
+        this.service =
+                RestProxy.create(
+                        AutoRestReportServiceForAzureService.class, this.httpPipeline, this.getSerializerAdapter());
     }
 
     /**

--- a/azure-tests/src/main/java/fixtures/azurereport/AutoRestReportServiceForAzureBuilder.java
+++ b/azure-tests/src/main/java/fixtures/azurereport/AutoRestReportServiceForAzureBuilder.java
@@ -6,6 +6,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** A builder for creating a new instance of the AutoRestReportServiceForAzure type. */
 @ServiceClientBuilder(serviceClients = {AutoRestReportServiceForAzure.class})
@@ -42,6 +44,22 @@ public final class AutoRestReportServiceForAzureBuilder {
         return this;
     }
 
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the AutoRestReportServiceForAzureBuilder.
+     */
+    public AutoRestReportServiceForAzureBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestReportServiceForAzure with the provided parameters.
      *
@@ -57,7 +75,10 @@ public final class AutoRestReportServiceForAzureBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestReportServiceForAzure client = new AutoRestReportServiceForAzure(pipeline, host);
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        AutoRestReportServiceForAzure client = new AutoRestReportServiceForAzure(pipeline, serializerAdapter, host);
         return client;
     }
 }

--- a/azure-tests/src/main/java/fixtures/paging/AutoRestPagingTestService.java
+++ b/azure-tests/src/main/java/fixtures/paging/AutoRestPagingTestService.java
@@ -5,6 +5,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** Initializes a new instance of the AutoRestPagingTestService type. */
 public final class AutoRestPagingTestService {
@@ -32,6 +34,18 @@ public final class AutoRestPagingTestService {
         return this.httpPipeline;
     }
 
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
     /** The Pagings object to access its operations. */
     private final Pagings pagings;
 
@@ -50,6 +64,7 @@ public final class AutoRestPagingTestService {
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
                 host);
     }
 
@@ -59,7 +74,18 @@ public final class AutoRestPagingTestService {
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
     AutoRestPagingTestService(HttpPipeline httpPipeline, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    }
+
+    /**
+     * Initializes an instance of AutoRestPagingTestService client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    AutoRestPagingTestService(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
         this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
         this.host = host;
         this.pagings = new Pagings(this);
     }

--- a/azure-tests/src/main/java/fixtures/paging/AutoRestPagingTestServiceBuilder.java
+++ b/azure-tests/src/main/java/fixtures/paging/AutoRestPagingTestServiceBuilder.java
@@ -6,6 +6,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** A builder for creating a new instance of the AutoRestPagingTestService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestPagingTestService.class})
@@ -42,6 +44,22 @@ public final class AutoRestPagingTestServiceBuilder {
         return this;
     }
 
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the AutoRestPagingTestServiceBuilder.
+     */
+    public AutoRestPagingTestServiceBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestPagingTestService with the provided parameters.
      *
@@ -57,7 +75,10 @@ public final class AutoRestPagingTestServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestPagingTestService client = new AutoRestPagingTestService(pipeline, host);
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        AutoRestPagingTestService client = new AutoRestPagingTestService(pipeline, serializerAdapter, host);
         return client;
     }
 }

--- a/azure-tests/src/main/java/fixtures/paging/Pagings.java
+++ b/azure-tests/src/main/java/fixtures/paging/Pagings.java
@@ -47,7 +47,7 @@ public final class Pagings {
      * @param client the instance of the service client containing this operation class.
      */
     Pagings(AutoRestPagingTestService client) {
-        this.service = RestProxy.create(PagingsService.class, client.getHttpPipeline());
+        this.service = RestProxy.create(PagingsService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/javagen/src/main/java/com/azure/autorest/mapper/ServiceClientMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ServiceClientMapper.java
@@ -123,8 +123,8 @@ public class ServiceClientMapper implements IMapper<CodeModel, ServiceClient> {
             }
         }
         serviceClientProperties.add(new ServiceClientProperty("The HTTP pipeline to send requests through", ClassType.HttpPipeline, "httpPipeline", true, null));
+        serviceClientProperties.add(new ServiceClientProperty("The serializer to serialize an object into a string", ClassType.SerializerAdapter, "serializerAdapter", true, null));
         if (settings.isFluent()) {
-            serviceClientProperties.add(new ServiceClientProperty("The serializer to serialize an object into a string", ClassType.SerializerAdapter, "serializerAdapter", true, null));
             serviceClientProperties.add(new ServiceClientProperty("The default poll interval for long-running operation", ClassType.Duration, "defaultPollInterval", true, null));
         }
         builder.properties(serviceClientProperties);
@@ -212,7 +212,7 @@ public class ServiceClientMapper implements IMapper<CodeModel, ServiceClient> {
         } else {
             serviceClientConstructors.add(new Constructor(new ArrayList<>()));
             serviceClientConstructors.add(new Constructor(Arrays.asList(httpPipelineParameter)));
-            //serviceClientConstructors.add(new Constructor(Arrays.asList(httpPipelineParameter, serializerAdapterParameter)));
+            serviceClientConstructors.add(new Constructor(Arrays.asList(httpPipelineParameter, serializerAdapterParameter)));
             builder.tokenCredentialParameter(tokenCredentialParameter)
                     .httpPipelineParameter(httpPipelineParameter)
                     .serializerAdapterParameter(serializerAdapterParameter)

--- a/javagen/src/main/java/com/azure/autorest/template/MethodGroupTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/MethodGroupTemplate.java
@@ -81,11 +81,7 @@ public class MethodGroupTemplate implements IJavaTemplate<MethodGroupClient, Jav
             {
                 if (methodGroupClient.getProxy() != null) {
                     ClassType proxyType = ClassType.RestProxy;
-                    if (settings.isFluent()) {
-                        constructor.line(String.format("this.service = %1$s.create(%2$s.class, client.getHttpPipeline(), client.getSerializerAdapter());", proxyType.getName(), methodGroupClient.getProxy().getName()));
-                    } else {
-                        constructor.line(String.format("this.service = %1$s.create(%2$s.class, client.getHttpPipeline());", proxyType.getName(), methodGroupClient.getProxy().getName()));
-                    }
+                    constructor.line(String.format("this.service = %1$s.create(%2$s.class, client.getHttpPipeline(), client.getSerializerAdapter());", proxyType.getName(), methodGroupClient.getProxy().getName()));
                 }
                 constructor.line("this.client = client;");
             });

--- a/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
@@ -44,9 +44,12 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ServiceClient
             commonProperties.add(new ServiceClientProperty("The environment to connect to", ClassType.AzureEnvironment, "environment", false, "AzureEnvironment.AZURE"));
         }
         commonProperties.add(new ServiceClientProperty("The HTTP pipeline to send requests through", ClassType.HttpPipeline, "pipeline", false, "new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build()"));
+        commonProperties.add(new ServiceClientProperty("The serializer to serialize an object into a string",
+          ClassType.SerializerAdapter, "serializerAdapter", false,
+          settings.isFluent() ? "new AzureJacksonAdapter()" : "JacksonAdapter.createDefaultSerializerAdapter()"));
+
         if (settings.isFluent()) {
-            commonProperties.add(new ServiceClientProperty("The serializer to serialize an object into a string", ClassType.SerializerAdapter, "serializerAdapter", false, settings.isFluent() ? "new AzureJacksonAdapter()" : "JacksonAdapter.createDefaultSerializerAdapter()"));
-            commonProperties.add(new ServiceClientProperty("The default poll interval for long-running operation", ClassType.Duration, "defaultPollInterval", false, "Duration.ofSeconds(30)"));
+          commonProperties.add(new ServiceClientProperty("The default poll interval for long-running operation", ClassType.Duration, "defaultPollInterval", false, "Duration.ofSeconds(30)"));
         }
 
         String buildReturnType;
@@ -154,7 +157,8 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ServiceClient
                 if (settings.isFluent()) {
                     function.line(String.format("%1$s client = new %2$s(pipeline, serializerAdapter, defaultPollInterval, environment%3$s);", serviceClient.getClassName(), serviceClient.getClassName(), constructorArgs));
                 } else {
-                    function.line(String.format("%1$s client = new %2$s(pipeline%3$s);", serviceClient.getClassName(), serviceClient.getClassName(), constructorArgs));
+                    function.line(String.format("%1$s client = new %2$s(pipeline, serializerAdapter%3$s);",
+                        serviceClient.getClassName(), serviceClient.getClassName(), constructorArgs));
                 }
                 function.line("return client;");
             });

--- a/javagen/src/main/java/com/azure/autorest/template/ServiceClientTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ServiceClientTemplate.java
@@ -226,30 +226,25 @@ public class ServiceClientTemplate implements IJavaTemplate<ServiceClient, JavaF
                         }
                     } else {
                         if (constructor.getParameters().isEmpty()) {
-                            //constructorBlock.line("this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build(), JacksonAdapter.createDefaultSerializerAdapter()%1$s);", constructorArgsFinal);
-                            constructorBlock.line("this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build()%1$s);", constructorArgsFinal);
+                            constructorBlock.line("this(new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build(), JacksonAdapter.createDefaultSerializerAdapter()%1$s);", constructorArgsFinal);
                         } else if (constructor.getParameters().equals(Arrays.asList(serviceClient.getHttpPipelineParameter()))) {
-                            //constructorBlock.line("this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter()%1$s);", constructorArgsFinal);
-                            constructorBlock.line("this.httpPipeline = httpPipeline;");
-                            constructorParametersCodes.accept(constructorBlock);
-
-                            for (ServiceClientProperty serviceClientProperty : serviceClient.getProperties().stream().filter(ServiceClientProperty::isReadOnly).collect(Collectors.toList())) {
-                                if (serviceClientProperty.getDefaultValueExpression() != null) {
-                                    constructorBlock.line("this.%s = %s;", serviceClientProperty.getName(), serviceClientProperty.getDefaultValueExpression());
-                                }
-                            }
-
-                            for (MethodGroupClient methodGroupClient : serviceClient.getMethodGroupClients()) {
-                                constructorBlock.line("this.%s = new %s(this);", methodGroupClient.getVariableName(), methodGroupClient.getClassName());
-                            }
-
-                            if (serviceClient.getProxy() != null) {
-                                if (settings.isFluent()) {
-                                    constructorBlock.line("this.service = %s.create(%s.class, this.httpPipeline, this.getSerializerAdapter());", ClassType.RestProxy.getName(), serviceClient.getProxy().getName());
-                                } else {
-                                    constructorBlock.line("this.service = %s.create(%s.class, this.httpPipeline);", ClassType.RestProxy.getName(), serviceClient.getProxy().getName());
-                                }
-                            }
+                            constructorBlock.line("this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter()%1$s);", constructorArgsFinal);
+//                            constructorBlock.line("this.httpPipeline = httpPipeline;");
+//                            constructorParametersCodes.accept(constructorBlock);
+//
+//                            for (ServiceClientProperty serviceClientProperty : serviceClient.getProperties().stream().filter(ServiceClientProperty::isReadOnly).collect(Collectors.toList())) {
+//                                if (serviceClientProperty.getDefaultValueExpression() != null) {
+//                                    constructorBlock.line("this.%s = %s;", serviceClientProperty.getName(), serviceClientProperty.getDefaultValueExpression());
+//                                }
+//                            }
+//
+//                            for (MethodGroupClient methodGroupClient : serviceClient.getMethodGroupClients()) {
+//                                constructorBlock.line("this.%s = new %s(this);", methodGroupClient.getVariableName(), methodGroupClient.getClassName());
+//                            }
+//
+//                            if (serviceClient.getProxy() != null) {
+//                                constructorBlock.line("this.service = %s.create(%s.class, this.httpPipeline, this.getSerializerAdapter());", ClassType.RestProxy.getName(), serviceClient.getProxy().getName());
+//                            }
                         } else if (constructor.getParameters().equals(Arrays.asList(serviceClient.getHttpPipelineParameter(), serviceClient.getSerializerAdapterParameter()))) {
                             constructorBlock.line("this.httpPipeline = httpPipeline;");
                             constructorBlock.line("this.serializerAdapter = serializerAdapter;");

--- a/vanilla-tests/src/main/java/fixtures/additionalproperties/AdditionalPropertiesClient.java
+++ b/vanilla-tests/src/main/java/fixtures/additionalproperties/AdditionalPropertiesClient.java
@@ -5,6 +5,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** Initializes a new instance of the AdditionalPropertiesClient type. */
 public final class AdditionalPropertiesClient {
@@ -32,6 +34,18 @@ public final class AdditionalPropertiesClient {
         return this.httpPipeline;
     }
 
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
     /** The Pets object to access its operations. */
     private final Pets pets;
 
@@ -50,6 +64,7 @@ public final class AdditionalPropertiesClient {
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
                 host);
     }
 
@@ -59,7 +74,18 @@ public final class AdditionalPropertiesClient {
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
     AdditionalPropertiesClient(HttpPipeline httpPipeline, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    }
+
+    /**
+     * Initializes an instance of AdditionalPropertiesClient client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    AdditionalPropertiesClient(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
         this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
         this.host = host;
         this.pets = new Pets(this);
     }

--- a/vanilla-tests/src/main/java/fixtures/additionalproperties/AdditionalPropertiesClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/additionalproperties/AdditionalPropertiesClientBuilder.java
@@ -6,6 +6,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** A builder for creating a new instance of the AdditionalPropertiesClient type. */
 @ServiceClientBuilder(serviceClients = {AdditionalPropertiesClient.class})
@@ -42,6 +44,22 @@ public final class AdditionalPropertiesClientBuilder {
         return this;
     }
 
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the AdditionalPropertiesClientBuilder.
+     */
+    public AdditionalPropertiesClientBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
     /**
      * Builds an instance of AdditionalPropertiesClient with the provided parameters.
      *
@@ -57,7 +75,10 @@ public final class AdditionalPropertiesClientBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AdditionalPropertiesClient client = new AdditionalPropertiesClient(pipeline, host);
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        AdditionalPropertiesClient client = new AdditionalPropertiesClient(pipeline, serializerAdapter, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/additionalproperties/Pets.java
+++ b/vanilla-tests/src/main/java/fixtures/additionalproperties/Pets.java
@@ -36,7 +36,7 @@ public final class Pets {
      * @param client the instance of the service client containing this operation class.
      */
     Pets(AdditionalPropertiesClient client) {
-        this.service = RestProxy.create(PetsService.class, client.getHttpPipeline());
+        this.service = RestProxy.create(PetsService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodyarray/Arrays.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyarray/Arrays.java
@@ -44,7 +44,7 @@ public final class Arrays {
      * @param client the instance of the service client containing this operation class.
      */
     Arrays(AutoRestSwaggerBATArrayService client) {
-        this.service = RestProxy.create(ArraysService.class, client.getHttpPipeline());
+        this.service = RestProxy.create(ArraysService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodyarray/AutoRestSwaggerBATArrayService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyarray/AutoRestSwaggerBATArrayService.java
@@ -5,6 +5,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** Initializes a new instance of the AutoRestSwaggerBATArrayService type. */
 public final class AutoRestSwaggerBATArrayService {
@@ -32,6 +34,18 @@ public final class AutoRestSwaggerBATArrayService {
         return this.httpPipeline;
     }
 
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
     /** The Arrays object to access its operations. */
     private final Arrays arrays;
 
@@ -50,6 +64,7 @@ public final class AutoRestSwaggerBATArrayService {
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
                 host);
     }
 
@@ -59,7 +74,18 @@ public final class AutoRestSwaggerBATArrayService {
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
     AutoRestSwaggerBATArrayService(HttpPipeline httpPipeline, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    }
+
+    /**
+     * Initializes an instance of AutoRestSwaggerBATArrayService client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    AutoRestSwaggerBATArrayService(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
         this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
         this.host = host;
         this.arrays = new Arrays(this);
     }

--- a/vanilla-tests/src/main/java/fixtures/bodyarray/AutoRestSwaggerBATArrayServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyarray/AutoRestSwaggerBATArrayServiceBuilder.java
@@ -6,6 +6,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** A builder for creating a new instance of the AutoRestSwaggerBATArrayService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestSwaggerBATArrayService.class})
@@ -42,6 +44,22 @@ public final class AutoRestSwaggerBATArrayServiceBuilder {
         return this;
     }
 
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the AutoRestSwaggerBATArrayServiceBuilder.
+     */
+    public AutoRestSwaggerBATArrayServiceBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestSwaggerBATArrayService with the provided parameters.
      *
@@ -57,7 +75,10 @@ public final class AutoRestSwaggerBATArrayServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestSwaggerBATArrayService client = new AutoRestSwaggerBATArrayService(pipeline, host);
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        AutoRestSwaggerBATArrayService client = new AutoRestSwaggerBATArrayService(pipeline, serializerAdapter, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodyboolean/AutoRestBoolTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyboolean/AutoRestBoolTestService.java
@@ -5,6 +5,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** Initializes a new instance of the AutoRestBoolTestService type. */
 public final class AutoRestBoolTestService {
@@ -32,6 +34,18 @@ public final class AutoRestBoolTestService {
         return this.httpPipeline;
     }
 
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
     /** The Bools object to access its operations. */
     private final Bools bools;
 
@@ -50,6 +64,7 @@ public final class AutoRestBoolTestService {
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
                 host);
     }
 
@@ -59,7 +74,18 @@ public final class AutoRestBoolTestService {
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
     AutoRestBoolTestService(HttpPipeline httpPipeline, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    }
+
+    /**
+     * Initializes an instance of AutoRestBoolTestService client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    AutoRestBoolTestService(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
         this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
         this.host = host;
         this.bools = new Bools(this);
     }

--- a/vanilla-tests/src/main/java/fixtures/bodyboolean/AutoRestBoolTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyboolean/AutoRestBoolTestServiceBuilder.java
@@ -6,6 +6,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** A builder for creating a new instance of the AutoRestBoolTestService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestBoolTestService.class})
@@ -42,6 +44,22 @@ public final class AutoRestBoolTestServiceBuilder {
         return this;
     }
 
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the AutoRestBoolTestServiceBuilder.
+     */
+    public AutoRestBoolTestServiceBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestBoolTestService with the provided parameters.
      *
@@ -57,7 +75,10 @@ public final class AutoRestBoolTestServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestBoolTestService client = new AutoRestBoolTestService(pipeline, host);
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        AutoRestBoolTestService client = new AutoRestBoolTestService(pipeline, serializerAdapter, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodyboolean/Bools.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyboolean/Bools.java
@@ -31,7 +31,7 @@ public final class Bools {
      * @param client the instance of the service client containing this operation class.
      */
     Bools(AutoRestBoolTestService client) {
-        this.service = RestProxy.create(BoolsService.class, client.getHttpPipeline());
+        this.service = RestProxy.create(BoolsService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodyboolean/quirks/AutoRestBoolTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyboolean/quirks/AutoRestBoolTestService.java
@@ -5,6 +5,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** Initializes a new instance of the AutoRestBoolTestService type. */
 public final class AutoRestBoolTestService {
@@ -32,6 +34,18 @@ public final class AutoRestBoolTestService {
         return this.httpPipeline;
     }
 
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
     /** The Bools object to access its operations. */
     private final Bools bools;
 
@@ -50,6 +64,7 @@ public final class AutoRestBoolTestService {
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
                 host);
     }
 
@@ -59,7 +74,18 @@ public final class AutoRestBoolTestService {
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
     AutoRestBoolTestService(HttpPipeline httpPipeline, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    }
+
+    /**
+     * Initializes an instance of AutoRestBoolTestService client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    AutoRestBoolTestService(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
         this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
         this.host = host;
         this.bools = new Bools(this);
     }

--- a/vanilla-tests/src/main/java/fixtures/bodyboolean/quirks/AutoRestBoolTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyboolean/quirks/AutoRestBoolTestServiceBuilder.java
@@ -6,6 +6,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** A builder for creating a new instance of the AutoRestBoolTestService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestBoolTestService.class})
@@ -42,6 +44,22 @@ public final class AutoRestBoolTestServiceBuilder {
         return this;
     }
 
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the AutoRestBoolTestServiceBuilder.
+     */
+    public AutoRestBoolTestServiceBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestBoolTestService with the provided parameters.
      *
@@ -57,7 +75,10 @@ public final class AutoRestBoolTestServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestBoolTestService client = new AutoRestBoolTestService(pipeline, host);
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        AutoRestBoolTestService client = new AutoRestBoolTestService(pipeline, serializerAdapter, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodyboolean/quirks/Bools.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyboolean/quirks/Bools.java
@@ -31,7 +31,7 @@ public final class Bools {
      * @param client the instance of the service client containing this operation class.
      */
     Bools(AutoRestBoolTestService client) {
-        this.service = RestProxy.create(BoolsService.class, client.getHttpPipeline());
+        this.service = RestProxy.create(BoolsService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodybyte/AutoRestSwaggerBATByteService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodybyte/AutoRestSwaggerBATByteService.java
@@ -5,6 +5,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** Initializes a new instance of the AutoRestSwaggerBATByteService type. */
 public final class AutoRestSwaggerBATByteService {
@@ -32,6 +34,18 @@ public final class AutoRestSwaggerBATByteService {
         return this.httpPipeline;
     }
 
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
     /** The ByteOperations object to access its operations. */
     private final ByteOperations byteOperations;
 
@@ -50,6 +64,7 @@ public final class AutoRestSwaggerBATByteService {
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
                 host);
     }
 
@@ -59,7 +74,18 @@ public final class AutoRestSwaggerBATByteService {
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
     AutoRestSwaggerBATByteService(HttpPipeline httpPipeline, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    }
+
+    /**
+     * Initializes an instance of AutoRestSwaggerBATByteService client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    AutoRestSwaggerBATByteService(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
         this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
         this.host = host;
         this.byteOperations = new ByteOperations(this);
     }

--- a/vanilla-tests/src/main/java/fixtures/bodybyte/AutoRestSwaggerBATByteServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodybyte/AutoRestSwaggerBATByteServiceBuilder.java
@@ -6,6 +6,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** A builder for creating a new instance of the AutoRestSwaggerBATByteService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestSwaggerBATByteService.class})
@@ -42,6 +44,22 @@ public final class AutoRestSwaggerBATByteServiceBuilder {
         return this;
     }
 
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the AutoRestSwaggerBATByteServiceBuilder.
+     */
+    public AutoRestSwaggerBATByteServiceBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestSwaggerBATByteService with the provided parameters.
      *
@@ -57,7 +75,10 @@ public final class AutoRestSwaggerBATByteServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestSwaggerBATByteService client = new AutoRestSwaggerBATByteService(pipeline, host);
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        AutoRestSwaggerBATByteService client = new AutoRestSwaggerBATByteService(pipeline, serializerAdapter, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodybyte/ByteOperations.java
+++ b/vanilla-tests/src/main/java/fixtures/bodybyte/ByteOperations.java
@@ -31,7 +31,8 @@ public final class ByteOperations {
      * @param client the instance of the service client containing this operation class.
      */
     ByteOperations(AutoRestSwaggerBATByteService client) {
-        this.service = RestProxy.create(ByteOperationsService.class, client.getHttpPipeline());
+        this.service =
+                RestProxy.create(ByteOperationsService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/Arrays.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/Arrays.java
@@ -32,7 +32,7 @@ public final class Arrays {
      * @param client the instance of the service client containing this operation class.
      */
     Arrays(AutoRestComplexTestService client) {
-        this.service = RestProxy.create(ArraysService.class, client.getHttpPipeline());
+        this.service = RestProxy.create(ArraysService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/AutoRestComplexTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/AutoRestComplexTestService.java
@@ -5,6 +5,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** Initializes a new instance of the AutoRestComplexTestService type. */
 public final class AutoRestComplexTestService {
@@ -42,6 +44,18 @@ public final class AutoRestComplexTestService {
      */
     public HttpPipeline getHttpPipeline() {
         return this.httpPipeline;
+    }
+
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
     }
 
     /** The Basics object to access its operations. */
@@ -158,6 +172,7 @@ public final class AutoRestComplexTestService {
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
                 host);
     }
 
@@ -167,7 +182,18 @@ public final class AutoRestComplexTestService {
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
     AutoRestComplexTestService(HttpPipeline httpPipeline, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    }
+
+    /**
+     * Initializes an instance of AutoRestComplexTestService client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    AutoRestComplexTestService(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
         this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
         this.host = host;
         this.apiVersion = "2016-02-29";
         this.basics = new Basics(this);

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/AutoRestComplexTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/AutoRestComplexTestServiceBuilder.java
@@ -6,6 +6,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** A builder for creating a new instance of the AutoRestComplexTestService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestComplexTestService.class})
@@ -42,6 +44,22 @@ public final class AutoRestComplexTestServiceBuilder {
         return this;
     }
 
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the AutoRestComplexTestServiceBuilder.
+     */
+    public AutoRestComplexTestServiceBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestComplexTestService with the provided parameters.
      *
@@ -57,7 +75,10 @@ public final class AutoRestComplexTestServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestComplexTestService client = new AutoRestComplexTestService(pipeline, host);
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        AutoRestComplexTestService client = new AutoRestComplexTestService(pipeline, serializerAdapter, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/Basics.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/Basics.java
@@ -33,7 +33,7 @@ public final class Basics {
      * @param client the instance of the service client containing this operation class.
      */
     Basics(AutoRestComplexTestService client) {
-        this.service = RestProxy.create(BasicsService.class, client.getHttpPipeline());
+        this.service = RestProxy.create(BasicsService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/Dictionarys.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/Dictionarys.java
@@ -32,7 +32,8 @@ public final class Dictionarys {
      * @param client the instance of the service client containing this operation class.
      */
     Dictionarys(AutoRestComplexTestService client) {
-        this.service = RestProxy.create(DictionarysService.class, client.getHttpPipeline());
+        this.service =
+                RestProxy.create(DictionarysService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/Flattencomplexs.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/Flattencomplexs.java
@@ -30,7 +30,8 @@ public final class Flattencomplexs {
      * @param client the instance of the service client containing this operation class.
      */
     Flattencomplexs(AutoRestComplexTestService client) {
-        this.service = RestProxy.create(FlattencomplexsService.class, client.getHttpPipeline());
+        this.service =
+                RestProxy.create(FlattencomplexsService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/Inheritances.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/Inheritances.java
@@ -32,7 +32,8 @@ public final class Inheritances {
      * @param client the instance of the service client containing this operation class.
      */
     Inheritances(AutoRestComplexTestService client) {
-        this.service = RestProxy.create(InheritancesService.class, client.getHttpPipeline());
+        this.service =
+                RestProxy.create(InheritancesService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/Polymorphicrecursives.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/Polymorphicrecursives.java
@@ -32,7 +32,9 @@ public final class Polymorphicrecursives {
      * @param client the instance of the service client containing this operation class.
      */
     Polymorphicrecursives(AutoRestComplexTestService client) {
-        this.service = RestProxy.create(PolymorphicrecursivesService.class, client.getHttpPipeline());
+        this.service =
+                RestProxy.create(
+                        PolymorphicrecursivesService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/Polymorphisms.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/Polymorphisms.java
@@ -35,7 +35,8 @@ public final class Polymorphisms {
      * @param client the instance of the service client containing this operation class.
      */
     Polymorphisms(AutoRestComplexTestService client) {
-        this.service = RestProxy.create(PolymorphismsService.class, client.getHttpPipeline());
+        this.service =
+                RestProxy.create(PolymorphismsService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/Primitives.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/Primitives.java
@@ -42,7 +42,8 @@ public final class Primitives {
      * @param client the instance of the service client containing this operation class.
      */
     Primitives(AutoRestComplexTestService client) {
-        this.service = RestProxy.create(PrimitivesService.class, client.getHttpPipeline());
+        this.service =
+                RestProxy.create(PrimitivesService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/Readonlypropertys.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/Readonlypropertys.java
@@ -32,7 +32,9 @@ public final class Readonlypropertys {
      * @param client the instance of the service client containing this operation class.
      */
     Readonlypropertys(AutoRestComplexTestService client) {
-        this.service = RestProxy.create(ReadonlypropertysService.class, client.getHttpPipeline());
+        this.service =
+                RestProxy.create(
+                        ReadonlypropertysService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodydate/AutoRestDateTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydate/AutoRestDateTestService.java
@@ -5,6 +5,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** Initializes a new instance of the AutoRestDateTestService type. */
 public final class AutoRestDateTestService {
@@ -32,6 +34,18 @@ public final class AutoRestDateTestService {
         return this.httpPipeline;
     }
 
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
     /** The DateOperations object to access its operations. */
     private final DateOperations dateOperations;
 
@@ -50,6 +64,7 @@ public final class AutoRestDateTestService {
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
                 host);
     }
 
@@ -59,7 +74,18 @@ public final class AutoRestDateTestService {
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
     AutoRestDateTestService(HttpPipeline httpPipeline, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    }
+
+    /**
+     * Initializes an instance of AutoRestDateTestService client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    AutoRestDateTestService(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
         this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
         this.host = host;
         this.dateOperations = new DateOperations(this);
     }

--- a/vanilla-tests/src/main/java/fixtures/bodydate/AutoRestDateTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydate/AutoRestDateTestServiceBuilder.java
@@ -6,6 +6,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** A builder for creating a new instance of the AutoRestDateTestService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestDateTestService.class})
@@ -42,6 +44,22 @@ public final class AutoRestDateTestServiceBuilder {
         return this;
     }
 
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the AutoRestDateTestServiceBuilder.
+     */
+    public AutoRestDateTestServiceBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestDateTestService with the provided parameters.
      *
@@ -57,7 +75,10 @@ public final class AutoRestDateTestServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestDateTestService client = new AutoRestDateTestService(pipeline, host);
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        AutoRestDateTestService client = new AutoRestDateTestService(pipeline, serializerAdapter, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodydate/DateOperations.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydate/DateOperations.java
@@ -32,7 +32,8 @@ public final class DateOperations {
      * @param client the instance of the service client containing this operation class.
      */
     DateOperations(AutoRestDateTestService client) {
-        this.service = RestProxy.create(DateOperationsService.class, client.getHttpPipeline());
+        this.service =
+                RestProxy.create(DateOperationsService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodydatetime/AutoRestDateTimeTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydatetime/AutoRestDateTimeTestService.java
@@ -5,6 +5,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** Initializes a new instance of the AutoRestDateTimeTestService type. */
 public final class AutoRestDateTimeTestService {
@@ -32,6 +34,18 @@ public final class AutoRestDateTimeTestService {
         return this.httpPipeline;
     }
 
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
     /** The DatetimeOperations object to access its operations. */
     private final DatetimeOperations datetimeOperations;
 
@@ -50,6 +64,7 @@ public final class AutoRestDateTimeTestService {
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
                 host);
     }
 
@@ -59,7 +74,18 @@ public final class AutoRestDateTimeTestService {
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
     AutoRestDateTimeTestService(HttpPipeline httpPipeline, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    }
+
+    /**
+     * Initializes an instance of AutoRestDateTimeTestService client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    AutoRestDateTimeTestService(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
         this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
         this.host = host;
         this.datetimeOperations = new DatetimeOperations(this);
     }

--- a/vanilla-tests/src/main/java/fixtures/bodydatetime/AutoRestDateTimeTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydatetime/AutoRestDateTimeTestServiceBuilder.java
@@ -6,6 +6,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** A builder for creating a new instance of the AutoRestDateTimeTestService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestDateTimeTestService.class})
@@ -42,6 +44,22 @@ public final class AutoRestDateTimeTestServiceBuilder {
         return this;
     }
 
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the AutoRestDateTimeTestServiceBuilder.
+     */
+    public AutoRestDateTimeTestServiceBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestDateTimeTestService with the provided parameters.
      *
@@ -57,7 +75,10 @@ public final class AutoRestDateTimeTestServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestDateTimeTestService client = new AutoRestDateTimeTestService(pipeline, host);
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        AutoRestDateTimeTestService client = new AutoRestDateTimeTestService(pipeline, serializerAdapter, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodydatetime/DatetimeOperations.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydatetime/DatetimeOperations.java
@@ -33,7 +33,9 @@ public final class DatetimeOperations {
      * @param client the instance of the service client containing this operation class.
      */
     DatetimeOperations(AutoRestDateTimeTestService client) {
-        this.service = RestProxy.create(DatetimeOperationsService.class, client.getHttpPipeline());
+        this.service =
+                RestProxy.create(
+                        DatetimeOperationsService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodydatetimerfc1123/AutoRestRFC1123DateTimeTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydatetimerfc1123/AutoRestRFC1123DateTimeTestService.java
@@ -5,6 +5,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** Initializes a new instance of the AutoRestRFC1123DateTimeTestService type. */
 public final class AutoRestRFC1123DateTimeTestService {
@@ -32,6 +34,18 @@ public final class AutoRestRFC1123DateTimeTestService {
         return this.httpPipeline;
     }
 
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
     /** The Datetimerfc1123s object to access its operations. */
     private final Datetimerfc1123s datetimerfc1123s;
 
@@ -50,6 +64,7 @@ public final class AutoRestRFC1123DateTimeTestService {
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
                 host);
     }
 
@@ -59,7 +74,18 @@ public final class AutoRestRFC1123DateTimeTestService {
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
     AutoRestRFC1123DateTimeTestService(HttpPipeline httpPipeline, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    }
+
+    /**
+     * Initializes an instance of AutoRestRFC1123DateTimeTestService client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    AutoRestRFC1123DateTimeTestService(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
         this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
         this.host = host;
         this.datetimerfc1123s = new Datetimerfc1123s(this);
     }

--- a/vanilla-tests/src/main/java/fixtures/bodydatetimerfc1123/AutoRestRFC1123DateTimeTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydatetimerfc1123/AutoRestRFC1123DateTimeTestServiceBuilder.java
@@ -6,6 +6,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** A builder for creating a new instance of the AutoRestRFC1123DateTimeTestService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestRFC1123DateTimeTestService.class})
@@ -42,6 +44,22 @@ public final class AutoRestRFC1123DateTimeTestServiceBuilder {
         return this;
     }
 
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the AutoRestRFC1123DateTimeTestServiceBuilder.
+     */
+    public AutoRestRFC1123DateTimeTestServiceBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestRFC1123DateTimeTestService with the provided parameters.
      *
@@ -57,7 +75,11 @@ public final class AutoRestRFC1123DateTimeTestServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestRFC1123DateTimeTestService client = new AutoRestRFC1123DateTimeTestService(pipeline, host);
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        AutoRestRFC1123DateTimeTestService client =
+                new AutoRestRFC1123DateTimeTestService(pipeline, serializerAdapter, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodydatetimerfc1123/Datetimerfc1123s.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydatetimerfc1123/Datetimerfc1123s.java
@@ -34,7 +34,9 @@ public final class Datetimerfc1123s {
      * @param client the instance of the service client containing this operation class.
      */
     Datetimerfc1123s(AutoRestRFC1123DateTimeTestService client) {
-        this.service = RestProxy.create(Datetimerfc1123sService.class, client.getHttpPipeline());
+        this.service =
+                RestProxy.create(
+                        Datetimerfc1123sService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodydictionary/AutoRestSwaggerBATDictionaryServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydictionary/AutoRestSwaggerBATDictionaryServiceBuilder.java
@@ -6,6 +6,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 import fixtures.bodydictionary.implementation.AutoRestSwaggerBATDictionaryServiceImpl;
 
 /** A builder for creating a new instance of the AutoRestSwaggerBATDictionaryService type. */
@@ -47,6 +49,22 @@ public final class AutoRestSwaggerBATDictionaryServiceBuilder {
         return this;
     }
 
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the AutoRestSwaggerBATDictionaryServiceBuilder.
+     */
+    public AutoRestSwaggerBATDictionaryServiceBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestSwaggerBATDictionaryServiceImpl with the provided parameters.
      *
@@ -62,7 +80,11 @@ public final class AutoRestSwaggerBATDictionaryServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestSwaggerBATDictionaryServiceImpl client = new AutoRestSwaggerBATDictionaryServiceImpl(pipeline, host);
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        AutoRestSwaggerBATDictionaryServiceImpl client =
+                new AutoRestSwaggerBATDictionaryServiceImpl(pipeline, serializerAdapter, host);
         return client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodydictionary/implementation/AutoRestSwaggerBATDictionaryServiceImpl.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydictionary/implementation/AutoRestSwaggerBATDictionaryServiceImpl.java
@@ -5,6 +5,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** Initializes a new instance of the AutoRestSwaggerBATDictionaryService type. */
 public final class AutoRestSwaggerBATDictionaryServiceImpl {
@@ -32,6 +34,18 @@ public final class AutoRestSwaggerBATDictionaryServiceImpl {
         return this.httpPipeline;
     }
 
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
     /** The DictionarysImpl object to access its operations. */
     private final DictionarysImpl dictionarys;
 
@@ -50,6 +64,7 @@ public final class AutoRestSwaggerBATDictionaryServiceImpl {
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
                 host);
     }
 
@@ -59,7 +74,19 @@ public final class AutoRestSwaggerBATDictionaryServiceImpl {
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
     public AutoRestSwaggerBATDictionaryServiceImpl(HttpPipeline httpPipeline, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    }
+
+    /**
+     * Initializes an instance of AutoRestSwaggerBATDictionaryService client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    public AutoRestSwaggerBATDictionaryServiceImpl(
+            HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
         this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
         this.host = host;
         this.dictionarys = new DictionarysImpl(this);
     }

--- a/vanilla-tests/src/main/java/fixtures/bodydictionary/implementation/DictionarysImpl.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydictionary/implementation/DictionarysImpl.java
@@ -40,7 +40,8 @@ public final class DictionarysImpl {
      * @param client the instance of the service client containing this operation class.
      */
     DictionarysImpl(AutoRestSwaggerBATDictionaryServiceImpl client) {
-        this.service = RestProxy.create(DictionarysService.class, client.getHttpPipeline());
+        this.service =
+                RestProxy.create(DictionarysService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodyduration/AutoRestDurationTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyduration/AutoRestDurationTestService.java
@@ -5,6 +5,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** Initializes a new instance of the AutoRestDurationTestService type. */
 public final class AutoRestDurationTestService {
@@ -32,6 +34,18 @@ public final class AutoRestDurationTestService {
         return this.httpPipeline;
     }
 
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
     /** The DurationOperations object to access its operations. */
     private final DurationOperations durationOperations;
 
@@ -50,6 +64,7 @@ public final class AutoRestDurationTestService {
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
                 host);
     }
 
@@ -59,7 +74,18 @@ public final class AutoRestDurationTestService {
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
     AutoRestDurationTestService(HttpPipeline httpPipeline, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    }
+
+    /**
+     * Initializes an instance of AutoRestDurationTestService client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    AutoRestDurationTestService(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
         this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
         this.host = host;
         this.durationOperations = new DurationOperations(this);
     }

--- a/vanilla-tests/src/main/java/fixtures/bodyduration/AutoRestDurationTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyduration/AutoRestDurationTestServiceBuilder.java
@@ -6,6 +6,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** A builder for creating a new instance of the AutoRestDurationTestService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestDurationTestService.class})
@@ -42,6 +44,22 @@ public final class AutoRestDurationTestServiceBuilder {
         return this;
     }
 
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the AutoRestDurationTestServiceBuilder.
+     */
+    public AutoRestDurationTestServiceBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestDurationTestService with the provided parameters.
      *
@@ -57,7 +75,10 @@ public final class AutoRestDurationTestServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestDurationTestService client = new AutoRestDurationTestService(pipeline, host);
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        AutoRestDurationTestService client = new AutoRestDurationTestService(pipeline, serializerAdapter, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodyduration/DurationOperations.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyduration/DurationOperations.java
@@ -32,7 +32,9 @@ public final class DurationOperations {
      * @param client the instance of the service client containing this operation class.
      */
     DurationOperations(AutoRestDurationTestService client) {
-        this.service = RestProxy.create(DurationOperationsService.class, client.getHttpPipeline());
+        this.service =
+                RestProxy.create(
+                        DurationOperationsService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodyfile/AutoRestSwaggerBATFileService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyfile/AutoRestSwaggerBATFileService.java
@@ -5,6 +5,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** Initializes a new instance of the AutoRestSwaggerBATFileService type. */
 public final class AutoRestSwaggerBATFileService {
@@ -32,6 +34,18 @@ public final class AutoRestSwaggerBATFileService {
         return this.httpPipeline;
     }
 
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
     /** The Files object to access its operations. */
     private final Files files;
 
@@ -50,6 +64,7 @@ public final class AutoRestSwaggerBATFileService {
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
                 host);
     }
 
@@ -59,7 +74,18 @@ public final class AutoRestSwaggerBATFileService {
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
     AutoRestSwaggerBATFileService(HttpPipeline httpPipeline, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    }
+
+    /**
+     * Initializes an instance of AutoRestSwaggerBATFileService client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    AutoRestSwaggerBATFileService(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
         this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
         this.host = host;
         this.files = new Files(this);
     }

--- a/vanilla-tests/src/main/java/fixtures/bodyfile/AutoRestSwaggerBATFileServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyfile/AutoRestSwaggerBATFileServiceBuilder.java
@@ -6,6 +6,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** A builder for creating a new instance of the AutoRestSwaggerBATFileService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestSwaggerBATFileService.class})
@@ -42,6 +44,22 @@ public final class AutoRestSwaggerBATFileServiceBuilder {
         return this;
     }
 
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the AutoRestSwaggerBATFileServiceBuilder.
+     */
+    public AutoRestSwaggerBATFileServiceBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestSwaggerBATFileService with the provided parameters.
      *
@@ -57,7 +75,10 @@ public final class AutoRestSwaggerBATFileServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestSwaggerBATFileService client = new AutoRestSwaggerBATFileService(pipeline, host);
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        AutoRestSwaggerBATFileService client = new AutoRestSwaggerBATFileService(pipeline, serializerAdapter, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodyfile/Files.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyfile/Files.java
@@ -36,7 +36,7 @@ public final class Files {
      * @param client the instance of the service client containing this operation class.
      */
     Files(AutoRestSwaggerBATFileService client) {
-        this.service = RestProxy.create(FilesService.class, client.getHttpPipeline());
+        this.service = RestProxy.create(FilesService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodyinteger/AutoRestIntegerTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyinteger/AutoRestIntegerTestService.java
@@ -5,6 +5,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** Initializes a new instance of the AutoRestIntegerTestService type. */
 public final class AutoRestIntegerTestService {
@@ -32,6 +34,18 @@ public final class AutoRestIntegerTestService {
         return this.httpPipeline;
     }
 
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
     /** The Ints object to access its operations. */
     private final Ints ints;
 
@@ -50,6 +64,7 @@ public final class AutoRestIntegerTestService {
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
                 host);
     }
 
@@ -59,7 +74,18 @@ public final class AutoRestIntegerTestService {
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
     AutoRestIntegerTestService(HttpPipeline httpPipeline, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    }
+
+    /**
+     * Initializes an instance of AutoRestIntegerTestService client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    AutoRestIntegerTestService(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
         this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
         this.host = host;
         this.ints = new Ints(this);
     }

--- a/vanilla-tests/src/main/java/fixtures/bodyinteger/AutoRestIntegerTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyinteger/AutoRestIntegerTestServiceBuilder.java
@@ -6,6 +6,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** A builder for creating a new instance of the AutoRestIntegerTestService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestIntegerTestService.class})
@@ -42,6 +44,22 @@ public final class AutoRestIntegerTestServiceBuilder {
         return this;
     }
 
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the AutoRestIntegerTestServiceBuilder.
+     */
+    public AutoRestIntegerTestServiceBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestIntegerTestService with the provided parameters.
      *
@@ -57,7 +75,10 @@ public final class AutoRestIntegerTestServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestIntegerTestService client = new AutoRestIntegerTestService(pipeline, host);
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        AutoRestIntegerTestService client = new AutoRestIntegerTestService(pipeline, serializerAdapter, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodyinteger/Ints.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyinteger/Ints.java
@@ -33,7 +33,7 @@ public final class Ints {
      * @param client the instance of the service client containing this operation class.
      */
     Ints(AutoRestIntegerTestService client) {
-        this.service = RestProxy.create(IntsService.class, client.getHttpPipeline());
+        this.service = RestProxy.create(IntsService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodynumber/AutoRestNumberTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodynumber/AutoRestNumberTestService.java
@@ -5,6 +5,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** Initializes a new instance of the AutoRestNumberTestService type. */
 public final class AutoRestNumberTestService {
@@ -32,6 +34,18 @@ public final class AutoRestNumberTestService {
         return this.httpPipeline;
     }
 
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
     /** The Numbers object to access its operations. */
     private final Numbers numbers;
 
@@ -50,6 +64,7 @@ public final class AutoRestNumberTestService {
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
                 host);
     }
 
@@ -59,7 +74,18 @@ public final class AutoRestNumberTestService {
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
     AutoRestNumberTestService(HttpPipeline httpPipeline, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    }
+
+    /**
+     * Initializes an instance of AutoRestNumberTestService client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    AutoRestNumberTestService(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
         this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
         this.host = host;
         this.numbers = new Numbers(this);
     }

--- a/vanilla-tests/src/main/java/fixtures/bodynumber/AutoRestNumberTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodynumber/AutoRestNumberTestServiceBuilder.java
@@ -6,6 +6,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** A builder for creating a new instance of the AutoRestNumberTestService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestNumberTestService.class})
@@ -42,6 +44,22 @@ public final class AutoRestNumberTestServiceBuilder {
         return this;
     }
 
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the AutoRestNumberTestServiceBuilder.
+     */
+    public AutoRestNumberTestServiceBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestNumberTestService with the provided parameters.
      *
@@ -57,7 +75,10 @@ public final class AutoRestNumberTestServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestNumberTestService client = new AutoRestNumberTestService(pipeline, host);
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        AutoRestNumberTestService client = new AutoRestNumberTestService(pipeline, serializerAdapter, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodynumber/Numbers.java
+++ b/vanilla-tests/src/main/java/fixtures/bodynumber/Numbers.java
@@ -32,7 +32,7 @@ public final class Numbers {
      * @param client the instance of the service client containing this operation class.
      */
     Numbers(AutoRestNumberTestService client) {
-        this.service = RestProxy.create(NumbersService.class, client.getHttpPipeline());
+        this.service = RestProxy.create(NumbersService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodystring/AutoRestSwaggerBATService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodystring/AutoRestSwaggerBATService.java
@@ -5,6 +5,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** Initializes a new instance of the AutoRestSwaggerBATService type. */
 public final class AutoRestSwaggerBATService {
@@ -30,6 +32,18 @@ public final class AutoRestSwaggerBATService {
      */
     public HttpPipeline getHttpPipeline() {
         return this.httpPipeline;
+    }
+
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
     }
 
     /** The StringOperations object to access its operations. */
@@ -62,6 +76,7 @@ public final class AutoRestSwaggerBATService {
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
                 host);
     }
 
@@ -71,7 +86,18 @@ public final class AutoRestSwaggerBATService {
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
     AutoRestSwaggerBATService(HttpPipeline httpPipeline, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    }
+
+    /**
+     * Initializes an instance of AutoRestSwaggerBATService client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    AutoRestSwaggerBATService(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
         this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
         this.host = host;
         this.stringOperations = new StringOperations(this);
         this.enums = new Enums(this);

--- a/vanilla-tests/src/main/java/fixtures/bodystring/AutoRestSwaggerBATServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodystring/AutoRestSwaggerBATServiceBuilder.java
@@ -6,6 +6,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** A builder for creating a new instance of the AutoRestSwaggerBATService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestSwaggerBATService.class})
@@ -42,6 +44,22 @@ public final class AutoRestSwaggerBATServiceBuilder {
         return this;
     }
 
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the AutoRestSwaggerBATServiceBuilder.
+     */
+    public AutoRestSwaggerBATServiceBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestSwaggerBATService with the provided parameters.
      *
@@ -57,7 +75,10 @@ public final class AutoRestSwaggerBATServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestSwaggerBATService client = new AutoRestSwaggerBATService(pipeline, host);
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        AutoRestSwaggerBATService client = new AutoRestSwaggerBATService(pipeline, serializerAdapter, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodystring/Enums.java
+++ b/vanilla-tests/src/main/java/fixtures/bodystring/Enums.java
@@ -33,7 +33,7 @@ public final class Enums {
      * @param client the instance of the service client containing this operation class.
      */
     Enums(AutoRestSwaggerBATService client) {
-        this.service = RestProxy.create(EnumsService.class, client.getHttpPipeline());
+        this.service = RestProxy.create(EnumsService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodystring/StringOperations.java
+++ b/vanilla-tests/src/main/java/fixtures/bodystring/StringOperations.java
@@ -33,7 +33,9 @@ public final class StringOperations {
      * @param client the instance of the service client containing this operation class.
      */
     StringOperations(AutoRestSwaggerBATService client) {
-        this.service = RestProxy.create(StringOperationsService.class, client.getHttpPipeline());
+        this.service =
+                RestProxy.create(
+                        StringOperationsService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/custombaseuri/AutoRestParameterizedHostTestClient.java
+++ b/vanilla-tests/src/main/java/fixtures/custombaseuri/AutoRestParameterizedHostTestClient.java
@@ -5,6 +5,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** Initializes a new instance of the AutoRestParameterizedHostTestClient type. */
 public final class AutoRestParameterizedHostTestClient {
@@ -32,6 +34,18 @@ public final class AutoRestParameterizedHostTestClient {
         return this.httpPipeline;
     }
 
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
     /** The Paths object to access its operations. */
     private final Paths paths;
 
@@ -50,6 +64,7 @@ public final class AutoRestParameterizedHostTestClient {
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
                 host);
     }
 
@@ -59,7 +74,18 @@ public final class AutoRestParameterizedHostTestClient {
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
     AutoRestParameterizedHostTestClient(HttpPipeline httpPipeline, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    }
+
+    /**
+     * Initializes an instance of AutoRestParameterizedHostTestClient client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    AutoRestParameterizedHostTestClient(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
         this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
         this.host = host;
         this.paths = new Paths(this);
     }

--- a/vanilla-tests/src/main/java/fixtures/custombaseuri/AutoRestParameterizedHostTestClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/custombaseuri/AutoRestParameterizedHostTestClientBuilder.java
@@ -6,6 +6,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** A builder for creating a new instance of the AutoRestParameterizedHostTestClient type. */
 @ServiceClientBuilder(serviceClients = {AutoRestParameterizedHostTestClient.class})
@@ -42,6 +44,22 @@ public final class AutoRestParameterizedHostTestClientBuilder {
         return this;
     }
 
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the AutoRestParameterizedHostTestClientBuilder.
+     */
+    public AutoRestParameterizedHostTestClientBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestParameterizedHostTestClient with the provided parameters.
      *
@@ -57,7 +75,11 @@ public final class AutoRestParameterizedHostTestClientBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestParameterizedHostTestClient client = new AutoRestParameterizedHostTestClient(pipeline, host);
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        AutoRestParameterizedHostTestClient client =
+                new AutoRestParameterizedHostTestClient(pipeline, serializerAdapter, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/custombaseuri/Paths.java
+++ b/vanilla-tests/src/main/java/fixtures/custombaseuri/Paths.java
@@ -29,7 +29,7 @@ public final class Paths {
      * @param client the instance of the service client containing this operation class.
      */
     Paths(AutoRestParameterizedHostTestClient client) {
-        this.service = RestProxy.create(PathsService.class, client.getHttpPipeline());
+        this.service = RestProxy.create(PathsService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/custombaseuri/moreoptions/AutoRestParameterizedCustomHostTestClient.java
+++ b/vanilla-tests/src/main/java/fixtures/custombaseuri/moreoptions/AutoRestParameterizedCustomHostTestClient.java
@@ -5,6 +5,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** Initializes a new instance of the AutoRestParameterizedCustomHostTestClient type. */
 public final class AutoRestParameterizedCustomHostTestClient {
@@ -44,6 +46,18 @@ public final class AutoRestParameterizedCustomHostTestClient {
         return this.httpPipeline;
     }
 
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
     /** The Paths object to access its operations. */
     private final Paths paths;
 
@@ -62,6 +76,7 @@ public final class AutoRestParameterizedCustomHostTestClient {
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
                 subscriptionId,
                 dnsSuffix);
     }
@@ -72,7 +87,19 @@ public final class AutoRestParameterizedCustomHostTestClient {
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
     AutoRestParameterizedCustomHostTestClient(HttpPipeline httpPipeline, String subscriptionId, String dnsSuffix) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), subscriptionId, dnsSuffix);
+    }
+
+    /**
+     * Initializes an instance of AutoRestParameterizedCustomHostTestClient client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    AutoRestParameterizedCustomHostTestClient(
+            HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String subscriptionId, String dnsSuffix) {
         this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
         this.subscriptionId = subscriptionId;
         this.dnsSuffix = dnsSuffix;
         this.paths = new Paths(this);

--- a/vanilla-tests/src/main/java/fixtures/custombaseuri/moreoptions/AutoRestParameterizedCustomHostTestClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/custombaseuri/moreoptions/AutoRestParameterizedCustomHostTestClientBuilder.java
@@ -6,6 +6,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** A builder for creating a new instance of the AutoRestParameterizedCustomHostTestClient type. */
 @ServiceClientBuilder(serviceClients = {AutoRestParameterizedCustomHostTestClient.class})
@@ -59,6 +61,22 @@ public final class AutoRestParameterizedCustomHostTestClientBuilder {
         return this;
     }
 
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the AutoRestParameterizedCustomHostTestClientBuilder.
+     */
+    public AutoRestParameterizedCustomHostTestClientBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestParameterizedCustomHostTestClient with the provided parameters.
      *
@@ -74,8 +92,11 @@ public final class AutoRestParameterizedCustomHostTestClientBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
         AutoRestParameterizedCustomHostTestClient client =
-                new AutoRestParameterizedCustomHostTestClient(pipeline, subscriptionId, dnsSuffix);
+                new AutoRestParameterizedCustomHostTestClient(pipeline, serializerAdapter, subscriptionId, dnsSuffix);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/custombaseuri/moreoptions/Paths.java
+++ b/vanilla-tests/src/main/java/fixtures/custombaseuri/moreoptions/Paths.java
@@ -31,7 +31,7 @@ public final class Paths {
      * @param client the instance of the service client containing this operation class.
      */
     Paths(AutoRestParameterizedCustomHostTestClient client) {
-        this.service = RestProxy.create(PathsService.class, client.getHttpPipeline());
+        this.service = RestProxy.create(PathsService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/extensibleenums/PetStoreInc.java
+++ b/vanilla-tests/src/main/java/fixtures/extensibleenums/PetStoreInc.java
@@ -5,6 +5,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** Initializes a new instance of the PetStoreInc type. */
 public final class PetStoreInc {
@@ -32,6 +34,18 @@ public final class PetStoreInc {
         return this.httpPipeline;
     }
 
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
     /** The Pets object to access its operations. */
     private final Pets pets;
 
@@ -50,6 +64,7 @@ public final class PetStoreInc {
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
                 host);
     }
 
@@ -59,7 +74,18 @@ public final class PetStoreInc {
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
     PetStoreInc(HttpPipeline httpPipeline, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    }
+
+    /**
+     * Initializes an instance of PetStoreInc client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    PetStoreInc(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
         this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
         this.host = host;
         this.pets = new Pets(this);
     }

--- a/vanilla-tests/src/main/java/fixtures/extensibleenums/PetStoreIncBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/extensibleenums/PetStoreIncBuilder.java
@@ -6,6 +6,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** A builder for creating a new instance of the PetStoreInc type. */
 @ServiceClientBuilder(serviceClients = {PetStoreInc.class})
@@ -42,6 +44,22 @@ public final class PetStoreIncBuilder {
         return this;
     }
 
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the PetStoreIncBuilder.
+     */
+    public PetStoreIncBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
     /**
      * Builds an instance of PetStoreInc with the provided parameters.
      *
@@ -57,7 +75,10 @@ public final class PetStoreIncBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        PetStoreInc client = new PetStoreInc(pipeline, host);
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        PetStoreInc client = new PetStoreInc(pipeline, serializerAdapter, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/extensibleenums/Pets.java
+++ b/vanilla-tests/src/main/java/fixtures/extensibleenums/Pets.java
@@ -33,7 +33,7 @@ public final class Pets {
      * @param client the instance of the service client containing this operation class.
      */
     Pets(PetStoreInc client) {
-        this.service = RestProxy.create(PetsService.class, client.getHttpPipeline());
+        this.service = RestProxy.create(PetsService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/head/AutoRestHeadTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/head/AutoRestHeadTestService.java
@@ -5,6 +5,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** Initializes a new instance of the AutoRestHeadTestService type. */
 public final class AutoRestHeadTestService {
@@ -32,6 +34,18 @@ public final class AutoRestHeadTestService {
         return this.httpPipeline;
     }
 
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
     /** The HttpSuccess object to access its operations. */
     private final HttpSuccess httpSuccess;
 
@@ -50,6 +64,7 @@ public final class AutoRestHeadTestService {
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
                 host);
     }
 
@@ -59,7 +74,18 @@ public final class AutoRestHeadTestService {
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
     AutoRestHeadTestService(HttpPipeline httpPipeline, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    }
+
+    /**
+     * Initializes an instance of AutoRestHeadTestService client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    AutoRestHeadTestService(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
         this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
         this.host = host;
         this.httpSuccess = new HttpSuccess(this);
     }

--- a/vanilla-tests/src/main/java/fixtures/head/AutoRestHeadTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/head/AutoRestHeadTestServiceBuilder.java
@@ -6,6 +6,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** A builder for creating a new instance of the AutoRestHeadTestService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestHeadTestService.class})
@@ -42,6 +44,22 @@ public final class AutoRestHeadTestServiceBuilder {
         return this;
     }
 
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the AutoRestHeadTestServiceBuilder.
+     */
+    public AutoRestHeadTestServiceBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestHeadTestService with the provided parameters.
      *
@@ -57,7 +75,10 @@ public final class AutoRestHeadTestServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestHeadTestService client = new AutoRestHeadTestService(pipeline, host);
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        AutoRestHeadTestService client = new AutoRestHeadTestService(pipeline, serializerAdapter, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/head/HttpSuccess.java
+++ b/vanilla-tests/src/main/java/fixtures/head/HttpSuccess.java
@@ -29,7 +29,8 @@ public final class HttpSuccess {
      * @param client the instance of the service client containing this operation class.
      */
     HttpSuccess(AutoRestHeadTestService client) {
-        this.service = RestProxy.create(HttpSuccessService.class, client.getHttpPipeline());
+        this.service =
+                RestProxy.create(HttpSuccessService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/header/AutoRestSwaggerBATHeaderService.java
+++ b/vanilla-tests/src/main/java/fixtures/header/AutoRestSwaggerBATHeaderService.java
@@ -5,6 +5,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** Initializes a new instance of the AutoRestSwaggerBATHeaderService type. */
 public final class AutoRestSwaggerBATHeaderService {
@@ -32,6 +34,18 @@ public final class AutoRestSwaggerBATHeaderService {
         return this.httpPipeline;
     }
 
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
     /** The Headers object to access its operations. */
     private final Headers headers;
 
@@ -50,6 +64,7 @@ public final class AutoRestSwaggerBATHeaderService {
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
                 host);
     }
 
@@ -59,7 +74,18 @@ public final class AutoRestSwaggerBATHeaderService {
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
     AutoRestSwaggerBATHeaderService(HttpPipeline httpPipeline, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    }
+
+    /**
+     * Initializes an instance of AutoRestSwaggerBATHeaderService client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    AutoRestSwaggerBATHeaderService(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
         this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
         this.host = host;
         this.headers = new Headers(this);
     }

--- a/vanilla-tests/src/main/java/fixtures/header/AutoRestSwaggerBATHeaderServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/header/AutoRestSwaggerBATHeaderServiceBuilder.java
@@ -6,6 +6,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** A builder for creating a new instance of the AutoRestSwaggerBATHeaderService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestSwaggerBATHeaderService.class})
@@ -42,6 +44,22 @@ public final class AutoRestSwaggerBATHeaderServiceBuilder {
         return this;
     }
 
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the AutoRestSwaggerBATHeaderServiceBuilder.
+     */
+    public AutoRestSwaggerBATHeaderServiceBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestSwaggerBATHeaderService with the provided parameters.
      *
@@ -57,7 +75,10 @@ public final class AutoRestSwaggerBATHeaderServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestSwaggerBATHeaderService client = new AutoRestSwaggerBATHeaderService(pipeline, host);
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        AutoRestSwaggerBATHeaderService client = new AutoRestSwaggerBATHeaderService(pipeline, serializerAdapter, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/header/Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/header/Headers.java
@@ -50,7 +50,7 @@ public final class Headers {
      * @param client the instance of the service client containing this operation class.
      */
     Headers(AutoRestSwaggerBATHeaderService client) {
-        this.service = RestProxy.create(HeadersService.class, client.getHttpPipeline());
+        this.service = RestProxy.create(HeadersService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/headexceptions/AutoRestHeadExceptionTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/headexceptions/AutoRestHeadExceptionTestService.java
@@ -5,6 +5,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** Initializes a new instance of the AutoRestHeadExceptionTestService type. */
 public final class AutoRestHeadExceptionTestService {
@@ -32,6 +34,18 @@ public final class AutoRestHeadExceptionTestService {
         return this.httpPipeline;
     }
 
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
     /** The HeadExceptions object to access its operations. */
     private final HeadExceptions headExceptions;
 
@@ -50,6 +64,7 @@ public final class AutoRestHeadExceptionTestService {
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
                 host);
     }
 
@@ -59,7 +74,18 @@ public final class AutoRestHeadExceptionTestService {
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
     AutoRestHeadExceptionTestService(HttpPipeline httpPipeline, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    }
+
+    /**
+     * Initializes an instance of AutoRestHeadExceptionTestService client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    AutoRestHeadExceptionTestService(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
         this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
         this.host = host;
         this.headExceptions = new HeadExceptions(this);
     }

--- a/vanilla-tests/src/main/java/fixtures/headexceptions/AutoRestHeadExceptionTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/headexceptions/AutoRestHeadExceptionTestServiceBuilder.java
@@ -6,6 +6,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** A builder for creating a new instance of the AutoRestHeadExceptionTestService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestHeadExceptionTestService.class})
@@ -42,6 +44,22 @@ public final class AutoRestHeadExceptionTestServiceBuilder {
         return this;
     }
 
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the AutoRestHeadExceptionTestServiceBuilder.
+     */
+    public AutoRestHeadExceptionTestServiceBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestHeadExceptionTestService with the provided parameters.
      *
@@ -57,7 +75,11 @@ public final class AutoRestHeadExceptionTestServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestHeadExceptionTestService client = new AutoRestHeadExceptionTestService(pipeline, host);
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        AutoRestHeadExceptionTestService client =
+                new AutoRestHeadExceptionTestService(pipeline, serializerAdapter, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/headexceptions/HeadExceptions.java
+++ b/vanilla-tests/src/main/java/fixtures/headexceptions/HeadExceptions.java
@@ -29,7 +29,8 @@ public final class HeadExceptions {
      * @param client the instance of the service client containing this operation class.
      */
     HeadExceptions(AutoRestHeadExceptionTestService client) {
-        this.service = RestProxy.create(HeadExceptionsService.class, client.getHttpPipeline());
+        this.service =
+                RestProxy.create(HeadExceptionsService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/httpinfrastructure/AutoRestHttpInfrastructureTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/httpinfrastructure/AutoRestHttpInfrastructureTestService.java
@@ -5,6 +5,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** Initializes a new instance of the AutoRestHttpInfrastructureTestService type. */
 public final class AutoRestHttpInfrastructureTestService {
@@ -30,6 +32,18 @@ public final class AutoRestHttpInfrastructureTestService {
      */
     public HttpPipeline getHttpPipeline() {
         return this.httpPipeline;
+    }
+
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
     }
 
     /** The HttpFailures object to access its operations. */
@@ -122,6 +136,7 @@ public final class AutoRestHttpInfrastructureTestService {
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
                 host);
     }
 
@@ -131,7 +146,18 @@ public final class AutoRestHttpInfrastructureTestService {
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
     AutoRestHttpInfrastructureTestService(HttpPipeline httpPipeline, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    }
+
+    /**
+     * Initializes an instance of AutoRestHttpInfrastructureTestService client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    AutoRestHttpInfrastructureTestService(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
         this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
         this.host = host;
         this.httpFailures = new HttpFailures(this);
         this.httpSuccess = new HttpSuccess(this);

--- a/vanilla-tests/src/main/java/fixtures/httpinfrastructure/AutoRestHttpInfrastructureTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/httpinfrastructure/AutoRestHttpInfrastructureTestServiceBuilder.java
@@ -6,6 +6,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** A builder for creating a new instance of the AutoRestHttpInfrastructureTestService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestHttpInfrastructureTestService.class})
@@ -42,6 +44,22 @@ public final class AutoRestHttpInfrastructureTestServiceBuilder {
         return this;
     }
 
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the AutoRestHttpInfrastructureTestServiceBuilder.
+     */
+    public AutoRestHttpInfrastructureTestServiceBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestHttpInfrastructureTestService with the provided parameters.
      *
@@ -57,7 +75,11 @@ public final class AutoRestHttpInfrastructureTestServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestHttpInfrastructureTestService client = new AutoRestHttpInfrastructureTestService(pipeline, host);
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        AutoRestHttpInfrastructureTestService client =
+                new AutoRestHttpInfrastructureTestService(pipeline, serializerAdapter, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/httpinfrastructure/HttpClientFailures.java
+++ b/vanilla-tests/src/main/java/fixtures/httpinfrastructure/HttpClientFailures.java
@@ -34,7 +34,9 @@ public final class HttpClientFailures {
      * @param client the instance of the service client containing this operation class.
      */
     HttpClientFailures(AutoRestHttpInfrastructureTestService client) {
-        this.service = RestProxy.create(HttpClientFailuresService.class, client.getHttpPipeline());
+        this.service =
+                RestProxy.create(
+                        HttpClientFailuresService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/httpinfrastructure/HttpFailures.java
+++ b/vanilla-tests/src/main/java/fixtures/httpinfrastructure/HttpFailures.java
@@ -30,7 +30,8 @@ public final class HttpFailures {
      * @param client the instance of the service client containing this operation class.
      */
     HttpFailures(AutoRestHttpInfrastructureTestService client) {
-        this.service = RestProxy.create(HttpFailuresService.class, client.getHttpPipeline());
+        this.service =
+                RestProxy.create(HttpFailuresService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/httpinfrastructure/HttpRedirects.java
+++ b/vanilla-tests/src/main/java/fixtures/httpinfrastructure/HttpRedirects.java
@@ -50,7 +50,8 @@ public final class HttpRedirects {
      * @param client the instance of the service client containing this operation class.
      */
     HttpRedirects(AutoRestHttpInfrastructureTestService client) {
-        this.service = RestProxy.create(HttpRedirectsService.class, client.getHttpPipeline());
+        this.service =
+                RestProxy.create(HttpRedirectsService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/httpinfrastructure/HttpRetrys.java
+++ b/vanilla-tests/src/main/java/fixtures/httpinfrastructure/HttpRetrys.java
@@ -35,7 +35,8 @@ public final class HttpRetrys {
      * @param client the instance of the service client containing this operation class.
      */
     HttpRetrys(AutoRestHttpInfrastructureTestService client) {
-        this.service = RestProxy.create(HttpRetrysService.class, client.getHttpPipeline());
+        this.service =
+                RestProxy.create(HttpRetrysService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/httpinfrastructure/HttpServerFailures.java
+++ b/vanilla-tests/src/main/java/fixtures/httpinfrastructure/HttpServerFailures.java
@@ -32,7 +32,9 @@ public final class HttpServerFailures {
      * @param client the instance of the service client containing this operation class.
      */
     HttpServerFailures(AutoRestHttpInfrastructureTestService client) {
-        this.service = RestProxy.create(HttpServerFailuresService.class, client.getHttpPipeline());
+        this.service =
+                RestProxy.create(
+                        HttpServerFailuresService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/httpinfrastructure/HttpSuccess.java
+++ b/vanilla-tests/src/main/java/fixtures/httpinfrastructure/HttpSuccess.java
@@ -35,7 +35,8 @@ public final class HttpSuccess {
      * @param client the instance of the service client containing this operation class.
      */
     HttpSuccess(AutoRestHttpInfrastructureTestService client) {
-        this.service = RestProxy.create(HttpSuccessService.class, client.getHttpPipeline());
+        this.service =
+                RestProxy.create(HttpSuccessService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/httpinfrastructure/MultipleResponses.java
+++ b/vanilla-tests/src/main/java/fixtures/httpinfrastructure/MultipleResponses.java
@@ -32,7 +32,9 @@ public final class MultipleResponses {
      * @param client the instance of the service client containing this operation class.
      */
     MultipleResponses(AutoRestHttpInfrastructureTestService client) {
-        this.service = RestProxy.create(MultipleResponsesService.class, client.getHttpPipeline());
+        this.service =
+                RestProxy.create(
+                        MultipleResponsesService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClient.java
+++ b/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClient.java
@@ -20,6 +20,8 @@ import com.azure.core.http.rest.Response;
 import com.azure.core.http.rest.RestProxy;
 import com.azure.core.util.Context;
 import com.azure.core.util.FluxUtil;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 import fixtures.mediatypes.models.ContentType;
 import fixtures.mediatypes.models.SourcePath;
 import java.nio.ByteBuffer;
@@ -55,12 +57,25 @@ public final class MediaTypesClient {
         return this.httpPipeline;
     }
 
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
     /** Initializes an instance of MediaTypesClient client. */
     MediaTypesClient(String host) {
         this(
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
                 host);
     }
 
@@ -70,9 +85,20 @@ public final class MediaTypesClient {
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
     MediaTypesClient(HttpPipeline httpPipeline, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    }
+
+    /**
+     * Initializes an instance of MediaTypesClient client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    MediaTypesClient(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
         this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
         this.host = host;
-        this.service = RestProxy.create(MediaTypesClientService.class, this.httpPipeline);
+        this.service = RestProxy.create(MediaTypesClientService.class, this.httpPipeline, this.getSerializerAdapter());
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClientBuilder.java
@@ -6,6 +6,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** A builder for creating a new instance of the MediaTypesClient type. */
 @ServiceClientBuilder(serviceClients = {MediaTypesClient.class})
@@ -42,6 +44,22 @@ public final class MediaTypesClientBuilder {
         return this;
     }
 
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the MediaTypesClientBuilder.
+     */
+    public MediaTypesClientBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
     /**
      * Builds an instance of MediaTypesClient with the provided parameters.
      *
@@ -57,7 +75,10 @@ public final class MediaTypesClientBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        MediaTypesClient client = new MediaTypesClient(pipeline, host);
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        MediaTypesClient client = new MediaTypesClient(pipeline, serializerAdapter, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/modelflattening/AutoRestResourceFlatteningTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/modelflattening/AutoRestResourceFlatteningTestService.java
@@ -21,6 +21,8 @@ import com.azure.core.http.rest.Response;
 import com.azure.core.http.rest.RestProxy;
 import com.azure.core.util.Context;
 import com.azure.core.util.FluxUtil;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 import fixtures.modelflattening.models.ErrorException;
 import fixtures.modelflattening.models.FlattenParameterGroup;
 import fixtures.modelflattening.models.FlattenedProduct;
@@ -62,12 +64,25 @@ public final class AutoRestResourceFlatteningTestService {
         return this.httpPipeline;
     }
 
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
     /** Initializes an instance of AutoRestResourceFlatteningTestService client. */
     AutoRestResourceFlatteningTestService(String host) {
         this(
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
                 host);
     }
 
@@ -77,9 +92,24 @@ public final class AutoRestResourceFlatteningTestService {
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
     AutoRestResourceFlatteningTestService(HttpPipeline httpPipeline, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    }
+
+    /**
+     * Initializes an instance of AutoRestResourceFlatteningTestService client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    AutoRestResourceFlatteningTestService(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
         this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
         this.host = host;
-        this.service = RestProxy.create(AutoRestResourceFlatteningTestServiceService.class, this.httpPipeline);
+        this.service =
+                RestProxy.create(
+                        AutoRestResourceFlatteningTestServiceService.class,
+                        this.httpPipeline,
+                        this.getSerializerAdapter());
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/modelflattening/AutoRestResourceFlatteningTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/modelflattening/AutoRestResourceFlatteningTestServiceBuilder.java
@@ -6,6 +6,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** A builder for creating a new instance of the AutoRestResourceFlatteningTestService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestResourceFlatteningTestService.class})
@@ -42,6 +44,22 @@ public final class AutoRestResourceFlatteningTestServiceBuilder {
         return this;
     }
 
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the AutoRestResourceFlatteningTestServiceBuilder.
+     */
+    public AutoRestResourceFlatteningTestServiceBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestResourceFlatteningTestService with the provided parameters.
      *
@@ -57,7 +75,11 @@ public final class AutoRestResourceFlatteningTestServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestResourceFlatteningTestService client = new AutoRestResourceFlatteningTestService(pipeline, host);
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        AutoRestResourceFlatteningTestService client =
+                new AutoRestResourceFlatteningTestService(pipeline, serializerAdapter, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/multipleinheritance/MultipleInheritanceServiceClient.java
+++ b/vanilla-tests/src/main/java/fixtures/multipleinheritance/MultipleInheritanceServiceClient.java
@@ -20,6 +20,8 @@ import com.azure.core.http.rest.Response;
 import com.azure.core.http.rest.RestProxy;
 import com.azure.core.util.Context;
 import com.azure.core.util.FluxUtil;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 import fixtures.multipleinheritance.models.Cat;
 import fixtures.multipleinheritance.models.ErrorException;
 import fixtures.multipleinheritance.models.Feline;
@@ -57,12 +59,25 @@ public final class MultipleInheritanceServiceClient {
         return this.httpPipeline;
     }
 
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
     /** Initializes an instance of MultipleInheritanceServiceClient client. */
     MultipleInheritanceServiceClient(String host) {
         this(
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
                 host);
     }
 
@@ -72,9 +87,22 @@ public final class MultipleInheritanceServiceClient {
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
     MultipleInheritanceServiceClient(HttpPipeline httpPipeline, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    }
+
+    /**
+     * Initializes an instance of MultipleInheritanceServiceClient client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    MultipleInheritanceServiceClient(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
         this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
         this.host = host;
-        this.service = RestProxy.create(MultipleInheritanceServiceClientService.class, this.httpPipeline);
+        this.service =
+                RestProxy.create(
+                        MultipleInheritanceServiceClientService.class, this.httpPipeline, this.getSerializerAdapter());
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/multipleinheritance/MultipleInheritanceServiceClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/multipleinheritance/MultipleInheritanceServiceClientBuilder.java
@@ -6,6 +6,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** A builder for creating a new instance of the MultipleInheritanceServiceClient type. */
 @ServiceClientBuilder(serviceClients = {MultipleInheritanceServiceClient.class})
@@ -42,6 +44,22 @@ public final class MultipleInheritanceServiceClientBuilder {
         return this;
     }
 
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the MultipleInheritanceServiceClientBuilder.
+     */
+    public MultipleInheritanceServiceClientBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
     /**
      * Builds an instance of MultipleInheritanceServiceClient with the provided parameters.
      *
@@ -57,7 +75,11 @@ public final class MultipleInheritanceServiceClientBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        MultipleInheritanceServiceClient client = new MultipleInheritanceServiceClient(pipeline, host);
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        MultipleInheritanceServiceClient client =
+                new MultipleInheritanceServiceClient(pipeline, serializerAdapter, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/nonstringenum/FloatOperations.java
+++ b/vanilla-tests/src/main/java/fixtures/nonstringenum/FloatOperations.java
@@ -32,7 +32,8 @@ public final class FloatOperations {
      * @param client the instance of the service client containing this operation class.
      */
     FloatOperations(NonStringEnumsClient client) {
-        this.service = RestProxy.create(FloatOperationsService.class, client.getHttpPipeline());
+        this.service =
+                RestProxy.create(FloatOperationsService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/nonstringenum/Ints.java
+++ b/vanilla-tests/src/main/java/fixtures/nonstringenum/Ints.java
@@ -32,7 +32,7 @@ public final class Ints {
      * @param client the instance of the service client containing this operation class.
      */
     Ints(NonStringEnumsClient client) {
-        this.service = RestProxy.create(IntsService.class, client.getHttpPipeline());
+        this.service = RestProxy.create(IntsService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/nonstringenum/NonStringEnumsClient.java
+++ b/vanilla-tests/src/main/java/fixtures/nonstringenum/NonStringEnumsClient.java
@@ -5,6 +5,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** Initializes a new instance of the NonStringEnumsClient type. */
 public final class NonStringEnumsClient {
@@ -30,6 +32,18 @@ public final class NonStringEnumsClient {
      */
     public HttpPipeline getHttpPipeline() {
         return this.httpPipeline;
+    }
+
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
     }
 
     /** The Ints object to access its operations. */
@@ -62,6 +76,7 @@ public final class NonStringEnumsClient {
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
                 host);
     }
 
@@ -71,7 +86,18 @@ public final class NonStringEnumsClient {
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
     NonStringEnumsClient(HttpPipeline httpPipeline, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    }
+
+    /**
+     * Initializes an instance of NonStringEnumsClient client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    NonStringEnumsClient(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
         this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
         this.host = host;
         this.ints = new Ints(this);
         this.floatOperations = new FloatOperations(this);

--- a/vanilla-tests/src/main/java/fixtures/nonstringenum/NonStringEnumsClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/nonstringenum/NonStringEnumsClientBuilder.java
@@ -6,6 +6,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** A builder for creating a new instance of the NonStringEnumsClient type. */
 @ServiceClientBuilder(serviceClients = {NonStringEnumsClient.class})
@@ -42,6 +44,22 @@ public final class NonStringEnumsClientBuilder {
         return this;
     }
 
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the NonStringEnumsClientBuilder.
+     */
+    public NonStringEnumsClientBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
     /**
      * Builds an instance of NonStringEnumsClient with the provided parameters.
      *
@@ -57,7 +75,10 @@ public final class NonStringEnumsClientBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        NonStringEnumsClient client = new NonStringEnumsClient(pipeline, host);
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        NonStringEnumsClient client = new NonStringEnumsClient(pipeline, serializerAdapter, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/parameterflattening/AutoRestParameterFlattening.java
+++ b/vanilla-tests/src/main/java/fixtures/parameterflattening/AutoRestParameterFlattening.java
@@ -5,6 +5,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** Initializes a new instance of the AutoRestParameterFlattening type. */
 public final class AutoRestParameterFlattening {
@@ -32,6 +34,18 @@ public final class AutoRestParameterFlattening {
         return this.httpPipeline;
     }
 
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
     /** The AvailabilitySets object to access its operations. */
     private final AvailabilitySets availabilitySets;
 
@@ -50,6 +64,7 @@ public final class AutoRestParameterFlattening {
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
                 host);
     }
 
@@ -59,7 +74,18 @@ public final class AutoRestParameterFlattening {
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
     AutoRestParameterFlattening(HttpPipeline httpPipeline, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    }
+
+    /**
+     * Initializes an instance of AutoRestParameterFlattening client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    AutoRestParameterFlattening(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
         this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
         this.host = host;
         this.availabilitySets = new AvailabilitySets(this);
     }

--- a/vanilla-tests/src/main/java/fixtures/parameterflattening/AutoRestParameterFlatteningBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/parameterflattening/AutoRestParameterFlatteningBuilder.java
@@ -6,6 +6,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** A builder for creating a new instance of the AutoRestParameterFlattening type. */
 @ServiceClientBuilder(serviceClients = {AutoRestParameterFlattening.class})
@@ -42,6 +44,22 @@ public final class AutoRestParameterFlatteningBuilder {
         return this;
     }
 
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the AutoRestParameterFlatteningBuilder.
+     */
+    public AutoRestParameterFlatteningBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestParameterFlattening with the provided parameters.
      *
@@ -57,7 +75,10 @@ public final class AutoRestParameterFlatteningBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestParameterFlattening client = new AutoRestParameterFlattening(pipeline, host);
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        AutoRestParameterFlattening client = new AutoRestParameterFlattening(pipeline, serializerAdapter, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/parameterflattening/AvailabilitySets.java
+++ b/vanilla-tests/src/main/java/fixtures/parameterflattening/AvailabilitySets.java
@@ -33,7 +33,9 @@ public final class AvailabilitySets {
      * @param client the instance of the service client containing this operation class.
      */
     AvailabilitySets(AutoRestParameterFlattening client) {
-        this.service = RestProxy.create(AvailabilitySetsService.class, client.getHttpPipeline());
+        this.service =
+                RestProxy.create(
+                        AvailabilitySetsService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/report/AutoRestReportService.java
+++ b/vanilla-tests/src/main/java/fixtures/report/AutoRestReportService.java
@@ -18,6 +18,8 @@ import com.azure.core.http.rest.Response;
 import com.azure.core.http.rest.RestProxy;
 import com.azure.core.util.Context;
 import com.azure.core.util.FluxUtil;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 import fixtures.report.models.ErrorException;
 import java.util.Map;
 import reactor.core.publisher.Mono;
@@ -51,12 +53,25 @@ public final class AutoRestReportService {
         return this.httpPipeline;
     }
 
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
     /** Initializes an instance of AutoRestReportService client. */
     AutoRestReportService(String host) {
         this(
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
                 host);
     }
 
@@ -66,9 +81,21 @@ public final class AutoRestReportService {
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
     AutoRestReportService(HttpPipeline httpPipeline, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    }
+
+    /**
+     * Initializes an instance of AutoRestReportService client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    AutoRestReportService(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
         this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
         this.host = host;
-        this.service = RestProxy.create(AutoRestReportServiceService.class, this.httpPipeline);
+        this.service =
+                RestProxy.create(AutoRestReportServiceService.class, this.httpPipeline, this.getSerializerAdapter());
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/report/AutoRestReportServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/report/AutoRestReportServiceBuilder.java
@@ -6,6 +6,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** A builder for creating a new instance of the AutoRestReportService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestReportService.class})
@@ -42,6 +44,22 @@ public final class AutoRestReportServiceBuilder {
         return this;
     }
 
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the AutoRestReportServiceBuilder.
+     */
+    public AutoRestReportServiceBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestReportService with the provided parameters.
      *
@@ -57,7 +75,10 @@ public final class AutoRestReportServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestReportService client = new AutoRestReportService(pipeline, host);
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        AutoRestReportService client = new AutoRestReportService(pipeline, serializerAdapter, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/requiredoptional/AutoRestRequiredOptionalTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/requiredoptional/AutoRestRequiredOptionalTestService.java
@@ -5,6 +5,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** Initializes a new instance of the AutoRestRequiredOptionalTestService type. */
 public final class AutoRestRequiredOptionalTestService {
@@ -68,6 +70,18 @@ public final class AutoRestRequiredOptionalTestService {
         return this.httpPipeline;
     }
 
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
     /** The Implicits object to access its operations. */
     private final Implicits implicits;
 
@@ -99,6 +113,7 @@ public final class AutoRestRequiredOptionalTestService {
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
                 requiredGlobalPath,
                 requiredGlobalQuery,
                 optionalGlobalQuery,
@@ -116,7 +131,30 @@ public final class AutoRestRequiredOptionalTestService {
             String requiredGlobalQuery,
             int optionalGlobalQuery,
             String host) {
+        this(
+                httpPipeline,
+                JacksonAdapter.createDefaultSerializerAdapter(),
+                requiredGlobalPath,
+                requiredGlobalQuery,
+                optionalGlobalQuery,
+                host);
+    }
+
+    /**
+     * Initializes an instance of AutoRestRequiredOptionalTestService client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    AutoRestRequiredOptionalTestService(
+            HttpPipeline httpPipeline,
+            SerializerAdapter serializerAdapter,
+            String requiredGlobalPath,
+            String requiredGlobalQuery,
+            int optionalGlobalQuery,
+            String host) {
         this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
         this.requiredGlobalPath = requiredGlobalPath;
         this.requiredGlobalQuery = requiredGlobalQuery;
         this.optionalGlobalQuery = optionalGlobalQuery;

--- a/vanilla-tests/src/main/java/fixtures/requiredoptional/AutoRestRequiredOptionalTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/requiredoptional/AutoRestRequiredOptionalTestServiceBuilder.java
@@ -6,6 +6,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** A builder for creating a new instance of the AutoRestRequiredOptionalTestService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestRequiredOptionalTestService.class})
@@ -90,6 +92,22 @@ public final class AutoRestRequiredOptionalTestServiceBuilder {
         return this;
     }
 
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the AutoRestRequiredOptionalTestServiceBuilder.
+     */
+    public AutoRestRequiredOptionalTestServiceBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestRequiredOptionalTestService with the provided parameters.
      *
@@ -105,9 +123,17 @@ public final class AutoRestRequiredOptionalTestServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
         AutoRestRequiredOptionalTestService client =
                 new AutoRestRequiredOptionalTestService(
-                        pipeline, requiredGlobalPath, requiredGlobalQuery, optionalGlobalQuery, host);
+                        pipeline,
+                        serializerAdapter,
+                        requiredGlobalPath,
+                        requiredGlobalQuery,
+                        optionalGlobalQuery,
+                        host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/requiredoptional/Explicits.java
+++ b/vanilla-tests/src/main/java/fixtures/requiredoptional/Explicits.java
@@ -43,7 +43,8 @@ public final class Explicits {
      * @param client the instance of the service client containing this operation class.
      */
     Explicits(AutoRestRequiredOptionalTestService client) {
-        this.service = RestProxy.create(ExplicitsService.class, client.getHttpPipeline());
+        this.service =
+                RestProxy.create(ExplicitsService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/requiredoptional/Implicits.java
+++ b/vanilla-tests/src/main/java/fixtures/requiredoptional/Implicits.java
@@ -34,7 +34,8 @@ public final class Implicits {
      * @param client the instance of the service client containing this operation class.
      */
     Implicits(AutoRestRequiredOptionalTestService client) {
-        this.service = RestProxy.create(ImplicitsService.class, client.getHttpPipeline());
+        this.service =
+                RestProxy.create(ImplicitsService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/url/AutoRestUrlTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/url/AutoRestUrlTestService.java
@@ -5,6 +5,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** Initializes a new instance of the AutoRestUrlTestService type. */
 public final class AutoRestUrlTestService {
@@ -56,6 +58,18 @@ public final class AutoRestUrlTestService {
         return this.httpPipeline;
     }
 
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
     /** The Paths object to access its operations. */
     private final Paths paths;
 
@@ -98,6 +112,7 @@ public final class AutoRestUrlTestService {
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
                 globalStringPath,
                 globalStringQuery,
                 host);
@@ -109,7 +124,23 @@ public final class AutoRestUrlTestService {
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
     AutoRestUrlTestService(HttpPipeline httpPipeline, String globalStringPath, String globalStringQuery, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), globalStringPath, globalStringQuery, host);
+    }
+
+    /**
+     * Initializes an instance of AutoRestUrlTestService client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    AutoRestUrlTestService(
+            HttpPipeline httpPipeline,
+            SerializerAdapter serializerAdapter,
+            String globalStringPath,
+            String globalStringQuery,
+            String host) {
         this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
         this.globalStringPath = globalStringPath;
         this.globalStringQuery = globalStringQuery;
         this.host = host;

--- a/vanilla-tests/src/main/java/fixtures/url/AutoRestUrlTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/url/AutoRestUrlTestServiceBuilder.java
@@ -6,6 +6,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** A builder for creating a new instance of the AutoRestUrlTestService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestUrlTestService.class})
@@ -74,6 +76,22 @@ public final class AutoRestUrlTestServiceBuilder {
         return this;
     }
 
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the AutoRestUrlTestServiceBuilder.
+     */
+    public AutoRestUrlTestServiceBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestUrlTestService with the provided parameters.
      *
@@ -89,7 +107,11 @@ public final class AutoRestUrlTestServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestUrlTestService client = new AutoRestUrlTestService(pipeline, globalStringPath, globalStringQuery, host);
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        AutoRestUrlTestService client =
+                new AutoRestUrlTestService(pipeline, serializerAdapter, globalStringPath, globalStringQuery, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/url/PathItems.java
+++ b/vanilla-tests/src/main/java/fixtures/url/PathItems.java
@@ -31,7 +31,8 @@ public final class PathItems {
      * @param client the instance of the service client containing this operation class.
      */
     PathItems(AutoRestUrlTestService client) {
-        this.service = RestProxy.create(PathItemsService.class, client.getHttpPipeline());
+        this.service =
+                RestProxy.create(PathItemsService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/url/Paths.java
+++ b/vanilla-tests/src/main/java/fixtures/url/Paths.java
@@ -38,7 +38,7 @@ public final class Paths {
      * @param client the instance of the service client containing this operation class.
      */
     Paths(AutoRestUrlTestService client) {
-        this.service = RestProxy.create(PathsService.class, client.getHttpPipeline());
+        this.service = RestProxy.create(PathsService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/url/Queries.java
+++ b/vanilla-tests/src/main/java/fixtures/url/Queries.java
@@ -37,7 +37,7 @@ public final class Queries {
      * @param client the instance of the service client containing this operation class.
      */
     Queries(AutoRestUrlTestService client) {
-        this.service = RestProxy.create(QueriesService.class, client.getHttpPipeline());
+        this.service = RestProxy.create(QueriesService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/url/multi/AutoRestUrlMutliCollectionFormatTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/url/multi/AutoRestUrlMutliCollectionFormatTestService.java
@@ -5,6 +5,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** Initializes a new instance of the AutoRestUrlMutliCollectionFormatTestService type. */
 public final class AutoRestUrlMutliCollectionFormatTestService {
@@ -32,6 +34,18 @@ public final class AutoRestUrlMutliCollectionFormatTestService {
         return this.httpPipeline;
     }
 
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
     /** The Queries object to access its operations. */
     private final Queries queries;
 
@@ -50,6 +64,7 @@ public final class AutoRestUrlMutliCollectionFormatTestService {
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
                 host);
     }
 
@@ -59,7 +74,19 @@ public final class AutoRestUrlMutliCollectionFormatTestService {
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
     AutoRestUrlMutliCollectionFormatTestService(HttpPipeline httpPipeline, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    }
+
+    /**
+     * Initializes an instance of AutoRestUrlMutliCollectionFormatTestService client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    AutoRestUrlMutliCollectionFormatTestService(
+            HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
         this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
         this.host = host;
         this.queries = new Queries(this);
     }

--- a/vanilla-tests/src/main/java/fixtures/url/multi/AutoRestUrlMutliCollectionFormatTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/url/multi/AutoRestUrlMutliCollectionFormatTestServiceBuilder.java
@@ -6,6 +6,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** A builder for creating a new instance of the AutoRestUrlMutliCollectionFormatTestService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestUrlMutliCollectionFormatTestService.class})
@@ -42,6 +44,22 @@ public final class AutoRestUrlMutliCollectionFormatTestServiceBuilder {
         return this;
     }
 
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the AutoRestUrlMutliCollectionFormatTestServiceBuilder.
+     */
+    public AutoRestUrlMutliCollectionFormatTestServiceBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestUrlMutliCollectionFormatTestService with the provided parameters.
      *
@@ -57,8 +75,11 @@ public final class AutoRestUrlMutliCollectionFormatTestServiceBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
         AutoRestUrlMutliCollectionFormatTestService client =
-                new AutoRestUrlMutliCollectionFormatTestService(pipeline, host);
+                new AutoRestUrlMutliCollectionFormatTestService(pipeline, serializerAdapter, host);
         return client;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/url/multi/Queries.java
+++ b/vanilla-tests/src/main/java/fixtures/url/multi/Queries.java
@@ -33,7 +33,7 @@ public final class Queries {
      * @param client the instance of the service client containing this operation class.
      */
     Queries(AutoRestUrlMutliCollectionFormatTestService client) {
-        this.service = RestProxy.create(QueriesService.class, client.getHttpPipeline());
+        this.service = RestProxy.create(QueriesService.class, client.getHttpPipeline(), client.getSerializerAdapter());
         this.client = client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/validation/AutoRestValidationTest.java
+++ b/vanilla-tests/src/main/java/fixtures/validation/AutoRestValidationTest.java
@@ -23,6 +23,8 @@ import com.azure.core.http.rest.Response;
 import com.azure.core.http.rest.RestProxy;
 import com.azure.core.util.Context;
 import com.azure.core.util.FluxUtil;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 import fixtures.validation.models.ErrorException;
 import fixtures.validation.models.Product;
 import reactor.core.publisher.Mono;
@@ -80,12 +82,25 @@ public final class AutoRestValidationTest {
         return this.httpPipeline;
     }
 
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
     /** Initializes an instance of AutoRestValidationTest client. */
     AutoRestValidationTest(String subscriptionId, String host) {
         this(
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
                 subscriptionId,
                 host);
     }
@@ -96,11 +111,24 @@ public final class AutoRestValidationTest {
      * @param httpPipeline The HTTP pipeline to send requests through.
      */
     AutoRestValidationTest(HttpPipeline httpPipeline, String subscriptionId, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), subscriptionId, host);
+    }
+
+    /**
+     * Initializes an instance of AutoRestValidationTest client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    AutoRestValidationTest(
+            HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String subscriptionId, String host) {
         this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
         this.subscriptionId = subscriptionId;
         this.host = host;
         this.apiVersion = "1.0.0";
-        this.service = RestProxy.create(AutoRestValidationTestService.class, this.httpPipeline);
+        this.service =
+                RestProxy.create(AutoRestValidationTestService.class, this.httpPipeline, this.getSerializerAdapter());
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/validation/AutoRestValidationTestBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/validation/AutoRestValidationTestBuilder.java
@@ -6,6 +6,8 @@ import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
 
 /** A builder for creating a new instance of the AutoRestValidationTest type. */
 @ServiceClientBuilder(serviceClients = {AutoRestValidationTest.class})
@@ -58,6 +60,22 @@ public final class AutoRestValidationTestBuilder {
         return this;
     }
 
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the AutoRestValidationTestBuilder.
+     */
+    public AutoRestValidationTestBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestValidationTest with the provided parameters.
      *
@@ -73,7 +91,10 @@ public final class AutoRestValidationTestBuilder {
                             .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                             .build();
         }
-        AutoRestValidationTest client = new AutoRestValidationTest(pipeline, subscriptionId, host);
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        AutoRestValidationTest client = new AutoRestValidationTest(pipeline, serializerAdapter, subscriptionId, host);
         return client;
     }
 }


### PR DESCRIPTION
This PR enables customizing the `SerializerAdapter`  that will be used in azure-core for serializing and deserializing request/response from the client library.