### PR TITLE
v4 fluentlite, return type conversion for Response<>

### DIFF
--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/ResourceParser.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/ResourceParser.java
@@ -12,6 +12,7 @@ import com.azure.autorest.fluent.model.arm.UrlPathSegments;
 import com.azure.autorest.fluent.model.clientmodel.FluentResourceCollection;
 import com.azure.autorest.fluent.model.clientmodel.FluentResourceModel;
 import com.azure.autorest.fluent.model.clientmodel.fluentmodel.ResourceCreate;
+import com.azure.autorest.model.clientmodel.ClientMethodType;
 import com.azure.autorest.model.clientmodel.ClientModel;
 import com.azure.core.http.HttpMethod;
 import org.slf4j.Logger;
@@ -99,7 +100,8 @@ public class ResourceParser {
             String methodName = rc.getMethodName();
             rc.getMethodReferences().addAll(
                     rc.getResourceCollection().getMethods().stream()
-                            .filter(m -> m.getInnerClientMethod().getName().equals(methodName))
+                            .filter(m -> m.getInnerClientMethod().getName().equals(methodName)
+                                    || (m.getInnerClientMethod().getType() == ClientMethodType.SimpleSyncRestResponse && m.getInnerClientMethod().getName().equals(methodName + "WithResponse")))
                             .collect(Collectors.toList()));
         });
 

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentResourceCollection.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentResourceCollection.java
@@ -55,7 +55,8 @@ public class FluentResourceCollection {
         this.methods.addAll(this.groupClient.getClientMethods().stream()
                 .filter(m -> m.getType() == ClientMethodType.SimpleSync
                         || m.getType() == ClientMethodType.PagingSync
-                        || m.getType() == ClientMethodType.LongRunningSync)
+                        || m.getType() == ClientMethodType.LongRunningSync
+                        || m.getType() == ClientMethodType.SimpleSyncRestResponse)
                 .map(FluentCollectionMethod::new)
                 .collect(Collectors.toList()));
     }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/ResourceCreate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/ResourceCreate.java
@@ -234,8 +234,10 @@ public class ResourceCreate {
             createStage.setCreateMethodWithContext(createMethodWithContext);
         }
 
