### PR TITLE
de-duplicate when param name conflict with existing one from client

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
@@ -121,7 +121,6 @@ public class ProxyMethodMapper implements IMapper<Operation, Map<Request, ProxyM
             // check for mediaTypes first as that is more specific than the knownMediaType
             // if there are multiple, we'll use the generic type
             if (request.getProtocol().getHttp().getMediaTypes() != null
-                && !request.getProtocol().getHttp().getMediaTypes().isEmpty()
                 && request.getProtocol().getHttp().getMediaTypes().size() == 1) {
                 requestContentType = request.getProtocol().getHttp().getMediaTypes().get(0);
             } else if (request.getProtocol().getHttp().getKnownMediaType() != null) {

--- a/javagen/src/main/java/com/azure/autorest/template/ProxyTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ProxyTemplate.java
@@ -14,8 +14,10 @@ import com.azure.autorest.util.CodeNamer;
 import io.netty.handler.codec.http.HttpResponseStatus;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
@@ -86,6 +88,8 @@ public class ProxyTemplate implements IJavaTemplate<Proxy, JavaClass> {
                         interfaceBlock.annotation(String.format("ResumeOperation"));
                     }
 
+                    Set<String> usedParameterNames = new HashSet<>();
+
                     for (ProxyMethodParameter parameter : restAPIMethod.getParameters()) {
                         StringBuilder parameterDeclarationBuilder = new StringBuilder();
 
@@ -122,7 +126,13 @@ public class ProxyTemplate implements IJavaTemplate<Proxy, JavaClass> {
                                 break;
                         }
 
-                        parameterDeclarationBuilder.append(parameter.getWireType() + " " + parameter.getName());
+                        String parameterName = parameter.getName();
+                        if (usedParameterNames.contains(parameterName)) {
+                            parameterName = parameterName + "Param";
+                        }
+                        usedParameterNames.add(parameterName);
+
+                        parameterDeclarationBuilder.append(parameter.getWireType() + " " + parameterName);
                         parameterDeclarationList.add(parameterDeclarationBuilder.toString());
                     }
 

--- a/javagen/src/main/java/com/azure/autorest/template/ProxyTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ProxyTemplate.java
@@ -126,6 +126,7 @@ public class ProxyTemplate implements IJavaTemplate<Proxy, JavaClass> {
                                 break;
                         }
 
+                        // avoid name conflict
                         String parameterName = parameter.getName();
                         if (usedParameterNames.contains(parameterName)) {
                             parameterName = parameterName + "Param";


### PR DESCRIPTION
Encountered a case that "endpoint" from client (fluent rename the "host" to "endpoint") conflict with "endpoint" from body parameter.
https://github.com/Azure/azure-rest-api-specs/blob/master/specification/cdn/resource-manager/Microsoft.Cdn/stable/2020-04-15/cdn.json#L606-L614

Tried same if parameter is "host", also conflicts with "$host". So that it might also happens to data-plane.

Tried to do this in `ProxyMethodMapper`, but the current code make is very hard to check duplication, since each parameter is done independently.
```
                parameters.add(Mappers.getProxyParameterMapper().map(parameter));
```

Let me know if better solution.