### PR TITLE
v4, let fluent use a different reference on client method visibility

### DIFF
--- a/azure-tests/src/main/java/fixtures/paging/Pagings.java
+++ b/azure-tests/src/main/java/fixtures/paging/Pagings.java
@@ -279,7 +279,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<Product>> getNoItemNamePagesSinglePageAsync() {
+    public Mono<PagedResponse<Product>> getNoItemNamePagesSinglePageAsync() {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -329,7 +329,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<Product>> getNullNextLinkNamePagesSinglePageAsync() {
+    public Mono<PagedResponse<Product>> getNullNextLinkNamePagesSinglePageAsync() {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -378,7 +378,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<Product>> getSinglePagesSinglePageAsync() {
+    public Mono<PagedResponse<Product>> getSinglePagesSinglePageAsync() {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -431,7 +431,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<Product>> getMultiplePagesSinglePageAsync(
+    public Mono<PagedResponse<Product>> getMultiplePagesSinglePageAsync(
             String clientRequestId, PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) {
         if (this.client.getHost() == null) {
             return Mono.error(
@@ -510,7 +510,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<Product>> getWithQueryParamsSinglePageAsync(int requiredQueryParameter) {
+    public Mono<PagedResponse<Product>> getWithQueryParamsSinglePageAsync(int requiredQueryParameter) {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -571,7 +571,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<Product>> nextOperationWithQueryParamsSinglePageAsync() {
+    public Mono<PagedResponse<Product>> nextOperationWithQueryParamsSinglePageAsync() {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -601,7 +601,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<Product>> getOdataMultiplePagesSinglePageAsync(
+    public Mono<PagedResponse<Product>> getOdataMultiplePagesSinglePageAsync(
             String clientRequestId, PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) {
         if (this.client.getHost() == null) {
             return Mono.error(
@@ -680,7 +680,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<Product>> getMultiplePagesWithOffsetSinglePageAsync(
+    public Mono<PagedResponse<Product>> getMultiplePagesWithOffsetSinglePageAsync(
             PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions, String clientRequestId) {
         if (this.client.getHost() == null) {
             return Mono.error(
@@ -757,7 +757,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<Product>> getMultiplePagesRetryFirstSinglePageAsync() {
+    public Mono<PagedResponse<Product>> getMultiplePagesRetryFirstSinglePageAsync() {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -811,7 +811,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<Product>> getMultiplePagesRetrySecondSinglePageAsync() {
+    public Mono<PagedResponse<Product>> getMultiplePagesRetrySecondSinglePageAsync() {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -864,7 +864,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<Product>> getSinglePagesFailureSinglePageAsync() {
+    public Mono<PagedResponse<Product>> getSinglePagesFailureSinglePageAsync() {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -915,7 +915,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<Product>> getMultiplePagesFailureSinglePageAsync() {
+    public Mono<PagedResponse<Product>> getMultiplePagesFailureSinglePageAsync() {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -966,7 +966,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<Product>> getMultiplePagesFailureUriSinglePageAsync() {
+    public Mono<PagedResponse<Product>> getMultiplePagesFailureUriSinglePageAsync() {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -1020,7 +1020,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<Product>> getMultiplePagesFragmentNextLinkSinglePageAsync(
+    public Mono<PagedResponse<Product>> getMultiplePagesFragmentNextLinkSinglePageAsync(
             String apiVersion, String tenant) {
         if (this.client.getHost() == null) {
             return Mono.error(
@@ -1089,7 +1089,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<Product>> getMultiplePagesFragmentWithGroupingNextLinkSinglePageAsync(
+    public Mono<PagedResponse<Product>> getMultiplePagesFragmentWithGroupingNextLinkSinglePageAsync(
             CustomParameterGroup customParameterGroup) {
         if (this.client.getHost() == null) {
             return Mono.error(
@@ -1161,7 +1161,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<Product>> getMultiplePagesLROSinglePageAsync(
+    public Mono<PagedResponse<Product>> getMultiplePagesLROSinglePageAsync(
             String clientRequestId, PagingGetMultiplePagesLroOptions pagingGetMultiplePagesLroOptions) {
         if (this.client.getHost() == null) {
             return Mono.error(
@@ -1241,8 +1241,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<Product>> nextFragmentSinglePageAsync(
-            String apiVersion, String tenant, String nextLink) {
+    public Mono<PagedResponse<Product>> nextFragmentSinglePageAsync(String apiVersion, String tenant, String nextLink) {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -1280,7 +1279,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<Product>> nextFragmentWithGroupingSinglePageAsync(
+    public Mono<PagedResponse<Product>> nextFragmentWithGroupingSinglePageAsync(
             String nextLink, CustomParameterGroup customParameterGroup) {
         if (this.client.getHost() == null) {
             return Mono.error(
@@ -1320,7 +1319,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<Product>> getPagingModelWithItemNameWithXMSClientNameSinglePageAsync() {
+    public Mono<PagedResponse<Product>> getPagingModelWithItemNameWithXMSClientNameSinglePageAsync() {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -1374,7 +1373,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<Product>> getNoItemNamePagesNextSinglePageAsync(String nextLink) {
+    public Mono<PagedResponse<Product>> getNoItemNamePagesNextSinglePageAsync(String nextLink) {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
         }
@@ -1400,7 +1399,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<Product>> getSinglePagesNextSinglePageAsync(String nextLink) {
+    public Mono<PagedResponse<Product>> getSinglePagesNextSinglePageAsync(String nextLink) {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
         }
@@ -1426,7 +1425,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<Product>> getMultiplePagesNextSinglePageAsync(String nextLink) {
+    public Mono<PagedResponse<Product>> getMultiplePagesNextSinglePageAsync(String nextLink) {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
         }
@@ -1452,7 +1451,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<Product>> getOdataMultiplePagesNextSinglePageAsync(String nextLink) {
+    public Mono<PagedResponse<Product>> getOdataMultiplePagesNextSinglePageAsync(String nextLink) {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
         }
@@ -1478,7 +1477,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<Product>> getMultiplePagesWithOffsetNextSinglePageAsync(String nextLink) {
+    public Mono<PagedResponse<Product>> getMultiplePagesWithOffsetNextSinglePageAsync(String nextLink) {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
         }
@@ -1504,7 +1503,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<Product>> getMultiplePagesRetryFirstNextSinglePageAsync(String nextLink) {
+    public Mono<PagedResponse<Product>> getMultiplePagesRetryFirstNextSinglePageAsync(String nextLink) {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
         }
@@ -1530,7 +1529,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<Product>> getMultiplePagesRetrySecondNextSinglePageAsync(String nextLink) {
+    public Mono<PagedResponse<Product>> getMultiplePagesRetrySecondNextSinglePageAsync(String nextLink) {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
         }
@@ -1556,7 +1555,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<Product>> getSinglePagesFailureNextSinglePageAsync(String nextLink) {
+    public Mono<PagedResponse<Product>> getSinglePagesFailureNextSinglePageAsync(String nextLink) {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
         }
@@ -1582,7 +1581,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<Product>> getMultiplePagesFailureNextSinglePageAsync(String nextLink) {
+    public Mono<PagedResponse<Product>> getMultiplePagesFailureNextSinglePageAsync(String nextLink) {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
         }
@@ -1608,7 +1607,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<Product>> getMultiplePagesFailureUriNextSinglePageAsync(String nextLink) {
+    public Mono<PagedResponse<Product>> getMultiplePagesFailureUriNextSinglePageAsync(String nextLink) {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
         }
@@ -1634,7 +1633,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<Product>> getMultiplePagesLRONextSinglePageAsync(String nextLink) {
+    public Mono<PagedResponse<Product>> getMultiplePagesLRONextSinglePageAsync(String nextLink) {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
         }
@@ -1660,7 +1659,7 @@ public final class Pagings {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<PagedResponse<Product>> getPagingModelWithItemNameWithXMSClientNameNextSinglePageAsync(
+    public Mono<PagedResponse<Product>> getPagingModelWithItemNameWithXMSClientNameNextSinglePageAsync(
             String nextLink) {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentClientMethodMapper.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentClientMethodMapper.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.azure.autorest.fluent.mapper;
+
+import com.azure.autorest.mapper.ClientMethodMapper;
+import com.azure.autorest.model.clientmodel.ClientMethodType;
+import com.azure.autorest.model.javamodel.JavaVisibility;
+
+public class FluentClientMethodMapper extends ClientMethodMapper {
+
+    private static final FluentClientMethodMapper instance = new FluentClientMethodMapper();
+
+    public static FluentClientMethodMapper getInstance() {
+        return instance;
+    }
+
+    @Override
+    protected JavaVisibility methodVisibility(ClientMethodType methodType, boolean hasContextParameter) {
+        JavaVisibility visibility;
+        if (hasContextParameter) {
+            switch (methodType) {
+                case PagingAsyncSinglePage:
+                case PagingAsync:
+                case LongRunningBeginAsync:
+                case LongRunningAsync:
+                case SimpleAsyncRestResponse:
+                    visibility = NOT_VISIBLE;
+                    break;
+
+                case SimpleAsync:
+                    visibility = NOT_GENERATE;
+                    break;
+
+                default:
+                    visibility = super.methodVisibility(methodType, hasContextParameter);
+                    break;
+            }
+        } else {
+            switch (methodType) {
+                case PagingAsyncSinglePage:
+                    visibility = NOT_VISIBLE;
+                    break;
+
+                default:
+                    visibility = super.methodVisibility(methodType, hasContextParameter);
+                    break;
+            }
+        }
+        return visibility;
+    }
+}

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentMapperFactory.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentMapperFactory.java
@@ -5,6 +5,7 @@
 
 package com.azure.autorest.fluent.mapper;
 
+import com.azure.autorest.mapper.ClientMethodMapper;
 import com.azure.autorest.mapper.DefaultMapperFactory;
 import com.azure.autorest.mapper.ExceptionMapper;
 import com.azure.autorest.mapper.MethodGroupMapper;
@@ -31,5 +32,10 @@ public class FluentMapperFactory extends DefaultMapperFactory {
     @Override
     public ExceptionMapper getExceptionMapper() {
         return FluentExceptionMapper.getInstance();
+    }
+
+    @Override
+    public ClientMethodMapper getClientMethodMapper() {
+        return FluentClientMethodMapper.getInstance();
     }
 }

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -490,6 +490,9 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
 
     /**
      * Extension for configuration on method visibility.
+     * <p>
+     * ClientMethodTemplate.writeMethod (and whether it is called) would also decide the visibility in generated code.
+     *
      * @param methodType the type of the client method.
      * @param hasContextParameter whether the method has Context parameter.
      * @return method visibility, null if do not generate.

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -43,10 +43,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
     private static ClientMethodMapper instance = new ClientMethodMapper();
     private Map<Operation, List<ClientMethod>> parsed = new HashMap<>();
 
-    private static JavaVisibility NOT_VISIBLE = JavaVisibility.Private;
-    private static JavaVisibility VISIBLE = JavaVisibility.Public;
-
-    private ClientMethodMapper() {
+    protected ClientMethodMapper() {
     }
 
     public static ClientMethodMapper getInstance() {
@@ -220,16 +217,18 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                                 .onlyRequiredParameters(false)
                                 .type(ClientMethodType.PagingAsyncSinglePage)
                                 .isGroupedParameterRequired(false)
-                                .methodVisibility(NOT_VISIBLE)
+                                .methodVisibility(methodVisibility(ClientMethodType.PagingAsyncSinglePage, false))
                                 .build());
                     }
                     if (settings.isContextClientMethodParameter()) {
+                        builder.methodVisibility(methodVisibility(ClientMethodType.PagingAsyncSinglePage, true));
                         addClientMethodWithContext(methods, builder, proxyMethod, parameters,
                                 ClientMethodType.PagingAsyncSinglePage, proxyMethod.getPagingAsyncSinglePageMethodName(),
                                 new ReturnValue(returnTypeDescription(operation, asyncRestResponseReturnType, syncReturnType),
                                         asyncRestResponseReturnType),
                                 details);
                     }
+                    builder.methodVisibility(VISIBLE);
 
                     if (!isNextMethod) {
                         if (settings.getSyncMethods() != JavaSettings.SyncMethodsGeneration.NONE) {
@@ -241,7 +240,6 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                                     .onlyRequiredParameters(false)
                                     .type(ClientMethodType.PagingAsync)
                                     .isGroupedParameterRequired(false)
-                                    .methodVisibility(VISIBLE)
                                     .build());
 
                             if (generateClientMethodWithOnlyRequiredParameters) {
@@ -262,7 +260,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                                             lroIntermediateType);
                                 }
 
-                                builder.methodVisibility(NOT_VISIBLE);
+                                builder.methodVisibility(methodVisibility(ClientMethodType.PagingAsync, true));
                                 addClientMethodWithContext(methods, builder, proxyMethod, parameters,
                                         ClientMethodType.PagingAsync, proxyMethod.getSimpleAsyncMethodName(),
                                         new ReturnValue(returnTypeDescription(operation, asyncReturnType, syncReturnType),
@@ -312,7 +310,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                         .build());
 
                 if (settings.isContextClientMethodParameter()) {
-                    builder.methodVisibility(NOT_VISIBLE);
+                    builder.methodVisibility(methodVisibility(ClientMethodType.SimpleAsyncRestResponse, true));
                     addClientMethodWithContext(methods, builder, parameters);
                     builder.methodVisibility(VISIBLE);
 
@@ -330,7 +328,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                             .build());
 
                     if (settings.isContextClientMethodParameter()) {
-                        builder.methodVisibility(NOT_VISIBLE);
+                        builder.methodVisibility(methodVisibility(ClientMethodType.LongRunningBeginAsync, true));
                         addClientMethodWithContext(methods, builder, parameters);
                         builder.methodVisibility(VISIBLE);
                     }
@@ -348,9 +346,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                             .build());
 
                     if (settings.isContextClientMethodParameter()) {
-                        builder.methodVisibility(NOT_VISIBLE);
                         addClientMethodWithContext(methods, builder, parameters);
-                        builder.methodVisibility(VISIBLE);
                     }
                 }
 
@@ -365,7 +361,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                             .build());
 
                     if (settings.isContextClientMethodParameter()) {
-                        builder.methodVisibility(NOT_VISIBLE);
+                        builder.methodVisibility(methodVisibility(ClientMethodType.LongRunningAsync, true));
                         addClientMethodWithContext(methods, builder, parameters);
                         builder.methodVisibility(VISIBLE);
                     }
@@ -416,7 +412,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                 }
 
                 if (settings.isContextClientMethodParameter()) {
-                    builder.methodVisibility(NOT_VISIBLE);
+                    builder.methodVisibility(methodVisibility(ClientMethodType.SimpleAsyncRestResponse, true));
                     addClientMethodWithContext(methods, builder, proxyMethod, parameters,
                         ClientMethodType.SimpleAsyncRestResponse, proxyMethod.getSimpleAsyncRestResponseMethodName(),
                         new ReturnValue(returnTypeDescription(operation, proxyMethod.getReturnType().getClientType(),
@@ -435,14 +431,14 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                             .isGroupedParameterRequired(false)
                             .build());
 
-                    // by guideline, do not provide Context for async method
-                    /*
                     if (settings.isContextClientMethodParameter()) {
-                        builder.methodVisibility(NOT_VISIBLE);
-                        addClientMethodWithContext(methods, builder, parameters);
-                        builder.methodVisibility(VISIBLE);
+                        JavaVisibility visibility = methodVisibility(ClientMethodType.SimpleAsync, true);
+                        if (visibility != NOT_GENERATE) {
+                            builder.methodVisibility(visibility);
+                            addClientMethodWithContext(methods, builder, parameters);
+                            builder.methodVisibility(VISIBLE);
+                        }
                     }
-                     */
 
                     if (generateClientMethodWithOnlyRequiredParameters) {
                         methods.add(builder
@@ -486,6 +482,20 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
         }
         parsed.put(operation, methods);
         return methods;
+    }
+
+    protected static final JavaVisibility NOT_VISIBLE = JavaVisibility.Private;
+    protected static final JavaVisibility VISIBLE = JavaVisibility.Public;
+    protected static final JavaVisibility NOT_GENERATE = null;
+
+    /**
+     * Extension for configuration on method visibility.
+     * @param methodType the type of the client method.
+     * @param hasContextParameter whether the method has Context parameter.
+     * @return method visibility, null if do not generate.
+     */
+    protected JavaVisibility methodVisibility(ClientMethodType methodType, boolean hasContextParameter) {
+        return VISIBLE;
     }
 
     private static final ClientMethodParameter CONTEXT_PARAM = new ClientMethodParameter.Builder()

--- a/vanilla-tests/src/main/java/fixtures/bodyboolean/Bools.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyboolean/Bools.java
@@ -101,7 +101,7 @@ public final class Bools {
      * @return true Boolean value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<Response<Boolean>> getTrueWithResponseAsync(Context context) {
+    public Mono<Response<Boolean>> getTrueWithResponseAsync(Context context) {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -119,6 +119,28 @@ public final class Bools {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Boolean> getTrueAsync() {
         return getTrueWithResponseAsync()
+                .flatMap(
+                        (Response<Boolean> res) -> {
+                            if (res.getValue() != null) {
+                                return Mono.just(res.getValue());
+                            } else {
+                                return Mono.empty();
+                            }
+                        });
+    }
+
+    /**
+     * Get true Boolean value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return true Boolean value.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Boolean> getTrueAsync(Context context) {
+        return getTrueWithResponseAsync(context)
                 .flatMap(
                         (Response<Boolean> res) -> {
                             if (res.getValue() != null) {
@@ -187,7 +209,7 @@ public final class Bools {
      * @return the completion.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<Response<Void>> putTrueWithResponseAsync(Context context) {
+    public Mono<Response<Void>> putTrueWithResponseAsync(Context context) {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -206,6 +228,20 @@ public final class Bools {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putTrueAsync() {
         return putTrueWithResponseAsync().flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Set Boolean value true.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putTrueAsync(Context context) {
+        return putTrueWithResponseAsync(context).flatMap((Response<Void> res) -> Mono.empty());
     }
 
     /**
@@ -259,7 +295,7 @@ public final class Bools {
      * @return false Boolean value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<Response<Boolean>> getFalseWithResponseAsync(Context context) {
+    public Mono<Response<Boolean>> getFalseWithResponseAsync(Context context) {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -277,6 +313,28 @@ public final class Bools {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Boolean> getFalseAsync() {
         return getFalseWithResponseAsync()
+                .flatMap(
+                        (Response<Boolean> res) -> {
+                            if (res.getValue() != null) {
+                                return Mono.just(res.getValue());
+                            } else {
+                                return Mono.empty();
+                            }
+                        });
+    }
+
+    /**
+     * Get false Boolean value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return false Boolean value.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Boolean> getFalseAsync(Context context) {
+        return getFalseWithResponseAsync(context)
                 .flatMap(
                         (Response<Boolean> res) -> {
                             if (res.getValue() != null) {
@@ -345,7 +403,7 @@ public final class Bools {
      * @return the completion.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<Response<Void>> putFalseWithResponseAsync(Context context) {
+    public Mono<Response<Void>> putFalseWithResponseAsync(Context context) {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -364,6 +422,20 @@ public final class Bools {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putFalseAsync() {
         return putFalseWithResponseAsync().flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Set Boolean value false.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putFalseAsync(Context context) {
+        return putFalseWithResponseAsync(context).flatMap((Response<Void> res) -> Mono.empty());
     }
 
     /**
@@ -417,7 +489,7 @@ public final class Bools {
      * @return null Boolean value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<Response<Boolean>> getNullWithResponseAsync(Context context) {
+    public Mono<Response<Boolean>> getNullWithResponseAsync(Context context) {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -435,6 +507,28 @@ public final class Bools {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Boolean> getNullAsync() {
         return getNullWithResponseAsync()
+                .flatMap(
+                        (Response<Boolean> res) -> {
+                            if (res.getValue() != null) {
+                                return Mono.just(res.getValue());
+                            } else {
+                                return Mono.empty();
+                            }
+                        });
+    }
+
+    /**
+     * Get null Boolean value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null Boolean value.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Boolean> getNullAsync(Context context) {
+        return getNullWithResponseAsync(context)
                 .flatMap(
                         (Response<Boolean> res) -> {
                             if (res.getValue() != null) {
@@ -502,7 +596,7 @@ public final class Bools {
      * @return invalid Boolean value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<Response<Boolean>> getInvalidWithResponseAsync(Context context) {
+    public Mono<Response<Boolean>> getInvalidWithResponseAsync(Context context) {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -520,6 +614,28 @@ public final class Bools {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Boolean> getInvalidAsync() {
         return getInvalidWithResponseAsync()
+                .flatMap(
+                        (Response<Boolean> res) -> {
+                            if (res.getValue() != null) {
+                                return Mono.just(res.getValue());
+                            } else {
+                                return Mono.empty();
+                            }
+                        });
+    }
+
+    /**
+     * Get invalid Boolean value.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return invalid Boolean value.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Boolean> getInvalidAsync(Context context) {
+        return getInvalidWithResponseAsync(context)
                 .flatMap(
                         (Response<Boolean> res) -> {
                             if (res.getValue() != null) {

--- a/vanilla-tests/src/main/java/fixtures/bodyfile/Files.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyfile/Files.java
@@ -89,7 +89,7 @@ public final class Files {
      * @return file.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<StreamResponse> getFileWithResponseAsync(Context context) {
+    public Mono<StreamResponse> getFileWithResponseAsync(Context context) {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -107,6 +107,20 @@ public final class Files {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Flux<ByteBuffer> getFileAsync() {
         return getFileWithResponseAsync().flatMapMany(StreamResponse::getValue);
+    }
+
+    /**
+     * Get file.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return file.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Flux<ByteBuffer> getFileAsync(Context context) {
+        return getFileWithResponseAsync(context).flatMapMany(StreamResponse::getValue);
     }
 
     /**
@@ -175,7 +189,7 @@ public final class Files {
      * @return a large file.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<StreamResponse> getFileLargeWithResponseAsync(Context context) {
+    public Mono<StreamResponse> getFileLargeWithResponseAsync(Context context) {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -193,6 +207,20 @@ public final class Files {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Flux<ByteBuffer> getFileLargeAsync() {
         return getFileLargeWithResponseAsync().flatMapMany(StreamResponse::getValue);
+    }
+
+    /**
+     * Get a large file.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a large file.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Flux<ByteBuffer> getFileLargeAsync(Context context) {
+        return getFileLargeWithResponseAsync(context).flatMapMany(StreamResponse::getValue);
     }
 
     /**
@@ -261,7 +289,7 @@ public final class Files {
      * @return empty file.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    private Mono<StreamResponse> getEmptyFileWithResponseAsync(Context context) {
+    public Mono<StreamResponse> getEmptyFileWithResponseAsync(Context context) {
         if (this.client.getHost() == null) {
             return Mono.error(
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
@@ -279,6 +307,20 @@ public final class Files {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Flux<ByteBuffer> getEmptyFileAsync() {
         return getEmptyFileWithResponseAsync().flatMapMany(StreamResponse::getValue);
+    }
+
+    /**
+     * Get empty file.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return empty file.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Flux<ByteBuffer> getEmptyFileAsync(Context context) {
+        return getEmptyFileWithResponseAsync(context).flatMapMany(StreamResponse::getValue);
     }
 
     /**


### PR DESCRIPTION
Add `ClientMethodMapper.methodVisibility` to have better control on which method is private or no need to generate at all.