### PR TITLE
Adding mapping for time types, Base64Url, Rfc1123DateTime

### DIFF
--- a/androidgen/src/main/java/com/azure/autorest/android/mapper/AndroidMapperFactory.java
+++ b/androidgen/src/main/java/com/azure/autorest/android/mapper/AndroidMapperFactory.java
@@ -5,10 +5,16 @@ import com.azure.autorest.mapper.DefaultMapperFactory;
 import com.azure.autorest.mapper.ExceptionMapper;
 import com.azure.autorest.mapper.MethodGroupMapper;
 import com.azure.autorest.mapper.ModelMapper;
+import com.azure.autorest.mapper.PrimitiveMapper;
 import com.azure.autorest.mapper.ProxyMethodMapper;
 import com.azure.autorest.mapper.ServiceClientMapper;
 
 public class AndroidMapperFactory extends DefaultMapperFactory {
+    @Override
+    public PrimitiveMapper getPrimitiveMapper() {
+        return AndroidPrimitiveMapper.getInstance();
+    }
+
     @Override
     public ModelMapper getModelMapper() {
         return AndroidModelMapper.getInstance();

--- a/androidgen/src/main/java/com/azure/autorest/android/mapper/AndroidPrimitiveMapper.java
+++ b/androidgen/src/main/java/com/azure/autorest/android/mapper/AndroidPrimitiveMapper.java
@@ -1,0 +1,46 @@
+package com.azure.autorest.android.mapper;
+
+import com.azure.autorest.mapper.PrimitiveMapper;
+import com.azure.autorest.model.clientmodel.ClassType;
+import com.azure.autorest.model.clientmodel.IType;
+
+public class AndroidPrimitiveMapper extends PrimitiveMapper {
+    private static AndroidPrimitiveMapper instance = new AndroidPrimitiveMapper();
+
+    protected AndroidPrimitiveMapper() {
+    }
+
+    public static PrimitiveMapper getInstance() {
+        return instance;
+    }
+
+    @Override
+    protected IType getBase64UrlClassType() {
+        return ClassType.AndroidBase64Url;
+    }
+
+    @Override
+    protected IType getLocalDateClassType() {
+        return ClassType.AndroidLocalDate;
+    }
+
+    @Override
+    protected IType getDateTimeClassType() {
+        return ClassType.AndroidDateTime;
+    }
+
+    @Override
+    protected IType getDurationClassType() {
+        return ClassType.AndroidDuration;
+    }
+
+    @Override
+    protected IType getDateTimeRfc1123ClassType() {
+        return ClassType.AndroidDateTimeRfc1123;
+    }
+
+    @Override
+    protected IType getUnixTimeDateTime() {
+        return ClassType.AndroidUnixTimeDateTime;
+    }
+}

--- a/androidgen/src/main/java/com/azure/autorest/android/model/AndroidClientModel.java
+++ b/androidgen/src/main/java/com/azure/autorest/android/model/AndroidClientModel.java
@@ -5,7 +5,6 @@ package com.azure.autorest.android.model;
 
 import com.azure.autorest.model.clientmodel.ClientModel;
 import com.azure.autorest.model.clientmodel.ClientModelProperty;
-import com.azure.autorest.extension.base.plugin.JavaSettings;
 import java.util.List;
 import java.util.Set;
 
@@ -27,21 +26,6 @@ public class AndroidClientModel extends ClientModel {
             imports.add("com.azure.android.core.annotation.Fluent");
         } else {
             imports.add("com.azure.android.core.annotation.Immutable");
-        }
-    }
-
-    @Override
-    public void addImportsTo(Set<String> imports, JavaSettings settings) {
-        super.addImportsTo(imports, settings);
-        replaceOffsetDateTime(imports);
-    }
-
-    private void replaceOffsetDateTime(Set<String> imports) {
-        final String offsetDateTimeImport = "java.time.OffsetDateTime";
-        final String androidOffsetDateTime = "org.threeten.bp.OffsetDateTime";
-        if (imports.contains(offsetDateTimeImport)) {
-            imports.remove(offsetDateTimeImport);
-            imports.add(androidOffsetDateTime);
         }
     }
 

--- a/androidgen/src/main/java/com/azure/autorest/android/model/AndroidProxyMethod.java
+++ b/androidgen/src/main/java/com/azure/autorest/android/model/AndroidProxyMethod.java
@@ -61,7 +61,12 @@ public class AndroidProxyMethod extends ProxyMethod {
         if (unexpectedExceptionType == ClassType.HttpResponseException) {
             imports.add("com.azure.android.core.http.exception.HttpResponseException");
         } else {
-            unexpectedExceptionType.addImportsTo(imports, false);
+            unexpectedExceptionType.addImportsTo(imports, includeImplementationImports);
+        }
+        if (getUnexpectedResponseExceptionTypes() != null) {
+            getUnexpectedResponseExceptionTypes()
+                    .keySet()
+                    .forEach(e -> e.addImportsTo(imports, includeImplementationImports));
         }
     }
 

--- a/javagen/src/main/java/com/azure/autorest/mapper/PrimitiveMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/PrimitiveMapper.java
@@ -16,11 +16,35 @@ public class PrimitiveMapper implements IMapper<PrimitiveSchema, IType> {
     private static PrimitiveMapper instance = new PrimitiveMapper();
     Map<PrimitiveSchema, IType> parsed = new HashMap<>();
 
-    private PrimitiveMapper() {
+    protected PrimitiveMapper() {
     }
 
     public static PrimitiveMapper getInstance() {
         return instance;
+    }
+
+    protected IType getBase64UrlClassType() {
+        return ClassType.Base64Url;
+    }
+
+    protected IType getLocalDateClassType() {
+        return ClassType.LocalDate;
+    }
+
+    protected IType getDateTimeClassType() {
+        return ClassType.DateTime;
+    }
+
+    protected IType getDurationClassType() {
+        return ClassType.Duration;
+    }
+
+    protected IType getDateTimeRfc1123ClassType() {
+        return ClassType.DateTimeRfc1123;
+    }
+
+    protected IType getUnixTimeDateTime() {
+        return ClassType.UnixTimeDateTime;
     }
 
     @Override
@@ -42,7 +66,7 @@ public class PrimitiveMapper implements IMapper<PrimitiveSchema, IType> {
             case BYTE_ARRAY:
                 ByteArraySchema byteArraySchema = (ByteArraySchema) primaryType;
                 if (byteArraySchema.getFormat() == ByteArraySchema.Format.BASE_64_URL) {
-                    iType = ClassType.Base64Url;
+                    iType = this.getBase64UrlClassType();
                 } else {
                     iType = ArrayType.ByteArray;
                 }
@@ -51,14 +75,14 @@ public class PrimitiveMapper implements IMapper<PrimitiveSchema, IType> {
                 iType = PrimitiveType.Char;
                 break;
             case DATE:
-                iType = ClassType.LocalDate;
+                iType = this.getLocalDateClassType();
                 break;
             case DATE_TIME:
                 DateTimeSchema dateTimeSchema = (DateTimeSchema) primaryType;
                 if (dateTimeSchema.getFormat() == DateTimeSchema.Format.DATE_TIME_RFC_1123) {
-                    iType = ClassType.DateTimeRfc1123;
+                    iType = this.getDateTimeRfc1123ClassType();
                 } else {
-                    iType = ClassType.DateTime;
+                    iType = this.getDateTimeClassType();
                 }
                 break;
             case TIME:
@@ -99,7 +123,7 @@ public class PrimitiveMapper implements IMapper<PrimitiveSchema, IType> {
                 iType = ClassType.URL;
                 break;
             case DURATION:
-                iType = ClassType.Duration;
+                iType = this.getDurationClassType();
                 break;
             case UNIXTIME:
                 iType = PrimitiveType.UnixTimeLong;

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
@@ -6,6 +6,7 @@ package com.azure.autorest.model.clientmodel;
 
 import com.azure.autorest.extension.base.model.extensionmodel.XmsExtensions;
 import com.azure.autorest.extension.base.plugin.JavaSettings;
+import com.azure.core.util.DateTimeRfc1123;
 
 import java.util.Arrays;
 import java.util.List;
@@ -49,10 +50,16 @@ public class ClassType implements IType {
     public static final ClassType Context = new ClassType.Builder().knownClass(com.azure.core.util.Context.class).build();
     public static final ClassType ClientLogger = new ClassType.Builder().knownClass(com.azure.core.util.logging.ClientLogger.class).build();
     public static final ClassType AzureEnvironment = new ClassType.Builder().packageName("com.azure.core.management").name("AzureEnvironment").build();
+
     public static final ClassType OkHttp3ResponseBody = new Builder().packageName("okhttp3").name("ResponseBody").build();
     public static final ClassType AndroidServiceClient = new Builder().packageName("com.azure.android.core.http").name("ServiceClient").build();
     public static final ClassType AndroidHttpResponseException = new ClassType.Builder().packageName("com.azure.android.core.http.exception").name("HttpResponseException").build();
-
+    public static final ClassType AndroidBase64Url = new Builder().packageName("com.azure.android.core.util").name("Base64Url").build();
+    public static final ClassType AndroidLocalDate = new ClassType.Builder().packageName("org.threeten.bp").name("LocalDate").defaultValueExpressionConverter((String defaultValueExpression) -> java.lang.String.format("LocalDate.parse(\"%1$s\")", defaultValueExpression)).build();
+    public static final ClassType AndroidDateTime = new ClassType.Builder().packageName("org.threeten.bp").name("OffsetDateTime").defaultValueExpressionConverter((String defaultValueExpression) -> java.lang.String.format("OffsetDateTime.parse(\"%1$s\")", defaultValueExpression)).build();
+    public static final ClassType AndroidDuration = new ClassType.Builder().packageName("org.threeten.bp").name("Duration").defaultValueExpressionConverter((String defaultValueExpression) -> java.lang.String.format("Duration.parse(\"%1$s\")", defaultValueExpression)).build();
+    public static final ClassType AndroidDateTimeRfc1123 = new Builder().packageName("com.azure.android.core.util").name("DateTimeRfc1123").defaultValueExpressionConverter((String defaultValueExpression) -> java.lang.String.format("new DateTimeRfc1123(\"%1$s\")", defaultValueExpression)).build();
+    public static final ClassType AndroidUnixTimeDateTime = new ClassType.Builder().packageName("org.threeten.bp").name("OffsetDateTime").build();
 
     private final String packageName;
     private final String name;

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientModel.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientModel.java
@@ -171,7 +171,7 @@ public class ClientModel {
      * @param imports The set of imports to add to.
      * @param settings The settings for this Java generator session.
      */
-    public void addImportsTo(Set<String> imports, JavaSettings settings) {
+    public final void addImportsTo(Set<String> imports, JavaSettings settings) {
         addReadWriteAnnotationImport(properties, imports);        
 
         if (needsFlatten) {


### PR DESCRIPTION
Adding mapping in the root mapper, given these types are imported no just for models but also for proxy parameters and client-methods.