-        // existing parent method after all stages is connected.
-        parentStage.setExistingParentMethod(this.getExistingParentMethod(parentStage));
+        if (parentStage != null) {
+            // existing parent method after all stages is connected.
+            parentStage.setExistingParentMethod(this.getExistingParentMethod(parentStage));
+        }
 
         // non-required properties
         List<FluentDefinitionStage> optionalFluentDefinitionStages = new ArrayList<>();

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/implmethod/WrapperPropertyImplementationMethod.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/implmethod/WrapperPropertyImplementationMethod.java
@@ -42,9 +42,9 @@ public class WrapperPropertyImplementationMethod implements WrapperMethod {
                         String unmodifiableMethodName = property.getClientType() instanceof ListType
                                 ? "unmodifiableList" : "unmodifiableMap";
 
-                        block.line(String.format("%1$s inner = this.%2$s().%3$s();", property.getClientType().toString(), ModelNaming.METHOD_INNER, property.getGetterName()));
-                        block.ifBlock("inner != null", ifBlock -> {
-                            block.methodReturn(TypeConversionUtils.unmodifiableCollection(property.getClientType(), "inner"));
+                        block.line(String.format("%1$s %2$s = this.%3$s().%4$s();", property.getClientType().toString(), TypeConversionUtils.tempPropertyName(), ModelNaming.METHOD_INNER, property.getGetterName()));
+                        block.ifBlock(String.format("%1$s != null", TypeConversionUtils.tempPropertyName()), ifBlock -> {
+                            block.methodReturn(TypeConversionUtils.unmodifiableCollection(property.getClientType(), TypeConversionUtils.tempPropertyName()));
                         }).elseBlock(elseBlock -> {
                             block.methodReturn("null");
                         });

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/implmethod/WrapperPropertyTypeConversionMethod.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/implmethod/WrapperPropertyTypeConversionMethod.java
@@ -47,9 +47,9 @@ public class WrapperPropertyTypeConversionMethod implements WrapperMethod {
                 .imports(imports)
                 .methodSignature(fluentProperty.getMethodSignature())
                 .method(block -> {
-                    block.line(String.format("%1$s inner = this.%2$s().%3$s();", property.getClientType().toString(), ModelNaming.METHOD_INNER, property.getGetterName()));
-                    block.ifBlock("inner != null", ifBlock -> {
-                        String expression = TypeConversionUtils.conversionExpression(property.getClientType(), "inner");
+                    block.line(String.format("%1$s %2$s = this.%3$s().%4$s();", property.getClientType().toString(), TypeConversionUtils.tempPropertyName(), ModelNaming.METHOD_INNER, property.getGetterName()));
+                    block.ifBlock(String.format("%1$s != null", TypeConversionUtils.tempPropertyName()), ifBlock -> {
+                        String expression = TypeConversionUtils.conversionExpression(property.getClientType(), TypeConversionUtils.tempPropertyName());
                         block.methodReturn(TypeConversionUtils.unmodifiableCollection(property.getClientType(), expression));
                     }).elseBlock(elseBlock -> {
                         block.methodReturn("null");

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/util/FluentUtils.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/util/FluentUtils.java
@@ -13,6 +13,7 @@ import com.azure.autorest.model.clientmodel.ListType;
 import com.azure.autorest.model.clientmodel.MapType;
 import com.azure.autorest.util.CodeNamer;
 import com.azure.core.http.rest.PagedIterable;
+import com.azure.core.http.rest.Response;
 import com.azure.core.util.CoreUtils;
 
 import java.util.Locale;
@@ -99,6 +100,9 @@ public class FluentUtils {
             if (PagedIterable.class.getSimpleName().equals(type.getName())) {
                 IType wrapperItemType = getFluentWrapperType(type.getTypeArguments()[0]);
                 wrapperType = wrapperItemType == type.getTypeArguments()[0] ? type : GenericType.PagedIterable(wrapperItemType);
+            } else if (Response.class.getSimpleName().equals(type.getName())) {
+                IType wrapperItemType = getFluentWrapperType(type.getTypeArguments()[0]);
+                wrapperType = wrapperItemType == type.getTypeArguments()[0] ? type : GenericType.Response(wrapperItemType);
             }
         }
         return wrapperType;

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/util/TypeConversionUtils.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/util/TypeConversionUtils.java
@@ -11,7 +11,9 @@ import com.azure.autorest.model.clientmodel.GenericType;
 import com.azure.autorest.model.clientmodel.IType;
 import com.azure.autorest.model.clientmodel.ListType;
 import com.azure.autorest.model.clientmodel.MapType;
+import com.azure.autorest.model.clientmodel.PrimitiveType;
 import com.azure.core.http.rest.PagedIterable;
+import com.azure.core.http.rest.Response;
 
 import java.util.Objects;
 
@@ -44,6 +46,14 @@ public class TypeConversionUtils {
                     String nestedPropertyName = nextPropertyName(propertyName);
                     expression = String.format("%1$s.mapPage(%2$s -> new %3$s(%4$s, this.%5$s()))", propertyName, nestedPropertyName, getModelImplName((ClassType) valueType), nestedPropertyName, ModelNaming.METHOD_MANAGER);
                 }
+            } else if (Response.class.getSimpleName().equals(type.getName())) {
+                IType valueType = type.getTypeArguments()[0];
+                if (valueType instanceof ClassType || valueType instanceof GenericType) {
+                    String valuePropertyName = propertyName + ".getValue()";
+                    expression = String.format("new SimpleResponse<>(%1$s.getRequest(), %1$s.getStatusCode(), %1$s.getHeaders(), %2$s)", propertyName, conversionExpression(valueType, valuePropertyName));
+                } else {
+                    expression = propertyName;
+                }
             }
         }
         Objects.requireNonNull(expression, "Unexpected scenario in WrapperTypeConversionMethod.conversionExpression. ClientType is " + clientType);
@@ -73,11 +83,28 @@ public class TypeConversionUtils {
         return ret;
     }
 
+    public static boolean isResponse(IType clientType) {
+        boolean ret = false;
+        if (clientType instanceof GenericType) {
+            GenericType type = (GenericType) clientType;
+            if (Response.class.getSimpleName().equals(type.getName())) {
+                ret = true;
+            }
+        }
+        return ret;
+    }
+
+    public static String tempPropertyName() {
+        return "inner";
+    }
+
     private static String nextPropertyName(String propertyName) {
-        if (propertyName.equals("inner")) {
-            return "inner1";
+        if (propertyName.equals(tempPropertyName())) {
+            return tempPropertyName() + "1";
+        } else if (propertyName.charAt(5) == '.') {
+            return tempPropertyName() + "1";
         } else {
-            return "inner" + (Integer.parseInt(propertyName.substring(5)) + 1);
+            return tempPropertyName() + (Integer.parseInt(propertyName.substring(tempPropertyName().length())) + 1);
         }
     }
 

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/util/TypeConversionUtils.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/util/TypeConversionUtils.java
@@ -11,7 +11,6 @@ import com.azure.autorest.model.clientmodel.GenericType;
 import com.azure.autorest.model.clientmodel.IType;
 import com.azure.autorest.model.clientmodel.ListType;
 import com.azure.autorest.model.clientmodel.MapType;
-import com.azure.autorest.model.clientmodel.PrimitiveType;
 import com.azure.core.http.rest.PagedIterable;
 import com.azure.core.http.rest.Response;
 

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientModelProperty.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientModelProperty.java
@@ -199,7 +199,9 @@ public class ClientModelProperty {
             imports.add("java.util.HashMap");
         }
 
-        getWireType().addImportsTo(imports, false);
+        if (getWireType() != null) {
+            getWireType().addImportsTo(imports, false);
+        }
         getClientType().addImportsTo(imports, false);
 
         if (getClientType().equals(ArrayType.ByteArray)) {


### PR DESCRIPTION
inner to interface for `Response` type.

```
    public Response<LegalHold> setLegalHoldWithResponse(
        String resourceGroupName, String accountName, String containerName, List<String> tags, Context context) {
        Response<LegalHoldInner> inner =
            this.inner().setLegalHoldWithResponse(resourceGroupName, accountName, containerName, tags, context);
        if (inner != null) {
            return new SimpleResponse<>(
                inner.getRequest(),
                inner.getStatusCode(),
                inner.getHeaders(),
                new LegalHoldImpl(inner.getValue(), this.manager()));
        } else {
            return null;
        }
    }
```