### PR TITLE
v4, support interface for resoruce collections

### DIFF
--- a/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
@@ -169,16 +169,18 @@ public class FluentGen extends NewPlugin {
                 javaPackage.addPackageInfo(packageInfo.getPackage(), "package-info", packageInfo);
             }
 
-            // Fluent manager
-            javaPackage.addFluentManager(fluentClient.getManager());
+            if (JavaSettings.getInstance().isFluentLite()) {
+                // Fluent manager
+                javaPackage.addFluentManager(fluentClient.getManager());
 
-            // Fluent resource model
-            for (FluentResourceModel model : fluentClient.getResourceModels()) {
-                javaPackage.addFluentResourceModel(model);
-            }
+                // Fluent resource model
+                for (FluentResourceModel model : fluentClient.getResourceModels()) {
+                    javaPackage.addFluentResourceModel(model);
+                }
 
-            for (FluentResourceCollection collection : fluentClient.getResourceCollections()) {
-                javaPackage.addFluentResourceCollection(collection);
+                for (FluentResourceCollection collection : fluentClient.getResourceCollections()) {
+                    javaPackage.addFluentResourceCollection(collection);
+                }
             }
 
             // Print to files

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
@@ -94,6 +94,8 @@ public class FluentGen extends NewPlugin {
             Client client = Mappers.getClientMapper().map(codeModel);
 
             FluentClient fluentClient = fluentMapper.map(codeModel, client);
+            
+            JavaSettings javaSettings = JavaSettings.getInstance();
 
             // Step 4: Write to templates
             logger.info("Java template for client model");
@@ -102,7 +104,7 @@ public class FluentGen extends NewPlugin {
             javaPackage
                     .addServiceClient(client.getServiceClient().getPackage(), client.getServiceClient().getClassName(),
                             client.getServiceClient());
-            if (JavaSettings.getInstance().shouldGenerateClientInterfaces()) {
+            if (javaSettings.shouldGenerateClientInterfaces()) {
                 javaPackage
                         .addServiceClientInterface(client.getServiceClient().getInterfaceName(), client.getServiceClient());
             }
@@ -113,12 +115,12 @@ public class FluentGen extends NewPlugin {
             javaPackage.addServiceClientBuilder(builderPackage,
                 client.getServiceClient().getInterfaceName() + builderSuffix, client.getServiceClient());
 
-            if (JavaSettings.getInstance().shouldGenerateSyncAsyncClients()) {
+            if (javaSettings.shouldGenerateSyncAsyncClients()) {
                 List<AsyncSyncClient> asyncClients = new ArrayList<>();
                 List<AsyncSyncClient> syncClients = new ArrayList<>();
                 ClientModelUtil.getAsyncSyncClients(client.getServiceClient(), asyncClients, syncClients);
 
-                if (!JavaSettings.getInstance().isFluentLite()) {
+                if (!javaSettings.isFluentLite()) {
                     // fluent lite only expose sync client
                     for (AsyncSyncClient asyncClient : asyncClients) {
                         javaPackage.addAsyncServiceClient(builderPackage, asyncClient);
@@ -133,7 +135,7 @@ public class FluentGen extends NewPlugin {
             // Method group
             for (MethodGroupClient methodGroupClient : client.getServiceClient().getMethodGroupClients()) {
                 javaPackage.addMethodGroup(methodGroupClient.getPackage(), methodGroupClient.getClassName(), methodGroupClient);
-                if (JavaSettings.getInstance().shouldGenerateClientInterfaces()) {
+                if (javaSettings.shouldGenerateClientInterfaces()) {
                     javaPackage.addMethodGroupInterface(methodGroupClient.getInterfaceName(), methodGroupClient);
                 }
             }
@@ -169,7 +171,7 @@ public class FluentGen extends NewPlugin {
                 javaPackage.addPackageInfo(packageInfo.getPackage(), "package-info", packageInfo);
             }
 
-            if (JavaSettings.getInstance().isFluentLite()) {
+            if (javaSettings.isFluentLite()) {
                 // Fluent manager
                 javaPackage.addFluentManager(fluentClient.getManager());
 

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
@@ -13,6 +13,7 @@ import com.azure.autorest.fluent.checker.JavaFormatter;
 import com.azure.autorest.fluent.mapper.FluentMapper;
 import com.azure.autorest.fluent.mapper.FluentMapperFactory;
 import com.azure.autorest.fluent.model.clientmodel.FluentClient;
+import com.azure.autorest.fluent.model.clientmodel.FluentResourceCollection;
 import com.azure.autorest.fluent.model.clientmodel.FluentResourceModel;
 import com.azure.autorest.fluent.model.javamodel.FluentJavaPackage;
 import com.azure.autorest.fluent.namer.FluentNamerFactory;
@@ -29,7 +30,6 @@ import com.azure.autorest.model.clientmodel.MethodGroupClient;
 import com.azure.autorest.model.clientmodel.PackageInfo;
 import com.azure.autorest.model.clientmodel.XmlSequenceWrapper;
 import com.azure.autorest.model.javamodel.JavaFile;
-import com.azure.autorest.model.javamodel.JavaPackage;
 import com.azure.autorest.template.Templates;
 import com.azure.autorest.util.ClientModelUtil;
 import com.azure.autorest.util.CodeNamer;
@@ -175,6 +175,10 @@ public class FluentGen extends NewPlugin {
             // Fluent resource model
             for (FluentResourceModel model : fluentClient.getResourceModels()) {
                 javaPackage.addFluentResourceModel(model);
+            }
+
+            for (FluentResourceCollection collection : fluentClient.getResourceCollections()) {
+                javaPackage.addFluentResourceCollection(collection);
             }
 
             // Print to files

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentMapper.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentMapper.java
@@ -32,6 +32,8 @@ public class FluentMapper {
 
     private static final Logger logger = LoggerFactory.getLogger(FluentMapper.class);
 
+    private static Client client;
+
     private final FluentJavaSettings fluentJavaSettings;
 
     public FluentMapper(FluentJavaSettings fluentJavaSettings) {
@@ -43,6 +45,8 @@ public class FluentMapper {
     }
 
     public FluentClient map(CodeModel codeModel, Client client) {
+        FluentMapper.client = client;
+
         FluentClient fluentClient = new FluentClient(client);
 
         fluentClient.setManager(new FluentManager(client, Utils.getJavaName(codeModel)));
@@ -58,6 +62,10 @@ public class FluentMapper {
                 .collect(Collectors.toList()));
 
         return fluentClient;
+    }
+
+    public static Client getClient() {
+        return client;
     }
 
     private void processInnerModel(CodeModel codeModel) {

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentMapper.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentMapper.java
@@ -52,6 +52,11 @@ public class FluentMapper {
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList()));
 
+        fluentClient.getResourceCollections().addAll(codeModel.getOperationGroups().stream()
+                .map(og -> FluentResourceCollectionMapper.getInstance().map(og))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList()));
+
         return fluentClient;
     }
 

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentResourceCollectionMapper.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentResourceCollectionMapper.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.azure.autorest.fluent.mapper;
+
+import com.azure.autorest.extension.base.model.codemodel.OperationGroup;
+import com.azure.autorest.fluent.model.clientmodel.FluentResourceCollection;
+import com.azure.autorest.mapper.IMapper;
+import com.azure.autorest.mapper.Mappers;
+import com.azure.autorest.model.clientmodel.MethodGroupClient;
+
+public class FluentResourceCollectionMapper implements IMapper<OperationGroup, FluentResourceCollection> {
+
+    private static final FluentResourceCollectionMapper INSTANCE = new FluentResourceCollectionMapper();
+
+    public static FluentResourceCollectionMapper getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public FluentResourceCollection map(OperationGroup operationGroup) {
+        FluentResourceCollection fluentResourceCollection = null;
+
+        MethodGroupClient groupClient = Mappers.getMethodGroupMapper().map(operationGroup);
+        if (groupClient != null) {
+            fluentResourceCollection = new FluentResourceCollection(groupClient);
+        }
+
+        return fluentResourceCollection;
+    }
+}

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentResourceModelMapper.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentResourceModelMapper.java
@@ -6,11 +6,17 @@
 package com.azure.autorest.fluent.mapper;
 
 import com.azure.autorest.extension.base.model.codemodel.ObjectSchema;
+import com.azure.autorest.fluent.model.arm.ResourceClientModel;
 import com.azure.autorest.fluent.model.clientmodel.FluentResourceModel;
 import com.azure.autorest.fluent.util.FluentUtils;
 import com.azure.autorest.mapper.IMapper;
 import com.azure.autorest.mapper.Mappers;
 import com.azure.autorest.model.clientmodel.ClientModel;
+import com.azure.core.util.CoreUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 public class FluentResourceModelMapper implements IMapper<ObjectSchema, FluentResourceModel> {
 
@@ -26,7 +32,31 @@ public class FluentResourceModelMapper implements IMapper<ObjectSchema, FluentRe
 
         ClientModel clientModel = Mappers.getModelMapper().map(objectSchema);
         if (clientModel != null && FluentUtils.isInnerClassType(clientModel.getPackage(), clientModel.getName())) {
-            fluentResourceModel = new FluentResourceModel(clientModel);
+            List<ClientModel> parentModels = new ArrayList<>();
+            String parentModelName = clientModel.getParentModelName();
+            while (!CoreUtils.isNullOrEmpty(parentModelName)) {
+                ClientModel parentModel = null;
+                for (ClientModel model : FluentMapper.getClient().getModels()) {
+                    if (parentModelName.equals(model.getName())) {
+                        parentModel = model;
+                        break;
+                    }
+                }
+
+                if (parentModel == null) {
+                    Optional<ClientModel> modelOpt = ResourceClientModel.getResourceClientModel(parentModelName);
+                    if (modelOpt.isPresent()) {
+                        parentModel = modelOpt.get();
+                    }
+                }
+
+                if (parentModel != null) {
+                    parentModels.add(parentModel);
+                }
+                parentModelName = parentModel == null ? null :parentModel.getParentModelName();
+            }
+
+            fluentResourceModel = new FluentResourceModel(clientModel, parentModels);
         }
 
         return fluentResourceModel;

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/arm/ResourceClientModel.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/arm/ResourceClientModel.java
@@ -5,12 +5,11 @@
 
 package com.azure.autorest.fluent.model.arm;
 
-import com.azure.autorest.fluent.model.ResourceType;
 import com.azure.autorest.fluent.model.ResourceTypeName;
 import com.azure.autorest.model.clientmodel.ClassType;
 import com.azure.autorest.model.clientmodel.ClientModel;
 import com.azure.autorest.model.clientmodel.ClientModelProperty;
-import com.azure.autorest.model.clientmodel.ListType;
+import com.azure.autorest.model.clientmodel.MapType;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -75,7 +74,7 @@ public class ResourceClientModel {
                             .description("Resource tags.")
                             .isRequired(false)
                             .isReadOnly(false)
-                            .clientType(new ListType(ClassType.String))
+                            .clientType(new MapType(ClassType.String))
                             .build()
             ))
             .build();

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/arm/ResourceClientModel.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/arm/ResourceClientModel.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.azure.autorest.fluent.model.arm;
+
+import com.azure.autorest.fluent.model.ResourceType;
+import com.azure.autorest.fluent.model.ResourceTypeName;
+import com.azure.autorest.model.clientmodel.ClassType;
+import com.azure.autorest.model.clientmodel.ClientModel;
+import com.azure.autorest.model.clientmodel.ClientModelProperty;
+import com.azure.autorest.model.clientmodel.ListType;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+
+public class ResourceClientModel {
+
+    private ResourceClientModel() {
+
+    }
+
+    private static final ClientModel MODEL_SUB_RESOURCE = new ClientModel.Builder()
+            .name(ResourceTypeName.SUB_RESOURCE)
+            .properties(Collections.singletonList(
+                    new ClientModelProperty.Builder()
+                            .name(ResourceTypeName.FIELD_ID)
+                            .description("Resource ID.")
+                            .clientType(ClassType.String)
+                            .build()
+            ))
+            .build();
+    private static final ClientModel MODEL_PROXY_RESOURCE = new ClientModel.Builder()
+            .name(ResourceTypeName.PROXY_RESOURCE)
+            .properties(Arrays.asList(
+                    new ClientModelProperty.Builder()
+                            .name(ResourceTypeName.FIELD_ID)
+                            .description("Resource ID.")
+                            .isRequired(true)
+                            .isReadOnly(true)
+                            .clientType(ClassType.String)
+                            .build(),
+                    new ClientModelProperty.Builder()
+                            .name(ResourceTypeName.FIELD_NAME)
+                            .description("Resource name.")
+                            .isRequired(true)
+                            .isReadOnly(true)
+                            .clientType(ClassType.String)
+                            .build(),
+                    new ClientModelProperty.Builder()
+                            .name(ResourceTypeName.FIELD_TYPE)
+                            .description("Resource type.")
+                            .isRequired(true)
+                            .isReadOnly(true)
+                            .clientType(ClassType.String)
+                            .build()
+            ))
+            .build();
+
+    private static final ClientModel MODEL_RESOURCE = new ClientModel.Builder()
+            .name(ResourceTypeName.RESOURCE)
+            .parentModelName(ResourceTypeName.PROXY_RESOURCE)
+            .properties(Arrays.asList(
+                    new ClientModelProperty.Builder()
+                            .name(ResourceTypeName.FIELD_LOCATION)
+                            .description("Resource location.")
+                            .isRequired(true)
+                            .isReadOnly(true)
+                            .clientType(ClassType.String)
+                            .build(),
+                    new ClientModelProperty.Builder()
+                            .name(ResourceTypeName.FIELD_TAGS)
+                            .description("Resource tags.")
+                            .isRequired(false)
+                            .isReadOnly(false)
+                            .clientType(new ListType(ClassType.String))
+                            .build()
+            ))
+            .build();
+
+    public static Optional<ClientModel> getResourceClientModel(String modelName) {
+        ClientModel model = null;
+
+        switch (modelName) {
+            case ResourceTypeName.RESOURCE:
+                model = MODEL_RESOURCE;
+                break;
+
+            case ResourceTypeName.PROXY_RESOURCE:
+                model = MODEL_PROXY_RESOURCE;
+                break;
+
+            case ResourceTypeName.SUB_RESOURCE:
+                model = MODEL_SUB_RESOURCE;
+                break;
+        }
+
+        return Optional.ofNullable(model);
+    }
+}

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentClient.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentClient.java
@@ -18,12 +18,18 @@ public class FluentClient {
 
     private final List<FluentResourceModel> resourceModels = new ArrayList<>();
 
+    private final List<FluentResourceCollection> resourceCollections = new ArrayList<>();
+
     public FluentClient(Client client) {
         this.client = client;
     }
 
     public List<FluentResourceModel> getResourceModels() {
         return resourceModels;
+    }
+
+    public List<FluentResourceCollection> getResourceCollections() {
+        return resourceCollections;
     }
 
     public FluentManager getManager() {

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentCollectionMethod.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentCollectionMethod.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.azure.autorest.fluent.model.clientmodel;
+
+import com.azure.autorest.extension.base.plugin.JavaSettings;
+import com.azure.autorest.fluent.util.FluentUtils;
+import com.azure.autorest.model.clientmodel.ClientMethod;
+import com.azure.autorest.model.clientmodel.IType;
+import com.azure.autorest.model.clientmodel.ProxyMethod;
+
+import java.util.Set;
+
+public class FluentCollectionMethod {
+
+    private final ClientMethod method;
+
+    private final IType fluentReturnType;
+
+    public FluentCollectionMethod(ClientMethod method) {
+        this.method = method;
+        this.fluentReturnType = FluentUtils.getFluentWrapperType(method.getReturnValue().getType());
+    }
+
+    public IType getFluentReturnType() {
+        return fluentReturnType;
+    }
+
+    public String getMethodSignature() {
+        return String.format("%1$s %2$s(%3$s)", this.getFluentReturnType(), method.getName(), method.getParametersDeclaration());
+    }
+
+    public String getDescription() {
+        return method.getDescription();
+    }
+
+    public ClientMethod getInnerClientMethod() {
+        return method;
+    }
+
+    public ProxyMethod getInnerProxyMethod() {
+        return method.getProxyMethod();
+    }
+
+    public void addImportsTo(Set<String> imports, boolean includeImplementationImports) {
+        this.getFluentReturnType().addImportsTo(imports, false);
+        method.addImportsTo(imports, includeImplementationImports, JavaSettings.getInstance());
+    }
+}

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentModelProperty.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentModelProperty.java
@@ -5,6 +5,7 @@
 
 package com.azure.autorest.fluent.model.clientmodel;
 
+import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.fluent.util.FluentUtils;
 import com.azure.autorest.model.clientmodel.ClassType;
 import com.azure.autorest.model.clientmodel.ClientModelProperty;
@@ -14,36 +15,46 @@ import com.azure.autorest.model.clientmodel.MapType;
 import com.azure.autorest.template.prototype.MethodTemplate;
 import com.azure.autorest.util.CodeNamer;
 
+import java.util.Set;
+
 public class FluentModelProperty {
 
-    private final ClientModelProperty clientModelProperty;
+    private final ClientModelProperty modelProperty;
 
-    private final IType clientType;
+    private final IType fluentType;
 
     private final WrapperPropertyImplementationMethod wrapperImplementationMethod;
 
     public FluentModelProperty(ClientModelProperty property) {
-        this.clientModelProperty = property;
-        this.clientType = getWrapperType(property.getClientType());
-        this.wrapperImplementationMethod = this.clientType == property.getClientType()
-                ? new WrapperPropertyImplementationMethod(this, this.clientModelProperty)
-                : new WrapperPropertyTypeConversionMethod(this, this.clientModelProperty);
+        this.modelProperty = property;
+        this.fluentType = getWrapperType(property.getClientType());
+        this.wrapperImplementationMethod = this.fluentType == property.getClientType()
+                ? new WrapperPropertyImplementationMethod(this, this.modelProperty)
+                : new WrapperPropertyTypeConversionMethod(this, this.modelProperty);
     }
 
     public String getName() {
-        return clientModelProperty.getName();
+        return modelProperty.getName();
     }
 
     public String getDescription() {
-        return clientModelProperty.getDescription();
+        return modelProperty.getDescription();
     }
 
-    public IType getClientType() {
-        return clientType;
+    public IType getFluentType() {
+        return fluentType;
     }
 
     public String getMethodSignature() {
-        return String.format("%1$s %2$s()", this.getClientType(), this.getGetterName());
+        return String.format("%1$s %2$s()", this.getFluentType(), this.getGetterName());
+    }
+
+    public void addImportsTo(Set<String> imports, boolean includeImplementationImports) {
+        this.fluentType.addImportsTo(imports, false);
+
+        if (includeImplementationImports) {
+            this.wrapperImplementationMethod.getMethodTemplate().addImportsTo(imports);
+        }
     }
 
     public MethodTemplate getImplementationMethodTemplate() {
@@ -51,7 +62,7 @@ public class FluentModelProperty {
     }
 
     private String getGetterName() {
-        return CodeNamer.getModelNamer().modelPropertyGetterName(clientModelProperty);
+        return CodeNamer.getModelNamer().modelPropertyGetterName(modelProperty);
     }
 
     private static IType getWrapperType(IType clientType) {

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentResourceCollection.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentResourceCollection.java
@@ -16,14 +16,20 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+// Fluent resource collection API. E.g. StorageAccounts.
 public class FluentResourceCollection {
 
+    // implementation client. E.g. StorageAccountsClientImpl.
     private final MethodGroupClient groupClient;
 
+    // class type for inner client. E.g. StorageAccountsClient (which is a layer over StorageAccountsClientImpl).
     private final ClassType innerClassType;
+
+    // class type for interface and implementation
     private final ClassType collectionInterfaceClassType;
     private final ClassType collectionImplementationClassType;
 
+    // API methods
     private final List<FluentCollectionMethod> methods = new ArrayList<>();;
 
     public FluentResourceCollection(MethodGroupClient groupClient) {
@@ -73,6 +79,7 @@ public class FluentResourceCollection {
         return innerClassType;
     }
 
+    // method signature for inner client
     public String getInnerMethodSignature() {
         return String.format("%1$s %2$s()", this.getInnerClassType().getName(), FluentUtils.getGetterName(ModelNaming.PROPERTY_INNER));
     }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentResourceCollection.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentResourceCollection.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.azure.autorest.fluent.model.clientmodel;
+
+import com.azure.autorest.extension.base.plugin.JavaSettings;
+import com.azure.autorest.fluent.util.FluentUtils;
+import com.azure.autorest.model.clientmodel.ClassType;
+import com.azure.autorest.model.clientmodel.ClientMethodType;
+import com.azure.autorest.model.clientmodel.MethodGroupClient;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class FluentResourceCollection {
+
+    private final MethodGroupClient groupClient;
+
+    private final ClassType innerClassType;
+    private final ClassType collectionInterfaceClassType;
+    private final ClassType collectionImplementationClassType;
+
+    private final List<FluentCollectionMethod> methods = new ArrayList<>();;
+
+    public FluentResourceCollection(MethodGroupClient groupClient) {
+        JavaSettings settings = JavaSettings.getInstance();
+
+        this.groupClient = groupClient;
+
+        this.collectionInterfaceClassType = new ClassType.Builder()
+                .packageName(settings.getPackage(settings.getModelsSubpackage()))
+                .name(groupClient.getInterfaceName())
+                .build();
+        this.collectionImplementationClassType = new ClassType.Builder()
+                .packageName(settings.getPackage(settings.getImplementationSubpackage()))
+                .name(groupClient.getInterfaceName() + "Impl")
+                .build();
+
+        this.innerClassType = new ClassType.Builder()
+                .packageName(settings.getPackage())
+                .name(groupClient.getClassBaseName() + "Client")
+                .build();
+
+        this.methods.addAll(this.groupClient.getClientMethods().stream()
+                .filter(m -> m.getType() == ClientMethodType.SimpleSync
+                        || m.getType() == ClientMethodType.PagingSync
+                        || m.getType() == ClientMethodType.LongRunningSync)
+                .map(FluentCollectionMethod::new)
+                .collect(Collectors.toList()));
+    }
+
+    public ClassType getCollectionInterfaceClassType() {
+        return collectionInterfaceClassType;
+    }
+
+    public ClassType getCollectionImplementationClassType() {
+        return collectionImplementationClassType;
+    }
+
+    public List<FluentCollectionMethod> getMethods() {
+        return methods;
+    }
+
+    public String getDescription() {
+        return String.format("Resource collection API of %s.", collectionInterfaceClassType.getName());
+    }
+
+    public ClassType getInnerClassType() {
+        return innerClassType;
+    }
+
+    public String getInnerMethodSignature() {
+        return String.format("%1$s %2$s()", this.getInnerClassType().getName(), FluentUtils.getGetterName(ModelNaming.PROPERTY_INNER));
+    }
+
+    public void addImportsTo(Set<String> imports, boolean includeImplementationImports) {
+        innerClassType.addImportsTo(imports, false);
+
+        this.getMethods().forEach(m -> m.addImportsTo(imports, includeImplementationImports));
+
+        if (includeImplementationImports) {
+            collectionInterfaceClassType.addImportsTo(imports, false);
+        }
+    }
+}

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentResourceModel.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentResourceModel.java
@@ -11,10 +11,8 @@ import com.azure.autorest.model.clientmodel.ClassType;
 import com.azure.autorest.model.clientmodel.ClientModel;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 // Fluent resource instance. E.g. StorageAccount.

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentResourceModel.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentResourceModel.java
@@ -12,6 +12,8 @@ import com.azure.autorest.model.clientmodel.ClientModel;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class FluentResourceModel {
 
@@ -35,9 +37,9 @@ public class FluentResourceModel {
                 .name(resourceInterfaceClassType.getName() + ModelNaming.MODEL_IMPL_SUFFIX)
                 .build();
 
-        this.model.getProperties().forEach(p -> {
-            properties.add(new FluentModelProperty(p));
-        });
+        properties.addAll(this.model.getProperties().stream()
+                .map(FluentModelProperty::new)
+                .collect(Collectors.toList()));
     }
 
 //    public ModelType getModelType() {
@@ -66,5 +68,15 @@ public class FluentResourceModel {
 
     public String getInnerMethodSignature() {
         return String.format("%1$s %2$s()", this.getInnerModel().getName(), FluentUtils.getGetterName(ModelNaming.PROPERTY_INNER));
+    }
+
+    public void addImportsTo(Set<String> imports, boolean includeImplementationImports) {
+        imports.add(this.getInnerModel().getFullName());
+
+        this.getProperties().forEach(p -> p.addImportsTo(imports, includeImplementationImports));
+
+        if (includeImplementationImports) {
+            resourceInterfaceClassType.addImportsTo(imports, false);
+        }
     }
 }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentResourceModel.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentResourceModel.java
@@ -11,25 +11,35 @@ import com.azure.autorest.model.clientmodel.ClassType;
 import com.azure.autorest.model.clientmodel.ClientModel;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
+// Fluent resource instance. E.g. StorageAccount.
+// Also include some simple wrapper class.
 public class FluentResourceModel {
 
+    // inner model. E.g. StorageAccountInner.
     private final ClientModel model;
+    // all parent models of the inner model (property of which need to be put to resource class as well)
+    private final List<ClientModel> parentModels;
 
     private final ModelType modelType = ModelType.WRAPPER;
 
+    // class type for interface and implementation
     private final ClassType resourceInterfaceClassType;
     private final ClassType resourceImplementationClassType;
 
+    // resource properties
     private final List<FluentModelProperty> properties = new ArrayList<>();
 
-    public FluentResourceModel(ClientModel model) {
+    public FluentResourceModel(ClientModel model, List<ClientModel> parentModels) {
         JavaSettings settings = JavaSettings.getInstance();
 
         this.model = model;
+        this.parentModels = parentModels;
 
         resourceInterfaceClassType = FluentUtils.resourceModelInterfaceClassType(model.getName());
         resourceImplementationClassType = new ClassType.Builder()
@@ -40,6 +50,17 @@ public class FluentResourceModel {
         properties.addAll(this.model.getProperties().stream()
                 .map(FluentModelProperty::new)
                 .collect(Collectors.toList()));
+
+        Set<String> propertyNames = properties.stream().map(FluentModelProperty::getName).collect(Collectors.toSet());
+        for (ClientModel parent : parentModels) {
+            List<FluentModelProperty> parentProperties = parent.getProperties().stream()
+                    .filter(p -> !propertyNames.contains(p.getName()))
+                    .map(FluentModelProperty::new)
+                    .collect(Collectors.toList());
+            properties.addAll(parentProperties);
+
+            propertyNames.addAll(parentProperties.stream().map(FluentModelProperty::getName).collect(Collectors.toSet()));
+        }
     }
 
 //    public ModelType getModelType() {
@@ -66,6 +87,7 @@ public class FluentResourceModel {
         return String.format("An immutable client-side representation of %s.", resourceInterfaceClassType.getName());
     }
 
+    // method signature for inner model
     public String getInnerMethodSignature() {
         return String.format("%1$s %2$s()", this.getInnerModel().getName(), FluentUtils.getGetterName(ModelNaming.PROPERTY_INNER));
     }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/WrapperPropertyImplementationMethod.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/WrapperPropertyImplementationMethod.java
@@ -14,6 +14,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+// Implementation method template for simple property
+// E.g. "return this.inner().sku()"
 public class WrapperPropertyImplementationMethod {
 
     protected MethodTemplate conversionMethodTemplate;

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/WrapperPropertyImplementationMethod.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/WrapperPropertyImplementationMethod.java
@@ -24,7 +24,7 @@ public class WrapperPropertyImplementationMethod {
 
     public WrapperPropertyImplementationMethod(FluentModelProperty fluentProperty, ClientModelProperty property) {
         Set<String> imports = new HashSet<>();
-        fluentProperty.getClientType().addImportsTo(imports, false);
+        fluentProperty.getFluentType().addImportsTo(imports, false);
         if (property.getClientType() instanceof ListType || property.getClientType() instanceof MapType) {
             // Type inner = ...
             property.getClientType().addImportsTo(imports, false);

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/WrapperPropertyTypeConversionMethod.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/WrapperPropertyTypeConversionMethod.java
@@ -18,6 +18,14 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+// Implementation method template for property requires conversion.
+// E.g.
+//    BlobRestoreStatusInner inner = this.inner().blobRestoreStatus();
+//    if (inner != null) {
+//        return new BlobRestoreStatusImpl(inner);
+//    } else {
+//        return null;
+//    }
 public class WrapperPropertyTypeConversionMethod extends WrapperPropertyImplementationMethod {
 
     public WrapperPropertyTypeConversionMethod(FluentModelProperty fluentProperty, ClientModelProperty property) {

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/WrapperPropertyTypeConversionMethod.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/WrapperPropertyTypeConversionMethod.java
@@ -22,7 +22,7 @@ public class WrapperPropertyTypeConversionMethod extends WrapperPropertyImplemen
 
     public WrapperPropertyTypeConversionMethod(FluentModelProperty fluentProperty, ClientModelProperty property) {
         Set<String> imports = new HashSet<>();
-        fluentProperty.getClientType().addImportsTo(imports, false);
+        fluentProperty.getFluentType().addImportsTo(imports, false);
         // Type inner = ...
         property.getClientType().addImportsTo(imports, false);
         // Collectors.toList

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/javamodel/FluentJavaPackage.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/javamodel/FluentJavaPackage.java
@@ -6,8 +6,11 @@
 package com.azure.autorest.fluent.model.javamodel;
 
 import com.azure.autorest.fluent.model.clientmodel.FluentManager;
+import com.azure.autorest.fluent.model.clientmodel.FluentResourceCollection;
 import com.azure.autorest.fluent.model.clientmodel.FluentResourceModel;
 import com.azure.autorest.fluent.template.FluentManagerTemplate;
+import com.azure.autorest.fluent.template.FluentResourceCollectionImplementationTemplate;
+import com.azure.autorest.fluent.template.FluentResourceCollectionInterfaceTemplate;
 import com.azure.autorest.fluent.template.FluentResourceModelImplementationTemplate;
 import com.azure.autorest.fluent.template.FluentResourceModelInterfaceTemplate;
 import com.azure.autorest.model.javamodel.JavaFile;
@@ -27,6 +30,20 @@ public class FluentJavaPackage extends JavaPackage {
                 model.getResourceImplementationClassType().getName());
         FluentResourceModelImplementationTemplate.getInstance().write(model, javaFile);
         getJavaFiles().add(javaFile);
+    }
+
+    public final void addFluentResourceCollection(FluentResourceCollection collection) {
+        JavaFile javaFile = getJavaFileFactory().createSourceFile(
+                collection.getCollectionInterfaceClassType().getPackage(),
+                collection.getCollectionInterfaceClassType().getName());
+        FluentResourceCollectionInterfaceTemplate.getInstance().write(collection, javaFile);
+        getJavaFiles().add(javaFile);
+
+//        javaFile = getJavaFileFactory().createSourceFile(
+//                collection.getCollectionImplementationClassType().getPackage(),
+//                collection.getCollectionImplementationClassType().getName());
+//        FluentResourceCollectionImplementationTemplate.getInstance().write(collection, javaFile);
+//        getJavaFiles().add(javaFile);
     }
 
     public final void addFluentManager(FluentManager model) {

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentResourceCollectionImplementationTemplate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentResourceCollectionImplementationTemplate.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.azure.autorest.fluent.template;
+
+import com.azure.autorest.fluent.model.clientmodel.FluentResourceCollection;
+import com.azure.autorest.model.javamodel.JavaFile;
+import com.azure.autorest.template.IJavaTemplate;
+
+public class FluentResourceCollectionImplementationTemplate implements IJavaTemplate<FluentResourceCollection, JavaFile> {
+
+    private static final FluentResourceCollectionImplementationTemplate INSTANCE = new FluentResourceCollectionImplementationTemplate();
+
+    public static FluentResourceCollectionImplementationTemplate getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public void write(FluentResourceCollection collection, JavaFile javaFile) {
+
+    }
+}

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentResourceCollectionInterfaceTemplate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentResourceCollectionInterfaceTemplate.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.azure.autorest.fluent.template;
+
+import com.azure.autorest.fluent.model.clientmodel.FluentResourceCollection;
+import com.azure.autorest.model.javamodel.JavaFile;
+import com.azure.autorest.template.ClientMethodTemplate;
+import com.azure.autorest.template.IJavaTemplate;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class FluentResourceCollectionInterfaceTemplate implements IJavaTemplate<FluentResourceCollection, JavaFile> {
+
+    private static final FluentResourceCollectionInterfaceTemplate INSTANCE = new FluentResourceCollectionInterfaceTemplate();
+
+    public static FluentResourceCollectionInterfaceTemplate getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public void write(FluentResourceCollection collection, JavaFile javaFile) {
+        Set<String> imports = new HashSet<>();
+        collection.addImportsTo(imports, false);
+        javaFile.declareImport(imports);
+
+        javaFile.javadocComment(comment -> {
+            comment.description(collection.getDescription());
+        });
+
+        javaFile.publicInterface(collection.getCollectionInterfaceClassType().getName(), interfaceBlock -> {
+            // methods
+            collection.getMethods().forEach(method -> {
+                ClientMethodTemplate.generateJavadoc(method.getInnerClientMethod(), interfaceBlock, method.getInnerProxyMethod(), true);
+
+                interfaceBlock.publicMethod(method.getMethodSignature());
+            });
+
+            // method for inner client
+            interfaceBlock.javadocComment(comment -> {
+                comment.description(String.format("Gets the inner %s client", collection.getInnerClassType().getFullName()));
+                comment.methodReturns("the inner client");
+            });
+            interfaceBlock.publicMethod(collection.getInnerMethodSignature());
+        });
+    }
+}

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentResourceModelImplementationTemplate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentResourceModelImplementationTemplate.java
@@ -25,14 +25,11 @@ public class FluentResourceModelImplementationTemplate implements IJavaTemplate<
 
     @Override
     public void write(FluentResourceModel model, JavaFile javaFile) {
-
         List<MethodTemplate> methodTemplates = new ArrayList<>();
         model.getProperties().forEach(p -> methodTemplates.add(p.getImplementationMethodTemplate()));
 
         Set<String> imports = new HashSet<>();
-        model.getResourceInterfaceClassType().addImportsTo(imports, false);
-        imports.add(model.getInnerModel().getFullName());
-        methodTemplates.forEach(m -> m.addImportsTo(imports));
+        model.addImportsTo(imports, true);
         javaFile.declareImport(imports);
 
         javaFile.publicFinalClass(String.format("%1$s implements %2$s", model.getResourceImplementationClassType().getName(), model.getResourceInterfaceClassType().getName()), classBlock -> {

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentResourceModelInterfaceTemplate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentResourceModelInterfaceTemplate.java
@@ -25,12 +25,10 @@ public class FluentResourceModelInterfaceTemplate implements IJavaTemplate<Fluen
     public void write(FluentResourceModel model, JavaFile javaFile) {
         Set<String> imports = new HashSet<>();
         imports.add(Immutable.class.getName());
-        imports.add(model.getInnerModel().getFullName());
-        model.getProperties().forEach(p -> p.getClientType().addImportsTo(imports, false));
+        model.addImportsTo(imports, false);
         javaFile.declareImport(imports);
 
-        javaFile.javadocComment(comment ->
-        {
+        javaFile.javadocComment(comment -> {
             comment.description(model.getDescription());
         });
 
@@ -39,7 +37,7 @@ public class FluentResourceModelInterfaceTemplate implements IJavaTemplate<Fluen
             // method for properties
             model.getProperties().forEach(property -> {
                 interfaceBlock.javadocComment(comment -> {
-                    comment.description(String.format("Get the %1$s property: %2$s", property.getName(), property.getDescription()));
+                    comment.description(String.format("Gets the %1$s property: %2$s", property.getName(), property.getDescription()));
                     comment.methodReturns(String.format("the %1$s value", property.getName()));
                 });
                 interfaceBlock.publicMethod(property.getMethodSignature());
@@ -47,11 +45,10 @@ public class FluentResourceModelInterfaceTemplate implements IJavaTemplate<Fluen
 
             // method for inner model
             interfaceBlock.javadocComment(comment -> {
-                comment.description(String.format("Get the inner %s object", model.getInnerModel().getFullName()));
+                comment.description(String.format("Gets the inner %s object", model.getInnerModel().getFullName()));
                 comment.methodReturns("the inner object");
             });
             interfaceBlock.publicMethod(model.getInnerMethodSignature());
         });
     }
-
 }

--- a/javagen/src/main/java/com/azure/autorest/mapper/MethodGroupMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/MethodGroupMapper.java
@@ -45,7 +45,7 @@ public class MethodGroupMapper implements IMapper<OperationGroup, MethodGroupCli
         builder.interfaceName(interfaceName);
         String className = interfaceName;
         if (settings.isFluent()) {
-            if (settings.shouldGenerateSyncAsyncClients()) {
+            if (settings.shouldGenerateClientAsImpl()) {
                 className += "ClientImpl";
             } else {
                 className += "Client";

--- a/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
@@ -278,7 +278,7 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
         //MethodPageDetails pageDetails = clientMethod.getMethodPageDetails();
 
         //boolean isFluentDelete = settings.isFluent() && restAPIMethod.getName().equalsIgnoreCase("Delete") && clientMethod.getMethodRequiredParameters().size() == 2;
-        generateJavadoc(clientMethod, typeBlock, restAPIMethod);
+        generateJavadoc(clientMethod, typeBlock, restAPIMethod, false);
 
         switch (clientMethod.getType()) {
             case PagingSync:
@@ -453,7 +453,15 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
         }
     }
 
-    protected void generateJavadoc(ClientMethod clientMethod, JavaType typeBlock, ProxyMethod restAPIMethod) {
+    /**
+     * Generate javadoc for client method.
+     *
+     * @param clientMethod client method
+     * @param typeBlock code block
+     * @param restAPIMethod proxy method
+     * @param useFullName whether to use fully-qualified name in javadoc
+     */
+    public static void generateJavadoc(ClientMethod clientMethod, JavaType typeBlock, ProxyMethod restAPIMethod, boolean useFullName) {
         typeBlock.javadocComment(comment -> {
             comment.description(clientMethod.getDescription());
             List<ClientMethodParameter> methodParameters = clientMethod.getOnlyRequiredParameters()
@@ -466,7 +474,10 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
                 comment.methodThrows("IllegalArgumentException", "thrown if parameters fail the validation");
             }
             if (restAPIMethod.getUnexpectedResponseExceptionType() != null) {
-                comment.methodThrows(restAPIMethod.getUnexpectedResponseExceptionType().toString(), "thrown if the request is rejected by server");
+                comment.methodThrows(useFullName
+                        ? restAPIMethod.getUnexpectedResponseExceptionType().getFullName()
+                        : restAPIMethod.getUnexpectedResponseExceptionType().getName(),
+                        "thrown if the request is rejected by server");
             }
             if (restAPIMethod.getUnexpectedResponseExceptionTypes() != null) {
                 for (Map.Entry<ClassType, List<HttpResponseStatus>> exception : restAPIMethod.getUnexpectedResponseExceptionTypes().entrySet()) {
@@ -480,7 +491,7 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
         });
     }
 
-    protected String parameterDescriptionOrDefault(ClientMethodParameter parameter) {
+    protected static String parameterDescriptionOrDefault(ClientMethodParameter parameter) {
         String paramJavadoc = parameter.getDescription();
         if (CoreUtils.isNullOrEmpty(paramJavadoc)) {
             paramJavadoc = String.format("The %1$s parameter", parameter.getName());


### PR DESCRIPTION
Sample interface (create/update pending to be put to fluent API).

```
// Copyright (c) Microsoft Corporation. All rights reserved.
// Licensed under the MIT License. See License.txt in the project root for
// license information.
//
// Code generated by Microsoft (R) AutoRest Code Generator.

package com.azure.mgmtlitetest.storage.models;

import com.azure.core.http.rest.PagedIterable;
import com.azure.core.util.Context;
import com.azure.mgmtlitetest.storage.StorageAccountsClient;
import com.azure.mgmtlitetest.storage.models.inner.StorageAccountInner;

/** Resource collection API of StorageAccounts. */
public interface StorageAccounts {
    /**
     * Checks that the storage account name is valid and is not already in use.
     *
     * @param name The storage account name.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     * @return the CheckNameAvailability operation response.
     */
    CheckNameAvailabilityResult checkNameAvailability(String name);

    /**
     * Checks that the storage account name is valid and is not already in use.
     *
     * @param name The storage account name.
     * @param context The context to associate with this operation.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     * @return the CheckNameAvailability operation response.
     */
    CheckNameAvailabilityResult checkNameAvailability(String name, Context context);

    /**
     * Asynchronously creates a new storage account with the specified parameters. If an account is already created and
     * a subsequent create request is issued with different properties, the account properties will be updated. If an
     * account is already created and a subsequent create or update request is issued with the exact same set of
     * properties, the request will succeed.
     *
     * @param resourceGroupName The name of the resource group within the user's subscription. The name is case
     *     insensitive.
     * @param accountName The name of the storage account within the specified resource group. Storage account names
     *     must be between 3 and 24 characters in length and use numbers and lower-case letters only.
     * @param parameters The parameters used when creating a storage account.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     * @return the storage account.
     */
    StorageAccount create(String resourceGroupName, String accountName, StorageAccountCreateParameters parameters);

    /**
     * Asynchronously creates a new storage account with the specified parameters. If an account is already created and
     * a subsequent create request is issued with different properties, the account properties will be updated. If an
     * account is already created and a subsequent create or update request is issued with the exact same set of
     * properties, the request will succeed.
     *
     * @param resourceGroupName The name of the resource group within the user's subscription. The name is case
     *     insensitive.
     * @param accountName The name of the storage account within the specified resource group. Storage account names
     *     must be between 3 and 24 characters in length and use numbers and lower-case letters only.
     * @param parameters The parameters used when creating a storage account.
     * @param context The context to associate with this operation.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     * @return the storage account.
     */
    StorageAccount create(
        String resourceGroupName, String accountName, StorageAccountCreateParameters parameters, Context context);

    /**
     * Deletes a storage account in Microsoft Azure.
     *
     * @param resourceGroupName The name of the resource group within the user's subscription. The name is case
     *     insensitive.
     * @param accountName The name of the storage account within the specified resource group. Storage account names
     *     must be between 3 and 24 characters in length and use numbers and lower-case letters only.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     */
    void delete(String resourceGroupName, String accountName);

    /**
     * Deletes a storage account in Microsoft Azure.
     *
     * @param resourceGroupName The name of the resource group within the user's subscription. The name is case
     *     insensitive.
     * @param accountName The name of the storage account within the specified resource group. Storage account names
     *     must be between 3 and 24 characters in length and use numbers and lower-case letters only.
     * @param context The context to associate with this operation.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     */
    void delete(String resourceGroupName, String accountName, Context context);

    /**
     * Returns the properties for the specified storage account including but not limited to name, SKU name, location,
     * and account status. The ListKeys operation should be used to retrieve storage keys.
     *
     * @param resourceGroupName The name of the resource group within the user's subscription. The name is case
     *     insensitive.
     * @param accountName The name of the storage account within the specified resource group. Storage account names
     *     must be between 3 and 24 characters in length and use numbers and lower-case letters only.
     * @param expand May be used to expand the properties within account's properties. By default, data is not included
     *     when fetching properties. Currently we only support geoReplicationStats and blobRestoreStatus.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     * @return the storage account.
     */
    StorageAccount getByResourceGroup(String resourceGroupName, String accountName, StorageAccountExpand expand);

    /**
     * Returns the properties for the specified storage account including but not limited to name, SKU name, location,
     * and account status. The ListKeys operation should be used to retrieve storage keys.
     *
     * @param resourceGroupName The name of the resource group within the user's subscription. The name is case
     *     insensitive.
     * @param accountName The name of the storage account within the specified resource group. Storage account names
     *     must be between 3 and 24 characters in length and use numbers and lower-case letters only.
     * @param expand May be used to expand the properties within account's properties. By default, data is not included
     *     when fetching properties. Currently we only support geoReplicationStats and blobRestoreStatus.
     * @param context The context to associate with this operation.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     * @return the storage account.
     */
    StorageAccount getByResourceGroup(
        String resourceGroupName, String accountName, StorageAccountExpand expand, Context context);

    /**
     * Returns the properties for the specified storage account including but not limited to name, SKU name, location,
     * and account status. The ListKeys operation should be used to retrieve storage keys.
     *
     * @param resourceGroupName The name of the resource group within the user's subscription. The name is case
     *     insensitive.
     * @param accountName The name of the storage account within the specified resource group. Storage account names
     *     must be between 3 and 24 characters in length and use numbers and lower-case letters only.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     * @return the storage account.
     */
    StorageAccount getByResourceGroup(String resourceGroupName, String accountName);

    /**
     * The update operation can be used to update the SKU, encryption, access tier, or tags for a storage account. It
     * can also be used to map the account to a custom domain. Only one custom domain is supported per storage account;
     * the replacement/change of custom domain is not supported. In order to replace an old custom domain, the old value
     * must be cleared/unregistered before a new value can be set. The update of multiple properties is supported. This
     * call does not change the storage keys for the account. If you want to change the storage account keys, use the
     * regenerate keys operation. The location and name of the storage account cannot be changed after creation.
     *
     * @param resourceGroupName The name of the resource group within the user's subscription. The name is case
     *     insensitive.
     * @param accountName The name of the storage account within the specified resource group. Storage account names
     *     must be between 3 and 24 characters in length and use numbers and lower-case letters only.
     * @param parameters The parameters that can be provided when updating the storage account properties.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     * @return the storage account.
     */
    StorageAccount update(String resourceGroupName, String accountName, StorageAccountUpdateParameters parameters);

    /**
     * The update operation can be used to update the SKU, encryption, access tier, or tags for a storage account. It
     * can also be used to map the account to a custom domain. Only one custom domain is supported per storage account;
     * the replacement/change of custom domain is not supported. In order to replace an old custom domain, the old value
     * must be cleared/unregistered before a new value can be set. The update of multiple properties is supported. This
     * call does not change the storage keys for the account. If you want to change the storage account keys, use the
     * regenerate keys operation. The location and name of the storage account cannot be changed after creation.
     *
     * @param resourceGroupName The name of the resource group within the user's subscription. The name is case
     *     insensitive.
     * @param accountName The name of the storage account within the specified resource group. Storage account names
     *     must be between 3 and 24 characters in length and use numbers and lower-case letters only.
     * @param parameters The parameters that can be provided when updating the storage account properties.
     * @param context The context to associate with this operation.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     * @return the storage account.
     */
    StorageAccount update(
        String resourceGroupName, String accountName, StorageAccountUpdateParameters parameters, Context context);

    /**
     * Lists all the storage accounts available under the subscription. Note that storage keys are not returned; use the
     * ListKeys operation for this.
     *
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     * @return the response from the List Storage Accounts operation.
     */
    PagedIterable<StorageAccountInner> list();

    /**
     * Lists all the storage accounts available under the subscription. Note that storage keys are not returned; use the
     * ListKeys operation for this.
     *
     * @param context The context to associate with this operation.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     * @return the response from the List Storage Accounts operation.
     */
    PagedIterable<StorageAccountInner> list(Context context);

    /**
     * Lists all the storage accounts available under the given resource group. Note that storage keys are not returned;
     * use the ListKeys operation for this.
     *
     * @param resourceGroupName The name of the resource group within the user's subscription. The name is case
     *     insensitive.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     * @return the response from the List Storage Accounts operation.
     */
    PagedIterable<StorageAccountInner> listByResourceGroup(String resourceGroupName);

    /**
     * Lists all the storage accounts available under the given resource group. Note that storage keys are not returned;
     * use the ListKeys operation for this.
     *
     * @param resourceGroupName The name of the resource group within the user's subscription. The name is case
     *     insensitive.
     * @param context The context to associate with this operation.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     * @return the response from the List Storage Accounts operation.
     */
    PagedIterable<StorageAccountInner> listByResourceGroup(String resourceGroupName, Context context);

    /**
     * Lists the access keys or Kerberos keys (if active directory enabled) for the specified storage account.
     *
     * @param resourceGroupName The name of the resource group within the user's subscription. The name is case
     *     insensitive.
     * @param accountName The name of the storage account within the specified resource group. Storage account names
     *     must be between 3 and 24 characters in length and use numbers and lower-case letters only.
     * @param expand Specifies type of the key to be listed. Possible value is kerb.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     * @return the response from the ListKeys operation.
     */
    StorageAccountListKeysResult listKeys(String resourceGroupName, String accountName, ListKeyExpand expand);

    /**
     * Lists the access keys or Kerberos keys (if active directory enabled) for the specified storage account.
     *
     * @param resourceGroupName The name of the resource group within the user's subscription. The name is case
     *     insensitive.
     * @param accountName The name of the storage account within the specified resource group. Storage account names
     *     must be between 3 and 24 characters in length and use numbers and lower-case letters only.
     * @param expand Specifies type of the key to be listed. Possible value is kerb.
     * @param context The context to associate with this operation.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     * @return the response from the ListKeys operation.
     */
    StorageAccountListKeysResult listKeys(
        String resourceGroupName, String accountName, ListKeyExpand expand, Context context);

    /**
     * Lists the access keys or Kerberos keys (if active directory enabled) for the specified storage account.
     *
     * @param resourceGroupName The name of the resource group within the user's subscription. The name is case
     *     insensitive.
     * @param accountName The name of the storage account within the specified resource group. Storage account names
     *     must be between 3 and 24 characters in length and use numbers and lower-case letters only.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     * @return the response from the ListKeys operation.
     */
    StorageAccountListKeysResult listKeys(String resourceGroupName, String accountName);

    /**
     * Regenerates one of the access keys or Kerberos keys for the specified storage account.
     *
     * @param resourceGroupName The name of the resource group within the user's subscription. The name is case
     *     insensitive.
     * @param accountName The name of the storage account within the specified resource group. Storage account names
     *     must be between 3 and 24 characters in length and use numbers and lower-case letters only.
     * @param keyName The name of storage keys that want to be regenerated, possible values are key1, key2, kerb1,
     *     kerb2.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     * @return the response from the ListKeys operation.
     */
    StorageAccountListKeysResult regenerateKey(String resourceGroupName, String accountName, String keyName);

    /**
     * Regenerates one of the access keys or Kerberos keys for the specified storage account.
     *
     * @param resourceGroupName The name of the resource group within the user's subscription. The name is case
     *     insensitive.
     * @param accountName The name of the storage account within the specified resource group. Storage account names
     *     must be between 3 and 24 characters in length and use numbers and lower-case letters only.
     * @param keyName The name of storage keys that want to be regenerated, possible values are key1, key2, kerb1,
     *     kerb2.
     * @param context The context to associate with this operation.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     * @return the response from the ListKeys operation.
     */
    StorageAccountListKeysResult regenerateKey(
        String resourceGroupName, String accountName, String keyName, Context context);

    /**
     * List SAS credentials of a storage account.
     *
     * @param resourceGroupName The name of the resource group within the user's subscription. The name is case
     *     insensitive.
     * @param accountName The name of the storage account within the specified resource group. Storage account names
     *     must be between 3 and 24 characters in length and use numbers and lower-case letters only.
     * @param parameters The parameters to list SAS credentials of a storage account.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     * @return the List SAS credentials operation response.
     */
    ListAccountSasResponse listAccountSas(
        String resourceGroupName, String accountName, AccountSasParameters parameters);

    /**
     * List SAS credentials of a storage account.
     *
     * @param resourceGroupName The name of the resource group within the user's subscription. The name is case
     *     insensitive.
     * @param accountName The name of the storage account within the specified resource group. Storage account names
     *     must be between 3 and 24 characters in length and use numbers and lower-case letters only.
     * @param parameters The parameters to list SAS credentials of a storage account.
     * @param context The context to associate with this operation.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     * @return the List SAS credentials operation response.
     */
    ListAccountSasResponse listAccountSas(
        String resourceGroupName, String accountName, AccountSasParameters parameters, Context context);

    /**
     * List service SAS credentials of a specific resource.
     *
     * @param resourceGroupName The name of the resource group within the user's subscription. The name is case
     *     insensitive.
     * @param accountName The name of the storage account within the specified resource group. Storage account names
     *     must be between 3 and 24 characters in length and use numbers and lower-case letters only.
     * @param parameters The parameters to list service SAS credentials of a specific resource.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     * @return the List service SAS credentials operation response.
     */
    ListServiceSasResponse listServiceSas(
        String resourceGroupName, String accountName, ServiceSasParameters parameters);

    /**
     * List service SAS credentials of a specific resource.
     *
     * @param resourceGroupName The name of the resource group within the user's subscription. The name is case
     *     insensitive.
     * @param accountName The name of the storage account within the specified resource group. Storage account names
     *     must be between 3 and 24 characters in length and use numbers and lower-case letters only.
     * @param parameters The parameters to list service SAS credentials of a specific resource.
     * @param context The context to associate with this operation.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     * @return the List service SAS credentials operation response.
     */
    ListServiceSasResponse listServiceSas(
        String resourceGroupName, String accountName, ServiceSasParameters parameters, Context context);

    /**
     * Failover request can be triggered for a storage account in case of availability issues. The failover occurs from
     * the storage account's primary cluster to secondary cluster for RA-GRS accounts. The secondary cluster will become
     * primary after failover.
     *
     * @param resourceGroupName The name of the resource group within the user's subscription. The name is case
     *     insensitive.
     * @param accountName The name of the storage account within the specified resource group. Storage account names
     *     must be between 3 and 24 characters in length and use numbers and lower-case letters only.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     */
    void failover(String resourceGroupName, String accountName);

    /**
     * Failover request can be triggered for a storage account in case of availability issues. The failover occurs from
     * the storage account's primary cluster to secondary cluster for RA-GRS accounts. The secondary cluster will become
     * primary after failover.
     *
     * @param resourceGroupName The name of the resource group within the user's subscription. The name is case
     *     insensitive.
     * @param accountName The name of the storage account within the specified resource group. Storage account names
     *     must be between 3 and 24 characters in length and use numbers and lower-case letters only.
     * @param context The context to associate with this operation.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     */
    void failover(String resourceGroupName, String accountName, Context context);

    /**
     * Restore blobs in the specified blob ranges.
     *
     * @param resourceGroupName The name of the resource group within the user's subscription. The name is case
     *     insensitive.
     * @param accountName The name of the storage account within the specified resource group. Storage account names
     *     must be between 3 and 24 characters in length and use numbers and lower-case letters only.
     * @param parameters Blob restore parameters.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     * @return blob restore status.
     */
    BlobRestoreStatus restoreBlobRanges(String resourceGroupName, String accountName, BlobRestoreParameters parameters);

    /**
     * Restore blobs in the specified blob ranges.
     *
     * @param resourceGroupName The name of the resource group within the user's subscription. The name is case
     *     insensitive.
     * @param accountName The name of the storage account within the specified resource group. Storage account names
     *     must be between 3 and 24 characters in length and use numbers and lower-case letters only.
     * @param parameters Blob restore parameters.
     * @param context The context to associate with this operation.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     * @return blob restore status.
     */
    BlobRestoreStatus restoreBlobRanges(
        String resourceGroupName, String accountName, BlobRestoreParameters parameters, Context context);

    /**
     * Revoke user delegation keys.
     *
     * @param resourceGroupName The name of the resource group within the user's subscription. The name is case
     *     insensitive.
     * @param accountName The name of the storage account within the specified resource group. Storage account names
     *     must be between 3 and 24 characters in length and use numbers and lower-case letters only.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     */
    void revokeUserDelegationKeys(String resourceGroupName, String accountName);

    /**
     * Revoke user delegation keys.
     *
     * @param resourceGroupName The name of the resource group within the user's subscription. The name is case
     *     insensitive.
     * @param accountName The name of the storage account within the specified resource group. Storage account names
     *     must be between 3 and 24 characters in length and use numbers and lower-case letters only.
     * @param context The context to associate with this operation.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     */
    void revokeUserDelegationKeys(String resourceGroupName, String accountName, Context context);

    /**
     * Gets the inner com.azure.mgmtlitetest.storage.StorageAccountsClient client.
     *
     * @return the inner client.
     */
    StorageAccountsClient inner();
}
```