### PR TITLE
Add missed wire type for proxy method

### DIFF
--- a/androidgen/src/main/java/com/azure/autorest/android/model/AndroidProxyMethod.java
+++ b/androidgen/src/main/java/com/azure/autorest/android/model/AndroidProxyMethod.java
@@ -52,6 +52,7 @@ public class AndroidProxyMethod extends ProxyMethod {
                     && parameter.getRequestParameterLocation() != RequestParameterLocation.Uri) {
                 imports.add(String.format("retrofit2.http.%1$s",
                         CodeNamer.toPascalCase(parameter.getRequestParameterLocation().toString())));
+                parameter.getWireType().addImportsTo(imports, false);
             }
             if (parameter.getRequestParameterLocation() == RequestParameterLocation.Body) {
                 imports.add("okhttp3.RequestBody");


### PR DESCRIPTION
When wire type is OffsetDateTime, we missed org.threeten.bp.OffsetDateTime;