### PR TITLE
v4 fluent, config m4 to use upper for enum value

### DIFF
--- a/fluentnamer/readme.md
+++ b/fluentnamer/readme.md
@@ -31,6 +31,7 @@ pipeline:
     flatten-models: true
     flatten-payloads: true
     naming:
+      choiceValue: upper
       preserve-uppercase-max-length: 2
       override:
         ip: Ip


### PR DESCRIPTION
@srnagar 

data-plane might want to do the same.

By default, m4 uses pascal for choice value, which removes "\_" or "-" etc. Then our CodeNamer will add the "\_" as seperator. For some value it produces very unpredictable result (e.g. "Standard_F72s_v2").