### PR TITLE
Add more configurations to client builder and misc bug fixes

### DIFF
--- a/azure-tests/src/main/java/fixtures/azurereport/AutoRestReportServiceForAzureBuilder.java
+++ b/azure-tests/src/main/java/fixtures/azurereport/AutoRestReportServiceForAzureBuilder.java
@@ -30,7 +30,7 @@ public final class AutoRestReportServiceForAzureBuilder {
     private final Map<String, String> properties = new HashMap<>();
 
     public AutoRestReportServiceForAzureBuilder() {
-        this.httpPipelinePolicies = new ArrayList<>();
+        this.pipelinePolicies = new ArrayList<>();
     }
 
     /*

--- a/azure-tests/src/main/java/fixtures/azurereport/AutoRestReportServiceForAzureBuilder.java
+++ b/azure-tests/src/main/java/fixtures/azurereport/AutoRestReportServiceForAzureBuilder.java
@@ -29,6 +29,10 @@ public final class AutoRestReportServiceForAzureBuilder {
 
     private final Map<String, String> properties = new HashMap<>();
 
+    public AutoRestReportServiceForAzureBuilder() {
+        this.httpPipelinePolicies = new ArrayList<>();
+    }
+
     /*
      * server parameter
      */

--- a/azure-tests/src/main/java/fixtures/azurereport/AutoRestReportServiceForAzureBuilder.java
+++ b/azure-tests/src/main/java/fixtures/azurereport/AutoRestReportServiceForAzureBuilder.java
@@ -1,17 +1,34 @@
 package fixtures.azurereport;
 
 import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** A builder for creating a new instance of the AutoRestReportServiceForAzure type. */
 @ServiceClientBuilder(serviceClients = {AutoRestReportServiceForAzure.class})
 public final class AutoRestReportServiceForAzureBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
     /*
      * server parameter
      */
@@ -60,6 +77,104 @@ public final class AutoRestReportServiceForAzureBuilder {
         return this;
     }
 
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the AutoRestReportServiceForAzureBuilder.
+     */
+    public AutoRestReportServiceForAzureBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the AutoRestReportServiceForAzureBuilder.
+     */
+    public AutoRestReportServiceForAzureBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the AutoRestReportServiceForAzureBuilder.
+     */
+    public AutoRestReportServiceForAzureBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The service API version that is used when making API requests.
+     */
+    private ServiceVersion serviceVersion;
+
+    /**
+     * Sets The service API version that is used when making API requests.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the AutoRestReportServiceForAzureBuilder.
+     */
+    public AutoRestReportServiceForAzureBuilder serviceVersion(ServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the AutoRestReportServiceForAzureBuilder.
+     */
+    public AutoRestReportServiceForAzureBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the AutoRestReportServiceForAzureBuilder.
+     */
+    public AutoRestReportServiceForAzureBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestReportServiceForAzure with the provided parameters.
      *
@@ -70,15 +185,37 @@ public final class AutoRestReportServiceForAzureBuilder {
             this.host = "http://localhost:3000";
         }
         if (pipeline == null) {
-            this.pipeline =
-                    new HttpPipelineBuilder()
-                            .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                            .build();
+            this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
         }
         AutoRestReportServiceForAzure client = new AutoRestReportServiceForAzure(pipeline, serializerAdapter, host);
         return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
     }
 }

--- a/azure-tests/src/main/java/fixtures/paging/AutoRestPagingTestServiceBuilder.java
+++ b/azure-tests/src/main/java/fixtures/paging/AutoRestPagingTestServiceBuilder.java
@@ -29,6 +29,10 @@ public final class AutoRestPagingTestServiceBuilder {
 
     private final Map<String, String> properties = new HashMap<>();
 
+    public AutoRestPagingTestServiceBuilder() {
+        this.httpPipelinePolicies = new ArrayList<>();
+    }
+
     /*
      * server parameter
      */

--- a/azure-tests/src/main/java/fixtures/paging/AutoRestPagingTestServiceBuilder.java
+++ b/azure-tests/src/main/java/fixtures/paging/AutoRestPagingTestServiceBuilder.java
@@ -30,7 +30,7 @@ public final class AutoRestPagingTestServiceBuilder {
     private final Map<String, String> properties = new HashMap<>();
 
     public AutoRestPagingTestServiceBuilder() {
-        this.httpPipelinePolicies = new ArrayList<>();
+        this.pipelinePolicies = new ArrayList<>();
     }
 
     /*

--- a/azure-tests/src/main/java/fixtures/paging/AutoRestPagingTestServiceBuilder.java
+++ b/azure-tests/src/main/java/fixtures/paging/AutoRestPagingTestServiceBuilder.java
@@ -1,17 +1,34 @@
 package fixtures.paging;
 
 import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** A builder for creating a new instance of the AutoRestPagingTestService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestPagingTestService.class})
 public final class AutoRestPagingTestServiceBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
     /*
      * server parameter
      */
@@ -60,6 +77,104 @@ public final class AutoRestPagingTestServiceBuilder {
         return this;
     }
 
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the AutoRestPagingTestServiceBuilder.
+     */
+    public AutoRestPagingTestServiceBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the AutoRestPagingTestServiceBuilder.
+     */
+    public AutoRestPagingTestServiceBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the AutoRestPagingTestServiceBuilder.
+     */
+    public AutoRestPagingTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The service API version that is used when making API requests.
+     */
+    private ServiceVersion serviceVersion;
+
+    /**
+     * Sets The service API version that is used when making API requests.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the AutoRestPagingTestServiceBuilder.
+     */
+    public AutoRestPagingTestServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the AutoRestPagingTestServiceBuilder.
+     */
+    public AutoRestPagingTestServiceBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the AutoRestPagingTestServiceBuilder.
+     */
+    public AutoRestPagingTestServiceBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestPagingTestService with the provided parameters.
      *
@@ -70,15 +185,37 @@ public final class AutoRestPagingTestServiceBuilder {
             this.host = "http://localhost:3000";
         }
         if (pipeline == null) {
-            this.pipeline =
-                    new HttpPipelineBuilder()
-                            .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                            .build();
+            this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
         }
         AutoRestPagingTestService client = new AutoRestPagingTestService(pipeline, serializerAdapter, host);
         return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
     }
 }

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
@@ -7,6 +7,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 
 /**
  Settings that are used by the Java AutoRest Generator.
@@ -89,7 +92,9 @@ public class JavaSettings
                     host.getStringValue("sync-methods", "essential"),
                     host.getBooleanValue("client-logger", false),
                     host.getBooleanValue("required-fields-as-ctor-args", false),
-                    host.getBooleanValue("service-interface-as-public", false));
+                    host.getBooleanValue("service-interface-as-public", false),
+                    host.getStringValue("artifact-id", ""),
+                    host.getStringValue("credential-types", "none"));
         }
         return _instance;
     }
@@ -136,7 +141,9 @@ public class JavaSettings
                          String syncMethods,
                          boolean clientLogger,
                          boolean requiredFieldsAsConstructorArgs,
-                         boolean serviceInterfaceAsPublic)
+                         boolean serviceInterfaceAsPublic,
+                         String artifactId,
+                         String credentialType)
     {
         this.azure = azure;
         this.fluent = fluent == null ? Fluent.NONE : (fluent.isEmpty() || fluent.equalsIgnoreCase("true") ? Fluent.PREMIUM : Fluent.valueOf(fluent.toUpperCase(Locale.ROOT)));
@@ -163,13 +170,32 @@ public class JavaSettings
         this.clientLogger = clientLogger;
         this.requiredFieldsAsConstructorArgs = requiredFieldsAsConstructorArgs;
         this.serviceInterfaceAsPublic = serviceInterfaceAsPublic;
+        this.artifactId = artifactId;
+
+        if (credentialType != null) {
+            String[] splits = credentialType.split(",");
+            this.credentialTypes = Arrays.stream(splits)
+                    .map(split -> split.trim())
+                    .map(type -> CredentialType.fromValue(credentialType))
+                    .collect(Collectors.toSet());
+        }
     }
 
+    private Set<CredentialType> credentialTypes;
+    public Set<CredentialType> getCredentialTypes() {
+        return credentialTypes;
+    }
 
     private boolean azure;
     public final boolean isAzure()
     {
         return azure;
+    }
+
+    private String artifactId;
+
+    public String getArtifactId() {
+        return artifactId;
     }
 
     public enum Fluent {
@@ -376,6 +402,25 @@ public class JavaSettings
     public final String getCustomTypesSubpackage()
     {
         return customTypesSubpackage;
+    }
+
+    public enum CredentialType {
+        TOKEN_CREDENTIAL,
+        AZURE_KEY_CREDENTIAL,
+        NONE;
+
+        public static CredentialType fromValue(String value) {
+            if (value == null) {
+                return null;
+            } else if (value.equals("tokencredential")) {
+                return TOKEN_CREDENTIAL;
+            } else if (value.equals("azurekeycredential")) {
+                return AZURE_KEY_CREDENTIAL;
+            } else if (value.equals("none")) {
+                return NONE;
+            }
+            return NONE;
+        }
     }
 
     private boolean clientLogger;

--- a/javagen/src/main/java/com/azure/autorest/Javagen.java
+++ b/javagen/src/main/java/com/azure/autorest/Javagen.java
@@ -145,6 +145,11 @@ public class Javagen extends NewPlugin {
                 String formattedSource = formatter.formatSourceAndFixImports(javaFile.getContents().toString());
                 writeFile(javaFile.getFilePath(), formattedSource, null);
             }
+            String artifactId = JavaSettings.getInstance().getArtifactId();
+            if (!(artifactId == null || artifactId.isEmpty())) {
+                writeFile("src/main/resources/" + artifactId + ".properties",
+                        "name=${project.artifactId}\nversion=${project" + ".version}\n", null);
+            }
         } catch (Exception ex) {
             LOGGER.error("Failed to generate code " + ex.getMessage(), ex);
             connection.sendError(1, 500, "Failed to generate code: " + ex.getMessage());

--- a/javagen/src/main/java/com/azure/autorest/mapper/ChoiceMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ChoiceMapper.java
@@ -50,7 +50,15 @@ public class ChoiceMapper implements IMapper<ChoiceSchema, IType> {
 
             List<ClientEnumValue> enumValues = new ArrayList<>();
             for (ChoiceValue enumValue : enumType.getChoices()) {
-                final String memberName = CodeNamer.getEnumMemberName(enumValue.getValue());
+                String enumName = enumValue.getValue();
+                if (enumValue.getLanguage() != null && enumValue.getLanguage().getJava() != null
+                        && enumValue.getLanguage().getJava().getName() != null) {
+                    enumName = enumValue.getLanguage().getJava().getName();
+                } else if(enumValue.getLanguage() != null && enumValue.getLanguage().getDefault() != null
+                        && enumValue.getLanguage().getDefault().getName() != null) {
+                    enumName = enumValue.getLanguage().getDefault().getName();
+                }
+                final String memberName = CodeNamer.getEnumMemberName(enumName);
                 long counter = enumValues.stream().filter(v -> v.getName().equals(memberName)).count();
                 if (counter > 0) {
                     enumValues.add(new ClientEnumValue(memberName + "_" + counter, enumValue.getValue()));

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMapper.java
@@ -108,7 +108,7 @@ public class ClientMapper implements IMapper<CodeModel, Client> {
         Map<String, PackageInfo> packageInfos = new HashMap<>();
         if (settings.shouldGenerateClientInterfaces() || !settings.shouldGenerateClientAsImpl()
                 || settings.getImplementationSubpackage() == null || settings.getImplementationSubpackage().isEmpty()
-                || settings.isFluent()) {
+                || settings.isFluent() || settings.shouldGenerateSyncAsyncClients()) {
             packageInfos.put(settings.getPackage(), new PackageInfo(
                 settings.getPackage(),
                 String.format("Package containing the classes for %s.\n%s", serviceClientName,

--- a/javagen/src/main/java/com/azure/autorest/mapper/SealedChoiceMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/SealedChoiceMapper.java
@@ -50,7 +50,15 @@ public class SealedChoiceMapper implements IMapper<SealedChoiceSchema, IType> {
 
             List<ClientEnumValue> enumValues = new ArrayList<>();
             for (ChoiceValue enumValue : enumType.getChoices()) {
-                String memberName = CodeNamer.getEnumMemberName(enumValue.getValue());
+                String enumName = enumValue.getValue();
+                if (enumValue.getLanguage() != null && enumValue.getLanguage().getJava() != null
+                        && enumValue.getLanguage().getJava().getName() != null) {
+                    enumName = enumValue.getLanguage().getJava().getName();
+                } else if(enumValue.getLanguage() != null && enumValue.getLanguage().getDefault() != null
+                        && enumValue.getLanguage().getDefault().getName() != null) {
+                    enumName = enumValue.getLanguage().getDefault().getName();
+                }
+                String memberName = CodeNamer.getEnumMemberName(enumName);
                 enumValues.add(new ClientEnumValue(memberName, enumValue.getValue()));
             }
 

--- a/javagen/src/main/java/com/azure/autorest/mapper/ServiceClientMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ServiceClientMapper.java
@@ -122,11 +122,15 @@ public class ServiceClientMapper implements IMapper<CodeModel, ServiceClient> {
                 }
             }
         }
-        serviceClientProperties.add(new ServiceClientProperty("The HTTP pipeline to send requests through", ClassType.HttpPipeline, "httpPipeline", true, null));
-        serviceClientProperties.add(new ServiceClientProperty("The serializer to serialize an object into a string", ClassType.SerializerAdapter, "serializerAdapter", true, null));
+        serviceClientProperties.add(new ServiceClientProperty("The HTTP pipeline to send requests through.",
+                ClassType.HttpPipeline, "httpPipeline", true, null));
+        serviceClientProperties.add(new ServiceClientProperty("The serializer to serialize an object into a "
+                + "string.", ClassType.SerializerAdapter, "serializerAdapter", true, null));
         if (settings.isFluent()) {
-            serviceClientProperties.add(new ServiceClientProperty("The default poll interval for long-running operation", ClassType.Duration, "defaultPollInterval", true, null));
+            serviceClientProperties.add(new ServiceClientProperty("The default poll interval for long-running "
+                    + "operation.", ClassType.Duration, "defaultPollInterval", true, null));
         }
+
         builder.properties(serviceClientProperties);
 
         ClientMethodParameter tokenCredentialParameter = new ClientMethodParameter.Builder()

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
@@ -50,6 +50,14 @@ public class ClassType implements IType {
     public static final ClassType Context = new ClassType.Builder().knownClass(com.azure.core.util.Context.class).build();
     public static final ClassType ClientLogger = new ClassType.Builder().knownClass(com.azure.core.util.logging.ClientLogger.class).build();
     public static final ClassType AzureEnvironment = new ClassType.Builder().packageName("com.azure.core.management").name("AzureEnvironment").build();
+    public static final ClassType HttpClient = new ClassType.Builder().knownClass(com.azure.core.http.HttpClient.class).build();
+    public static final ClassType HttpPipelinePolicy = new ClassType.Builder().knownClass(com.azure.core.http.policy.HttpPipelinePolicy.class).build();
+    public static final ClassType HttpLogOptions = new ClassType.Builder().knownClass(com.azure.core.http.policy.HttpLogOptions.class).build();
+    public static final ClassType Configuration = new ClassType.Builder().knownClass(com.azure.core.util.Configuration.class).build();
+    public static final ClassType ServiceVersion = new ClassType.Builder().knownClass(com.azure.core.util.ServiceVersion.class).build();
+    public static final ClassType AzureKeyCredential = new ClassType.Builder().knownClass(com.azure.core.credential.AzureKeyCredential.class).build();
+    public static final ClassType RetryPolicy = new ClassType.Builder().knownClass(com.azure.core.http.policy.RetryPolicy.class).build();
+
 
     private final String packageName;
     private final String name;

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ServiceClientProperty.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ServiceClientProperty.java
@@ -23,6 +23,11 @@ public class ServiceClientProperty {
      * The name of this property.
      */
     private String name;
+
+    /**
+     * THe accessor method suffix of this property
+     */
+    private String accessorMethodSuffix;
     /**
      * Get whether or not this property's value can be changed by the client library.
      */
