### PR TITLE
Remove javadoc for setter method when setter method is not generated

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -216,7 +216,7 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                     }
                 });
 
-                if (!property.getIsReadOnly()) {
+                if(!property.getIsReadOnly() && !(settings.isRequiredFieldsAsConstructorArgs() && property.isRequired())) {
                     classBlock.javadocComment(settings.getMaximumJavadocCommentWidth(), (comment) -> {
                         if (property.getDescription() == null || property.getDescription().contains(MISSING_SCHEMA)) {
                             comment.description(String.format("Set the %s property", property.getName()));
@@ -228,36 +228,34 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                         comment.methodReturns(String.format("the %s object itself.", model.getName()));
                     });
 
-                    if(!(settings.isRequiredFieldsAsConstructorArgs() && property.isRequired())) {
-                        classBlock.publicMethod(String.format("%s %s(%s %s)",
-                            model.getName(), property.getSetterName(), propertyClientType, property.getName()),
-                            (methodBlock) -> {
-                                String expression;
-                                if (propertyClientType.equals(ArrayType.ByteArray)) {
-                                    expression = String.format("CoreUtils.clone(%s)", property.getName());
+                    classBlock.publicMethod(String.format("%s %s(%s %s)",
+                        model.getName(), property.getSetterName(), propertyClientType, property.getName()),
+                        (methodBlock) -> {
+                            String expression;
+                            if (propertyClientType.equals(ArrayType.ByteArray)) {
+                                expression = String.format("CoreUtils.clone(%s)", property.getName());
+                            } else {
+                                expression = property.getName();
+                            }
+                            if (propertyClientType != propertyType) {
+                                methodBlock.ifBlock(String.format("%s == null", property.getName()),
+                                    (ifBlock) -> ifBlock.line("this.%s = null;", property.getName()))
+                                    .elseBlock((elseBlock) -> {
+                                        String sourceTypeName = propertyClientType.toString();
+                                        String targetTypeName = propertyType.toString();
+                                        String propertyConversion = propertyType.convertFromClientType(expression);
+                                        elseBlock.line("this.%s = %s;", property.getName(), propertyConversion);
+                                    });
+                            } else {
+                                if (settings.shouldGenerateXmlSerialization() && property.getIsXmlWrapper()) {
+                                    methodBlock.line("this.%s = new %s(%s);", property.getName(),
+                                        propertyXmlWrapperClassName.apply(property), expression);
                                 } else {
-                                    expression = property.getName();
+                                    methodBlock.line("this.%s = %s;", property.getName(), expression);
                                 }
-                                if (propertyClientType != propertyType) {
-                                    methodBlock.ifBlock(String.format("%s == null", property.getName()),
-                                        (ifBlock) -> ifBlock.line("this.%s = null;", property.getName()))
-                                        .elseBlock((elseBlock) -> {
-                                            String sourceTypeName = propertyClientType.toString();
-                                            String targetTypeName = propertyType.toString();
-                                            String propertyConversion = propertyType.convertFromClientType(expression);
-                                            elseBlock.line("this.%s = %s;", property.getName(), propertyConversion);
-                                        });
-                                } else {
-                                    if (settings.shouldGenerateXmlSerialization() && property.getIsXmlWrapper()) {
-                                        methodBlock.line("this.%s = new %s(%s);", property.getName(),
-                                            propertyXmlWrapperClassName.apply(property), expression);
-                                    } else {
-                                        methodBlock.line("this.%s = %s;", property.getName(), expression);
-                                    }
-                                }
-                                methodBlock.methodReturn("this");
-                            });
-                    }
+                            }
+                            methodBlock.methodReturn("this");
+                        });
                 }
 
                 if (property.isAdditionalProperties()) {

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Fish.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Fish.java
@@ -75,12 +75,6 @@ public class Fish {
     }
 
     /**
-     * Set the length property: The length property.
-     *
-     * @param length the length value to set.
-     * @return the Fish object itself.
-     */
-    /**
      * Get the siblings property: The siblings property.
      *
      * @return the siblings value.

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Shark.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Shark.java
@@ -73,12 +73,6 @@ public class Shark extends Fish {
     }
 
     /**
-     * Set the birthday property: The birthday property.
-     *
-     * @param birthday the birthday value to set.
-     * @return the Shark object itself.
-     */
-    /**
      * Validates the instance.
      *
      * @throws IllegalArgumentException thrown if the instance is not valid.

--- a/vanilla-tests/src/main/java/fixtures/bodynumber/Numbers.java
+++ b/vanilla-tests/src/main/java/fixtures/bodynumber/Numbers.java
@@ -384,7 +384,7 @@ public final class Numbers {
     /**
      * Put big float value 3.402823e+20.
      *
-     * @param numberBody The numberBody parameter.
+     * @param numberBody number body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -402,7 +402,7 @@ public final class Numbers {
     /**
      * Put big float value 3.402823e+20.
      *
-     * @param numberBody The numberBody parameter.
+     * @param numberBody number body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -416,7 +416,7 @@ public final class Numbers {
     /**
      * Put big float value 3.402823e+20.
      *
-     * @param numberBody The numberBody parameter.
+     * @param numberBody number body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -482,7 +482,7 @@ public final class Numbers {
     /**
      * Put big double value 2.5976931e+101.
      *
-     * @param numberBody The numberBody parameter.
+     * @param numberBody number body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -500,7 +500,7 @@ public final class Numbers {
     /**
      * Put big double value 2.5976931e+101.
      *
-     * @param numberBody The numberBody parameter.
+     * @param numberBody number body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -514,7 +514,7 @@ public final class Numbers {
     /**
      * Put big double value 2.5976931e+101.
      *
-     * @param numberBody The numberBody parameter.
+     * @param numberBody number body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -768,7 +768,7 @@ public final class Numbers {
     /**
      * Put big decimal value 2.5976931e+101.
      *
-     * @param numberBody The numberBody parameter.
+     * @param numberBody number body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -789,7 +789,7 @@ public final class Numbers {
     /**
      * Put big decimal value 2.5976931e+101.
      *
-     * @param numberBody The numberBody parameter.
+     * @param numberBody number body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -803,7 +803,7 @@ public final class Numbers {
     /**
      * Put big decimal value 2.5976931e+101.
      *
-     * @param numberBody The numberBody parameter.
+     * @param numberBody number body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1042,7 +1042,7 @@ public final class Numbers {
     /**
      * Put small float value 3.402823e-20.
      *
-     * @param numberBody The numberBody parameter.
+     * @param numberBody number body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1060,7 +1060,7 @@ public final class Numbers {
     /**
      * Put small float value 3.402823e-20.
      *
-     * @param numberBody The numberBody parameter.
+     * @param numberBody number body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1074,7 +1074,7 @@ public final class Numbers {
     /**
      * Put small float value 3.402823e-20.
      *
-     * @param numberBody The numberBody parameter.
+     * @param numberBody number body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1140,7 +1140,7 @@ public final class Numbers {
     /**
      * Put small double value 2.5976931e-101.
      *
-     * @param numberBody The numberBody parameter.
+     * @param numberBody number body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1158,7 +1158,7 @@ public final class Numbers {
     /**
      * Put small double value 2.5976931e-101.
      *
-     * @param numberBody The numberBody parameter.
+     * @param numberBody number body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1172,7 +1172,7 @@ public final class Numbers {
     /**
      * Put small double value 2.5976931e-101.
      *
-     * @param numberBody The numberBody parameter.
+     * @param numberBody number body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1238,7 +1238,7 @@ public final class Numbers {
     /**
      * Put small decimal value 2.5976931e-101.
      *
-     * @param numberBody The numberBody parameter.
+     * @param numberBody number body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1259,7 +1259,7 @@ public final class Numbers {
     /**
      * Put small decimal value 2.5976931e-101.
      *
-     * @param numberBody The numberBody parameter.
+     * @param numberBody number body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -1273,7 +1273,7 @@ public final class Numbers {
     /**
      * Put small decimal value 2.5976931e-101.
      *
-     * @param numberBody The numberBody parameter.
+     * @param numberBody number body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.

--- a/vanilla-tests/src/main/java/fixtures/bodystring/Enums.java
+++ b/vanilla-tests/src/main/java/fixtures/bodystring/Enums.java
@@ -131,7 +131,7 @@ public final class Enums {
     /**
      * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
-     * @param stringBody The stringBody parameter.
+     * @param stringBody string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -152,7 +152,7 @@ public final class Enums {
     /**
      * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
-     * @param stringBody The stringBody parameter.
+     * @param stringBody string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -166,7 +166,7 @@ public final class Enums {
     /**
      * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
-     * @param stringBody The stringBody parameter.
+     * @param stringBody string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -227,7 +227,7 @@ public final class Enums {
     /**
      * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
-     * @param enumStringBody The enumStringBody parameter.
+     * @param enumStringBody enum string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -248,7 +248,7 @@ public final class Enums {
     /**
      * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
-     * @param enumStringBody The enumStringBody parameter.
+     * @param enumStringBody enum string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -262,7 +262,7 @@ public final class Enums {
     /**
      * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
-     * @param enumStringBody The enumStringBody parameter.
+     * @param enumStringBody enum string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -323,7 +323,7 @@ public final class Enums {
     /**
      * Sends value 'green-color' from a constant.
      *
-     * @param enumStringBody The enumStringBody parameter.
+     * @param enumStringBody enum string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -347,7 +347,7 @@ public final class Enums {
     /**
      * Sends value 'green-color' from a constant.
      *
-     * @param enumStringBody The enumStringBody parameter.
+     * @param enumStringBody enum string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -361,7 +361,7 @@ public final class Enums {
     /**
      * Sends value 'green-color' from a constant.
      *
-     * @param enumStringBody The enumStringBody parameter.
+     * @param enumStringBody enum string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.

--- a/vanilla-tests/src/main/java/fixtures/bodystring/StringOperations.java
+++ b/vanilla-tests/src/main/java/fixtures/bodystring/StringOperations.java
@@ -170,7 +170,7 @@ public final class StringOperations {
     /**
      * Set string value null.
      *
-     * @param stringBody The stringBody parameter.
+     * @param stringBody string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -188,7 +188,7 @@ public final class StringOperations {
     /**
      * Set string value null.
      *
-     * @param stringBody The stringBody parameter.
+     * @param stringBody string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -202,7 +202,7 @@ public final class StringOperations {
     /**
      * Set string value null.
      *
-     * @param stringBody The stringBody parameter.
+     * @param stringBody string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -632,7 +632,7 @@ public final class StringOperations {
     /**
      * Put value that is base64url encoded.
      *
-     * @param stringBody The stringBody parameter.
+     * @param stringBody string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -655,7 +655,7 @@ public final class StringOperations {
     /**
      * Put value that is base64url encoded.
      *
-     * @param stringBody The stringBody parameter.
+     * @param stringBody string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -669,7 +669,7 @@ public final class StringOperations {
     /**
      * Put value that is base64url encoded.
      *
-     * @param stringBody The stringBody parameter.
+     * @param stringBody string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.

--- a/vanilla-tests/src/main/java/fixtures/extensibleenums/Pets.java
+++ b/vanilla-tests/src/main/java/fixtures/extensibleenums/Pets.java
@@ -58,11 +58,13 @@ public final class Pets {
     }
 
     /**
+     * get pet by id.
+     *
      * @param petId Pet id.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response.
+     * @return pet by id.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Pet>> getByPetIdWithResponseAsync(String petId) {
@@ -77,11 +79,13 @@ public final class Pets {
     }
 
     /**
+     * get pet by id.
+     *
      * @param petId Pet id.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response.
+     * @return pet by id.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Pet> getByPetIdAsync(String petId) {
@@ -97,11 +101,13 @@ public final class Pets {
     }
 
     /**
+     * get pet by id.
+     *
      * @param petId Pet id.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response.
+     * @return pet by id.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Pet getByPetId(String petId) {
@@ -109,7 +115,9 @@ public final class Pets {
     }
 
     /**
-     * @param petParam The petParam parameter.
+     * add pet.
+     *
+     * @param petParam pet param.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -128,7 +136,9 @@ public final class Pets {
     }
 
     /**
-     * @param petParam The petParam parameter.
+     * add pet.
+     *
+     * @param petParam pet param.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -148,7 +158,9 @@ public final class Pets {
     }
 
     /**
-     * @param petParam The petParam parameter.
+     * add pet.
+     *
+     * @param petParam pet param.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.

--- a/vanilla-tests/src/main/java/fixtures/extensibleenums/models/Pet.java
+++ b/vanilla-tests/src/main/java/fixtures/extensibleenums/models/Pet.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @Fluent
 public final class Pet {
     /*
-     * The name property.
+     * name
      */
     @JsonProperty(value = "name")
     private String name;
@@ -25,7 +25,7 @@ public final class Pet {
     private IntEnum intEnum;
 
     /**
-     * Get the name property: The name property.
+     * Get the name property: name.
      *
      * @return the name value.
      */
@@ -34,7 +34,7 @@ public final class Pet {
     }
 
     /**
-     * Set the name property: The name property.
+     * Set the name property: name.
      *
      * @param name the name value to set.
      * @return the Pet object itself.


### PR DESCRIPTION
Javadocs for setter methods were getting generating for properties that were marked as required and option to move required fields to ctor was enabled. This PR removes the javadoc when no setter method is generated.