### PR TITLE
v4 enum name

### DIFF
--- a/fluent-tests/prepare-tests.bat
+++ b/fluent-tests/prepare-tests.bat
@@ -11,8 +11,9 @@ RMDIR /S /Q "src/main/java/com/azure/mgmttest"
 RMDIR /S /Q "src/main/java/com/azure/mgmtlitetest"
 
 SET AUTOREST_CORE_VERSION=3.0.6282
-SET COMMON_ARGUMENTS=--java --use:../ --output-folder=./ --license-header=MICROSOFT_MIT_SMALL --sync-methods=all --azure-arm --fluent --required-parameter-client-methods --add-context-parameter --context-client-method-parameter --track1-naming --client-side-validations --client-logger
-SET FLUENTLITE_ARGUMENTS=--java --use:../ --output-folder=./ --license-header=MICROSOFT_MIT_SMALL --sync-methods=all --azure-arm --fluent=lite --required-parameter-client-methods --add-context-parameter --context-client-method-parameter --track1-naming --client-side-validations --client-logger --generate-sync-async-clients
+SET MODELERFOUR_ARGUMENTS=--pipeline.modelerfour.additional-checks=false --pipeline.modelerfour.lenient-model-deduplication=true
+SET COMMON_ARGUMENTS=--java --use:../ --output-folder=./ %MODELERFOUR_ARGUMENTS% --license-header=MICROSOFT_MIT_SMALL --sync-methods=all --azure-arm --fluent --required-parameter-client-methods --add-context-parameter --context-client-method-parameter --track1-naming --client-side-validations --client-logger
+SET FLUENTLITE_ARGUMENTS=--java --use:../ --output-folder=./ %MODELERFOUR_ARGUMENTS% --license-header=MICROSOFT_MIT_SMALL --sync-methods=all --azure-arm --fluent=lite --required-parameter-client-methods --add-context-parameter --context-client-method-parameter --track1-naming --client-side-validations --client-logger --generate-sync-async-clients
 
 REM fluent premium
 CALL autorest --version=%AUTOREST_CORE_VERSION% %COMMON_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/resources/resource-manager/Microsoft.Resources/stable/2019-08-01/resources.json --namespace=com.azure.mgmttest.resources

--- a/fluentnamer/readme.md
+++ b/fluentnamer/readme.md
@@ -26,8 +26,6 @@ pipeline:
   # "Shake the tree", and normalize the model
   modelerfour:
     input: openapi-document/multi-api/identity     # the plugin where we get inputs from
-    additional-checks: false
-    lenient-model-deduplication: true
     flatten-models: true
     flatten-payloads: true
     naming:

--- a/javagen/src/main/java/com/azure/autorest/mapper/ChoiceMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ChoiceMapper.java
@@ -51,12 +51,14 @@ public class ChoiceMapper implements IMapper<ChoiceSchema, IType> {
             List<ClientEnumValue> enumValues = new ArrayList<>();
             for (ChoiceValue enumValue : enumType.getChoices()) {
                 String enumName = enumValue.getValue();
-                if (enumValue.getLanguage() != null && enumValue.getLanguage().getJava() != null
-                        && enumValue.getLanguage().getJava().getName() != null) {
-                    enumName = enumValue.getLanguage().getJava().getName();
-                } else if(enumValue.getLanguage() != null && enumValue.getLanguage().getDefault() != null
-                        && enumValue.getLanguage().getDefault().getName() != null) {
-                    enumName = enumValue.getLanguage().getDefault().getName();
+                if (!settings.isFluent()) {
+                    if (enumValue.getLanguage() != null && enumValue.getLanguage().getJava() != null
+                            && enumValue.getLanguage().getJava().getName() != null) {
+                        enumName = enumValue.getLanguage().getJava().getName();
+                    } else if (enumValue.getLanguage() != null && enumValue.getLanguage().getDefault() != null
+                            && enumValue.getLanguage().getDefault().getName() != null) {
+                        enumName = enumValue.getLanguage().getDefault().getName();
+                    }
                 }
                 final String memberName = CodeNamer.getEnumMemberName(enumName);
                 long counter = enumValues.stream().filter(v -> v.getName().equals(memberName)).count();

--- a/javagen/src/main/java/com/azure/autorest/mapper/SealedChoiceMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/SealedChoiceMapper.java
@@ -51,12 +51,14 @@ public class SealedChoiceMapper implements IMapper<SealedChoiceSchema, IType> {
             List<ClientEnumValue> enumValues = new ArrayList<>();
             for (ChoiceValue enumValue : enumType.getChoices()) {
                 String enumName = enumValue.getValue();
-                if (enumValue.getLanguage() != null && enumValue.getLanguage().getJava() != null
-                        && enumValue.getLanguage().getJava().getName() != null) {
-                    enumName = enumValue.getLanguage().getJava().getName();
-                } else if(enumValue.getLanguage() != null && enumValue.getLanguage().getDefault() != null
-                        && enumValue.getLanguage().getDefault().getName() != null) {
-                    enumName = enumValue.getLanguage().getDefault().getName();
+                if (!settings.isFluent()) {
+                    if (enumValue.getLanguage() != null && enumValue.getLanguage().getJava() != null
+                            && enumValue.getLanguage().getJava().getName() != null) {
+                        enumName = enumValue.getLanguage().getJava().getName();
+                    } else if (enumValue.getLanguage() != null && enumValue.getLanguage().getDefault() != null
+                            && enumValue.getLanguage().getDefault().getName() != null) {
+                        enumName = enumValue.getLanguage().getDefault().getName();
+                    }
                 }
                 String memberName = CodeNamer.getEnumMemberName(enumName);
                 enumValues.add(new ClientEnumValue(memberName, enumValue.getValue()));

--- a/javagen/src/main/java/com/azure/autorest/util/CodeNamer.java
+++ b/javagen/src/main/java/com/azure/autorest/util/CodeNamer.java
@@ -212,6 +212,7 @@ public class CodeNamer {
         }
 
         String result = removeInvalidCharacters(name.replaceAll("[\\\\/.+ -]+", "_"));
+        result = result.replaceAll("_+", "_");  // merge multiple underlines
         Function<Character, Boolean> isUpper = c -> c >= 'A' && c <= 'Z';
         Function<Character, Boolean> isLower = c -> c >= 'a' && c <= 'z';
         for (int i = 1; i < result.length() - 1; i++) {

--- a/javagen/src/main/java/com/azure/autorest/util/CodeNamer.java
+++ b/javagen/src/main/java/com/azure/autorest/util/CodeNamer.java
@@ -212,7 +212,7 @@ public class CodeNamer {
         }
 
         String result = removeInvalidCharacters(name.replaceAll("[\\\\/.+ -]+", "_"));
-        result = result.replaceAll("_+", "_");  // merge multiple underlines
+        result = result.replaceAll("_{2,}", "_");  // merge multiple underlines
         Function<Character, Boolean> isUpper = c -> c >= 'A' && c <= 'Z';
         Function<Character, Boolean> isLower = c -> c >= 'a' && c <= 'z';
         for (int i = 1; i < result.length() - 1; i++) {

--- a/javagen/src/test/java/com/azure/autorest/util/CodeNamerTests.java
+++ b/javagen/src/test/java/com/azure/autorest/util/CodeNamerTests.java
@@ -27,5 +27,7 @@ public class CodeNamerTests {
         Assert.assertEquals("ALL", CodeNamer.getEnumMemberName("$all"));
 
         Assert.assertEquals("ALL", CodeNamer.getEnumMemberName("all*"));
+
+        Assert.assertEquals("SYSTEM_ASSIGNED_USER_ASSIGNED", CodeNamer.getEnumMemberName("SystemAssigned, UserAssigned"));
     }
 }


### PR DESCRIPTION
Temporary disable enum value naming by m4. It produces crazy ones like IPv4 -> I_PV4, and TLSv1_1 -> TL_SV1_1

Also collapse multiple underscore in a row to a single underscore.