@@ -41,9 +46,15 @@ public class ServiceClientProperty {
      * @param defaultValueExpression The expression that evaluates to this property's default value.
      */
     public ServiceClientProperty(String description, IType type, String name, boolean readOnly, String defaultValueExpression) {
+        this(description, type, name, name, readOnly, defaultValueExpression);
+    }
+
+    public ServiceClientProperty(String description, IType type, String name, String accessorMethodSuffix, boolean readOnly,
+            String defaultValueExpression) {
         this.description = description;
         this.type = type;
         this.name = name;
+        this.accessorMethodSuffix = accessorMethodSuffix;
         this.readOnly = readOnly;
         this.defaultValueExpression = defaultValueExpression;
     }
@@ -58,6 +69,10 @@ public class ServiceClientProperty {
 
     public final String getName() {
         return name;
+    }
+
+    public final String getAccessorMethodSuffix() {
+        return accessorMethodSuffix;
     }
 
     public final boolean isReadOnly() {

--- a/javagen/src/main/java/com/azure/autorest/model/javamodel/JavaClass.java
+++ b/javagen/src/main/java/com/azure/autorest/model/javamodel/JavaClass.java
@@ -35,9 +35,21 @@ public class JavaClass implements JavaType {
         addNewLine = true;
     }
 
+    public final void privateFinalMemberVariable(String variableType, String variableName, String finalValue) {
+        addExpectedNewLine();
+        contents.line(String.format("private final %1$s %2$s = %3$s;", variableType, variableName, finalValue));
+        addNewLine = true;
+    }
+
     public final void publicStaticFinalVariable(String variableDeclaration) {
         addExpectedNewLine();
         contents.line(String.format("public static final %1$s;", variableDeclaration));
+        addNewLine = true;
+    }
+
+    public final void privateStaticFinalVariable(String variableDeclaration) {
+        addExpectedNewLine();
+        contents.line(String.format("private static final %1$s;", variableDeclaration));
         addNewLine = true;
     }
 

--- a/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
@@ -4,12 +4,10 @@ package com.azure.autorest.template;
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-
-import com.azure.autorest.model.clientmodel.AsyncSyncClient;
-import com.azure.autorest.model.clientmodel.ClassType;
 import com.azure.autorest.extension.base.plugin.JavaSettings;
-import com.azure.autorest.model.clientmodel.ServiceClient;
-import com.azure.autorest.model.clientmodel.ServiceClientProperty;
+import com.azure.autorest.extension.base.plugin.JavaSettings.CredentialType;
+import com.azure.autorest.model.clientmodel.*;
+import com.azure.autorest.model.javamodel.JavaClass;
 import com.azure.autorest.model.javamodel.JavaFile;
 import com.azure.autorest.model.javamodel.JavaVisibility;
 import com.azure.autorest.util.ClientModelUtil;
@@ -39,18 +37,7 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ServiceClient
         JavaSettings settings = JavaSettings.getInstance();
         String serviceClientBuilderName = serviceClient.getInterfaceName() + ClientModelUtil.getBuilderSuffix();
 
-        ArrayList<ServiceClientProperty> commonProperties = new ArrayList<ServiceClientProperty>();
-        if (settings.isAzureOrFluent()) {
-            commonProperties.add(new ServiceClientProperty("The environment to connect to", ClassType.AzureEnvironment, "environment", false, "AzureEnvironment.AZURE"));
-        }
-        commonProperties.add(new ServiceClientProperty("The HTTP pipeline to send requests through", ClassType.HttpPipeline, "pipeline", false, "new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build()"));
-        commonProperties.add(new ServiceClientProperty("The serializer to serialize an object into a string",
-          ClassType.SerializerAdapter, "serializerAdapter", false,
-          settings.isFluent() ? "new AzureJacksonAdapter()" : "JacksonAdapter.createDefaultSerializerAdapter()"));
-
-        if (settings.isFluent()) {
-          commonProperties.add(new ServiceClientProperty("The default poll interval for long-running operation", ClassType.Duration, "defaultPollInterval", false, "Duration.ofSeconds(30)"));
-        }
+        ArrayList<ServiceClientProperty> commonProperties = addCommonClientProperties(settings);
 
         String buildReturnType;
         if (!settings.isFluent() && settings.shouldGenerateClientInterfaces()) {
@@ -62,7 +49,16 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ServiceClient
         Set<String> imports = new HashSet<String>();
         serviceClient.addImportsTo(imports, false, true, settings);
         commonProperties.forEach(p -> p.addImportsTo(imports, false));
+        imports.add("java.util.List");
+        imports.add("java.util.Map");
+        imports.add("java.util.HashMap");
+        imports.add("java.util.ArrayList");
         imports.add("com.azure.core.annotation.ServiceClientBuilder");
+        imports.add("com.azure.core.http.policy.BearerTokenAuthenticationPolicy");
+        imports.add("com.azure.core.http.policy.HttpPolicyProviders");
+        imports.add("com.azure.core.http.policy.HttpLoggingPolicy");
+        imports.add("com.azure.core.http.policy.HttpPipelinePolicy");
+        imports.add("com.azure.core.util.CoreUtils");
         imports.add(settings.isFluent() ? "com.azure.core.management.serializer.AzureJacksonAdapter" : "com.azure.core.util.serializer.JacksonAdapter");
 
         List<AsyncSyncClient> asyncClients = new ArrayList<>();
@@ -103,27 +99,56 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ServiceClient
         javaFile.annotation(String.format("ServiceClientBuilder(serviceClients = %1$s)", builderTypes.toString()));
         javaFile.publicFinalClass(serviceClientBuilderName, classBlock ->
         {
+
+            classBlock.privateStaticFinalVariable("String SDK_NAME = \"name\"");
+            classBlock.privateStaticFinalVariable("String SDK_VERSION = \"version\"");
+            String propertiesValue = "new HashMap<>()";
+            if (!settings.getArtifactId().isEmpty()) {
+                propertiesValue = "CoreUtils.getProperties" + "(\"" + settings.getArtifactId() + ".properties\")";
+            }
+            classBlock.privateFinalMemberVariable("Map<String, String>", "properties", propertiesValue);
+
             // Add ServiceClient client property variables, getters, and setters
-            for (ServiceClientProperty serviceClientProperty : Stream
-                    .concat(serviceClient.getProperties().stream().filter(p -> !p.isReadOnly()), commonProperties.stream()).collect(Collectors.toList())) {
+            List<ServiceClientProperty> clientProperties = Stream
+                    .concat(serviceClient.getProperties().stream().filter(p -> !p.isReadOnly()),
+                            commonProperties.stream()).collect(Collectors.toList());
+
+            for (ServiceClientProperty serviceClientProperty : clientProperties) {
                 classBlock.blockComment(settings.getMaximumJavadocCommentWidth(), comment ->
                 {
                     comment.line(serviceClientProperty.getDescription());
                 });
                 classBlock.privateMemberVariable(String.format("%1$s %2$s", serviceClientProperty.getType(), serviceClientProperty.getName()));
 
-                classBlock.javadocComment(comment ->
-                {
-                    comment.description(String.format("Sets %1$s", serviceClientProperty.getDescription()));
-                    comment.param(serviceClientProperty.getName(), String.format("the %1$s value.", serviceClientProperty.getName()));
-                    comment.methodReturns(String.format("the %1$s", serviceClientBuilderName));
-                });
-                classBlock.publicMethod(String.format("%1$s %2$s(%3$s %4$s)", serviceClientBuilderName, CodeNamer.toCamelCase(serviceClientProperty.getName()), serviceClientProperty.getType(), serviceClientProperty.getName()), function ->
-                {
-                    function.line(String.format("this.%1$s = %2$s;", serviceClientProperty.getName(), serviceClientProperty.getName()));
-                    function.methodReturn("this");
-                });
+                if (!serviceClientProperty.isReadOnly()) {
+                    classBlock.javadocComment(comment ->
+                    {
+                        comment.description(String.format("Sets %1$s", serviceClientProperty.getDescription()));
+                        comment.param(serviceClientProperty.getName(), String.format("the %1$s value.", serviceClientProperty.getName()));
+                        comment.methodReturns(String.format("the %1$s", serviceClientBuilderName));
+                    });
+
+                    classBlock.publicMethod(String.format("%1$s %2$s(%3$s %4$s)", serviceClientBuilderName,
+                            CodeNamer.toCamelCase(serviceClientProperty.getAccessorMethodSuffix()), serviceClientProperty.getType(),
+                            serviceClientProperty.getName()), function ->
+                    {
+                        function.line(String.format("this.%1$s = %2$s;", serviceClientProperty.getName(), serviceClientProperty.getName()));
+                        function.methodReturn("this");
+                    });
+                }
             }
+
+            classBlock.javadocComment(comment ->
+            {
+                comment.description("Adds a custom Http pipeline policy.");
+                comment.param("customPolicy", "The custom Http pipeline policy to add.");
+                comment.methodReturns(String.format("the %1$s", serviceClientBuilderName));
+            });
+            classBlock.publicMethod(String.format("%1$s %2$s(%3$s %4$s)", serviceClientBuilderName,
+                    "addPolicy", "HttpPipelinePolicy", "customPolicy"), function -> {
+                function.line("pipelinePolicies.add(customPolicy);");
+                function.methodReturn("this");
+            });
 
             String buildMethodName = this.primaryBuildMethodName(settings);
             JavaVisibility visibility = settings.shouldGenerateSyncAsyncClients() ? JavaVisibility.Private : JavaVisibility.Public;
@@ -136,7 +161,7 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ServiceClient
             });
             classBlock.method(visibility, null, String.format("%1$s %2$s()", buildReturnType, buildMethodName), function ->
             {
-                for (ServiceClientProperty serviceClientProperty : Stream.concat(serviceClient.getProperties().stream().filter(p -> !p.isReadOnly()), commonProperties.stream()).collect(Collectors.toList())) {
+                for (ServiceClientProperty serviceClientProperty : clientProperties) {
                     if (serviceClientProperty.getDefaultValueExpression() != null) {
                         function.ifBlock(String.format("%1$s == null", serviceClientProperty.getName()), ifBlock ->
                         {
@@ -162,6 +187,8 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ServiceClient
                 }
                 function.line("return client;");
             });
+
+            addCreateHttpPipelineMethod(settings, buildReturnType, classBlock, clientProperties, buildMethodName);
 
             if (JavaSettings.getInstance().shouldGenerateSyncAsyncClients()) {
                 if (!settings.isFluentLite()) {
@@ -208,6 +235,93 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ServiceClient
             }
         });
 
+    }
+
+    private void addCreateHttpPipelineMethod(JavaSettings settings, String buildReturnType, JavaClass classBlock, List<ServiceClientProperty> clientProperties, String buildMethodName) {
+        classBlock.privateMethod(String.format("HttpPipeline createHttpPipeline()", buildReturnType,
+                buildMethodName), function -> {
+            function.line("Configuration buildConfiguration = (configuration == null) ? Configuration"
+                    + ".getGlobalConfiguration() : configuration;");
+
+            function.ifBlock("httpLogOptions == null", action -> {
+                function.line("httpLogOptions = new HttpLogOptions();");
+            });
+
+            function.line("List<HttpPipelinePolicy> policies = new ArrayList<>();");
+
+            if (settings.getCredentialTypes().contains(CredentialType.AZURE_KEY_CREDENTIAL)) {
+                function.ifBlock("azureKeyCredential != null", action -> {
+                    function.line("policies.add(new AzureKeyCredentialPolicy(\"api-key\", azureKeyCredential));");
+                });
+            }
+            if (settings.getCredentialTypes().contains(CredentialType.TOKEN_CREDENTIAL) && clientProperties.stream()
+                    .anyMatch(clientProperty -> clientProperty.getName().equals("endpoint"))) {
+                function.ifBlock("tokenCredential != null", action -> {
+                    function.line("policies.add(new BearerTokenAuthenticationPolicy(tokenCredential, String"
+                            + ".format(\"%s/.default\", endpoint)));");
+                });
+            }
+
+            function.line("String clientName = properties.getOrDefault(SDK_NAME, \"UnknownName\");");
+            function.line("String clientVersion = properties.getOrDefault(SDK_VERSION, \"UnknownVersion\");");
+
+            function.line("policies.add(new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, "
+                    + "clientVersion, buildConfiguration));");
+
+            function.line("HttpPolicyProviders.addBeforeRetryPolicies(policies);");
+            function.line("policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);");
+            function.line("policies.add(new CookiePolicy());");
+            function.line("policies.addAll(this.pipelinePolicies);");
+            function.line("HttpPolicyProviders.addAfterRetryPolicies(policies);");
+
+            function.line("policies.add(new HttpLoggingPolicy(httpLogOptions));");
+
+            function.line("HttpPipeline httpPipeline = new HttpPipelineBuilder().policies(policies.toArray(new "
+                    + "HttpPipelinePolicy[0])).httpClient(httpClient).build();");
+            function.methodReturn("httpPipeline");
+        });
+    }
+
+    private ArrayList<ServiceClientProperty> addCommonClientProperties(JavaSettings settings) {
+        ArrayList<ServiceClientProperty> commonProperties = new ArrayList<ServiceClientProperty>();
+        if (settings.isAzureOrFluent()) {
+            commonProperties.add(new ServiceClientProperty("The environment to connect to", ClassType.AzureEnvironment, "environment", false, "AzureEnvironment.AZURE"));
+        }
+        commonProperties.add(new ServiceClientProperty("The HTTP pipeline to send requests through", ClassType.HttpPipeline, "pipeline", false,
+                "createHttpPipeline()"));
+
+        commonProperties.add(new ServiceClientProperty("The serializer to serialize an object into a string",
+          ClassType.SerializerAdapter, "serializerAdapter", false,
+          settings.isFluent() ? "new AzureJacksonAdapter()" : "JacksonAdapter.createDefaultSerializerAdapter()"));
+
+        commonProperties.add(new ServiceClientProperty("The HTTP client used to send the request.",
+                ClassType.HttpClient, "httpClient", false, null));
+        commonProperties.add(new ServiceClientProperty("The configuration store that is used during "
+                + "construction of the service client.", ClassType.Configuration, "configuration", false, null));
+
+        if (settings.getCredentialTypes().contains(CredentialType.AZURE_KEY_CREDENTIAL)) {
+            commonProperties.add(new ServiceClientProperty("The Azure Key Credential used for authentication.",
+                    ClassType.AzureKeyCredential, "azureKeyCredential", "credential", false, null));
+        }
+        if (settings.getCredentialTypes().contains(CredentialType.TOKEN_CREDENTIAL)) {
+            commonProperties.add(new ServiceClientProperty("The TokenCredential used for authentication.",
+                    ClassType.TokenCredential, "tokenCredential", "credential", false, null));
+        }
+
+        commonProperties.add(new ServiceClientProperty("The logging configuration for HTTP requests and "
+                + "responses.", ClassType.HttpLogOptions, "httpLogOptions", false, null));
+        commonProperties.add(new ServiceClientProperty("The service API version that is used when making "
+                + "API requests.", ClassType.ServiceVersion, "serviceVersion", false, null));
+        commonProperties.add(new ServiceClientProperty("The retry policy that will attempt to retry failed "
+                + "requests, if applicable.", ClassType.RetryPolicy, "retryPolicy", false, null));
+
+        commonProperties.add(new ServiceClientProperty("The list of Http pipeline policies to add.",
+                new ListType(ClassType.HttpPipelinePolicy), "pipelinePolicies", true, null));
+
+        if (settings.isFluent()) {
+            commonProperties.add(new ServiceClientProperty("The default poll interval for long-running operation", ClassType.Duration, "defaultPollInterval", false, "Duration.ofSeconds(30)"));
+        }
+        return commonProperties;
     }
 
     /**

--- a/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
@@ -99,25 +99,22 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ServiceClient
         javaFile.annotation(String.format("ServiceClientBuilder(serviceClients = %1$s)", builderTypes.toString()));
         javaFile.publicFinalClass(serviceClientBuilderName, classBlock ->
         {
-
-            classBlock.privateStaticFinalVariable("String SDK_NAME = \"name\"");
-            classBlock.privateStaticFinalVariable("String SDK_VERSION = \"version\"");
-            String propertiesValue = "new HashMap<>()";
-            if (!settings.getArtifactId().isEmpty()) {
-                propertiesValue = "CoreUtils.getProperties" + "(\"" + settings.getArtifactId() + ".properties\")";
+            if (!settings.isAzureOrFluent()) {
+                classBlock.privateStaticFinalVariable("String SDK_NAME = \"name\"");
+                classBlock.privateStaticFinalVariable("String SDK_VERSION = \"version\"");
+                String propertiesValue = "new HashMap<>()";
+                if (!settings.getArtifactId().isEmpty()) {
+                    propertiesValue = "CoreUtils.getProperties" + "(\"" + settings.getArtifactId() + ".properties\")";
+                }
+                classBlock.privateFinalMemberVariable("Map<String, String>", "properties", propertiesValue);
+                classBlock.publicConstructor(String.format("%1$s()", serviceClientBuilderName), javaBlock -> {
+                    javaBlock.line("this.pipelinePolicies = new ArrayList<>();");
+                });
             }
-            classBlock.privateFinalMemberVariable("Map<String, String>", "properties", propertiesValue);
-
             // Add ServiceClient client property variables, getters, and setters
             List<ServiceClientProperty> clientProperties = Stream
                     .concat(serviceClient.getProperties().stream().filter(p -> !p.isReadOnly()),
                             commonProperties.stream()).collect(Collectors.toList());
-
-            if (!settings.isAzureOrFluent()) {
-                classBlock.publicConstructor(String.format("%1$s()", serviceClientBuilderName), javaBlock -> {
-                    javaBlock.line("this.httpPipelinePolicies = new ArrayList<>();");
-                });
-            }
 
             for (ServiceClientProperty serviceClientProperty : clientProperties) {
                 classBlock.blockComment(settings.getMaximumJavadocCommentWidth(), comment ->

--- a/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
@@ -113,6 +113,12 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ServiceClient
                     .concat(serviceClient.getProperties().stream().filter(p -> !p.isReadOnly()),
                             commonProperties.stream()).collect(Collectors.toList());
 
+            if (!settings.isAzureOrFluent()) {
+                classBlock.publicConstructor(String.format("%1$s()", serviceClientBuilderName), javaBlock -> {
+                    javaBlock.line("this.httpPipelinePolicies = new ArrayList<>();");
+                });
+            }
+
             for (ServiceClientProperty serviceClientProperty : clientProperties) {
                 classBlock.blockComment(settings.getMaximumJavadocCommentWidth(), comment ->
                 {
@@ -190,7 +196,9 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ServiceClient
                 function.line("return client;");
             });
 
-            addCreateHttpPipelineMethod(settings, buildReturnType, classBlock, clientProperties, buildMethodName);
+            if (!settings.isAzureOrFluent()) {
+                addCreateHttpPipelineMethod(settings, buildReturnType, classBlock, clientProperties, buildMethodName);
+            }
 
             if (JavaSettings.getInstance().shouldGenerateSyncAsyncClients()) {
                 if (!settings.isFluentLite()) {

--- a/vanilla-tests/src/main/java/fixtures/additionalproperties/AdditionalPropertiesClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/additionalproperties/AdditionalPropertiesClientBuilder.java
@@ -30,7 +30,7 @@ public final class AdditionalPropertiesClientBuilder {
     private final Map<String, String> properties = new HashMap<>();
 
     public AdditionalPropertiesClientBuilder() {
-        this.httpPipelinePolicies = new ArrayList<>();
+        this.pipelinePolicies = new ArrayList<>();
     }
 
     /*

--- a/vanilla-tests/src/main/java/fixtures/additionalproperties/AdditionalPropertiesClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/additionalproperties/AdditionalPropertiesClientBuilder.java
@@ -29,6 +29,10 @@ public final class AdditionalPropertiesClientBuilder {
 
     private final Map<String, String> properties = new HashMap<>();
 
+    public AdditionalPropertiesClientBuilder() {
+        this.httpPipelinePolicies = new ArrayList<>();
+    }
+
     /*
      * server parameter
      */

--- a/vanilla-tests/src/main/java/fixtures/additionalproperties/AdditionalPropertiesClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/additionalproperties/AdditionalPropertiesClientBuilder.java
@@ -1,17 +1,34 @@
 package fixtures.additionalproperties;
 
 import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** A builder for creating a new instance of the AdditionalPropertiesClient type. */
 @ServiceClientBuilder(serviceClients = {AdditionalPropertiesClient.class})
 public final class AdditionalPropertiesClientBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
     /*
      * server parameter
      */
@@ -60,6 +77,104 @@ public final class AdditionalPropertiesClientBuilder {
         return this;
     }
 
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the AdditionalPropertiesClientBuilder.
+     */
+    public AdditionalPropertiesClientBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the AdditionalPropertiesClientBuilder.
+     */
+    public AdditionalPropertiesClientBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the AdditionalPropertiesClientBuilder.
+     */
+    public AdditionalPropertiesClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The service API version that is used when making API requests.
+     */
+    private ServiceVersion serviceVersion;
+
+    /**
+     * Sets The service API version that is used when making API requests.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the AdditionalPropertiesClientBuilder.
+     */
+    public AdditionalPropertiesClientBuilder serviceVersion(ServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the AdditionalPropertiesClientBuilder.
+     */
+    public AdditionalPropertiesClientBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the AdditionalPropertiesClientBuilder.
+     */
+    public AdditionalPropertiesClientBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
     /**
      * Builds an instance of AdditionalPropertiesClient with the provided parameters.
      *
@@ -70,15 +185,37 @@ public final class AdditionalPropertiesClientBuilder {
             this.host = "http://localhost:3000";
         }
         if (pipeline == null) {
-            this.pipeline =
-                    new HttpPipelineBuilder()
-                            .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                            .build();
+            this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
         }
         AdditionalPropertiesClient client = new AdditionalPropertiesClient(pipeline, serializerAdapter, host);
         return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodyarray/AutoRestSwaggerBATArrayServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyarray/AutoRestSwaggerBATArrayServiceBuilder.java
@@ -29,6 +29,10 @@ public final class AutoRestSwaggerBATArrayServiceBuilder {
 
     private final Map<String, String> properties = new HashMap<>();
 
+    public AutoRestSwaggerBATArrayServiceBuilder() {
+        this.httpPipelinePolicies = new ArrayList<>();
+    }
+
     /*
      * server parameter
      */

--- a/vanilla-tests/src/main/java/fixtures/bodyarray/AutoRestSwaggerBATArrayServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyarray/AutoRestSwaggerBATArrayServiceBuilder.java
@@ -1,17 +1,34 @@
 package fixtures.bodyarray;
 
 import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** A builder for creating a new instance of the AutoRestSwaggerBATArrayService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestSwaggerBATArrayService.class})
 public final class AutoRestSwaggerBATArrayServiceBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
     /*
      * server parameter
      */
@@ -60,6 +77,104 @@ public final class AutoRestSwaggerBATArrayServiceBuilder {
         return this;
     }
 
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the AutoRestSwaggerBATArrayServiceBuilder.
+     */
+    public AutoRestSwaggerBATArrayServiceBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the AutoRestSwaggerBATArrayServiceBuilder.
+     */
+    public AutoRestSwaggerBATArrayServiceBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the AutoRestSwaggerBATArrayServiceBuilder.
+     */
+    public AutoRestSwaggerBATArrayServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The service API version that is used when making API requests.
+     */
+    private ServiceVersion serviceVersion;
+
+    /**
+     * Sets The service API version that is used when making API requests.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the AutoRestSwaggerBATArrayServiceBuilder.
+     */
+    public AutoRestSwaggerBATArrayServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the AutoRestSwaggerBATArrayServiceBuilder.
+     */
+    public AutoRestSwaggerBATArrayServiceBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the AutoRestSwaggerBATArrayServiceBuilder.
+     */
+    public AutoRestSwaggerBATArrayServiceBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestSwaggerBATArrayService with the provided parameters.
      *
@@ -70,15 +185,37 @@ public final class AutoRestSwaggerBATArrayServiceBuilder {
             this.host = "http://localhost:3000";
         }
         if (pipeline == null) {
-            this.pipeline =
-                    new HttpPipelineBuilder()
-                            .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                            .build();
+            this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
         }
         AutoRestSwaggerBATArrayService client = new AutoRestSwaggerBATArrayService(pipeline, serializerAdapter, host);
         return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodyarray/AutoRestSwaggerBATArrayServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyarray/AutoRestSwaggerBATArrayServiceBuilder.java
@@ -30,7 +30,7 @@ public final class AutoRestSwaggerBATArrayServiceBuilder {
     private final Map<String, String> properties = new HashMap<>();
 
     public AutoRestSwaggerBATArrayServiceBuilder() {
-        this.httpPipelinePolicies = new ArrayList<>();
+        this.pipelinePolicies = new ArrayList<>();
     }
 
     /*

--- a/vanilla-tests/src/main/java/fixtures/bodyboolean/AutoRestBoolTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyboolean/AutoRestBoolTestServiceBuilder.java
@@ -1,17 +1,34 @@
 package fixtures.bodyboolean;
 
 import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** A builder for creating a new instance of the AutoRestBoolTestService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestBoolTestService.class})
 public final class AutoRestBoolTestServiceBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
     /*
      * server parameter
      */
@@ -60,6 +77,104 @@ public final class AutoRestBoolTestServiceBuilder {
         return this;
     }
 
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the AutoRestBoolTestServiceBuilder.
+     */
+    public AutoRestBoolTestServiceBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the AutoRestBoolTestServiceBuilder.
+     */
+    public AutoRestBoolTestServiceBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the AutoRestBoolTestServiceBuilder.
+     */
+    public AutoRestBoolTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The service API version that is used when making API requests.
+     */
+    private ServiceVersion serviceVersion;
+
+    /**
+     * Sets The service API version that is used when making API requests.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the AutoRestBoolTestServiceBuilder.
+     */
+    public AutoRestBoolTestServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the AutoRestBoolTestServiceBuilder.
+     */
+    public AutoRestBoolTestServiceBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the AutoRestBoolTestServiceBuilder.
+     */
+    public AutoRestBoolTestServiceBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestBoolTestService with the provided parameters.
      *
@@ -70,15 +185,37 @@ public final class AutoRestBoolTestServiceBuilder {
             this.host = "http://localhost:3000";
         }
         if (pipeline == null) {
-            this.pipeline =
-                    new HttpPipelineBuilder()
-                            .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                            .build();
+            this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
         }
         AutoRestBoolTestService client = new AutoRestBoolTestService(pipeline, serializerAdapter, host);
         return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodyboolean/AutoRestBoolTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyboolean/AutoRestBoolTestServiceBuilder.java
@@ -30,7 +30,7 @@ public final class AutoRestBoolTestServiceBuilder {
     private final Map<String, String> properties = new HashMap<>();
 
     public AutoRestBoolTestServiceBuilder() {
-        this.httpPipelinePolicies = new ArrayList<>();
+        this.pipelinePolicies = new ArrayList<>();
     }
 
     /*

--- a/vanilla-tests/src/main/java/fixtures/bodyboolean/AutoRestBoolTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyboolean/AutoRestBoolTestServiceBuilder.java
@@ -29,6 +29,10 @@ public final class AutoRestBoolTestServiceBuilder {
 
     private final Map<String, String> properties = new HashMap<>();
 
+    public AutoRestBoolTestServiceBuilder() {
+        this.httpPipelinePolicies = new ArrayList<>();
+    }
+
     /*
      * server parameter
      */

--- a/vanilla-tests/src/main/java/fixtures/bodyboolean/quirks/AutoRestBoolTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyboolean/quirks/AutoRestBoolTestServiceBuilder.java
@@ -1,17 +1,34 @@
 package fixtures.bodyboolean.quirks;
 
 import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** A builder for creating a new instance of the AutoRestBoolTestService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestBoolTestService.class})
 public final class AutoRestBoolTestServiceBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
     /*
      * server parameter
      */
@@ -60,6 +77,104 @@ public final class AutoRestBoolTestServiceBuilder {
         return this;
     }
 
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the AutoRestBoolTestServiceBuilder.
+     */
+    public AutoRestBoolTestServiceBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the AutoRestBoolTestServiceBuilder.
+     */
+    public AutoRestBoolTestServiceBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the AutoRestBoolTestServiceBuilder.
+     */
+    public AutoRestBoolTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The service API version that is used when making API requests.
+     */
+    private ServiceVersion serviceVersion;
+
+    /**
+     * Sets The service API version that is used when making API requests.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the AutoRestBoolTestServiceBuilder.
+     */
+    public AutoRestBoolTestServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the AutoRestBoolTestServiceBuilder.
+     */
+    public AutoRestBoolTestServiceBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the AutoRestBoolTestServiceBuilder.
+     */
+    public AutoRestBoolTestServiceBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestBoolTestService with the provided parameters.
      *
@@ -70,15 +185,37 @@ public final class AutoRestBoolTestServiceBuilder {
             this.host = "http://localhost:3000";
         }
         if (pipeline == null) {
-            this.pipeline =
-                    new HttpPipelineBuilder()
-                            .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                            .build();
+            this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
         }
         AutoRestBoolTestService client = new AutoRestBoolTestService(pipeline, serializerAdapter, host);
         return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodyboolean/quirks/AutoRestBoolTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyboolean/quirks/AutoRestBoolTestServiceBuilder.java
@@ -30,7 +30,7 @@ public final class AutoRestBoolTestServiceBuilder {
     private final Map<String, String> properties = new HashMap<>();
 
     public AutoRestBoolTestServiceBuilder() {
-        this.httpPipelinePolicies = new ArrayList<>();
+        this.pipelinePolicies = new ArrayList<>();
     }
 
     /*

--- a/vanilla-tests/src/main/java/fixtures/bodyboolean/quirks/AutoRestBoolTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyboolean/quirks/AutoRestBoolTestServiceBuilder.java
@@ -29,6 +29,10 @@ public final class AutoRestBoolTestServiceBuilder {
 
     private final Map<String, String> properties = new HashMap<>();
 
+    public AutoRestBoolTestServiceBuilder() {
+        this.httpPipelinePolicies = new ArrayList<>();
+    }
+
     /*
      * server parameter
      */

--- a/vanilla-tests/src/main/java/fixtures/bodybyte/AutoRestSwaggerBATByteServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodybyte/AutoRestSwaggerBATByteServiceBuilder.java
@@ -30,7 +30,7 @@ public final class AutoRestSwaggerBATByteServiceBuilder {
     private final Map<String, String> properties = new HashMap<>();
 
     public AutoRestSwaggerBATByteServiceBuilder() {
-        this.httpPipelinePolicies = new ArrayList<>();
+        this.pipelinePolicies = new ArrayList<>();
     }
 
     /*

--- a/vanilla-tests/src/main/java/fixtures/bodybyte/AutoRestSwaggerBATByteServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodybyte/AutoRestSwaggerBATByteServiceBuilder.java
@@ -1,17 +1,34 @@
 package fixtures.bodybyte;
 
 import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** A builder for creating a new instance of the AutoRestSwaggerBATByteService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestSwaggerBATByteService.class})
 public final class AutoRestSwaggerBATByteServiceBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
     /*
      * server parameter
      */
@@ -60,6 +77,104 @@ public final class AutoRestSwaggerBATByteServiceBuilder {
         return this;
     }
 
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the AutoRestSwaggerBATByteServiceBuilder.
+     */
+    public AutoRestSwaggerBATByteServiceBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the AutoRestSwaggerBATByteServiceBuilder.
+     */
+    public AutoRestSwaggerBATByteServiceBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the AutoRestSwaggerBATByteServiceBuilder.
+     */
+    public AutoRestSwaggerBATByteServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The service API version that is used when making API requests.
+     */
+    private ServiceVersion serviceVersion;
+
+    /**
+     * Sets The service API version that is used when making API requests.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the AutoRestSwaggerBATByteServiceBuilder.
+     */
+    public AutoRestSwaggerBATByteServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the AutoRestSwaggerBATByteServiceBuilder.
+     */
+    public AutoRestSwaggerBATByteServiceBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the AutoRestSwaggerBATByteServiceBuilder.
+     */
+    public AutoRestSwaggerBATByteServiceBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestSwaggerBATByteService with the provided parameters.
      *
@@ -70,15 +185,37 @@ public final class AutoRestSwaggerBATByteServiceBuilder {
             this.host = "http://localhost:3000";
         }
         if (pipeline == null) {
-            this.pipeline =
-                    new HttpPipelineBuilder()
-                            .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                            .build();
+            this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
         }
         AutoRestSwaggerBATByteService client = new AutoRestSwaggerBATByteService(pipeline, serializerAdapter, host);
         return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodybyte/AutoRestSwaggerBATByteServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodybyte/AutoRestSwaggerBATByteServiceBuilder.java
@@ -29,6 +29,10 @@ public final class AutoRestSwaggerBATByteServiceBuilder {
 
     private final Map<String, String> properties = new HashMap<>();
 
+    public AutoRestSwaggerBATByteServiceBuilder() {
+        this.httpPipelinePolicies = new ArrayList<>();
+    }
+
     /*
      * server parameter
      */

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/AutoRestComplexTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/AutoRestComplexTestServiceBuilder.java
@@ -1,17 +1,34 @@
 package fixtures.bodycomplex;
 
 import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** A builder for creating a new instance of the AutoRestComplexTestService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestComplexTestService.class})
 public final class AutoRestComplexTestServiceBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
     /*
      * server parameter
      */
@@ -60,6 +77,104 @@ public final class AutoRestComplexTestServiceBuilder {
         return this;
     }
 
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the AutoRestComplexTestServiceBuilder.
+     */
+    public AutoRestComplexTestServiceBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the AutoRestComplexTestServiceBuilder.
+     */
+    public AutoRestComplexTestServiceBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the AutoRestComplexTestServiceBuilder.
+     */
+    public AutoRestComplexTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The service API version that is used when making API requests.
+     */
+    private ServiceVersion serviceVersion;
+
+    /**
+     * Sets The service API version that is used when making API requests.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the AutoRestComplexTestServiceBuilder.
+     */
+    public AutoRestComplexTestServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the AutoRestComplexTestServiceBuilder.
+     */
+    public AutoRestComplexTestServiceBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the AutoRestComplexTestServiceBuilder.
+     */
+    public AutoRestComplexTestServiceBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestComplexTestService with the provided parameters.
      *
@@ -70,15 +185,37 @@ public final class AutoRestComplexTestServiceBuilder {
             this.host = "http://localhost:3000";
         }
         if (pipeline == null) {
-            this.pipeline =
-                    new HttpPipelineBuilder()
-                            .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                            .build();
+            this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
         }
         AutoRestComplexTestService client = new AutoRestComplexTestService(pipeline, serializerAdapter, host);
         return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/AutoRestComplexTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/AutoRestComplexTestServiceBuilder.java
@@ -30,7 +30,7 @@ public final class AutoRestComplexTestServiceBuilder {
     private final Map<String, String> properties = new HashMap<>();
 
     public AutoRestComplexTestServiceBuilder() {
-        this.httpPipelinePolicies = new ArrayList<>();
+        this.pipelinePolicies = new ArrayList<>();
     }
 
     /*

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/AutoRestComplexTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/AutoRestComplexTestServiceBuilder.java
@@ -29,6 +29,10 @@ public final class AutoRestComplexTestServiceBuilder {
 
     private final Map<String, String> properties = new HashMap<>();
 
+    public AutoRestComplexTestServiceBuilder() {
+        this.httpPipelinePolicies = new ArrayList<>();
+    }
+
     /*
      * server parameter
      */

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/GoblinSharkColor.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/GoblinSharkColor.java
@@ -16,10 +16,10 @@ public final class GoblinSharkColor extends ExpandableStringEnum<GoblinSharkColo
     public static final GoblinSharkColor BROWN = fromString("brown");
 
     /** Static value RED for GoblinSharkColor. */
-    public static final GoblinSharkColor RED = fromString("RED");
+    public static final GoblinSharkColor UPPER_RED = fromString("RED");
 
     /** Static value red for GoblinSharkColor. */
-    public static final GoblinSharkColor RED_1 = fromString("red");
+    public static final GoblinSharkColor LOWER_RED = fromString("red");
 
     /**
      * Creates or finds a GoblinSharkColor from its string representation.

--- a/vanilla-tests/src/main/java/fixtures/bodydate/AutoRestDateTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydate/AutoRestDateTestServiceBuilder.java
@@ -1,17 +1,34 @@
 package fixtures.bodydate;
 
 import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** A builder for creating a new instance of the AutoRestDateTestService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestDateTestService.class})
 public final class AutoRestDateTestServiceBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
     /*
      * server parameter
      */
@@ -60,6 +77,104 @@ public final class AutoRestDateTestServiceBuilder {
         return this;
     }
 
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the AutoRestDateTestServiceBuilder.
+     */
+    public AutoRestDateTestServiceBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the AutoRestDateTestServiceBuilder.
+     */
+    public AutoRestDateTestServiceBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the AutoRestDateTestServiceBuilder.
+     */
+    public AutoRestDateTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The service API version that is used when making API requests.
+     */
+    private ServiceVersion serviceVersion;
+
+    /**
+     * Sets The service API version that is used when making API requests.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the AutoRestDateTestServiceBuilder.
+     */
+    public AutoRestDateTestServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the AutoRestDateTestServiceBuilder.
+     */
+    public AutoRestDateTestServiceBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the AutoRestDateTestServiceBuilder.
+     */
+    public AutoRestDateTestServiceBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestDateTestService with the provided parameters.
      *
@@ -70,15 +185,37 @@ public final class AutoRestDateTestServiceBuilder {
             this.host = "http://localhost:3000";
         }
         if (pipeline == null) {
-            this.pipeline =
-                    new HttpPipelineBuilder()
-                            .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                            .build();
+            this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
         }
         AutoRestDateTestService client = new AutoRestDateTestService(pipeline, serializerAdapter, host);
         return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodydate/AutoRestDateTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydate/AutoRestDateTestServiceBuilder.java
@@ -29,6 +29,10 @@ public final class AutoRestDateTestServiceBuilder {
 
     private final Map<String, String> properties = new HashMap<>();
 
+    public AutoRestDateTestServiceBuilder() {
+        this.httpPipelinePolicies = new ArrayList<>();
+    }
+
     /*
      * server parameter
      */

--- a/vanilla-tests/src/main/java/fixtures/bodydate/AutoRestDateTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydate/AutoRestDateTestServiceBuilder.java
@@ -30,7 +30,7 @@ public final class AutoRestDateTestServiceBuilder {
     private final Map<String, String> properties = new HashMap<>();
 
     public AutoRestDateTestServiceBuilder() {
-        this.httpPipelinePolicies = new ArrayList<>();
+        this.pipelinePolicies = new ArrayList<>();
     }
 
     /*

--- a/vanilla-tests/src/main/java/fixtures/bodydatetime/AutoRestDateTimeTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydatetime/AutoRestDateTimeTestServiceBuilder.java
@@ -1,17 +1,34 @@
 package fixtures.bodydatetime;
 
 import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** A builder for creating a new instance of the AutoRestDateTimeTestService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestDateTimeTestService.class})
 public final class AutoRestDateTimeTestServiceBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
     /*
      * server parameter
      */
@@ -60,6 +77,104 @@ public final class AutoRestDateTimeTestServiceBuilder {
         return this;
     }
 
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the AutoRestDateTimeTestServiceBuilder.
+     */
+    public AutoRestDateTimeTestServiceBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the AutoRestDateTimeTestServiceBuilder.
+     */
+    public AutoRestDateTimeTestServiceBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the AutoRestDateTimeTestServiceBuilder.
+     */
+    public AutoRestDateTimeTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The service API version that is used when making API requests.
+     */
+    private ServiceVersion serviceVersion;
+
+    /**
+     * Sets The service API version that is used when making API requests.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the AutoRestDateTimeTestServiceBuilder.
+     */
+    public AutoRestDateTimeTestServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the AutoRestDateTimeTestServiceBuilder.
+     */
+    public AutoRestDateTimeTestServiceBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the AutoRestDateTimeTestServiceBuilder.
+     */
+    public AutoRestDateTimeTestServiceBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestDateTimeTestService with the provided parameters.
      *
@@ -70,15 +185,37 @@ public final class AutoRestDateTimeTestServiceBuilder {
             this.host = "http://localhost:3000";
         }
         if (pipeline == null) {
-            this.pipeline =
-                    new HttpPipelineBuilder()
-                            .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                            .build();
+            this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
         }
         AutoRestDateTimeTestService client = new AutoRestDateTimeTestService(pipeline, serializerAdapter, host);
         return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodydatetime/AutoRestDateTimeTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydatetime/AutoRestDateTimeTestServiceBuilder.java
@@ -29,6 +29,10 @@ public final class AutoRestDateTimeTestServiceBuilder {
 
     private final Map<String, String> properties = new HashMap<>();
 
+    public AutoRestDateTimeTestServiceBuilder() {
+        this.httpPipelinePolicies = new ArrayList<>();
+    }
+
     /*
      * server parameter
      */

--- a/vanilla-tests/src/main/java/fixtures/bodydatetime/AutoRestDateTimeTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydatetime/AutoRestDateTimeTestServiceBuilder.java
@@ -30,7 +30,7 @@ public final class AutoRestDateTimeTestServiceBuilder {
     private final Map<String, String> properties = new HashMap<>();
 
     public AutoRestDateTimeTestServiceBuilder() {
-        this.httpPipelinePolicies = new ArrayList<>();
+        this.pipelinePolicies = new ArrayList<>();
     }
 
     /*

--- a/vanilla-tests/src/main/java/fixtures/bodydatetimerfc1123/AutoRestRFC1123DateTimeTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydatetimerfc1123/AutoRestRFC1123DateTimeTestServiceBuilder.java
@@ -1,17 +1,34 @@
 package fixtures.bodydatetimerfc1123;
 
 import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** A builder for creating a new instance of the AutoRestRFC1123DateTimeTestService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestRFC1123DateTimeTestService.class})
 public final class AutoRestRFC1123DateTimeTestServiceBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
     /*
      * server parameter
      */
@@ -60,6 +77,104 @@ public final class AutoRestRFC1123DateTimeTestServiceBuilder {
         return this;
     }
 
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the AutoRestRFC1123DateTimeTestServiceBuilder.
+     */
+    public AutoRestRFC1123DateTimeTestServiceBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the AutoRestRFC1123DateTimeTestServiceBuilder.
+     */
+    public AutoRestRFC1123DateTimeTestServiceBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the AutoRestRFC1123DateTimeTestServiceBuilder.
+     */
+    public AutoRestRFC1123DateTimeTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The service API version that is used when making API requests.
+     */
+    private ServiceVersion serviceVersion;
+
+    /**
+     * Sets The service API version that is used when making API requests.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the AutoRestRFC1123DateTimeTestServiceBuilder.
+     */
+    public AutoRestRFC1123DateTimeTestServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the AutoRestRFC1123DateTimeTestServiceBuilder.
+     */
+    public AutoRestRFC1123DateTimeTestServiceBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the AutoRestRFC1123DateTimeTestServiceBuilder.
+     */
+    public AutoRestRFC1123DateTimeTestServiceBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestRFC1123DateTimeTestService with the provided parameters.
      *
@@ -70,10 +185,7 @@ public final class AutoRestRFC1123DateTimeTestServiceBuilder {
             this.host = "http://localhost:3000";
         }
         if (pipeline == null) {
-            this.pipeline =
-                    new HttpPipelineBuilder()
-                            .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                            .build();
+            this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
@@ -81,5 +193,30 @@ public final class AutoRestRFC1123DateTimeTestServiceBuilder {
         AutoRestRFC1123DateTimeTestService client =
                 new AutoRestRFC1123DateTimeTestService(pipeline, serializerAdapter, host);
         return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodydatetimerfc1123/AutoRestRFC1123DateTimeTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydatetimerfc1123/AutoRestRFC1123DateTimeTestServiceBuilder.java
@@ -29,6 +29,10 @@ public final class AutoRestRFC1123DateTimeTestServiceBuilder {
 
     private final Map<String, String> properties = new HashMap<>();
 
+    public AutoRestRFC1123DateTimeTestServiceBuilder() {
+        this.httpPipelinePolicies = new ArrayList<>();
+    }
+
     /*
      * server parameter
      */

--- a/vanilla-tests/src/main/java/fixtures/bodydatetimerfc1123/AutoRestRFC1123DateTimeTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydatetimerfc1123/AutoRestRFC1123DateTimeTestServiceBuilder.java
@@ -30,7 +30,7 @@ public final class AutoRestRFC1123DateTimeTestServiceBuilder {
     private final Map<String, String> properties = new HashMap<>();
 
     public AutoRestRFC1123DateTimeTestServiceBuilder() {
-        this.httpPipelinePolicies = new ArrayList<>();
+        this.pipelinePolicies = new ArrayList<>();
     }
 
     /*

--- a/vanilla-tests/src/main/java/fixtures/bodydictionary/AutoRestSwaggerBATDictionaryServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydictionary/AutoRestSwaggerBATDictionaryServiceBuilder.java
@@ -34,6 +34,10 @@ public final class AutoRestSwaggerBATDictionaryServiceBuilder {
 
     private final Map<String, String> properties = new HashMap<>();
 
+    public AutoRestSwaggerBATDictionaryServiceBuilder() {
+        this.httpPipelinePolicies = new ArrayList<>();
+    }
+
     /*
      * server parameter
      */

--- a/vanilla-tests/src/main/java/fixtures/bodydictionary/AutoRestSwaggerBATDictionaryServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydictionary/AutoRestSwaggerBATDictionaryServiceBuilder.java
@@ -35,7 +35,7 @@ public final class AutoRestSwaggerBATDictionaryServiceBuilder {
     private final Map<String, String> properties = new HashMap<>();
 
     public AutoRestSwaggerBATDictionaryServiceBuilder() {
-        this.httpPipelinePolicies = new ArrayList<>();
+        this.pipelinePolicies = new ArrayList<>();
     }
 
     /*

--- a/vanilla-tests/src/main/java/fixtures/bodydictionary/AutoRestSwaggerBATDictionaryServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydictionary/AutoRestSwaggerBATDictionaryServiceBuilder.java
@@ -1,14 +1,25 @@
 package fixtures.bodydictionary;
 
 import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import fixtures.bodydictionary.implementation.AutoRestSwaggerBATDictionaryServiceImpl;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** A builder for creating a new instance of the AutoRestSwaggerBATDictionaryService type. */
 @ServiceClientBuilder(
@@ -17,6 +28,12 @@ import fixtures.bodydictionary.implementation.AutoRestSwaggerBATDictionaryServic
             AutoRestSwaggerBATDictionaryServiceAsyncClient.class
         })
 public final class AutoRestSwaggerBATDictionaryServiceBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
     /*
      * server parameter
      */
@@ -65,6 +82,104 @@ public final class AutoRestSwaggerBATDictionaryServiceBuilder {
         return this;
     }
 
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the AutoRestSwaggerBATDictionaryServiceBuilder.
+     */
+    public AutoRestSwaggerBATDictionaryServiceBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the AutoRestSwaggerBATDictionaryServiceBuilder.
+     */
+    public AutoRestSwaggerBATDictionaryServiceBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the AutoRestSwaggerBATDictionaryServiceBuilder.
+     */
+    public AutoRestSwaggerBATDictionaryServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The service API version that is used when making API requests.
+     */
+    private ServiceVersion serviceVersion;
+
+    /**
+     * Sets The service API version that is used when making API requests.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the AutoRestSwaggerBATDictionaryServiceBuilder.
+     */
+    public AutoRestSwaggerBATDictionaryServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the AutoRestSwaggerBATDictionaryServiceBuilder.
+     */
+    public AutoRestSwaggerBATDictionaryServiceBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the AutoRestSwaggerBATDictionaryServiceBuilder.
+     */
+    public AutoRestSwaggerBATDictionaryServiceBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestSwaggerBATDictionaryServiceImpl with the provided parameters.
      *
@@ -75,10 +190,7 @@ public final class AutoRestSwaggerBATDictionaryServiceBuilder {
             this.host = "http://localhost:3000";
         }
         if (pipeline == null) {
-            this.pipeline =
-                    new HttpPipelineBuilder()
-                            .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                            .build();
+            this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
@@ -86,6 +198,31 @@ public final class AutoRestSwaggerBATDictionaryServiceBuilder {
         AutoRestSwaggerBATDictionaryServiceImpl client =
                 new AutoRestSwaggerBATDictionaryServiceImpl(pipeline, serializerAdapter, host);
         return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/bodydictionary/package-info.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydictionary/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Package containing the classes for AutoRestSwaggerBATDictionaryService. Test Infrastructure for AutoRest Swagger BAT.
+ */
+package fixtures.bodydictionary;

--- a/vanilla-tests/src/main/java/fixtures/bodyduration/AutoRestDurationTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyduration/AutoRestDurationTestServiceBuilder.java
@@ -29,6 +29,10 @@ public final class AutoRestDurationTestServiceBuilder {
 
     private final Map<String, String> properties = new HashMap<>();
 
+    public AutoRestDurationTestServiceBuilder() {
+        this.httpPipelinePolicies = new ArrayList<>();
+    }
+
     /*
      * server parameter
      */

--- a/vanilla-tests/src/main/java/fixtures/bodyduration/AutoRestDurationTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyduration/AutoRestDurationTestServiceBuilder.java
@@ -1,17 +1,34 @@
 package fixtures.bodyduration;
 
 import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** A builder for creating a new instance of the AutoRestDurationTestService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestDurationTestService.class})
 public final class AutoRestDurationTestServiceBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
     /*
      * server parameter
      */
@@ -60,6 +77,104 @@ public final class AutoRestDurationTestServiceBuilder {
         return this;
     }
 
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the AutoRestDurationTestServiceBuilder.
+     */
+    public AutoRestDurationTestServiceBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the AutoRestDurationTestServiceBuilder.
+     */
+    public AutoRestDurationTestServiceBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the AutoRestDurationTestServiceBuilder.
+     */
+    public AutoRestDurationTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The service API version that is used when making API requests.
+     */
+    private ServiceVersion serviceVersion;
+
+    /**
+     * Sets The service API version that is used when making API requests.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the AutoRestDurationTestServiceBuilder.
+     */
+    public AutoRestDurationTestServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the AutoRestDurationTestServiceBuilder.
+     */
+    public AutoRestDurationTestServiceBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the AutoRestDurationTestServiceBuilder.
+     */
+    public AutoRestDurationTestServiceBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestDurationTestService with the provided parameters.
      *
@@ -70,15 +185,37 @@ public final class AutoRestDurationTestServiceBuilder {
             this.host = "http://localhost:3000";
         }
         if (pipeline == null) {
-            this.pipeline =
-                    new HttpPipelineBuilder()
-                            .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                            .build();
+            this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
         }
         AutoRestDurationTestService client = new AutoRestDurationTestService(pipeline, serializerAdapter, host);
         return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodyduration/AutoRestDurationTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyduration/AutoRestDurationTestServiceBuilder.java
@@ -30,7 +30,7 @@ public final class AutoRestDurationTestServiceBuilder {
     private final Map<String, String> properties = new HashMap<>();
 
     public AutoRestDurationTestServiceBuilder() {
-        this.httpPipelinePolicies = new ArrayList<>();
+        this.pipelinePolicies = new ArrayList<>();
     }
 
     /*

--- a/vanilla-tests/src/main/java/fixtures/bodyfile/AutoRestSwaggerBATFileServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyfile/AutoRestSwaggerBATFileServiceBuilder.java
@@ -30,7 +30,7 @@ public final class AutoRestSwaggerBATFileServiceBuilder {
     private final Map<String, String> properties = new HashMap<>();
 
     public AutoRestSwaggerBATFileServiceBuilder() {
-        this.httpPipelinePolicies = new ArrayList<>();
+        this.pipelinePolicies = new ArrayList<>();
     }
 
     /*

--- a/vanilla-tests/src/main/java/fixtures/bodyfile/AutoRestSwaggerBATFileServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyfile/AutoRestSwaggerBATFileServiceBuilder.java
@@ -29,6 +29,10 @@ public final class AutoRestSwaggerBATFileServiceBuilder {
 
     private final Map<String, String> properties = new HashMap<>();
 
+    public AutoRestSwaggerBATFileServiceBuilder() {
+        this.httpPipelinePolicies = new ArrayList<>();
+    }
+
     /*
      * server parameter
      */

--- a/vanilla-tests/src/main/java/fixtures/bodyfile/AutoRestSwaggerBATFileServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyfile/AutoRestSwaggerBATFileServiceBuilder.java
@@ -1,17 +1,34 @@
 package fixtures.bodyfile;
 
 import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** A builder for creating a new instance of the AutoRestSwaggerBATFileService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestSwaggerBATFileService.class})
 public final class AutoRestSwaggerBATFileServiceBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
     /*
      * server parameter
      */
@@ -60,6 +77,104 @@ public final class AutoRestSwaggerBATFileServiceBuilder {
         return this;
     }
 
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the AutoRestSwaggerBATFileServiceBuilder.
+     */
+    public AutoRestSwaggerBATFileServiceBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the AutoRestSwaggerBATFileServiceBuilder.
+     */
+    public AutoRestSwaggerBATFileServiceBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the AutoRestSwaggerBATFileServiceBuilder.
+     */
+    public AutoRestSwaggerBATFileServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The service API version that is used when making API requests.
+     */
+    private ServiceVersion serviceVersion;
+
+    /**
+     * Sets The service API version that is used when making API requests.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the AutoRestSwaggerBATFileServiceBuilder.
+     */
+    public AutoRestSwaggerBATFileServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the AutoRestSwaggerBATFileServiceBuilder.
+     */
+    public AutoRestSwaggerBATFileServiceBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the AutoRestSwaggerBATFileServiceBuilder.
+     */
+    public AutoRestSwaggerBATFileServiceBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestSwaggerBATFileService with the provided parameters.
      *
@@ -70,15 +185,37 @@ public final class AutoRestSwaggerBATFileServiceBuilder {
             this.host = "http://localhost:3000";
         }
         if (pipeline == null) {
-            this.pipeline =
-                    new HttpPipelineBuilder()
-                            .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                            .build();
+            this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
         }
         AutoRestSwaggerBATFileService client = new AutoRestSwaggerBATFileService(pipeline, serializerAdapter, host);
         return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodyinteger/AutoRestIntegerTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyinteger/AutoRestIntegerTestServiceBuilder.java
@@ -29,6 +29,10 @@ public final class AutoRestIntegerTestServiceBuilder {
 
     private final Map<String, String> properties = new HashMap<>();
 
+    public AutoRestIntegerTestServiceBuilder() {
+        this.httpPipelinePolicies = new ArrayList<>();
+    }
+
     /*
      * server parameter
      */

--- a/vanilla-tests/src/main/java/fixtures/bodyinteger/AutoRestIntegerTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyinteger/AutoRestIntegerTestServiceBuilder.java
@@ -1,17 +1,34 @@
 package fixtures.bodyinteger;
 
 import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** A builder for creating a new instance of the AutoRestIntegerTestService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestIntegerTestService.class})
 public final class AutoRestIntegerTestServiceBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
     /*
      * server parameter
      */
@@ -60,6 +77,104 @@ public final class AutoRestIntegerTestServiceBuilder {
         return this;
     }
 
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the AutoRestIntegerTestServiceBuilder.
+     */
+    public AutoRestIntegerTestServiceBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the AutoRestIntegerTestServiceBuilder.
+     */
+    public AutoRestIntegerTestServiceBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the AutoRestIntegerTestServiceBuilder.
+     */
+    public AutoRestIntegerTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The service API version that is used when making API requests.
+     */
+    private ServiceVersion serviceVersion;
+
+    /**
+     * Sets The service API version that is used when making API requests.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the AutoRestIntegerTestServiceBuilder.
+     */
+    public AutoRestIntegerTestServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the AutoRestIntegerTestServiceBuilder.
+     */
+    public AutoRestIntegerTestServiceBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the AutoRestIntegerTestServiceBuilder.
+     */
+    public AutoRestIntegerTestServiceBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestIntegerTestService with the provided parameters.
      *
@@ -70,15 +185,37 @@ public final class AutoRestIntegerTestServiceBuilder {
             this.host = "http://localhost:3000";
         }
         if (pipeline == null) {
-            this.pipeline =
-                    new HttpPipelineBuilder()
-                            .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                            .build();
+            this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
         }
         AutoRestIntegerTestService client = new AutoRestIntegerTestService(pipeline, serializerAdapter, host);
         return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodyinteger/AutoRestIntegerTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyinteger/AutoRestIntegerTestServiceBuilder.java
@@ -30,7 +30,7 @@ public final class AutoRestIntegerTestServiceBuilder {
     private final Map<String, String> properties = new HashMap<>();
 
     public AutoRestIntegerTestServiceBuilder() {
-        this.httpPipelinePolicies = new ArrayList<>();
+        this.pipelinePolicies = new ArrayList<>();
     }
 
     /*

--- a/vanilla-tests/src/main/java/fixtures/bodynumber/AutoRestNumberTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodynumber/AutoRestNumberTestServiceBuilder.java
@@ -1,17 +1,34 @@
 package fixtures.bodynumber;
 
 import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** A builder for creating a new instance of the AutoRestNumberTestService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestNumberTestService.class})
 public final class AutoRestNumberTestServiceBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
     /*
      * server parameter
      */
@@ -60,6 +77,104 @@ public final class AutoRestNumberTestServiceBuilder {
         return this;
     }
 
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the AutoRestNumberTestServiceBuilder.
+     */
+    public AutoRestNumberTestServiceBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the AutoRestNumberTestServiceBuilder.
+     */
+    public AutoRestNumberTestServiceBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the AutoRestNumberTestServiceBuilder.
+     */
+    public AutoRestNumberTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The service API version that is used when making API requests.
+     */
+    private ServiceVersion serviceVersion;
+
+    /**
+     * Sets The service API version that is used when making API requests.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the AutoRestNumberTestServiceBuilder.
+     */
+    public AutoRestNumberTestServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the AutoRestNumberTestServiceBuilder.
+     */
+    public AutoRestNumberTestServiceBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the AutoRestNumberTestServiceBuilder.
+     */
+    public AutoRestNumberTestServiceBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestNumberTestService with the provided parameters.
      *
@@ -70,15 +185,37 @@ public final class AutoRestNumberTestServiceBuilder {
             this.host = "http://localhost:3000";
         }
         if (pipeline == null) {
-            this.pipeline =
-                    new HttpPipelineBuilder()
-                            .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                            .build();
+            this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
         }
         AutoRestNumberTestService client = new AutoRestNumberTestService(pipeline, serializerAdapter, host);
         return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodynumber/AutoRestNumberTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodynumber/AutoRestNumberTestServiceBuilder.java
@@ -30,7 +30,7 @@ public final class AutoRestNumberTestServiceBuilder {
     private final Map<String, String> properties = new HashMap<>();
 
     public AutoRestNumberTestServiceBuilder() {
-        this.httpPipelinePolicies = new ArrayList<>();
+        this.pipelinePolicies = new ArrayList<>();
     }
 
     /*

--- a/vanilla-tests/src/main/java/fixtures/bodynumber/AutoRestNumberTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodynumber/AutoRestNumberTestServiceBuilder.java
@@ -29,6 +29,10 @@ public final class AutoRestNumberTestServiceBuilder {
 
     private final Map<String, String> properties = new HashMap<>();
 
+    public AutoRestNumberTestServiceBuilder() {
+        this.httpPipelinePolicies = new ArrayList<>();
+    }
+
     /*
      * server parameter
      */

--- a/vanilla-tests/src/main/java/fixtures/bodystring/AutoRestSwaggerBATServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodystring/AutoRestSwaggerBATServiceBuilder.java
@@ -29,6 +29,10 @@ public final class AutoRestSwaggerBATServiceBuilder {
 
     private final Map<String, String> properties = new HashMap<>();
 
+    public AutoRestSwaggerBATServiceBuilder() {
+        this.httpPipelinePolicies = new ArrayList<>();
+    }
+
     /*
      * server parameter
      */

--- a/vanilla-tests/src/main/java/fixtures/bodystring/AutoRestSwaggerBATServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodystring/AutoRestSwaggerBATServiceBuilder.java
@@ -30,7 +30,7 @@ public final class AutoRestSwaggerBATServiceBuilder {
     private final Map<String, String> properties = new HashMap<>();
 
     public AutoRestSwaggerBATServiceBuilder() {
-        this.httpPipelinePolicies = new ArrayList<>();
+        this.pipelinePolicies = new ArrayList<>();
     }
 
     /*

--- a/vanilla-tests/src/main/java/fixtures/bodystring/AutoRestSwaggerBATServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodystring/AutoRestSwaggerBATServiceBuilder.java
@@ -1,17 +1,34 @@
 package fixtures.bodystring;
 
 import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** A builder for creating a new instance of the AutoRestSwaggerBATService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestSwaggerBATService.class})
 public final class AutoRestSwaggerBATServiceBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
     /*
      * server parameter
      */
@@ -60,6 +77,104 @@ public final class AutoRestSwaggerBATServiceBuilder {
         return this;
     }
 
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the AutoRestSwaggerBATServiceBuilder.
+     */
+    public AutoRestSwaggerBATServiceBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the AutoRestSwaggerBATServiceBuilder.
+     */
+    public AutoRestSwaggerBATServiceBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the AutoRestSwaggerBATServiceBuilder.
+     */
+    public AutoRestSwaggerBATServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The service API version that is used when making API requests.
+     */
+    private ServiceVersion serviceVersion;
+
+    /**
+     * Sets The service API version that is used when making API requests.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the AutoRestSwaggerBATServiceBuilder.
+     */
+    public AutoRestSwaggerBATServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the AutoRestSwaggerBATServiceBuilder.
+     */
+    public AutoRestSwaggerBATServiceBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the AutoRestSwaggerBATServiceBuilder.
+     */
+    public AutoRestSwaggerBATServiceBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestSwaggerBATService with the provided parameters.
      *
@@ -70,15 +185,37 @@ public final class AutoRestSwaggerBATServiceBuilder {
             this.host = "http://localhost:3000";
         }
         if (pipeline == null) {
-            this.pipeline =
-                    new HttpPipelineBuilder()
-                            .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                            .build();
+            this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
         }
         AutoRestSwaggerBATService client = new AutoRestSwaggerBATService(pipeline, serializerAdapter, host);
         return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/custombaseuri/AutoRestParameterizedHostTestClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/custombaseuri/AutoRestParameterizedHostTestClientBuilder.java
@@ -1,17 +1,34 @@
 package fixtures.custombaseuri;
 
 import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** A builder for creating a new instance of the AutoRestParameterizedHostTestClient type. */
 @ServiceClientBuilder(serviceClients = {AutoRestParameterizedHostTestClient.class})
 public final class AutoRestParameterizedHostTestClientBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
     /*
      * A string value that is used as a global part of the parameterized host
      */
@@ -60,6 +77,104 @@ public final class AutoRestParameterizedHostTestClientBuilder {
         return this;
     }
 
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the AutoRestParameterizedHostTestClientBuilder.
+     */
+    public AutoRestParameterizedHostTestClientBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the AutoRestParameterizedHostTestClientBuilder.
+     */
+    public AutoRestParameterizedHostTestClientBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the AutoRestParameterizedHostTestClientBuilder.
+     */
+    public AutoRestParameterizedHostTestClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The service API version that is used when making API requests.
+     */
+    private ServiceVersion serviceVersion;
+
+    /**
+     * Sets The service API version that is used when making API requests.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the AutoRestParameterizedHostTestClientBuilder.
+     */
+    public AutoRestParameterizedHostTestClientBuilder serviceVersion(ServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the AutoRestParameterizedHostTestClientBuilder.
+     */
+    public AutoRestParameterizedHostTestClientBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the AutoRestParameterizedHostTestClientBuilder.
+     */
+    public AutoRestParameterizedHostTestClientBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestParameterizedHostTestClient with the provided parameters.
      *
@@ -70,10 +185,7 @@ public final class AutoRestParameterizedHostTestClientBuilder {
             this.host = "host";
         }
         if (pipeline == null) {
-            this.pipeline =
-                    new HttpPipelineBuilder()
-                            .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                            .build();
+            this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
@@ -81,5 +193,30 @@ public final class AutoRestParameterizedHostTestClientBuilder {
         AutoRestParameterizedHostTestClient client =
                 new AutoRestParameterizedHostTestClient(pipeline, serializerAdapter, host);
         return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/custombaseuri/AutoRestParameterizedHostTestClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/custombaseuri/AutoRestParameterizedHostTestClientBuilder.java
@@ -29,6 +29,10 @@ public final class AutoRestParameterizedHostTestClientBuilder {
 
     private final Map<String, String> properties = new HashMap<>();
 
+    public AutoRestParameterizedHostTestClientBuilder() {
+        this.httpPipelinePolicies = new ArrayList<>();
+    }
+
     /*
      * A string value that is used as a global part of the parameterized host
      */

--- a/vanilla-tests/src/main/java/fixtures/custombaseuri/AutoRestParameterizedHostTestClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/custombaseuri/AutoRestParameterizedHostTestClientBuilder.java
@@ -30,7 +30,7 @@ public final class AutoRestParameterizedHostTestClientBuilder {
     private final Map<String, String> properties = new HashMap<>();
 
     public AutoRestParameterizedHostTestClientBuilder() {
-        this.httpPipelinePolicies = new ArrayList<>();
+        this.pipelinePolicies = new ArrayList<>();
     }
 
     /*

--- a/vanilla-tests/src/main/java/fixtures/custombaseuri/moreoptions/AutoRestParameterizedCustomHostTestClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/custombaseuri/moreoptions/AutoRestParameterizedCustomHostTestClientBuilder.java
@@ -29,6 +29,10 @@ public final class AutoRestParameterizedCustomHostTestClientBuilder {
 
     private final Map<String, String> properties = new HashMap<>();
 
+    public AutoRestParameterizedCustomHostTestClientBuilder() {
+        this.httpPipelinePolicies = new ArrayList<>();
+    }
+
     /*
      * The subscription id with value 'test12'.
      */

--- a/vanilla-tests/src/main/java/fixtures/custombaseuri/moreoptions/AutoRestParameterizedCustomHostTestClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/custombaseuri/moreoptions/AutoRestParameterizedCustomHostTestClientBuilder.java
@@ -1,17 +1,34 @@
 package fixtures.custombaseuri.moreoptions;
 
 import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** A builder for creating a new instance of the AutoRestParameterizedCustomHostTestClient type. */
 @ServiceClientBuilder(serviceClients = {AutoRestParameterizedCustomHostTestClient.class})
 public final class AutoRestParameterizedCustomHostTestClientBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
     /*
      * The subscription id with value 'test12'.
      */
@@ -77,6 +94,104 @@ public final class AutoRestParameterizedCustomHostTestClientBuilder {
         return this;
     }
 
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the AutoRestParameterizedCustomHostTestClientBuilder.
+     */
+    public AutoRestParameterizedCustomHostTestClientBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the AutoRestParameterizedCustomHostTestClientBuilder.
+     */
+    public AutoRestParameterizedCustomHostTestClientBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the AutoRestParameterizedCustomHostTestClientBuilder.
+     */
+    public AutoRestParameterizedCustomHostTestClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The service API version that is used when making API requests.
+     */
+    private ServiceVersion serviceVersion;
+
+    /**
+     * Sets The service API version that is used when making API requests.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the AutoRestParameterizedCustomHostTestClientBuilder.
+     */
+    public AutoRestParameterizedCustomHostTestClientBuilder serviceVersion(ServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the AutoRestParameterizedCustomHostTestClientBuilder.
+     */
+    public AutoRestParameterizedCustomHostTestClientBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the AutoRestParameterizedCustomHostTestClientBuilder.
+     */
+    public AutoRestParameterizedCustomHostTestClientBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestParameterizedCustomHostTestClient with the provided parameters.
      *
@@ -87,10 +202,7 @@ public final class AutoRestParameterizedCustomHostTestClientBuilder {
             this.dnsSuffix = "host";
         }
         if (pipeline == null) {
-            this.pipeline =
-                    new HttpPipelineBuilder()
-                            .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                            .build();
+            this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
@@ -98,5 +210,30 @@ public final class AutoRestParameterizedCustomHostTestClientBuilder {
         AutoRestParameterizedCustomHostTestClient client =
                 new AutoRestParameterizedCustomHostTestClient(pipeline, serializerAdapter, subscriptionId, dnsSuffix);
         return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/custombaseuri/moreoptions/AutoRestParameterizedCustomHostTestClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/custombaseuri/moreoptions/AutoRestParameterizedCustomHostTestClientBuilder.java
@@ -30,7 +30,7 @@ public final class AutoRestParameterizedCustomHostTestClientBuilder {
     private final Map<String, String> properties = new HashMap<>();
 
     public AutoRestParameterizedCustomHostTestClientBuilder() {
-        this.httpPipelinePolicies = new ArrayList<>();
+        this.pipelinePolicies = new ArrayList<>();
     }
 
     /*

--- a/vanilla-tests/src/main/java/fixtures/extensibleenums/PetStoreIncBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/extensibleenums/PetStoreIncBuilder.java
@@ -29,6 +29,10 @@ public final class PetStoreIncBuilder {
 
     private final Map<String, String> properties = new HashMap<>();
 
+    public PetStoreIncBuilder() {
+        this.httpPipelinePolicies = new ArrayList<>();
+    }
+
     /*
      * server parameter
      */

--- a/vanilla-tests/src/main/java/fixtures/extensibleenums/PetStoreIncBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/extensibleenums/PetStoreIncBuilder.java
@@ -30,7 +30,7 @@ public final class PetStoreIncBuilder {
     private final Map<String, String> properties = new HashMap<>();
 
     public PetStoreIncBuilder() {
-        this.httpPipelinePolicies = new ArrayList<>();
+        this.pipelinePolicies = new ArrayList<>();
     }
 
     /*

--- a/vanilla-tests/src/main/java/fixtures/extensibleenums/PetStoreIncBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/extensibleenums/PetStoreIncBuilder.java
@@ -1,17 +1,34 @@
 package fixtures.extensibleenums;
 
 import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** A builder for creating a new instance of the PetStoreInc type. */
 @ServiceClientBuilder(serviceClients = {PetStoreInc.class})
 public final class PetStoreIncBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
     /*
      * server parameter
      */
@@ -60,6 +77,104 @@ public final class PetStoreIncBuilder {
         return this;
     }
 
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the PetStoreIncBuilder.
+     */
+    public PetStoreIncBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the PetStoreIncBuilder.
+     */
+    public PetStoreIncBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the PetStoreIncBuilder.
+     */
+    public PetStoreIncBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The service API version that is used when making API requests.
+     */
+    private ServiceVersion serviceVersion;
+
+    /**
+     * Sets The service API version that is used when making API requests.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the PetStoreIncBuilder.
+     */
+    public PetStoreIncBuilder serviceVersion(ServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the PetStoreIncBuilder.
+     */
+    public PetStoreIncBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the PetStoreIncBuilder.
+     */
+    public PetStoreIncBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
     /**
      * Builds an instance of PetStoreInc with the provided parameters.
      *
@@ -70,15 +185,37 @@ public final class PetStoreIncBuilder {
             this.host = "http://localhost:3000";
         }
         if (pipeline == null) {
-            this.pipeline =
-                    new HttpPipelineBuilder()
-                            .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                            .build();
+            this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
         }
         PetStoreInc client = new PetStoreInc(pipeline, serializerAdapter, host);
         return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/head/AutoRestHeadTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/head/AutoRestHeadTestServiceBuilder.java
@@ -1,17 +1,34 @@
 package fixtures.head;
 
 import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** A builder for creating a new instance of the AutoRestHeadTestService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestHeadTestService.class})
 public final class AutoRestHeadTestServiceBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
     /*
      * server parameter
      */
@@ -60,6 +77,104 @@ public final class AutoRestHeadTestServiceBuilder {
         return this;
     }
 
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the AutoRestHeadTestServiceBuilder.
+     */
+    public AutoRestHeadTestServiceBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the AutoRestHeadTestServiceBuilder.
+     */
+    public AutoRestHeadTestServiceBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the AutoRestHeadTestServiceBuilder.
+     */
+    public AutoRestHeadTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The service API version that is used when making API requests.
+     */
+    private ServiceVersion serviceVersion;
+
+    /**
+     * Sets The service API version that is used when making API requests.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the AutoRestHeadTestServiceBuilder.
+     */
+    public AutoRestHeadTestServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the AutoRestHeadTestServiceBuilder.
+     */
+    public AutoRestHeadTestServiceBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the AutoRestHeadTestServiceBuilder.
+     */
+    public AutoRestHeadTestServiceBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestHeadTestService with the provided parameters.
      *
@@ -70,15 +185,37 @@ public final class AutoRestHeadTestServiceBuilder {
             this.host = "http://localhost:3000";
         }
         if (pipeline == null) {
-            this.pipeline =
-                    new HttpPipelineBuilder()
-                            .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                            .build();
+            this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
         }
         AutoRestHeadTestService client = new AutoRestHeadTestService(pipeline, serializerAdapter, host);
         return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/head/AutoRestHeadTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/head/AutoRestHeadTestServiceBuilder.java
@@ -29,6 +29,10 @@ public final class AutoRestHeadTestServiceBuilder {
 
     private final Map<String, String> properties = new HashMap<>();
 
+    public AutoRestHeadTestServiceBuilder() {
+        this.httpPipelinePolicies = new ArrayList<>();
+    }
+
     /*
      * server parameter
      */

--- a/vanilla-tests/src/main/java/fixtures/head/AutoRestHeadTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/head/AutoRestHeadTestServiceBuilder.java
@@ -30,7 +30,7 @@ public final class AutoRestHeadTestServiceBuilder {
     private final Map<String, String> properties = new HashMap<>();
 
     public AutoRestHeadTestServiceBuilder() {
-        this.httpPipelinePolicies = new ArrayList<>();
+        this.pipelinePolicies = new ArrayList<>();
     }
 
     /*

--- a/vanilla-tests/src/main/java/fixtures/header/AutoRestSwaggerBATHeaderServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/header/AutoRestSwaggerBATHeaderServiceBuilder.java
@@ -30,7 +30,7 @@ public final class AutoRestSwaggerBATHeaderServiceBuilder {
     private final Map<String, String> properties = new HashMap<>();
 
     public AutoRestSwaggerBATHeaderServiceBuilder() {
-        this.httpPipelinePolicies = new ArrayList<>();
+        this.pipelinePolicies = new ArrayList<>();
     }
 
     /*

--- a/vanilla-tests/src/main/java/fixtures/header/AutoRestSwaggerBATHeaderServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/header/AutoRestSwaggerBATHeaderServiceBuilder.java
@@ -1,17 +1,34 @@
 package fixtures.header;
 
 import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** A builder for creating a new instance of the AutoRestSwaggerBATHeaderService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestSwaggerBATHeaderService.class})
 public final class AutoRestSwaggerBATHeaderServiceBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
     /*
      * server parameter
      */
@@ -60,6 +77,104 @@ public final class AutoRestSwaggerBATHeaderServiceBuilder {
         return this;
     }
 
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the AutoRestSwaggerBATHeaderServiceBuilder.
+     */
+    public AutoRestSwaggerBATHeaderServiceBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the AutoRestSwaggerBATHeaderServiceBuilder.
+     */
+    public AutoRestSwaggerBATHeaderServiceBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the AutoRestSwaggerBATHeaderServiceBuilder.
+     */
+    public AutoRestSwaggerBATHeaderServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The service API version that is used when making API requests.
+     */
+    private ServiceVersion serviceVersion;
+
+    /**
+     * Sets The service API version that is used when making API requests.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the AutoRestSwaggerBATHeaderServiceBuilder.
+     */
+    public AutoRestSwaggerBATHeaderServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the AutoRestSwaggerBATHeaderServiceBuilder.
+     */
+    public AutoRestSwaggerBATHeaderServiceBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the AutoRestSwaggerBATHeaderServiceBuilder.
+     */
+    public AutoRestSwaggerBATHeaderServiceBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestSwaggerBATHeaderService with the provided parameters.
      *
@@ -70,15 +185,37 @@ public final class AutoRestSwaggerBATHeaderServiceBuilder {
             this.host = "http://localhost:3000";
         }
         if (pipeline == null) {
-            this.pipeline =
-                    new HttpPipelineBuilder()
-                            .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                            .build();
+            this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
         }
         AutoRestSwaggerBATHeaderService client = new AutoRestSwaggerBATHeaderService(pipeline, serializerAdapter, host);
         return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/header/AutoRestSwaggerBATHeaderServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/header/AutoRestSwaggerBATHeaderServiceBuilder.java
@@ -29,6 +29,10 @@ public final class AutoRestSwaggerBATHeaderServiceBuilder {
 
     private final Map<String, String> properties = new HashMap<>();
 
+    public AutoRestSwaggerBATHeaderServiceBuilder() {
+        this.httpPipelinePolicies = new ArrayList<>();
+    }
+
     /*
      * server parameter
      */

--- a/vanilla-tests/src/main/java/fixtures/headexceptions/AutoRestHeadExceptionTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/headexceptions/AutoRestHeadExceptionTestServiceBuilder.java
@@ -29,6 +29,10 @@ public final class AutoRestHeadExceptionTestServiceBuilder {
 
     private final Map<String, String> properties = new HashMap<>();
 
+    public AutoRestHeadExceptionTestServiceBuilder() {
+        this.httpPipelinePolicies = new ArrayList<>();
+    }
+
     /*
      * server parameter
      */

--- a/vanilla-tests/src/main/java/fixtures/headexceptions/AutoRestHeadExceptionTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/headexceptions/AutoRestHeadExceptionTestServiceBuilder.java
@@ -1,17 +1,34 @@
 package fixtures.headexceptions;
 
 import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** A builder for creating a new instance of the AutoRestHeadExceptionTestService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestHeadExceptionTestService.class})
 public final class AutoRestHeadExceptionTestServiceBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
     /*
      * server parameter
      */
@@ -60,6 +77,104 @@ public final class AutoRestHeadExceptionTestServiceBuilder {
         return this;
     }
 
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the AutoRestHeadExceptionTestServiceBuilder.
+     */
+    public AutoRestHeadExceptionTestServiceBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the AutoRestHeadExceptionTestServiceBuilder.
+     */
+    public AutoRestHeadExceptionTestServiceBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the AutoRestHeadExceptionTestServiceBuilder.
+     */
+    public AutoRestHeadExceptionTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The service API version that is used when making API requests.
+     */
+    private ServiceVersion serviceVersion;
+
+    /**
+     * Sets The service API version that is used when making API requests.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the AutoRestHeadExceptionTestServiceBuilder.
+     */
+    public AutoRestHeadExceptionTestServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the AutoRestHeadExceptionTestServiceBuilder.
+     */
+    public AutoRestHeadExceptionTestServiceBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the AutoRestHeadExceptionTestServiceBuilder.
+     */
+    public AutoRestHeadExceptionTestServiceBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestHeadExceptionTestService with the provided parameters.
      *
@@ -70,10 +185,7 @@ public final class AutoRestHeadExceptionTestServiceBuilder {
             this.host = "http://localhost:3000";
         }
         if (pipeline == null) {
-            this.pipeline =
-                    new HttpPipelineBuilder()
-                            .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                            .build();
+            this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
@@ -81,5 +193,30 @@ public final class AutoRestHeadExceptionTestServiceBuilder {
         AutoRestHeadExceptionTestService client =
                 new AutoRestHeadExceptionTestService(pipeline, serializerAdapter, host);
         return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/headexceptions/AutoRestHeadExceptionTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/headexceptions/AutoRestHeadExceptionTestServiceBuilder.java
@@ -30,7 +30,7 @@ public final class AutoRestHeadExceptionTestServiceBuilder {
     private final Map<String, String> properties = new HashMap<>();
 
     public AutoRestHeadExceptionTestServiceBuilder() {
-        this.httpPipelinePolicies = new ArrayList<>();
+        this.pipelinePolicies = new ArrayList<>();
     }
 
     /*

--- a/vanilla-tests/src/main/java/fixtures/httpinfrastructure/AutoRestHttpInfrastructureTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/httpinfrastructure/AutoRestHttpInfrastructureTestServiceBuilder.java
@@ -1,17 +1,34 @@
 package fixtures.httpinfrastructure;
 
 import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** A builder for creating a new instance of the AutoRestHttpInfrastructureTestService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestHttpInfrastructureTestService.class})
 public final class AutoRestHttpInfrastructureTestServiceBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
     /*
      * server parameter
      */
@@ -60,6 +77,104 @@ public final class AutoRestHttpInfrastructureTestServiceBuilder {
         return this;
     }
 
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the AutoRestHttpInfrastructureTestServiceBuilder.
+     */
+    public AutoRestHttpInfrastructureTestServiceBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the AutoRestHttpInfrastructureTestServiceBuilder.
+     */
+    public AutoRestHttpInfrastructureTestServiceBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the AutoRestHttpInfrastructureTestServiceBuilder.
+     */
+    public AutoRestHttpInfrastructureTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The service API version that is used when making API requests.
+     */
+    private ServiceVersion serviceVersion;
+
+    /**
+     * Sets The service API version that is used when making API requests.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the AutoRestHttpInfrastructureTestServiceBuilder.
+     */
+    public AutoRestHttpInfrastructureTestServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the AutoRestHttpInfrastructureTestServiceBuilder.
+     */
+    public AutoRestHttpInfrastructureTestServiceBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the AutoRestHttpInfrastructureTestServiceBuilder.
+     */
+    public AutoRestHttpInfrastructureTestServiceBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestHttpInfrastructureTestService with the provided parameters.
      *
@@ -70,10 +185,7 @@ public final class AutoRestHttpInfrastructureTestServiceBuilder {
             this.host = "http://localhost:3000";
         }
         if (pipeline == null) {
-            this.pipeline =
-                    new HttpPipelineBuilder()
-                            .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                            .build();
+            this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
@@ -81,5 +193,30 @@ public final class AutoRestHttpInfrastructureTestServiceBuilder {
         AutoRestHttpInfrastructureTestService client =
                 new AutoRestHttpInfrastructureTestService(pipeline, serializerAdapter, host);
         return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/httpinfrastructure/AutoRestHttpInfrastructureTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/httpinfrastructure/AutoRestHttpInfrastructureTestServiceBuilder.java
@@ -30,7 +30,7 @@ public final class AutoRestHttpInfrastructureTestServiceBuilder {
     private final Map<String, String> properties = new HashMap<>();
 
     public AutoRestHttpInfrastructureTestServiceBuilder() {
-        this.httpPipelinePolicies = new ArrayList<>();
+        this.pipelinePolicies = new ArrayList<>();
     }
 
     /*

--- a/vanilla-tests/src/main/java/fixtures/httpinfrastructure/AutoRestHttpInfrastructureTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/httpinfrastructure/AutoRestHttpInfrastructureTestServiceBuilder.java
@@ -29,6 +29,10 @@ public final class AutoRestHttpInfrastructureTestServiceBuilder {
 
     private final Map<String, String> properties = new HashMap<>();
 
+    public AutoRestHttpInfrastructureTestServiceBuilder() {
+        this.httpPipelinePolicies = new ArrayList<>();
+    }
+
     /*
      * server parameter
      */

--- a/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClientBuilder.java
@@ -30,7 +30,7 @@ public final class MediaTypesClientBuilder {
     private final Map<String, String> properties = new HashMap<>();
 
     public MediaTypesClientBuilder() {
-        this.httpPipelinePolicies = new ArrayList<>();
+        this.pipelinePolicies = new ArrayList<>();
     }
 
     /*

--- a/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClientBuilder.java
@@ -29,6 +29,10 @@ public final class MediaTypesClientBuilder {
 
     private final Map<String, String> properties = new HashMap<>();
 
+    public MediaTypesClientBuilder() {
+        this.httpPipelinePolicies = new ArrayList<>();
+    }
+
     /*
      * server parameter
      */

--- a/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClientBuilder.java
@@ -1,17 +1,34 @@
 package fixtures.mediatypes;
 
 import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** A builder for creating a new instance of the MediaTypesClient type. */
 @ServiceClientBuilder(serviceClients = {MediaTypesClient.class})
 public final class MediaTypesClientBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
     /*
      * server parameter
      */
@@ -60,6 +77,104 @@ public final class MediaTypesClientBuilder {
         return this;
     }
 
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the MediaTypesClientBuilder.
+     */
+    public MediaTypesClientBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the MediaTypesClientBuilder.
+     */
+    public MediaTypesClientBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the MediaTypesClientBuilder.
+     */
+    public MediaTypesClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The service API version that is used when making API requests.
+     */
+    private ServiceVersion serviceVersion;
+
+    /**
+     * Sets The service API version that is used when making API requests.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the MediaTypesClientBuilder.
+     */
+    public MediaTypesClientBuilder serviceVersion(ServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the MediaTypesClientBuilder.
+     */
+    public MediaTypesClientBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the MediaTypesClientBuilder.
+     */
+    public MediaTypesClientBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
     /**
      * Builds an instance of MediaTypesClient with the provided parameters.
      *
@@ -70,15 +185,37 @@ public final class MediaTypesClientBuilder {
             this.host = "http://localhost:3000";
         }
         if (pipeline == null) {
-            this.pipeline =
-                    new HttpPipelineBuilder()
-                            .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                            .build();
+            this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
         }
         MediaTypesClient client = new MediaTypesClient(pipeline, serializerAdapter, host);
         return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/modelflattening/AutoRestResourceFlatteningTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/modelflattening/AutoRestResourceFlatteningTestServiceBuilder.java
@@ -30,7 +30,7 @@ public final class AutoRestResourceFlatteningTestServiceBuilder {
     private final Map<String, String> properties = new HashMap<>();
 
     public AutoRestResourceFlatteningTestServiceBuilder() {
-        this.httpPipelinePolicies = new ArrayList<>();
+        this.pipelinePolicies = new ArrayList<>();
     }
 
     /*

--- a/vanilla-tests/src/main/java/fixtures/modelflattening/AutoRestResourceFlatteningTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/modelflattening/AutoRestResourceFlatteningTestServiceBuilder.java
@@ -1,17 +1,34 @@
 package fixtures.modelflattening;
 
 import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** A builder for creating a new instance of the AutoRestResourceFlatteningTestService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestResourceFlatteningTestService.class})
 public final class AutoRestResourceFlatteningTestServiceBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
     /*
      * server parameter
      */
@@ -60,6 +77,104 @@ public final class AutoRestResourceFlatteningTestServiceBuilder {
         return this;
     }
 
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the AutoRestResourceFlatteningTestServiceBuilder.
+     */
+    public AutoRestResourceFlatteningTestServiceBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the AutoRestResourceFlatteningTestServiceBuilder.
+     */
+    public AutoRestResourceFlatteningTestServiceBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the AutoRestResourceFlatteningTestServiceBuilder.
+     */
+    public AutoRestResourceFlatteningTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The service API version that is used when making API requests.
+     */
+    private ServiceVersion serviceVersion;
+
+    /**
+     * Sets The service API version that is used when making API requests.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the AutoRestResourceFlatteningTestServiceBuilder.
+     */
+    public AutoRestResourceFlatteningTestServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the AutoRestResourceFlatteningTestServiceBuilder.
+     */
+    public AutoRestResourceFlatteningTestServiceBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the AutoRestResourceFlatteningTestServiceBuilder.
+     */
+    public AutoRestResourceFlatteningTestServiceBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestResourceFlatteningTestService with the provided parameters.
      *
@@ -70,10 +185,7 @@ public final class AutoRestResourceFlatteningTestServiceBuilder {
             this.host = "http://localhost:3000";
         }
         if (pipeline == null) {
-            this.pipeline =
-                    new HttpPipelineBuilder()
-                            .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                            .build();
+            this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
@@ -81,5 +193,30 @@ public final class AutoRestResourceFlatteningTestServiceBuilder {
         AutoRestResourceFlatteningTestService client =
                 new AutoRestResourceFlatteningTestService(pipeline, serializerAdapter, host);
         return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/modelflattening/AutoRestResourceFlatteningTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/modelflattening/AutoRestResourceFlatteningTestServiceBuilder.java
@@ -29,6 +29,10 @@ public final class AutoRestResourceFlatteningTestServiceBuilder {
 
     private final Map<String, String> properties = new HashMap<>();
 
+    public AutoRestResourceFlatteningTestServiceBuilder() {
+        this.httpPipelinePolicies = new ArrayList<>();
+    }
+
     /*
      * server parameter
      */

--- a/vanilla-tests/src/main/java/fixtures/multipleinheritance/MultipleInheritanceServiceClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/multipleinheritance/MultipleInheritanceServiceClientBuilder.java
@@ -29,6 +29,10 @@ public final class MultipleInheritanceServiceClientBuilder {
 
     private final Map<String, String> properties = new HashMap<>();
 
+    public MultipleInheritanceServiceClientBuilder() {
+        this.httpPipelinePolicies = new ArrayList<>();
+    }
+
     /*
      * server parameter
      */

--- a/vanilla-tests/src/main/java/fixtures/multipleinheritance/MultipleInheritanceServiceClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/multipleinheritance/MultipleInheritanceServiceClientBuilder.java
@@ -30,7 +30,7 @@ public final class MultipleInheritanceServiceClientBuilder {
     private final Map<String, String> properties = new HashMap<>();
 
     public MultipleInheritanceServiceClientBuilder() {
-        this.httpPipelinePolicies = new ArrayList<>();
+        this.pipelinePolicies = new ArrayList<>();
     }
 
     /*

--- a/vanilla-tests/src/main/java/fixtures/multipleinheritance/MultipleInheritanceServiceClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/multipleinheritance/MultipleInheritanceServiceClientBuilder.java
@@ -1,17 +1,34 @@
 package fixtures.multipleinheritance;
 
 import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** A builder for creating a new instance of the MultipleInheritanceServiceClient type. */
 @ServiceClientBuilder(serviceClients = {MultipleInheritanceServiceClient.class})
 public final class MultipleInheritanceServiceClientBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
     /*
      * server parameter
      */
@@ -60,6 +77,104 @@ public final class MultipleInheritanceServiceClientBuilder {
         return this;
     }
 
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the MultipleInheritanceServiceClientBuilder.
+     */
+    public MultipleInheritanceServiceClientBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the MultipleInheritanceServiceClientBuilder.
+     */
+    public MultipleInheritanceServiceClientBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the MultipleInheritanceServiceClientBuilder.
+     */
+    public MultipleInheritanceServiceClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The service API version that is used when making API requests.
+     */
+    private ServiceVersion serviceVersion;
+
+    /**
+     * Sets The service API version that is used when making API requests.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the MultipleInheritanceServiceClientBuilder.
+     */
+    public MultipleInheritanceServiceClientBuilder serviceVersion(ServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the MultipleInheritanceServiceClientBuilder.
+     */
+    public MultipleInheritanceServiceClientBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the MultipleInheritanceServiceClientBuilder.
+     */
+    public MultipleInheritanceServiceClientBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
     /**
      * Builds an instance of MultipleInheritanceServiceClient with the provided parameters.
      *
@@ -70,10 +185,7 @@ public final class MultipleInheritanceServiceClientBuilder {
             this.host = "http://localhost:3000";
         }
         if (pipeline == null) {
-            this.pipeline =
-                    new HttpPipelineBuilder()
-                            .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                            .build();
+            this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
@@ -81,5 +193,30 @@ public final class MultipleInheritanceServiceClientBuilder {
         MultipleInheritanceServiceClient client =
                 new MultipleInheritanceServiceClient(pipeline, serializerAdapter, host);
         return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/nonstringenum/NonStringEnumsClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/nonstringenum/NonStringEnumsClientBuilder.java
@@ -29,6 +29,10 @@ public final class NonStringEnumsClientBuilder {
 
     private final Map<String, String> properties = new HashMap<>();
 
+    public NonStringEnumsClientBuilder() {
+        this.httpPipelinePolicies = new ArrayList<>();
+    }
+
     /*
      * server parameter
      */

--- a/vanilla-tests/src/main/java/fixtures/nonstringenum/NonStringEnumsClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/nonstringenum/NonStringEnumsClientBuilder.java
@@ -30,7 +30,7 @@ public final class NonStringEnumsClientBuilder {
     private final Map<String, String> properties = new HashMap<>();
 
     public NonStringEnumsClientBuilder() {
-        this.httpPipelinePolicies = new ArrayList<>();
+        this.pipelinePolicies = new ArrayList<>();
     }
 
     /*

--- a/vanilla-tests/src/main/java/fixtures/nonstringenum/NonStringEnumsClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/nonstringenum/NonStringEnumsClientBuilder.java
@@ -1,17 +1,34 @@
 package fixtures.nonstringenum;
 
 import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** A builder for creating a new instance of the NonStringEnumsClient type. */
 @ServiceClientBuilder(serviceClients = {NonStringEnumsClient.class})
 public final class NonStringEnumsClientBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
     /*
      * server parameter
      */
@@ -60,6 +77,104 @@ public final class NonStringEnumsClientBuilder {
         return this;
     }
 
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the NonStringEnumsClientBuilder.
+     */
+    public NonStringEnumsClientBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the NonStringEnumsClientBuilder.
+     */
+    public NonStringEnumsClientBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the NonStringEnumsClientBuilder.
+     */
+    public NonStringEnumsClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The service API version that is used when making API requests.
+     */
+    private ServiceVersion serviceVersion;
+
+    /**
+     * Sets The service API version that is used when making API requests.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the NonStringEnumsClientBuilder.
+     */
+    public NonStringEnumsClientBuilder serviceVersion(ServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the NonStringEnumsClientBuilder.
+     */
+    public NonStringEnumsClientBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the NonStringEnumsClientBuilder.
+     */
+    public NonStringEnumsClientBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
     /**
      * Builds an instance of NonStringEnumsClient with the provided parameters.
      *
@@ -70,15 +185,37 @@ public final class NonStringEnumsClientBuilder {
             this.host = "http://localhost:3000";
         }
         if (pipeline == null) {
-            this.pipeline =
-                    new HttpPipelineBuilder()
-                            .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                            .build();
+            this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
         }
         NonStringEnumsClient client = new NonStringEnumsClient(pipeline, serializerAdapter, host);
         return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/nonstringenum/models/FloatEnum.java
+++ b/vanilla-tests/src/main/java/fixtures/nonstringenum/models/FloatEnum.java
@@ -7,19 +7,19 @@ import java.util.Collection;
 /** Defines values for FloatEnum. */
 public final class FloatEnum extends ExpandableStringEnum<FloatEnum> {
     /** Static value 200.4 for FloatEnum. */
-    public static final FloatEnum TWO_ZERO_ZERO_FOUR = fromFloat(200.4f);
+    public static final FloatEnum TWO_HUNDRED4 = fromFloat(200.4f);
 
     /** Static value 403.4 for FloatEnum. */
-    public static final FloatEnum FOUR_ZERO_THREE_FOUR = fromFloat(403.4f);
+    public static final FloatEnum FOUR_HUNDRED_THREE4 = fromFloat(403.4f);
 
     /** Static value 405.3 for FloatEnum. */
-    public static final FloatEnum FOUR_ZERO_FIVE_THREE = fromFloat(405.3f);
+    public static final FloatEnum FOUR_HUNDRED_FIVE3 = fromFloat(405.3f);
 
     /** Static value 406.2 for FloatEnum. */
-    public static final FloatEnum FOUR_ZERO_SIX_TWO = fromFloat(406.2f);
+    public static final FloatEnum FOUR_HUNDRED_SIX2 = fromFloat(406.2f);
 
     /** Static value 429.1 for FloatEnum. */
-    public static final FloatEnum FOUR_TWO_NINE_ONE = fromFloat(429.1f);
+    public static final FloatEnum FOUR_HUNDRED_TWENTY_NINE1 = fromFloat(429.1f);
 
     /**
      * Creates or finds a FloatEnum from its string representation.

--- a/vanilla-tests/src/main/java/fixtures/nonstringenum/models/IntEnum.java
+++ b/vanilla-tests/src/main/java/fixtures/nonstringenum/models/IntEnum.java
@@ -7,19 +7,19 @@ import java.util.Collection;
 /** Defines values for IntEnum. */
 public final class IntEnum extends ExpandableStringEnum<IntEnum> {
     /** Static value 200 for IntEnum. */
-    public static final IntEnum TWO_ZERO_ZERO = fromInt(200);
+    public static final IntEnum TWO_HUNDRED = fromInt(200);
 
     /** Static value 403 for IntEnum. */
-    public static final IntEnum FOUR_ZERO_THREE = fromInt(403);
+    public static final IntEnum FOUR_HUNDRED_THREE = fromInt(403);
 
     /** Static value 405 for IntEnum. */
-    public static final IntEnum FOUR_ZERO_FIVE = fromInt(405);
+    public static final IntEnum FOUR_HUNDRED_FIVE = fromInt(405);
 
     /** Static value 406 for IntEnum. */
-    public static final IntEnum FOUR_ZERO_SIX = fromInt(406);
+    public static final IntEnum FOUR_HUNDRED_SIX = fromInt(406);
 
     /** Static value 429 for IntEnum. */
-    public static final IntEnum FOUR_TWO_NINE = fromInt(429);
+    public static final IntEnum FOUR_HUNDRED_TWENTY_NINE = fromInt(429);
 
     /**
      * Creates or finds a IntEnum from its string representation.

--- a/vanilla-tests/src/main/java/fixtures/parameterflattening/AutoRestParameterFlatteningBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/parameterflattening/AutoRestParameterFlatteningBuilder.java
@@ -1,17 +1,34 @@
 package fixtures.parameterflattening;
 
 import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** A builder for creating a new instance of the AutoRestParameterFlattening type. */
 @ServiceClientBuilder(serviceClients = {AutoRestParameterFlattening.class})
 public final class AutoRestParameterFlatteningBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
     /*
      * server parameter
      */
@@ -60,6 +77,104 @@ public final class AutoRestParameterFlatteningBuilder {
         return this;
     }
 
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the AutoRestParameterFlatteningBuilder.
+     */
+    public AutoRestParameterFlatteningBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the AutoRestParameterFlatteningBuilder.
+     */
+    public AutoRestParameterFlatteningBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the AutoRestParameterFlatteningBuilder.
+     */
+    public AutoRestParameterFlatteningBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The service API version that is used when making API requests.
+     */
+    private ServiceVersion serviceVersion;
+
+    /**
+     * Sets The service API version that is used when making API requests.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the AutoRestParameterFlatteningBuilder.
+     */
+    public AutoRestParameterFlatteningBuilder serviceVersion(ServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the AutoRestParameterFlatteningBuilder.
+     */
+    public AutoRestParameterFlatteningBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the AutoRestParameterFlatteningBuilder.
+     */
+    public AutoRestParameterFlatteningBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestParameterFlattening with the provided parameters.
      *
@@ -70,15 +185,37 @@ public final class AutoRestParameterFlatteningBuilder {
             this.host = "http://localhost:3000";
         }
         if (pipeline == null) {
-            this.pipeline =
-                    new HttpPipelineBuilder()
-                            .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                            .build();
+            this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
         }
         AutoRestParameterFlattening client = new AutoRestParameterFlattening(pipeline, serializerAdapter, host);
         return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/parameterflattening/AutoRestParameterFlatteningBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/parameterflattening/AutoRestParameterFlatteningBuilder.java
@@ -30,7 +30,7 @@ public final class AutoRestParameterFlatteningBuilder {
     private final Map<String, String> properties = new HashMap<>();
 
     public AutoRestParameterFlatteningBuilder() {
-        this.httpPipelinePolicies = new ArrayList<>();
+        this.pipelinePolicies = new ArrayList<>();
     }
 
     /*

--- a/vanilla-tests/src/main/java/fixtures/parameterflattening/AutoRestParameterFlatteningBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/parameterflattening/AutoRestParameterFlatteningBuilder.java
@@ -29,6 +29,10 @@ public final class AutoRestParameterFlatteningBuilder {
 
     private final Map<String, String> properties = new HashMap<>();
 
+    public AutoRestParameterFlatteningBuilder() {
+        this.httpPipelinePolicies = new ArrayList<>();
+    }
+
     /*
      * server parameter
      */

--- a/vanilla-tests/src/main/java/fixtures/report/AutoRestReportServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/report/AutoRestReportServiceBuilder.java
@@ -29,6 +29,10 @@ public final class AutoRestReportServiceBuilder {
 
     private final Map<String, String> properties = new HashMap<>();
 
+    public AutoRestReportServiceBuilder() {
+        this.httpPipelinePolicies = new ArrayList<>();
+    }
+
     /*
      * server parameter
      */

--- a/vanilla-tests/src/main/java/fixtures/report/AutoRestReportServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/report/AutoRestReportServiceBuilder.java
@@ -1,17 +1,34 @@
 package fixtures.report;
 
 import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** A builder for creating a new instance of the AutoRestReportService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestReportService.class})
 public final class AutoRestReportServiceBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
     /*
      * server parameter
      */
@@ -60,6 +77,104 @@ public final class AutoRestReportServiceBuilder {
         return this;
     }
 
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the AutoRestReportServiceBuilder.
+     */
+    public AutoRestReportServiceBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the AutoRestReportServiceBuilder.
+     */
+    public AutoRestReportServiceBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the AutoRestReportServiceBuilder.
+     */
+    public AutoRestReportServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The service API version that is used when making API requests.
+     */
+    private ServiceVersion serviceVersion;
+
+    /**
+     * Sets The service API version that is used when making API requests.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the AutoRestReportServiceBuilder.
+     */
+    public AutoRestReportServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the AutoRestReportServiceBuilder.
+     */
+    public AutoRestReportServiceBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the AutoRestReportServiceBuilder.
+     */
+    public AutoRestReportServiceBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestReportService with the provided parameters.
      *
@@ -70,15 +185,37 @@ public final class AutoRestReportServiceBuilder {
             this.host = "http://localhost:3000";
         }
         if (pipeline == null) {
-            this.pipeline =
-                    new HttpPipelineBuilder()
-                            .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                            .build();
+            this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
         }
         AutoRestReportService client = new AutoRestReportService(pipeline, serializerAdapter, host);
         return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/report/AutoRestReportServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/report/AutoRestReportServiceBuilder.java
@@ -30,7 +30,7 @@ public final class AutoRestReportServiceBuilder {
     private final Map<String, String> properties = new HashMap<>();
 
     public AutoRestReportServiceBuilder() {
-        this.httpPipelinePolicies = new ArrayList<>();
+        this.pipelinePolicies = new ArrayList<>();
     }
 
     /*

--- a/vanilla-tests/src/main/java/fixtures/requiredoptional/AutoRestRequiredOptionalTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/requiredoptional/AutoRestRequiredOptionalTestServiceBuilder.java
@@ -1,17 +1,34 @@
 package fixtures.requiredoptional;
 
 import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** A builder for creating a new instance of the AutoRestRequiredOptionalTestService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestRequiredOptionalTestService.class})
 public final class AutoRestRequiredOptionalTestServiceBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
     /*
      * number of items to skip
      */
@@ -108,6 +125,104 @@ public final class AutoRestRequiredOptionalTestServiceBuilder {
         return this;
     }
 
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the AutoRestRequiredOptionalTestServiceBuilder.
+     */
+    public AutoRestRequiredOptionalTestServiceBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the AutoRestRequiredOptionalTestServiceBuilder.
+     */
+    public AutoRestRequiredOptionalTestServiceBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the AutoRestRequiredOptionalTestServiceBuilder.
+     */
+    public AutoRestRequiredOptionalTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The service API version that is used when making API requests.
+     */
+    private ServiceVersion serviceVersion;
+
+    /**
+     * Sets The service API version that is used when making API requests.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the AutoRestRequiredOptionalTestServiceBuilder.
+     */
+    public AutoRestRequiredOptionalTestServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the AutoRestRequiredOptionalTestServiceBuilder.
+     */
+    public AutoRestRequiredOptionalTestServiceBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the AutoRestRequiredOptionalTestServiceBuilder.
+     */
+    public AutoRestRequiredOptionalTestServiceBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestRequiredOptionalTestService with the provided parameters.
      *
@@ -118,10 +233,7 @@ public final class AutoRestRequiredOptionalTestServiceBuilder {
             this.host = "http://localhost:3000";
         }
         if (pipeline == null) {
-            this.pipeline =
-                    new HttpPipelineBuilder()
-                            .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                            .build();
+            this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
@@ -135,5 +247,30 @@ public final class AutoRestRequiredOptionalTestServiceBuilder {
                         optionalGlobalQuery,
                         host);
         return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/requiredoptional/AutoRestRequiredOptionalTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/requiredoptional/AutoRestRequiredOptionalTestServiceBuilder.java
@@ -30,7 +30,7 @@ public final class AutoRestRequiredOptionalTestServiceBuilder {
     private final Map<String, String> properties = new HashMap<>();
 
     public AutoRestRequiredOptionalTestServiceBuilder() {
-        this.httpPipelinePolicies = new ArrayList<>();
+        this.pipelinePolicies = new ArrayList<>();
     }
 
     /*

--- a/vanilla-tests/src/main/java/fixtures/requiredoptional/AutoRestRequiredOptionalTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/requiredoptional/AutoRestRequiredOptionalTestServiceBuilder.java
@@ -29,6 +29,10 @@ public final class AutoRestRequiredOptionalTestServiceBuilder {
 
     private final Map<String, String> properties = new HashMap<>();
 
+    public AutoRestRequiredOptionalTestServiceBuilder() {
+        this.httpPipelinePolicies = new ArrayList<>();
+    }
+
     /*
      * number of items to skip
      */

--- a/vanilla-tests/src/main/java/fixtures/url/AutoRestUrlTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/url/AutoRestUrlTestServiceBuilder.java
@@ -30,7 +30,7 @@ public final class AutoRestUrlTestServiceBuilder {
     private final Map<String, String> properties = new HashMap<>();
 
     public AutoRestUrlTestServiceBuilder() {
-        this.httpPipelinePolicies = new ArrayList<>();
+        this.pipelinePolicies = new ArrayList<>();
     }
 
     /*

--- a/vanilla-tests/src/main/java/fixtures/url/AutoRestUrlTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/url/AutoRestUrlTestServiceBuilder.java
@@ -1,17 +1,34 @@
 package fixtures.url;
 
 import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** A builder for creating a new instance of the AutoRestUrlTestService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestUrlTestService.class})
 public final class AutoRestUrlTestServiceBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
     /*
      * A string value 'globalItemStringPath' that appears in the path
      */
@@ -92,6 +109,104 @@ public final class AutoRestUrlTestServiceBuilder {
         return this;
     }
 
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the AutoRestUrlTestServiceBuilder.
+     */
+    public AutoRestUrlTestServiceBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the AutoRestUrlTestServiceBuilder.
+     */
+    public AutoRestUrlTestServiceBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the AutoRestUrlTestServiceBuilder.
+     */
+    public AutoRestUrlTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The service API version that is used when making API requests.
+     */
+    private ServiceVersion serviceVersion;
+
+    /**
+     * Sets The service API version that is used when making API requests.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the AutoRestUrlTestServiceBuilder.
+     */
+    public AutoRestUrlTestServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the AutoRestUrlTestServiceBuilder.
+     */
+    public AutoRestUrlTestServiceBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the AutoRestUrlTestServiceBuilder.
+     */
+    public AutoRestUrlTestServiceBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestUrlTestService with the provided parameters.
      *
@@ -102,10 +217,7 @@ public final class AutoRestUrlTestServiceBuilder {
             this.host = "http://localhost:3000";
         }
         if (pipeline == null) {
-            this.pipeline =
-                    new HttpPipelineBuilder()
-                            .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                            .build();
+            this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
@@ -113,5 +225,30 @@ public final class AutoRestUrlTestServiceBuilder {
         AutoRestUrlTestService client =
                 new AutoRestUrlTestService(pipeline, serializerAdapter, globalStringPath, globalStringQuery, host);
         return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/url/AutoRestUrlTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/url/AutoRestUrlTestServiceBuilder.java
@@ -29,6 +29,10 @@ public final class AutoRestUrlTestServiceBuilder {
 
     private final Map<String, String> properties = new HashMap<>();
 
+    public AutoRestUrlTestServiceBuilder() {
+        this.httpPipelinePolicies = new ArrayList<>();
+    }
+
     /*
      * A string value 'globalItemStringPath' that appears in the path
      */

--- a/vanilla-tests/src/main/java/fixtures/url/multi/AutoRestUrlMutliCollectionFormatTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/url/multi/AutoRestUrlMutliCollectionFormatTestServiceBuilder.java
@@ -29,6 +29,10 @@ public final class AutoRestUrlMutliCollectionFormatTestServiceBuilder {
 
     private final Map<String, String> properties = new HashMap<>();
 
+    public AutoRestUrlMutliCollectionFormatTestServiceBuilder() {
+        this.httpPipelinePolicies = new ArrayList<>();
+    }
+
     /*
      * server parameter
      */

--- a/vanilla-tests/src/main/java/fixtures/url/multi/AutoRestUrlMutliCollectionFormatTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/url/multi/AutoRestUrlMutliCollectionFormatTestServiceBuilder.java
@@ -30,7 +30,7 @@ public final class AutoRestUrlMutliCollectionFormatTestServiceBuilder {
     private final Map<String, String> properties = new HashMap<>();
 
     public AutoRestUrlMutliCollectionFormatTestServiceBuilder() {
-        this.httpPipelinePolicies = new ArrayList<>();
+        this.pipelinePolicies = new ArrayList<>();
     }
 
     /*

--- a/vanilla-tests/src/main/java/fixtures/url/multi/AutoRestUrlMutliCollectionFormatTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/url/multi/AutoRestUrlMutliCollectionFormatTestServiceBuilder.java
@@ -1,17 +1,34 @@
 package fixtures.url.multi;
 
 import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** A builder for creating a new instance of the AutoRestUrlMutliCollectionFormatTestService type. */
 @ServiceClientBuilder(serviceClients = {AutoRestUrlMutliCollectionFormatTestService.class})
 public final class AutoRestUrlMutliCollectionFormatTestServiceBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
     /*
      * server parameter
      */
@@ -60,6 +77,104 @@ public final class AutoRestUrlMutliCollectionFormatTestServiceBuilder {
         return this;
     }
 
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the AutoRestUrlMutliCollectionFormatTestServiceBuilder.
+     */
+    public AutoRestUrlMutliCollectionFormatTestServiceBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the AutoRestUrlMutliCollectionFormatTestServiceBuilder.
+     */
+    public AutoRestUrlMutliCollectionFormatTestServiceBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the AutoRestUrlMutliCollectionFormatTestServiceBuilder.
+     */
+    public AutoRestUrlMutliCollectionFormatTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The service API version that is used when making API requests.
+     */
+    private ServiceVersion serviceVersion;
+
+    /**
+     * Sets The service API version that is used when making API requests.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the AutoRestUrlMutliCollectionFormatTestServiceBuilder.
+     */
+    public AutoRestUrlMutliCollectionFormatTestServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the AutoRestUrlMutliCollectionFormatTestServiceBuilder.
+     */
+    public AutoRestUrlMutliCollectionFormatTestServiceBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the AutoRestUrlMutliCollectionFormatTestServiceBuilder.
+     */
+    public AutoRestUrlMutliCollectionFormatTestServiceBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestUrlMutliCollectionFormatTestService with the provided parameters.
      *
@@ -70,10 +185,7 @@ public final class AutoRestUrlMutliCollectionFormatTestServiceBuilder {
             this.host = "http://localhost:3000";
         }
         if (pipeline == null) {
-            this.pipeline =
-                    new HttpPipelineBuilder()
-                            .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                            .build();
+            this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
@@ -81,5 +193,30 @@ public final class AutoRestUrlMutliCollectionFormatTestServiceBuilder {
         AutoRestUrlMutliCollectionFormatTestService client =
                 new AutoRestUrlMutliCollectionFormatTestService(pipeline, serializerAdapter, host);
         return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/validation/AutoRestValidationTestBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/validation/AutoRestValidationTestBuilder.java
@@ -29,6 +29,10 @@ public final class AutoRestValidationTestBuilder {
 
     private final Map<String, String> properties = new HashMap<>();
 
+    public AutoRestValidationTestBuilder() {
+        this.httpPipelinePolicies = new ArrayList<>();
+    }
+
     /*
      * Subscription ID.
      */

--- a/vanilla-tests/src/main/java/fixtures/validation/AutoRestValidationTestBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/validation/AutoRestValidationTestBuilder.java
@@ -1,17 +1,34 @@
 package fixtures.validation;
 
 import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** A builder for creating a new instance of the AutoRestValidationTest type. */
 @ServiceClientBuilder(serviceClients = {AutoRestValidationTest.class})
 public final class AutoRestValidationTestBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
     /*
      * Subscription ID.
      */
@@ -76,6 +93,104 @@ public final class AutoRestValidationTestBuilder {
         return this;
     }
 
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the AutoRestValidationTestBuilder.
+     */
+    public AutoRestValidationTestBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the AutoRestValidationTestBuilder.
+     */
+    public AutoRestValidationTestBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the AutoRestValidationTestBuilder.
+     */
+    public AutoRestValidationTestBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The service API version that is used when making API requests.
+     */
+    private ServiceVersion serviceVersion;
+
+    /**
+     * Sets The service API version that is used when making API requests.
+     *
+     * @param serviceVersion the serviceVersion value.
+     * @return the AutoRestValidationTestBuilder.
+     */
+    public AutoRestValidationTestBuilder serviceVersion(ServiceVersion serviceVersion) {
+        this.serviceVersion = serviceVersion;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the AutoRestValidationTestBuilder.
+     */
+    public AutoRestValidationTestBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the AutoRestValidationTestBuilder.
+     */
+    public AutoRestValidationTestBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
     /**
      * Builds an instance of AutoRestValidationTest with the provided parameters.
      *
@@ -86,15 +201,37 @@ public final class AutoRestValidationTestBuilder {
             this.host = "http://localhost:3000";
         }
         if (pipeline == null) {
-            this.pipeline =
-                    new HttpPipelineBuilder()
-                            .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                            .build();
+            this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
         }
         AutoRestValidationTest client = new AutoRestValidationTest(pipeline, serializerAdapter, subscriptionId, host);
         return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/validation/AutoRestValidationTestBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/validation/AutoRestValidationTestBuilder.java
@@ -30,7 +30,7 @@ public final class AutoRestValidationTestBuilder {
     private final Map<String, String> properties = new HashMap<>();
 
     public AutoRestValidationTestBuilder() {
-        this.httpPipelinePolicies = new ArrayList<>();
+        this.pipelinePolicies = new ArrayList<>();
     }
 
     /*

--- a/vanilla-tests/src/test/java/fixtures/nonstringenum/NonStringEnumTests.java
+++ b/vanilla-tests/src/test/java/fixtures/nonstringenum/NonStringEnumTests.java
@@ -18,22 +18,22 @@ public class NonStringEnumTests {
     @Test
     public void getInt() {
         IntEnum actual = client.getInts().get();
-        assertEquals(IntEnum.FOUR_TWO_NINE, actual);
+        assertEquals(IntEnum.FOUR_HUNDRED_TWENTY_NINE, actual);
     }
 
     @Test
     public void putInt() {
-        client.getInts().put(IntEnum.TWO_ZERO_ZERO);
+        client.getInts().put(IntEnum.TWO_HUNDRED);
     }
 
     @Test
     public void getFloat() {
         FloatEnum actual = client.getFloatOperations().get();
-        assertEquals(FloatEnum.FOUR_TWO_NINE_ONE, actual);
+        assertEquals(FloatEnum.FOUR_HUNDRED_TWENTY_NINE1, actual);
     }
 
     @Test
     public void putFloat() {
-        client.getFloatOperations().put(FloatEnum.TWO_ZERO_ZERO_FOUR);
+        client.getFloatOperations().put(FloatEnum.TWO_HUNDRED4);
     }
 }


### PR DESCRIPTION
This PR includes changes to:
- Builder template to add some more common configuration setters to reduce the gap between generated code and handwritten code
- Use `x-ms-enum` name if defined for enum names
- Optionally add `artifactname.properties` file to resources directory 
