### PR TITLE
v4, private client method for listSinglePage/listNextPage, and Async with Context

### DIFF
--- a/azure-tests/src/main/java/fixtures/paging/Pagings.java
+++ b/azure-tests/src/main/java/fixtures/paging/Pagings.java
@@ -279,7 +279,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getNoItemNamePagesSinglePageAsync() {
+    private Mono<PagedResponse<Product>> getNoItemNamePagesSinglePageAsync() {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -329,7 +329,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getNullNextLinkNamePagesSinglePageAsync() {
+    private Mono<PagedResponse<Product>> getNullNextLinkNamePagesSinglePageAsync() {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -378,7 +378,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getSinglePagesSinglePageAsync() {
+    private Mono<PagedResponse<Product>> getSinglePagesSinglePageAsync() {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -431,7 +431,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getMultiplePagesSinglePageAsync(
+    private Mono<PagedResponse<Product>> getMultiplePagesSinglePageAsync(
             String clientRequestId, PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) {
         if (this.client.getHost() == null) {
             return Mono.error(
@@ -510,7 +510,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getWithQueryParamsSinglePageAsync(int requiredQueryParameter) {
+    private Mono<PagedResponse<Product>> getWithQueryParamsSinglePageAsync(int requiredQueryParameter) {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -571,7 +571,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> nextOperationWithQueryParamsSinglePageAsync() {
+    private Mono<PagedResponse<Product>> nextOperationWithQueryParamsSinglePageAsync() {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -601,7 +601,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getOdataMultiplePagesSinglePageAsync(
+    private Mono<PagedResponse<Product>> getOdataMultiplePagesSinglePageAsync(
             String clientRequestId, PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) {
         if (this.client.getHost() == null) {
             return Mono.error(
@@ -680,7 +680,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getMultiplePagesWithOffsetSinglePageAsync(
+    private Mono<PagedResponse<Product>> getMultiplePagesWithOffsetSinglePageAsync(
             PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions, String clientRequestId) {
         if (this.client.getHost() == null) {
             return Mono.error(
@@ -757,7 +757,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getMultiplePagesRetryFirstSinglePageAsync() {
+    private Mono<PagedResponse<Product>> getMultiplePagesRetryFirstSinglePageAsync() {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -811,7 +811,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getMultiplePagesRetrySecondSinglePageAsync() {
+    private Mono<PagedResponse<Product>> getMultiplePagesRetrySecondSinglePageAsync() {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -864,7 +864,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getSinglePagesFailureSinglePageAsync() {
+    private Mono<PagedResponse<Product>> getSinglePagesFailureSinglePageAsync() {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -915,7 +915,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getMultiplePagesFailureSinglePageAsync() {
+    private Mono<PagedResponse<Product>> getMultiplePagesFailureSinglePageAsync() {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -966,7 +966,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getMultiplePagesFailureUriSinglePageAsync() {
+    private Mono<PagedResponse<Product>> getMultiplePagesFailureUriSinglePageAsync() {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -1020,7 +1020,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getMultiplePagesFragmentNextLinkSinglePageAsync(
+    private Mono<PagedResponse<Product>> getMultiplePagesFragmentNextLinkSinglePageAsync(
             String apiVersion, String tenant) {
         if (this.client.getHost() == null) {
             return Mono.error(
@@ -1089,7 +1089,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getMultiplePagesFragmentWithGroupingNextLinkSinglePageAsync(
+    private Mono<PagedResponse<Product>> getMultiplePagesFragmentWithGroupingNextLinkSinglePageAsync(
             CustomParameterGroup customParameterGroup) {
         if (this.client.getHost() == null) {
             return Mono.error(
@@ -1161,7 +1161,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getMultiplePagesLROSinglePageAsync(
+    private Mono<PagedResponse<Product>> getMultiplePagesLROSinglePageAsync(
             String clientRequestId, PagingGetMultiplePagesLroOptions pagingGetMultiplePagesLroOptions) {
         if (this.client.getHost() == null) {
             return Mono.error(
@@ -1241,7 +1241,8 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> nextFragmentSinglePageAsync(String apiVersion, String tenant, String nextLink) {
+    private Mono<PagedResponse<Product>> nextFragmentSinglePageAsync(
+            String apiVersion, String tenant, String nextLink) {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -1279,7 +1280,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> nextFragmentWithGroupingSinglePageAsync(
+    private Mono<PagedResponse<Product>> nextFragmentWithGroupingSinglePageAsync(
             String nextLink, CustomParameterGroup customParameterGroup) {
         if (this.client.getHost() == null) {
             return Mono.error(
@@ -1319,7 +1320,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getPagingModelWithItemNameWithXMSClientNameSinglePageAsync() {
+    private Mono<PagedResponse<Product>> getPagingModelWithItemNameWithXMSClientNameSinglePageAsync() {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -1373,7 +1374,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getNoItemNamePagesNextSinglePageAsync(String nextLink) {
+    private Mono<PagedResponse<Product>> getNoItemNamePagesNextSinglePageAsync(String nextLink) {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
         }
@@ -1399,7 +1400,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getSinglePagesNextSinglePageAsync(String nextLink) {
+    private Mono<PagedResponse<Product>> getSinglePagesNextSinglePageAsync(String nextLink) {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
         }
@@ -1425,7 +1426,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getMultiplePagesNextSinglePageAsync(String nextLink) {
+    private Mono<PagedResponse<Product>> getMultiplePagesNextSinglePageAsync(String nextLink) {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
         }
@@ -1451,7 +1452,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getOdataMultiplePagesNextSinglePageAsync(String nextLink) {
+    private Mono<PagedResponse<Product>> getOdataMultiplePagesNextSinglePageAsync(String nextLink) {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
         }
@@ -1477,7 +1478,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getMultiplePagesWithOffsetNextSinglePageAsync(String nextLink) {
+    private Mono<PagedResponse<Product>> getMultiplePagesWithOffsetNextSinglePageAsync(String nextLink) {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
         }
@@ -1503,7 +1504,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getMultiplePagesRetryFirstNextSinglePageAsync(String nextLink) {
+    private Mono<PagedResponse<Product>> getMultiplePagesRetryFirstNextSinglePageAsync(String nextLink) {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
         }
@@ -1529,7 +1530,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getMultiplePagesRetrySecondNextSinglePageAsync(String nextLink) {
+    private Mono<PagedResponse<Product>> getMultiplePagesRetrySecondNextSinglePageAsync(String nextLink) {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
         }
@@ -1555,7 +1556,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getSinglePagesFailureNextSinglePageAsync(String nextLink) {
+    private Mono<PagedResponse<Product>> getSinglePagesFailureNextSinglePageAsync(String nextLink) {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
         }
@@ -1581,7 +1582,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getMultiplePagesFailureNextSinglePageAsync(String nextLink) {
+    private Mono<PagedResponse<Product>> getMultiplePagesFailureNextSinglePageAsync(String nextLink) {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
         }
@@ -1607,7 +1608,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getMultiplePagesFailureUriNextSinglePageAsync(String nextLink) {
+    private Mono<PagedResponse<Product>> getMultiplePagesFailureUriNextSinglePageAsync(String nextLink) {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
         }
@@ -1633,7 +1634,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getMultiplePagesLRONextSinglePageAsync(String nextLink) {
+    private Mono<PagedResponse<Product>> getMultiplePagesLRONextSinglePageAsync(String nextLink) {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
         }
@@ -1659,7 +1660,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getPagingModelWithItemNameWithXMSClientNameNextSinglePageAsync(
+    private Mono<PagedResponse<Product>> getPagingModelWithItemNameWithXMSClientNameNextSinglePageAsync(
             String nextLink) {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentClientMethodTemplate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentClientMethodTemplate.java
@@ -36,7 +36,7 @@ public class FluentClientMethodTemplate extends ClientMethodTemplate {
         String restAPIMethodArgumentList = String.join(", ", clientMethod.getProxyMethodArguments(settings));
         String serviceMethodCall = String.format("service.%s(%s)", restAPIMethod.getName(), restAPIMethodArgumentList);
         if (clientMethod.getMethodPageDetails().nonNullNextLink()) {
-            typeBlock.publicMethod(clientMethod.getDeclaration(), function -> {
+            writeMethod(typeBlock, clientMethod.getMethodVisibility(), clientMethod.getDeclaration(), function -> {
                 AddValidations(function, clientMethod.getRequiredNullableParameterExpressions(), clientMethod.getValidateExpressions(), settings);
                 AddOptionalAndConstantVariables(function, clientMethod, restAPIMethod.getParameters(), settings);
                 ApplyParameterTransformations(function, clientMethod, settings);
@@ -115,7 +115,7 @@ public class FluentClientMethodTemplate extends ClientMethodTemplate {
                 });
             });
         } else {
-            typeBlock.publicMethod(clientMethod.getDeclaration(), function -> {
+            writeMethod(typeBlock, clientMethod.getMethodVisibility(), clientMethod.getDeclaration(), function -> {
                 AddValidations(function, clientMethod.getRequiredNullableParameterExpressions(), clientMethod.getValidateExpressions(), settings);
                 AddOptionalAndConstantVariables(function, clientMethod, restAPIMethod.getParameters(), settings);
                 ApplyParameterTransformations(function, clientMethod, settings);
@@ -202,7 +202,7 @@ public class FluentClientMethodTemplate extends ClientMethodTemplate {
         boolean mergeContextParameter = settings.getAddContextParameter() && (settings.isContextClientMethodParameter() && contextInParameters(clientMethod));
 
         typeBlock.annotation("ServiceMethod(returns = ReturnType.SINGLE)");
-        typeBlock.publicMethod(clientMethod.getDeclaration(), function -> {
+        writeMethod(typeBlock, clientMethod.getMethodVisibility(), clientMethod.getDeclaration(), function -> {
             AddValidations(function, clientMethod.getRequiredNullableParameterExpressions(), clientMethod.getValidateExpressions(), settings);
             AddOptionalAndConstantVariables(function, clientMethod, restAPIMethod.getParameters(), settings);
             ApplyParameterTransformations(function, clientMethod, settings);
@@ -227,7 +227,7 @@ public class FluentClientMethodTemplate extends ClientMethodTemplate {
     @Override
     protected void generateLongRunningAsync(ClientMethod clientMethod, JavaType typeBlock, ProxyMethod restAPIMethod, JavaSettings settings) {
         typeBlock.annotation("ServiceMethod(returns = ReturnType.SINGLE)");
-        typeBlock.publicMethod(clientMethod.getDeclaration(), function -> {
+        writeMethod(typeBlock, clientMethod.getMethodVisibility(), clientMethod.getDeclaration(), function -> {
             AddOptionalVariables(function, clientMethod, restAPIMethod.getParameters(), settings);
             function.line("return %s(%s)", "begin" + CodeNamer.toPascalCase(restAPIMethod.getSimpleAsyncMethodName()), clientMethod.getArgumentList());
             function.indent(() -> {
@@ -242,7 +242,7 @@ public class FluentClientMethodTemplate extends ClientMethodTemplate {
         String contextParam = mergeContextParameter ? "context" : "Context.NONE";
 
         typeBlock.annotation("ServiceMethod(returns = ReturnType.SINGLE)");
-        typeBlock.publicMethod(clientMethod.getDeclaration(), function -> {
+        writeMethod(typeBlock, clientMethod.getMethodVisibility(), clientMethod.getDeclaration(), function -> {
             IType classType = ((GenericType) clientMethod.getReturnValue().getType().getClientType()).getTypeArguments()[1];
 
             AddOptionalVariables(function, clientMethod, restAPIMethod.getParameters(), settings);

--- a/generate.bat
+++ b/generate.bat
@@ -1,5 +1,5 @@
-set VANILLA_ARGUMENTS=--version=3.0.6282 --java --use:.\ --output-folder=vanilla-tests --sync-methods=all --client-side-validations --add-context-parameter
-set AZURE_ARGUMENTS=--version=3.0.6282 --java --use:.\ --output-folder=azure-tests --sync-methods=all --client-side-validations --add-context-parameter
+set VANILLA_ARGUMENTS=--version=3.0.6282 --java --use:. --output-folder=vanilla-tests --sync-methods=all --client-side-validations --add-context-parameter
+set AZURE_ARGUMENTS=--version=3.0.6282 --java --use:. --output-folder=azure-tests --sync-methods=all --client-side-validations --add-context-parameter
 
 call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/additionalProperties.json --namespace=fixtures.additionalproperties
 call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/body-array.json --namespace=fixtures.bodyarray

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -26,6 +26,7 @@ import com.azure.autorest.model.clientmodel.PrimitiveType;
 import com.azure.autorest.model.clientmodel.ProxyMethod;
 import com.azure.autorest.model.clientmodel.ProxyMethodParameter;
 import com.azure.autorest.model.clientmodel.ReturnValue;
+import com.azure.autorest.model.javamodel.JavaVisibility;
 import com.azure.autorest.util.CodeNamer;
 import com.azure.autorest.util.SchemaUtil;
 import com.azure.core.http.HttpMethod;
@@ -41,6 +42,9 @@ import java.util.stream.Collectors;
 public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>> {
     private static ClientMethodMapper instance = new ClientMethodMapper();
     private Map<Operation, List<ClientMethod>> parsed = new HashMap<>();
+
+    private static JavaVisibility NOT_VISIBLE = JavaVisibility.Private;
+    private static JavaVisibility VISIBLE = JavaVisibility.Public;
 
     private ClientMethodMapper() {
     }
@@ -211,6 +215,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                                 .onlyRequiredParameters(false)
                                 .type(ClientMethodType.PagingAsyncSinglePage)
                                 .isGroupedParameterRequired(false)
+                                .methodVisibility(NOT_VISIBLE)
                                 .build());
                     }
                     if (settings.isContextClientMethodParameter()) {
@@ -231,6 +236,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                                     .onlyRequiredParameters(false)
                                     .type(ClientMethodType.PagingAsync)
                                     .isGroupedParameterRequired(false)
+                                    .methodVisibility(VISIBLE)
                                     .build());
 
                             if (generateClientMethodWithOnlyRequiredParameters) {
@@ -251,11 +257,13 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                                             lroIntermediateType);
                                 }
 
+                                builder.methodVisibility(NOT_VISIBLE);
                                 addClientMethodWithContext(methods, builder, proxyMethod, parameters,
                                         ClientMethodType.PagingAsync, proxyMethod.getSimpleAsyncMethodName(),
                                         new ReturnValue(returnTypeDescription(operation, asyncReturnType, syncReturnType),
                                                 asyncReturnType),
                                         detailsWithContext);
+                                builder.methodVisibility(VISIBLE);
                             }
                         }
 
@@ -293,7 +301,10 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                         .build());
 
                 if (settings.isContextClientMethodParameter()) {
+                    builder.methodVisibility(NOT_VISIBLE);
                     addClientMethodWithContext(methods, builder, parameters);
+                    builder.methodVisibility(VISIBLE);
+
                 }
 
                 if (settings.getSyncMethods() != JavaSettings.SyncMethodsGeneration.NONE) {
@@ -308,7 +319,9 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                             .build());
 
                     if (settings.isContextClientMethodParameter()) {
+                        builder.methodVisibility(NOT_VISIBLE);
                         addClientMethodWithContext(methods, builder, parameters);
+                        builder.methodVisibility(VISIBLE);
                     }
                 }
 
@@ -324,7 +337,9 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                             .build());
 
                     if (settings.isContextClientMethodParameter()) {
+                        builder.methodVisibility(NOT_VISIBLE);
                         addClientMethodWithContext(methods, builder, parameters);
+                        builder.methodVisibility(VISIBLE);
                     }
                 }
 
@@ -339,7 +354,9 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                             .build());
 
                     if (settings.isContextClientMethodParameter()) {
+                        builder.methodVisibility(NOT_VISIBLE);
                         addClientMethodWithContext(methods, builder, parameters);
+                        builder.methodVisibility(VISIBLE);
                     }
 
                     if (generateClientMethodWithOnlyRequiredParameters) {
@@ -388,11 +405,13 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                 }
 
                 if (settings.isContextClientMethodParameter()) {
+                    builder.methodVisibility(NOT_VISIBLE);
                     addClientMethodWithContext(methods, builder, proxyMethod, parameters,
                         ClientMethodType.SimpleAsyncRestResponse, proxyMethod.getSimpleAsyncRestResponseMethodName(),
                         new ReturnValue(returnTypeDescription(operation, proxyMethod.getReturnType().getClientType(),
                             syncReturnType), proxyMethod.getReturnType().getClientType()),
                         null);
+                    builder.methodVisibility(VISIBLE);
                 }
 
                 if (settings.getSyncMethods() != JavaSettings.SyncMethodsGeneration.NONE) {
@@ -406,7 +425,9 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                             .build());
 
                     if (settings.isContextClientMethodParameter()) {
+                        builder.methodVisibility(NOT_VISIBLE);
                         addClientMethodWithContext(methods, builder, parameters);
+                        builder.methodVisibility(VISIBLE);
                     }
 
                     if (generateClientMethodWithOnlyRequiredParameters) {

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientMethod.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientMethod.java
@@ -10,6 +10,7 @@ package com.azure.autorest.model.clientmodel;
 import com.azure.autorest.extension.base.model.codemodel.RequestParameterLocation;
 import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.extension.base.plugin.JavaSettings.SyncMethodsGeneration;
+import com.azure.autorest.model.javamodel.JavaVisibility;
 import com.azure.autorest.util.CodeNamer;
 import java.util.List;
 import java.util.Map;
@@ -77,6 +78,8 @@ public class ClientMethod {
      */
     private List<MethodTransformationDetail> methodTransformationDetails;
 
+    private JavaVisibility methodVisibility;
+
     /**
      * Create a new ClientMethod with the provided properties.
      * @param description The description of this ClientMethod.
@@ -94,7 +97,7 @@ public class ClientMethod {
      * @param methodPageDetails The pagination information if this is a paged method.
      * @param methodTransformationDetails The parameter transformations before calling ProxyMethod.
      */
-    private ClientMethod(String description, ReturnValue returnValue, String name, List<ClientMethodParameter> parameters, boolean onlyRequiredParameters, ClientMethodType type, ProxyMethod proxyMethod, Map<String, String> validateExpressions, String clientReference, List<String> requiredNullableParameterExpressions, boolean isGroupedParameterRequired, String groupedParameterTypeName, MethodPageDetails methodPageDetails, List<MethodTransformationDetail> methodTransformationDetails) {
+    private ClientMethod(String description, ReturnValue returnValue, String name, List<ClientMethodParameter> parameters, boolean onlyRequiredParameters, ClientMethodType type, ProxyMethod proxyMethod, Map<String, String> validateExpressions, String clientReference, List<String> requiredNullableParameterExpressions, boolean isGroupedParameterRequired, String groupedParameterTypeName, MethodPageDetails methodPageDetails, List<MethodTransformationDetail> methodTransformationDetails, JavaVisibility methodVisibility) {
         this.description = description;
         this.returnValue = returnValue;
         this.name = name;
@@ -109,6 +112,7 @@ public class ClientMethod {
         this.groupedParameterTypeName = groupedParameterTypeName;
         this.methodPageDetails = methodPageDetails;
         this.methodTransformationDetails = methodTransformationDetails;
+        this.methodVisibility = methodVisibility;
     }
 
     public final String getDescription() {
@@ -245,6 +249,10 @@ public class ClientMethod {
         return restAPIMethodArguments;
     }
 
+    public JavaVisibility getMethodVisibility() {
+        return methodVisibility;
+    }
+
     /**
      * Add this ClientMethod's imports to the provided ISet of imports.
      * @param imports The set of imports to add to.
@@ -309,6 +317,7 @@ public class ClientMethod {
         private String groupedParameterTypeName;
         private MethodPageDetails methodPageDetails;
         private List<MethodTransformationDetail> methodTransformationDetails;
+        private JavaVisibility methodVisibility = JavaVisibility.Public;
 
         /**
          * Sets the description of this ClientMethod.
@@ -451,6 +460,16 @@ public class ClientMethod {
         }
 
         /**
+         * Sets the parameter method visibility.
+         * @param methodVisibility the method visibility, default is Public.
+         * @return the Builder itself
+         */
+        public Builder methodVisibility(JavaVisibility methodVisibility) {
+            this.methodVisibility = methodVisibility;
+            return this;
+        }
+
+        /**
          * @return an immutable ClientMethod instance with the configurations on this builder.
          */
         public ClientMethod build() {
@@ -468,7 +487,8 @@ public class ClientMethod {
                     isGroupedParameterRequired,
                     groupedParameterTypeName,
                     methodPageDetails,
-                    methodTransformationDetails);
+                    methodTransformationDetails,
+                    methodVisibility);
         }
     }
 }

--- a/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
@@ -20,14 +20,19 @@ import com.azure.autorest.model.clientmodel.PrimitiveType;
 import com.azure.autorest.model.clientmodel.ProxyMethod;
 import com.azure.autorest.model.clientmodel.ProxyMethodParameter;
 import com.azure.autorest.model.javamodel.JavaBlock;
+import com.azure.autorest.model.javamodel.JavaClass;
 import com.azure.autorest.model.javamodel.JavaIfBlock;
 import com.azure.autorest.model.javamodel.JavaType;
+import com.azure.autorest.model.javamodel.JavaVisibility;
 import com.azure.autorest.util.CodeNamer;
 import com.azure.core.util.CoreUtils;
 import io.netty.handler.codec.http.HttpResponseStatus;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 /**
@@ -266,6 +271,18 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
                             clientMethod.getOnlyRequiredParameters() && !parameter.getIsRequired(),
                             parameter.getIsConstant() || alwaysNull));
                 }
+            }
+        }
+    }
+
+    protected static void writeMethod(JavaType typeBlock,
+                          JavaVisibility visibility, String methodSignature, Consumer<JavaBlock> method) {
+        if (visibility == JavaVisibility.Public) {
+            typeBlock.publicMethod(methodSignature, method);
+        } else {
+            if (typeBlock instanceof JavaClass) {
+                JavaClass classBlock = (JavaClass) typeBlock;
+                classBlock.method(visibility, null, methodSignature, method);
             }
         }
     }
@@ -509,7 +526,7 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
         typeBlock.annotation("ServiceMethod(returns = ReturnType.SINGLE)");
 
         if (clientMethod.getMethodPageDetails().nonNullNextLink()) {
-            typeBlock.publicMethod(clientMethod.getDeclaration(), function -> {
+            writeMethod(typeBlock, clientMethod.getMethodVisibility(), clientMethod.getDeclaration(), function -> {
                 AddValidations(function, clientMethod.getRequiredNullableParameterExpressions(), clientMethod.getValidateExpressions(), settings);
                 AddOptionalAndConstantVariables(function, clientMethod, restAPIMethod.getParameters(), settings);
                 ApplyParameterTransformations(function, clientMethod, settings);
@@ -545,7 +562,7 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
                 });
             });
         } else {
-            typeBlock.publicMethod(clientMethod.getDeclaration(), function -> {
+            writeMethod(typeBlock, clientMethod.getMethodVisibility(), clientMethod.getDeclaration(), function -> {
                 AddValidations(function, clientMethod.getRequiredNullableParameterExpressions(), clientMethod.getValidateExpressions(), settings);
                 AddOptionalAndConstantVariables(function, clientMethod, restAPIMethod.getParameters(), settings);
                 ApplyParameterTransformations(function, clientMethod, settings);
@@ -585,7 +602,7 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
 
     protected void generateSimpleAsyncRestResponse(ClientMethod clientMethod, JavaType typeBlock, ProxyMethod restAPIMethod, JavaSettings settings) {
         typeBlock.annotation("ServiceMethod(returns = ReturnType.SINGLE)");
-        typeBlock.publicMethod(clientMethod.getDeclaration(), function -> {
+        writeMethod(typeBlock, clientMethod.getMethodVisibility(), clientMethod.getDeclaration(), function -> {
             AddValidations(function, clientMethod.getRequiredNullableParameterExpressions(), clientMethod.getValidateExpressions(), settings);
             AddOptionalAndConstantVariables(function, clientMethod, restAPIMethod.getParameters(), settings);
             ApplyParameterTransformations(function, clientMethod, settings);

--- a/vanilla-tests/src/main/java/fixtures/bodyboolean/Bools.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyboolean/Bools.java
@@ -101,7 +101,7 @@ public final class Bools {
      * @return true Boolean value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<Boolean>> getTrueWithResponseAsync(Context context) {
+    private Mono<Response<Boolean>> getTrueWithResponseAsync(Context context) {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -209,7 +209,7 @@ public final class Bools {
      * @return the completion.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<Void>> putTrueWithResponseAsync(Context context) {
+    private Mono<Response<Void>> putTrueWithResponseAsync(Context context) {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -295,7 +295,7 @@ public final class Bools {
      * @return false Boolean value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<Boolean>> getFalseWithResponseAsync(Context context) {
+    private Mono<Response<Boolean>> getFalseWithResponseAsync(Context context) {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -403,7 +403,7 @@ public final class Bools {
      * @return the completion.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<Void>> putFalseWithResponseAsync(Context context) {
+    private Mono<Response<Void>> putFalseWithResponseAsync(Context context) {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -489,7 +489,7 @@ public final class Bools {
      * @return null Boolean value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<Boolean>> getNullWithResponseAsync(Context context) {
+    private Mono<Response<Boolean>> getNullWithResponseAsync(Context context) {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -596,7 +596,7 @@ public final class Bools {
      * @return invalid Boolean value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<Boolean>> getInvalidWithResponseAsync(Context context) {
+    private Mono<Response<Boolean>> getInvalidWithResponseAsync(Context context) {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));


### PR DESCRIPTION
sample code

```
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<DeploymentOperationInner>> getAtScopeWithResponseAsync(
+    private Mono<Response<DeploymentOperationInner>> getAtScopeWithResponseAsync(
         String scope, String deploymentName, String operationId, Context context) {
         if (this.client.getEndpoint() == null) {
             return Mono
@@ -399,7 +399,7 @@ public final class DeploymentOperationsClient {
      * @return all deployments operations for a deployment.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<DeploymentOperationInner>> listAtScopeSinglePageAsync(
+    private Mono<PagedResponse<DeploymentOperationInner>> listAtScopeSinglePageAsync(
         String scope, String deploymentName, Integer top) {
         if (this.client.getEndpoint() == null) {
             return Mono
```

It makes these method private so other client method can still calls them.