### PR TITLE
v4, fix client interface

### DIFF
--- a/fluent-tests/prepare-tests.bat
+++ b/fluent-tests/prepare-tests.bat
@@ -12,7 +12,7 @@ RMDIR /S /Q "src/main/java/com/azure/mgmtlitetest"
 
 SET AUTOREST_CORE_VERSION=3.0.6282
 SET MODELERFOUR_ARGUMENTS=--pipeline.modelerfour.additional-checks=false --pipeline.modelerfour.lenient-model-deduplication=true
-SET COMMON_ARGUMENTS=--java --use:../ --output-folder=./ %MODELERFOUR_ARGUMENTS% --license-header=MICROSOFT_MIT_SMALL --sync-methods=all --azure-arm --fluent --required-parameter-client-methods --add-context-parameter --context-client-method-parameter --track1-naming --client-side-validations --client-logger
+SET COMMON_ARGUMENTS=--java --use:../ --output-folder=./ %MODELERFOUR_ARGUMENTS% --license-header=MICROSOFT_MIT_SMALL --generate-client-interfaces --sync-methods=all --azure-arm --fluent --required-parameter-client-methods --add-context-parameter --context-client-method-parameter --track1-naming --client-side-validations --client-logger
 SET FLUENTLITE_ARGUMENTS=--java --use:../ --output-folder=./ %MODELERFOUR_ARGUMENTS% --license-header=MICROSOFT_MIT_SMALL --sync-methods=all --azure-arm --fluent=lite --required-parameter-client-methods --add-context-parameter --context-client-method-parameter --track1-naming --client-side-validations --client-logger --generate-sync-async-clients
 
 REM fluent premium

--- a/fluent-tests/spotbugs-exclude.xml
+++ b/fluent-tests/spotbugs-exclude.xml
@@ -7,7 +7,7 @@
   </Match>
 
   <Match>
-    <Package name="~com\.azure\.mgmttest\.(.+)\.fluent"/>
+    <Package name="~com\.azure\.mgmttest\.(.+)\.implementation"/>
     <Bug pattern="NP_LOAD_OF_KNOWN_NULL_VALUE,SIC_INNER_SHOULD_BE_STATIC_ANON,SKIPPED_CLASS_TOO_BIG"/>
   </Match>
 </FindBugsFilter>

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
@@ -100,12 +100,13 @@ public class FluentGen extends NewPlugin {
             logger.info("Java template for client model");
             FluentJavaPackage javaPackage = new FluentJavaPackage();
             // Service client
+            String interfacePackage = ClientModelUtil.getServiceClientInterfacePackageName();
             javaPackage
                     .addServiceClient(client.getServiceClient().getPackage(), client.getServiceClient().getClassName(),
                             client.getServiceClient());
             if (javaSettings.shouldGenerateClientInterfaces()) {
                 javaPackage
-                        .addServiceClientInterface(client.getServiceClient().getInterfaceName(), client.getServiceClient());
+                        .addServiceClientInterface(interfacePackage, client.getServiceClient().getInterfaceName(), client.getServiceClient());
             }
 
             // Service client builder
@@ -135,7 +136,7 @@ public class FluentGen extends NewPlugin {
             for (MethodGroupClient methodGroupClient : client.getServiceClient().getMethodGroupClients()) {
                 javaPackage.addMethodGroup(methodGroupClient.getPackage(), methodGroupClient.getClassName(), methodGroupClient);
                 if (javaSettings.shouldGenerateClientInterfaces()) {
-                    javaPackage.addMethodGroupInterface(methodGroupClient.getInterfaceName(), methodGroupClient);
+                    javaPackage.addMethodGroupInterface(interfacePackage, methodGroupClient.getInterfaceName(), methodGroupClient);
                 }
             }
 

--- a/generate
+++ b/generate
@@ -10,7 +10,7 @@ autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure
 autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/body-boolean.quirks.json --namespace=fixtures.bodyboolean.quirks
 autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/body-complex.json --namespace=fixtures.bodycomplex --required-fields-as-ctor-args=true
 autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/body-file.json --namespace=fixtures.bodyfile --context-client-method-parameter
-autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/body-string.json --namespace=fixtures.bodystring
+autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/body-string.json --namespace=fixtures.bodystring --generate-client-interfaces
 autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/custom-baseUrl.json --namespace=fixtures.custombaseuri
 autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/custom-baseUrl-more-options.json --namespace=fixtures.custombaseuri.moreoptions
 autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/head.json --namespace=fixtures.head

--- a/generate.bat
+++ b/generate.bat
@@ -7,7 +7,7 @@ call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com
 call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/body-boolean.quirks.json --namespace=fixtures.bodyboolean.quirks
 call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/body-complex.json --namespace=fixtures.bodycomplex --required-fields-as-ctor-args=true
 call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/body-file.json --namespace=fixtures.bodyfile --context-client-method-parameter
-call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/body-string.json --namespace=fixtures.bodystring
+call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/body-string.json --namespace=fixtures.bodystring --generate-client-interfaces
 call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/custom-baseUrl.json --namespace=fixtures.custombaseuri
 call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/custom-baseUrl-more-options.json --namespace=fixtures.custombaseuri.moreoptions
 call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/head.json --namespace=fixtures.head

--- a/javagen/src/main/java/com/azure/autorest/mapper/MethodGroupMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/MethodGroupMapper.java
@@ -82,14 +82,20 @@ public class MethodGroupMapper implements IMapper<OperationGroup, MethodGroupCli
         builder.proxy(proxyBuilder.build())
                 .serviceClientName(serviceClientName);
 
+        builder.variableName(CodeNamer.toCamelCase(interfaceName));
+
+        if (settings.isFluent() && settings.shouldGenerateClientInterfaces()) {
+            interfaceName += "Client";
+            builder.interfaceName(interfaceName);
+        }
+
+        builder.variableType(settings.shouldGenerateClientInterfaces() ? interfaceName : className);
+
         List<String> implementedInterfaces = new ArrayList<>();
-        if (!settings.isFluent() && settings.shouldGenerateClientInterfaces()) {
+        if (settings.shouldGenerateClientInterfaces()) {
             implementedInterfaces.add(interfaceName);
         }
         builder.implementedInterfaces(implementedInterfaces);
-
-        builder.variableType(settings.shouldGenerateClientInterfaces() ? interfaceName : className);
-        builder.variableName(CodeNamer.toCamelCase(interfaceName));
 
         String packageName;
         if (settings.isFluent()) {

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/MethodGroupClient.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/MethodGroupClient.java
@@ -1,6 +1,8 @@
 package com.azure.autorest.model.clientmodel;
 
 import com.azure.autorest.extension.base.plugin.JavaSettings;
+import com.azure.autorest.util.ClientModelUtil;
+
 import java.util.List;
 import java.util.Set;
 
@@ -145,6 +147,11 @@ public class MethodGroupClient {
             //ClassType proxyType = settings.isAzureOrFluent() ? ClassType.AzureProxy : ClassType.RestProxy;
             ClassType proxyType = ClassType.RestProxy;
             imports.add(proxyType.getFullName());
+
+            if (settings.shouldGenerateClientInterfaces()) {
+                String interfacePackage = ClientModelUtil.getServiceClientInterfacePackageName();
+                imports.add(String.format("%1$s.%2$s", interfacePackage, this.getInterfaceName()));
+            }
         }
 
         getProxy().addImportsTo(imports, includeImplementationImports, settings);

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ServiceClient.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ServiceClient.java
@@ -1,6 +1,8 @@
 package com.azure.autorest.model.clientmodel;
 
 import com.azure.autorest.extension.base.plugin.JavaSettings;
+import com.azure.autorest.util.ClientModelUtil;
+
 import java.util.List;
 import java.util.Set;
 
@@ -186,6 +188,12 @@ public class ServiceClient {
             if (!settings.shouldGenerateClientInterfaces()) {
                 for (MethodGroupClient methodGroupClient : getMethodGroupClients()) {
                     imports.add(String.format("%1$s.%2$s", methodGroupClient.getPackage(), methodGroupClient.getClassName()));
+                }
+            } else {
+                String interfacePackage = ClientModelUtil.getServiceClientInterfacePackageName();
+                imports.add(String.format("%1$s.%2$s", interfacePackage, this.getInterfaceName()));
+                for (MethodGroupClient methodGroupClient : this.getMethodGroupClients()) {
+                    imports.add(String.format("%1$s.%2$s", interfacePackage, methodGroupClient.getInterfaceName()));
                 }
             }
         }

--- a/javagen/src/main/java/com/azure/autorest/model/javamodel/JavaPackage.java
+++ b/javagen/src/main/java/com/azure/autorest/model/javamodel/JavaPackage.java
@@ -65,6 +65,12 @@ public class JavaPackage {
         javaFiles.add(javaFile);
     }
 
+    public final void addServiceClientInterface(String package_Keyword, String name, ServiceClient model) {
+        JavaFile javaFile = javaFileFactory.createSourceFile(package_Keyword, name);
+        Templates.getServiceClientInterfaceTemplate().write(model, javaFile);
+        javaFiles.add(javaFile);
+    }
+
     public final void addServiceClientBuilder(String name, ServiceClient model) {
         JavaFile javaFile = javaFileFactory.createSourceFile(settings.getPackage(), name);
         Templates.getServiceClientBuilderTemplate().write(model, javaFile);
@@ -85,6 +91,12 @@ public class JavaPackage {
 
     public final void addMethodGroupInterface(String name, MethodGroupClient model) {
         JavaFile javaFile = javaFileFactory.createSourceFile(settings.getPackage(), name);
+        Templates.getMethodGroupInterfaceTemplate().write(model, javaFile);
+        javaFiles.add(javaFile);
+    }
+
+    public final void addMethodGroupInterface(String package_Keyword, String name, MethodGroupClient model) {
+        JavaFile javaFile = javaFileFactory.createSourceFile(package_Keyword, name);
         Templates.getMethodGroupInterfaceTemplate().write(model, javaFile);
         javaFiles.add(javaFile);
     }

--- a/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
@@ -22,6 +22,7 @@ import com.azure.autorest.model.clientmodel.ProxyMethodParameter;
 import com.azure.autorest.model.javamodel.JavaBlock;
 import com.azure.autorest.model.javamodel.JavaClass;
 import com.azure.autorest.model.javamodel.JavaIfBlock;
+import com.azure.autorest.model.javamodel.JavaInterface;
 import com.azure.autorest.model.javamodel.JavaType;
 import com.azure.autorest.model.javamodel.JavaVisibility;
 import com.azure.autorest.util.CodeNamer;
@@ -294,6 +295,11 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
     }
 
     public final void write(ClientMethod clientMethod, JavaType typeBlock) {
+        final boolean writingInterface = typeBlock instanceof JavaInterface;
+        if (clientMethod.getMethodVisibility() != JavaVisibility.Public && writingInterface) {
+            return;
+        }
+
         JavaSettings settings = JavaSettings.getInstance();
 
         ProxyMethod restAPIMethod = clientMethod.getProxyMethod();
@@ -301,7 +307,8 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
 
         //MethodPageDetails pageDetails = clientMethod.getMethodPageDetails();
 
-        generateJavadoc(clientMethod, typeBlock, restAPIMethod, false);
+        // interface need a fully-qualified exception class name, since exception is usually only included in ProxyMethod
+        generateJavadoc(clientMethod, typeBlock, restAPIMethod, writingInterface);
 
         switch (clientMethod.getType()) {
             case PagingSync:
@@ -488,9 +495,9 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
      * @param clientMethod client method
      * @param typeBlock code block
      * @param restAPIMethod proxy method
-     * @param useFullName whether to use fully-qualified name in javadoc
+     * @param useFullClassName whether to use fully-qualified class name in javadoc
      */
-    public static void generateJavadoc(ClientMethod clientMethod, JavaType typeBlock, ProxyMethod restAPIMethod, boolean useFullName) {
+    public static void generateJavadoc(ClientMethod clientMethod, JavaType typeBlock, ProxyMethod restAPIMethod, boolean useFullClassName) {
         typeBlock.javadocComment(comment -> {
             comment.description(clientMethod.getDescription());
             List<ClientMethodParameter> methodParameters = clientMethod.getOnlyRequiredParameters()
@@ -503,7 +510,7 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
                 comment.methodThrows("IllegalArgumentException", "thrown if parameters fail the validation");
             }
             if (restAPIMethod != null && restAPIMethod.getUnexpectedResponseExceptionType() != null) {
-                comment.methodThrows(useFullName
+                comment.methodThrows(useFullClassName
                         ? restAPIMethod.getUnexpectedResponseExceptionType().getFullName()
                         : restAPIMethod.getUnexpectedResponseExceptionType().getName(),
                         "thrown if the request is rejected by server");

--- a/javagen/src/main/java/com/azure/autorest/template/MethodGroupInterfaceTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/MethodGroupInterfaceTemplate.java
@@ -2,10 +2,13 @@ package com.azure.autorest.template;
 
 import com.azure.autorest.model.clientmodel.ClientMethod;
 import com.azure.autorest.extension.base.plugin.JavaSettings;
+import com.azure.autorest.model.clientmodel.IType;
 import com.azure.autorest.model.clientmodel.MethodGroupClient;
 import com.azure.autorest.model.javamodel.JavaFile;
 
 import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -30,11 +33,15 @@ public class MethodGroupInterfaceTemplate implements IJavaTemplate<MethodGroupCl
         methodGroupClient.addImportsTo(imports, false, settings);
         javaFile.declareImport(imports);
 
+        List<String> interfaces = methodGroupClient.getSupportedInterfaces().stream()
+                .map(IType::toString).collect(Collectors.toList());
+        String parentDeclaration = !interfaces.isEmpty() ? String.format(" extends %1$s", String.join(", ", interfaces)) : "";
+
         javaFile.javadocComment(settings.getMaximumJavadocCommentWidth(), (comment) ->
         {
             comment.description(String.format("An instance of this class provides access to all the operations defined in %1$s.", methodGroupClient.getInterfaceName()));
         });
-        javaFile.publicInterface(methodGroupClient.getInterfaceName(), interfaceBlock ->
+        javaFile.publicInterface(String.format("%1$s%2$s", methodGroupClient.getInterfaceName(), parentDeclaration), interfaceBlock ->
         {
             for (ClientMethod clientMethod : methodGroupClient.getClientMethods()) {
                 Templates.getClientMethodTemplate().write(clientMethod, interfaceBlock);

--- a/javagen/src/main/java/com/azure/autorest/template/ServiceClientInterfaceTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ServiceClientInterfaceTemplate.java
@@ -11,6 +11,7 @@ import com.azure.autorest.model.clientmodel.MethodGroupClient;
 import com.azure.autorest.model.clientmodel.ServiceClient;
 import com.azure.autorest.model.clientmodel.ServiceClientProperty;
 import com.azure.autorest.model.javamodel.JavaFile;
+import com.azure.autorest.model.javamodel.JavaVisibility;
 import com.azure.autorest.util.CodeNamer;
 
 import java.util.HashSet;
@@ -40,21 +41,23 @@ public class ServiceClientInterfaceTemplate implements IJavaTemplate<ServiceClie
         javaFile.publicInterface(serviceClient.getInterfaceName(), interfaceBlock ->
         {
             for (ServiceClientProperty property : serviceClient.getProperties()) {
-                interfaceBlock.javadocComment(comment ->
-                {
-                    comment.description(String.format("Gets %1$s", property.getDescription()));
-                    comment.methodReturns(String.format("the %1$s value", property.getName()));
-                });
-                interfaceBlock.publicMethod(String.format("%1$s get%2$s()", property.getType(), CodeNamer.toPascalCase(property.getName())));
-
-                if (!property.isReadOnly()) {
+                if (property.getMethodVisibility() == JavaVisibility.Public) {
                     interfaceBlock.javadocComment(comment ->
                     {
-                        comment.description(String.format("Sets %1$s", property.getDescription()));
-                        comment.param(property.getName(), String.format("the %1$s value", property.getName()));
-                        comment.methodReturns("the service client itself");
+                        comment.description(String.format("Gets %1$s", property.getDescription()));
+                        comment.methodReturns(String.format("the %1$s value", property.getName()));
                     });
-                    interfaceBlock.publicMethod(String.format("%1$s set%2$s(%3$s %4$s)", serviceClient.getInterfaceName(), CodeNamer.toPascalCase(property.getName()), property.getType(), property.getName()));
+                    interfaceBlock.publicMethod(String.format("%1$s get%2$s()", property.getType(), CodeNamer.toPascalCase(property.getName())));
+
+                    /* if (!property.isReadOnly()) {
+                        interfaceBlock.javadocComment(comment ->
+                        {
+                            comment.description(String.format("Sets %1$s", property.getDescription()));
+                            comment.param(property.getName(), String.format("the %1$s value", property.getName()));
+                            comment.methodReturns("the service client itself");
+                        });
+                        interfaceBlock.publicMethod(String.format("%1$s set%2$s(%3$s %4$s)", serviceClient.getInterfaceName(), CodeNamer.toPascalCase(property.getName()), property.getType(), property.getName()));
+                    } */
                 }
             }
 
@@ -64,7 +67,7 @@ public class ServiceClientInterfaceTemplate implements IJavaTemplate<ServiceClie
                     comment.description(String.format("Gets the %1$s object to access its operations.", methodGroupClient.getInterfaceName()));
                     comment.methodReturns(String.format("the %1$s object.", methodGroupClient.getInterfaceName()));
                 });
-                interfaceBlock.publicMethod(String.format("%1$s %2$s()", methodGroupClient.getInterfaceName(), methodGroupClient.getVariableName()));
+                interfaceBlock.publicMethod(String.format("%1$s get%2$s()", methodGroupClient.getInterfaceName(), CodeNamer.toPascalCase(methodGroupClient.getVariableName())));
             }
 
             for (ClientMethod clientMethod : serviceClient.getClientMethods()) {

--- a/javagen/src/main/java/com/azure/autorest/template/ServiceClientTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ServiceClientTemplate.java
@@ -51,11 +51,11 @@ public class ServiceClientTemplate implements IJavaTemplate<ServiceClient, JavaF
     public final void write(ServiceClient serviceClient, JavaFile javaFile) {
         JavaSettings settings = JavaSettings.getInstance();
         String serviceClientClassDeclaration = String.format("%1$s", serviceClient.getClassName());
-        if (!settings.isFluent() && settings.shouldGenerateClientInterfaces()) {
-            serviceClientClassDeclaration += String.format(" implements %1$s", serviceClient.getInterfaceName());
-        }
         if (settings.isFluentPremium()) {
             serviceClientClassDeclaration += String.format(" extends %1$s", "AzureServiceClient");
+        }
+        if (settings.shouldGenerateClientInterfaces()) {
+            serviceClientClassDeclaration += String.format(" implements %1$s", serviceClient.getInterfaceName());
         }
 
         Set<String> imports = new HashSet<String>();

--- a/javagen/src/main/java/com/azure/autorest/util/ClientModelUtil.java
+++ b/javagen/src/main/java/com/azure/autorest/util/ClientModelUtil.java
@@ -92,7 +92,7 @@ public class ClientModelUtil {
     public static String getBuilderSuffix() {
         JavaSettings settings = JavaSettings.getInstance();
         StringBuilder builderSuffix = new StringBuilder();
-        if (settings.shouldGenerateClientAsImpl() && !settings.shouldGenerateSyncAsyncClients()) {
+        if (! settings.isFluent() && settings.shouldGenerateClientAsImpl() && !settings.shouldGenerateSyncAsyncClients()) {
             builderSuffix.append("Impl");
         }
         builderSuffix.append("Builder");
@@ -114,7 +114,7 @@ public class ClientModelUtil {
         JavaSettings settings = JavaSettings.getInstance();
         String subpackage = settings.shouldGenerateClientAsImpl() ? settings.getImplementationSubpackage() : null;
         if (settings.isFluent()) {
-            if (settings.shouldGenerateSyncAsyncClients()) {
+            if (settings.shouldGenerateSyncAsyncClients() || settings.shouldGenerateClientInterfaces()) {
                 subpackage = settings.getImplementationSubpackage();
             } else {
                 subpackage = settings.getFluentSubpackage();
@@ -132,6 +132,15 @@ public class ClientModelUtil {
             return settings.getPackage(settings.getFluentSubpackage());
         } else {
             return getServiceClientBuilderPackageName(serviceClient);
+        }
+    }
+
+    public static String getServiceClientInterfacePackageName() {
+        JavaSettings settings = JavaSettings.getInstance();
+        if (settings.isFluent()) {
+            return settings.getPackage(settings.getFluentSubpackage());
+        } else {
+            return settings.getPackage();
         }
     }
 }

--- a/javagen/src/main/java/com/azure/autorest/util/ClientModelUtil.java
+++ b/javagen/src/main/java/com/azure/autorest/util/ClientModelUtil.java
@@ -92,7 +92,7 @@ public class ClientModelUtil {
     public static String getBuilderSuffix() {
         JavaSettings settings = JavaSettings.getInstance();
         StringBuilder builderSuffix = new StringBuilder();
-        if (! settings.isFluent() && settings.shouldGenerateClientAsImpl() && !settings.shouldGenerateSyncAsyncClients()) {
+        if (!settings.isFluent() && settings.shouldGenerateClientAsImpl() && !settings.shouldGenerateSyncAsyncClients()) {
             builderSuffix.append("Impl");
         }
         builderSuffix.append("Builder");

--- a/vanilla-tests/src/main/java/fixtures/bodystring/AutoRestSwaggerBATService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodystring/AutoRestSwaggerBATService.java
@@ -1,111 +1,42 @@
 package fixtures.bodystring;
 
 import com.azure.core.http.HttpPipeline;
-import com.azure.core.http.HttpPipelineBuilder;
-import com.azure.core.http.policy.CookiePolicy;
-import com.azure.core.http.policy.RetryPolicy;
-import com.azure.core.http.policy.UserAgentPolicy;
-import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 
-/** Initializes a new instance of the AutoRestSwaggerBATService type. */
-public final class AutoRestSwaggerBATService {
-    /** server parameter. */
-    private final String host;
-
+/** The interface for AutoRestSwaggerBATService class. */
+public interface AutoRestSwaggerBATService {
     /**
      * Gets server parameter.
      *
      * @return the host value.
      */
-    public String getHost() {
-        return this.host;
-    }
-
-    /** The HTTP pipeline to send requests through. */
-    private final HttpPipeline httpPipeline;
+    String getHost();
 
     /**
      * Gets The HTTP pipeline to send requests through.
      *
      * @return the httpPipeline value.
      */
-    public HttpPipeline getHttpPipeline() {
-        return this.httpPipeline;
-    }
-
-    /** The serializer to serialize an object into a string. */
-    private final SerializerAdapter serializerAdapter;
+    HttpPipeline getHttpPipeline();
 
     /**
      * Gets The serializer to serialize an object into a string.
      *
      * @return the serializerAdapter value.
      */
-    public SerializerAdapter getSerializerAdapter() {
-        return this.serializerAdapter;
-    }
-
-    /** The StringOperations object to access its operations. */
-    private final StringOperations stringOperations;
+    SerializerAdapter getSerializerAdapter();
 
     /**
      * Gets the StringOperations object to access its operations.
      *
      * @return the StringOperations object.
      */
-    public StringOperations getStringOperations() {
-        return this.stringOperations;
-    }
-
-    /** The Enums object to access its operations. */
-    private final Enums enums;
+    StringOperations getStringOperations();
 
     /**
      * Gets the Enums object to access its operations.
      *
      * @return the Enums object.
      */
-    public Enums getEnums() {
-        return this.enums;
-    }
-
-    /**
-     * Initializes an instance of AutoRestSwaggerBATService client.
-     *
-     * @param host server parameter.
-     */
-    AutoRestSwaggerBATService(String host) {
-        this(
-                new HttpPipelineBuilder()
-                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                        .build(),
-                JacksonAdapter.createDefaultSerializerAdapter(),
-                host);
-    }
-
-    /**
-     * Initializes an instance of AutoRestSwaggerBATService client.
-     *
-     * @param httpPipeline The HTTP pipeline to send requests through.
-     * @param host server parameter.
-     */
-    AutoRestSwaggerBATService(HttpPipeline httpPipeline, String host) {
-        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
-    }
-
-    /**
-     * Initializes an instance of AutoRestSwaggerBATService client.
-     *
-     * @param httpPipeline The HTTP pipeline to send requests through.
-     * @param serializerAdapter The serializer to serialize an object into a string.
-     * @param host server parameter.
-     */
-    AutoRestSwaggerBATService(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
-        this.httpPipeline = httpPipeline;
-        this.serializerAdapter = serializerAdapter;
-        this.host = host;
-        this.stringOperations = new StringOperations(this);
-        this.enums = new Enums(this);
-    }
+    Enums getEnums();
 }

--- a/vanilla-tests/src/main/java/fixtures/bodystring/Enums.java
+++ b/vanilla-tests/src/main/java/fixtures/bodystring/Enums.java
@@ -1,373 +1,206 @@
 package fixtures.bodystring;
 
-import com.azure.core.annotation.BodyParam;
-import com.azure.core.annotation.ExpectedResponses;
-import com.azure.core.annotation.Get;
-import com.azure.core.annotation.Host;
-import com.azure.core.annotation.HostParam;
-import com.azure.core.annotation.Put;
 import com.azure.core.annotation.ReturnType;
-import com.azure.core.annotation.ServiceInterface;
 import com.azure.core.annotation.ServiceMethod;
-import com.azure.core.annotation.UnexpectedResponseExceptionType;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.RestProxy;
-import com.azure.core.util.Context;
-import com.azure.core.util.FluxUtil;
 import fixtures.bodystring.models.Colors;
-import fixtures.bodystring.models.ErrorException;
 import fixtures.bodystring.models.RefColorConstant;
 import reactor.core.publisher.Mono;
 
 /** An instance of this class provides access to all the operations defined in Enums. */
-public final class Enums {
-    /** The proxy service used to perform REST calls. */
-    private final EnumsService service;
-
-    /** The service client containing this operation class. */
-    private final AutoRestSwaggerBATService client;
-
-    /**
-     * Initializes an instance of Enums.
-     *
-     * @param client the instance of the service client containing this operation class.
-     */
-    Enums(AutoRestSwaggerBATService client) {
-        this.service = RestProxy.create(EnumsService.class, client.getHttpPipeline(), client.getSerializerAdapter());
-        this.client = client;
-    }
-
-    /**
-     * The interface defining all the services for AutoRestSwaggerBATServiceEnums to be used by the proxy service to
-     * perform REST calls.
-     */
-    @Host("{$host}")
-    @ServiceInterface(name = "AutoRestSwaggerBATSe")
-    private interface EnumsService {
-        @Get("/string/enum/notExpandable")
-        @ExpectedResponses({200})
-        @UnexpectedResponseExceptionType(ErrorException.class)
-        Mono<Response<Colors>> getNotExpandable(@HostParam("$host") String host, Context context);
-
-        @Put("/string/enum/notExpandable")
-        @ExpectedResponses({200})
-        @UnexpectedResponseExceptionType(ErrorException.class)
-        Mono<Response<Void>> putNotExpandable(
-                @HostParam("$host") String host, @BodyParam("application/json") Colors stringBody, Context context);
-
-        @Get("/string/enum/Referenced")
-        @ExpectedResponses({200})
-        @UnexpectedResponseExceptionType(ErrorException.class)
-        Mono<Response<Colors>> getReferenced(@HostParam("$host") String host, Context context);
-
-        @Put("/string/enum/Referenced")
-        @ExpectedResponses({200})
-        @UnexpectedResponseExceptionType(ErrorException.class)
-        Mono<Response<Void>> putReferenced(
-                @HostParam("$host") String host, @BodyParam("application/json") Colors enumStringBody, Context context);
-
-        @Get("/string/enum/ReferencedConstant")
-        @ExpectedResponses({200})
-        @UnexpectedResponseExceptionType(ErrorException.class)
-        Mono<Response<RefColorConstant>> getReferencedConstant(@HostParam("$host") String host, Context context);
-
-        @Put("/string/enum/ReferencedConstant")
-        @ExpectedResponses({200})
-        @UnexpectedResponseExceptionType(ErrorException.class)
-        Mono<Response<Void>> putReferencedConstant(
-                @HostParam("$host") String host,
-                @BodyParam("application/json") RefColorConstant enumStringBody,
-                Context context);
-    }
-
+public interface Enums {
     /**
      * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<Colors>> getNotExpandableWithResponseAsync() {
-        if (this.client.getHost() == null) {
-            return Mono.error(
-                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
-        }
-        return FluxUtil.withContext(context -> service.getNotExpandable(this.client.getHost(), context));
-    }
+    Mono<Response<Colors>> getNotExpandableWithResponseAsync();
 
     /**
      * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Colors> getNotExpandableAsync() {
-        return getNotExpandableWithResponseAsync()
-                .flatMap(
-                        (Response<Colors> res) -> {
-                            if (res.getValue() != null) {
-                                return Mono.just(res.getValue());
-                            } else {
-                                return Mono.empty();
-                            }
-                        });
-    }
+    Mono<Colors> getNotExpandableAsync();
 
     /**
      * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Colors getNotExpandable() {
-        return getNotExpandableAsync().block();
-    }
+    Colors getNotExpandable();
 
     /**
      * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
      * @param stringBody string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the completion.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<Void>> putNotExpandableWithResponseAsync(Colors stringBody) {
-        if (this.client.getHost() == null) {
-            return Mono.error(
-                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
-        }
-        if (stringBody == null) {
-            return Mono.error(new IllegalArgumentException("Parameter stringBody is required and cannot be null."));
-        }
-        return FluxUtil.withContext(context -> service.putNotExpandable(this.client.getHost(), stringBody, context));
-    }
+    Mono<Response<Void>> putNotExpandableWithResponseAsync(Colors stringBody);
 
     /**
      * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
      * @param stringBody string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the completion.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Void> putNotExpandableAsync(Colors stringBody) {
-        return putNotExpandableWithResponseAsync(stringBody).flatMap((Response<Void> res) -> Mono.empty());
-    }
+    Mono<Void> putNotExpandableAsync(Colors stringBody);
 
     /**
      * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
      * @param stringBody string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public void putNotExpandable(Colors stringBody) {
-        putNotExpandableAsync(stringBody).block();
-    }
+    void putNotExpandable(Colors stringBody);
 
     /**
      * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<Colors>> getReferencedWithResponseAsync() {
-        if (this.client.getHost() == null) {
-            return Mono.error(
-                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
-        }
-        return FluxUtil.withContext(context -> service.getReferenced(this.client.getHost(), context));
-    }
+    Mono<Response<Colors>> getReferencedWithResponseAsync();
 
     /**
      * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Colors> getReferencedAsync() {
-        return getReferencedWithResponseAsync()
-                .flatMap(
-                        (Response<Colors> res) -> {
-                            if (res.getValue() != null) {
-                                return Mono.just(res.getValue());
-                            } else {
-                                return Mono.empty();
-                            }
-                        });
-    }
+    Mono<Colors> getReferencedAsync();
 
     /**
      * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Colors getReferenced() {
-        return getReferencedAsync().block();
-    }
+    Colors getReferenced();
 
     /**
      * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
      * @param enumStringBody enum string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the completion.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<Void>> putReferencedWithResponseAsync(Colors enumStringBody) {
-        if (this.client.getHost() == null) {
-            return Mono.error(
-                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
-        }
-        if (enumStringBody == null) {
-            return Mono.error(new IllegalArgumentException("Parameter enumStringBody is required and cannot be null."));
-        }
-        return FluxUtil.withContext(context -> service.putReferenced(this.client.getHost(), enumStringBody, context));
-    }
+    Mono<Response<Void>> putReferencedWithResponseAsync(Colors enumStringBody);
 
     /**
      * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
      * @param enumStringBody enum string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the completion.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Void> putReferencedAsync(Colors enumStringBody) {
-        return putReferencedWithResponseAsync(enumStringBody).flatMap((Response<Void> res) -> Mono.empty());
-    }
+    Mono<Void> putReferencedAsync(Colors enumStringBody);
 
     /**
      * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      *
      * @param enumStringBody enum string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public void putReferenced(Colors enumStringBody) {
-        putReferencedAsync(enumStringBody).block();
-    }
+    void putReferenced(Colors enumStringBody);
 
     /**
      * Get value 'green-color' from the constant.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return value 'green-color' from the constant.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<RefColorConstant>> getReferencedConstantWithResponseAsync() {
-        if (this.client.getHost() == null) {
-            return Mono.error(
-                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
-        }
-        return FluxUtil.withContext(context -> service.getReferencedConstant(this.client.getHost(), context));
-    }
+    Mono<Response<RefColorConstant>> getReferencedConstantWithResponseAsync();
 
     /**
      * Get value 'green-color' from the constant.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return value 'green-color' from the constant.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<RefColorConstant> getReferencedConstantAsync() {
-        return getReferencedConstantWithResponseAsync()
-                .flatMap(
-                        (Response<RefColorConstant> res) -> {
-                            if (res.getValue() != null) {
-                                return Mono.just(res.getValue());
-                            } else {
-                                return Mono.empty();
-                            }
-                        });
-    }
+    Mono<RefColorConstant> getReferencedConstantAsync();
 
     /**
      * Get value 'green-color' from the constant.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return value 'green-color' from the constant.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public RefColorConstant getReferencedConstant() {
-        return getReferencedConstantAsync().block();
-    }
+    RefColorConstant getReferencedConstant();
 
     /**
      * Sends value 'green-color' from a constant.
      *
      * @param enumStringBody enum string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the completion.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<Void>> putReferencedConstantWithResponseAsync(RefColorConstant enumStringBody) {
-        if (this.client.getHost() == null) {
-            return Mono.error(
-                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
-        }
-        if (enumStringBody == null) {
-            return Mono.error(new IllegalArgumentException("Parameter enumStringBody is required and cannot be null."));
-        } else {
-            enumStringBody.validate();
-        }
-        return FluxUtil.withContext(
-                context -> service.putReferencedConstant(this.client.getHost(), enumStringBody, context));
-    }
+    Mono<Response<Void>> putReferencedConstantWithResponseAsync(RefColorConstant enumStringBody);
 
     /**
      * Sends value 'green-color' from a constant.
      *
      * @param enumStringBody enum string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the completion.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Void> putReferencedConstantAsync(RefColorConstant enumStringBody) {
-        return putReferencedConstantWithResponseAsync(enumStringBody).flatMap((Response<Void> res) -> Mono.empty());
-    }
+    Mono<Void> putReferencedConstantAsync(RefColorConstant enumStringBody);
 
     /**
      * Sends value 'green-color' from a constant.
      *
      * @param enumStringBody enum string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public void putReferencedConstant(RefColorConstant enumStringBody) {
-        putReferencedConstantAsync(enumStringBody).block();
-    }
+    void putReferencedConstant(RefColorConstant enumStringBody);
 }

--- a/vanilla-tests/src/main/java/fixtures/bodystring/StringOperations.java
+++ b/vanilla-tests/src/main/java/fixtures/bodystring/StringOperations.java
@@ -1,754 +1,434 @@
 package fixtures.bodystring;
 
-import com.azure.core.annotation.BodyParam;
-import com.azure.core.annotation.ExpectedResponses;
-import com.azure.core.annotation.Get;
-import com.azure.core.annotation.Host;
-import com.azure.core.annotation.HostParam;
-import com.azure.core.annotation.Put;
 import com.azure.core.annotation.ReturnType;
-import com.azure.core.annotation.ReturnValueWireType;
-import com.azure.core.annotation.ServiceInterface;
 import com.azure.core.annotation.ServiceMethod;
-import com.azure.core.annotation.UnexpectedResponseExceptionType;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.RestProxy;
-import com.azure.core.util.Base64Url;
-import com.azure.core.util.Context;
-import com.azure.core.util.FluxUtil;
-import fixtures.bodystring.models.ErrorException;
 import reactor.core.publisher.Mono;
 
 /** An instance of this class provides access to all the operations defined in StringOperations. */
-public final class StringOperations {
-    /** The proxy service used to perform REST calls. */
-    private final StringOperationsService service;
-
-    /** The service client containing this operation class. */
-    private final AutoRestSwaggerBATService client;
-
-    /**
-     * Initializes an instance of StringOperations.
-     *
-     * @param client the instance of the service client containing this operation class.
-     */
-    StringOperations(AutoRestSwaggerBATService client) {
-        this.service =
-                RestProxy.create(
-                        StringOperationsService.class, client.getHttpPipeline(), client.getSerializerAdapter());
-        this.client = client;
-    }
-
-    /**
-     * The interface defining all the services for AutoRestSwaggerBATServiceStringOperations to be used by the proxy
-     * service to perform REST calls.
-     */
-    @Host("{$host}")
-    @ServiceInterface(name = "AutoRestSwaggerBATSe")
-    private interface StringOperationsService {
-        @Get("/string/null")
-        @ExpectedResponses({200})
-        @UnexpectedResponseExceptionType(ErrorException.class)
-        Mono<Response<String>> getNull(@HostParam("$host") String host, Context context);
-
-        @Put("/string/null")
-        @ExpectedResponses({200})
-        @UnexpectedResponseExceptionType(ErrorException.class)
-        Mono<Response<Void>> putNull(
-                @HostParam("$host") String host, @BodyParam("application/json") String stringBody, Context context);
-
-        @Get("/string/empty")
-        @ExpectedResponses({200})
-        @UnexpectedResponseExceptionType(ErrorException.class)
-        Mono<Response<String>> getEmpty(@HostParam("$host") String host, Context context);
-
-        @Put("/string/empty")
-        @ExpectedResponses({200})
-        @UnexpectedResponseExceptionType(ErrorException.class)
-        Mono<Response<Void>> putEmpty(
-                @HostParam("$host") String host, @BodyParam("application/json") String stringBody, Context context);
-
-        @Get("/string/mbcs")
-        @ExpectedResponses({200})
-        @UnexpectedResponseExceptionType(ErrorException.class)
-        Mono<Response<String>> getMbcs(@HostParam("$host") String host, Context context);
-
-        @Put("/string/mbcs")
-        @ExpectedResponses({200})
-        @UnexpectedResponseExceptionType(ErrorException.class)
-        Mono<Response<Void>> putMbcs(
-                @HostParam("$host") String host, @BodyParam("application/json") String stringBody, Context context);
-
-        @Get("/string/whitespace")
-        @ExpectedResponses({200})
-        @UnexpectedResponseExceptionType(ErrorException.class)
-        Mono<Response<String>> getWhitespace(@HostParam("$host") String host, Context context);
-
-        @Put("/string/whitespace")
-        @ExpectedResponses({200})
-        @UnexpectedResponseExceptionType(ErrorException.class)
-        Mono<Response<Void>> putWhitespace(
-                @HostParam("$host") String host, @BodyParam("application/json") String stringBody, Context context);
-
-        @Get("/string/notProvided")
-        @ExpectedResponses({200})
-        @UnexpectedResponseExceptionType(ErrorException.class)
-        Mono<Response<String>> getNotProvided(@HostParam("$host") String host, Context context);
-
-        @Get("/string/base64Encoding")
-        @ExpectedResponses({200})
-        @UnexpectedResponseExceptionType(ErrorException.class)
-        Mono<Response<byte[]>> getBase64Encoded(@HostParam("$host") String host, Context context);
-
-        @Get("/string/base64UrlEncoding")
-        @ExpectedResponses({200})
-        @ReturnValueWireType(Base64Url.class)
-        @UnexpectedResponseExceptionType(ErrorException.class)
-        Mono<Response<byte[]>> getBase64UrlEncoded(@HostParam("$host") String host, Context context);
-
-        @Put("/string/base64UrlEncoding")
-        @ExpectedResponses({200})
-        @UnexpectedResponseExceptionType(ErrorException.class)
-        Mono<Response<Void>> putBase64UrlEncoded(
-                @HostParam("$host") String host, @BodyParam("application/json") Base64Url stringBody, Context context);
-
-        @Get("/string/nullBase64UrlEncoding")
-        @ExpectedResponses({200})
-        @ReturnValueWireType(Base64Url.class)
-        @UnexpectedResponseExceptionType(ErrorException.class)
-        Mono<Response<byte[]>> getNullBase64UrlEncoded(@HostParam("$host") String host, Context context);
-    }
-
+public interface StringOperations {
     /**
      * Get null string value value.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null string value value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<String>> getNullWithResponseAsync() {
-        if (this.client.getHost() == null) {
-            return Mono.error(
-                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
-        }
-        return FluxUtil.withContext(context -> service.getNull(this.client.getHost(), context));
-    }
+    Mono<Response<String>> getNullWithResponseAsync();
 
     /**
      * Get null string value value.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null string value value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<String> getNullAsync() {
-        return getNullWithResponseAsync()
-                .flatMap(
-                        (Response<String> res) -> {
-                            if (res.getValue() != null) {
-                                return Mono.just(res.getValue());
-                            } else {
-                                return Mono.empty();
-                            }
-                        });
-    }
+    Mono<String> getNullAsync();
 
     /**
      * Get null string value value.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null string value value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public String getNull() {
-        return getNullAsync().block();
-    }
+    String getNull();
 
     /**
      * Set string value null.
      *
      * @param stringBody string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the completion.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<Void>> putNullWithResponseAsync(String stringBody) {
-        if (this.client.getHost() == null) {
-            return Mono.error(
-                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
-        }
-        return FluxUtil.withContext(context -> service.putNull(this.client.getHost(), stringBody, context));
-    }
+    Mono<Response<Void>> putNullWithResponseAsync(String stringBody);
 
     /**
      * Set string value null.
      *
      * @param stringBody string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the completion.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Void> putNullAsync(String stringBody) {
-        return putNullWithResponseAsync(stringBody).flatMap((Response<Void> res) -> Mono.empty());
-    }
+    Mono<Void> putNullAsync(String stringBody);
 
     /**
      * Set string value null.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the completion.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Void> putNullAsync() {
-        final String stringBody = null;
-        return putNullWithResponseAsync(stringBody).flatMap((Response<Void> res) -> Mono.empty());
-    }
+    Mono<Void> putNullAsync();
 
     /**
      * Set string value null.
      *
      * @param stringBody string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public void putNull(String stringBody) {
-        putNullAsync(stringBody).block();
-    }
+    void putNull(String stringBody);
 
     /**
      * Set string value null.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public void putNull() {
-        final String stringBody = null;
-        putNullAsync(stringBody).block();
-    }
+    void putNull();
 
     /**
      * Get empty string value value ''.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return empty string value value ''.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<String>> getEmptyWithResponseAsync() {
-        if (this.client.getHost() == null) {
-            return Mono.error(
-                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
-        }
-        return FluxUtil.withContext(context -> service.getEmpty(this.client.getHost(), context));
-    }
+    Mono<Response<String>> getEmptyWithResponseAsync();
 
     /**
      * Get empty string value value ''.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return empty string value value ''.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<String> getEmptyAsync() {
-        return getEmptyWithResponseAsync()
-                .flatMap(
-                        (Response<String> res) -> {
-                            if (res.getValue() != null) {
-                                return Mono.just(res.getValue());
-                            } else {
-                                return Mono.empty();
-                            }
-                        });
-    }
+    Mono<String> getEmptyAsync();
 
     /**
      * Get empty string value value ''.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return empty string value value ''.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public String getEmpty() {
-        return getEmptyAsync().block();
-    }
+    String getEmpty();
 
     /**
      * Set string value empty ''.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the completion.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<Void>> putEmptyWithResponseAsync() {
-        if (this.client.getHost() == null) {
-            return Mono.error(
-                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
-        }
-        final String stringBody = "";
-        return FluxUtil.withContext(context -> service.putEmpty(this.client.getHost(), stringBody, context));
-    }
+    Mono<Response<Void>> putEmptyWithResponseAsync();
 
     /**
      * Set string value empty ''.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the completion.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Void> putEmptyAsync() {
-        return putEmptyWithResponseAsync().flatMap((Response<Void> res) -> Mono.empty());
-    }
+    Mono<Void> putEmptyAsync();
 
     /**
      * Set string value empty ''.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public void putEmpty() {
-        putEmptyAsync().block();
-    }
+    void putEmpty();
 
     /**
      * Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<String>> getMbcsWithResponseAsync() {
-        if (this.client.getHost() == null) {
-            return Mono.error(
-                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
-        }
-        return FluxUtil.withContext(context -> service.getMbcs(this.client.getHost(), context));
-    }
+    Mono<Response<String>> getMbcsWithResponseAsync();
 
     /**
      * Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<String> getMbcsAsync() {
-        return getMbcsWithResponseAsync()
-                .flatMap(
-                        (Response<String> res) -> {
-                            if (res.getValue() != null) {
-                                return Mono.just(res.getValue());
-                            } else {
-                                return Mono.empty();
-                            }
-                        });
-    }
+    Mono<String> getMbcsAsync();
 
     /**
      * Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public String getMbcs() {
-        return getMbcsAsync().block();
-    }
+    String getMbcs();
 
     /**
      * Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the completion.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<Void>> putMbcsWithResponseAsync() {
-        if (this.client.getHost() == null) {
-            return Mono.error(
-                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
-        }
-        final String stringBody = "啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€";
-        return FluxUtil.withContext(context -> service.putMbcs(this.client.getHost(), stringBody, context));
-    }
+    Mono<Response<Void>> putMbcsWithResponseAsync();
 
     /**
      * Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the completion.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Void> putMbcsAsync() {
-        return putMbcsWithResponseAsync().flatMap((Response<Void> res) -> Mono.empty());
-    }
+    Mono<Void> putMbcsAsync();
 
     /**
      * Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public void putMbcs() {
-        putMbcsAsync().block();
-    }
+    void putMbcs();
 
     /**
      * Get string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for
      * all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time
      *     for all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<String>> getWhitespaceWithResponseAsync() {
-        if (this.client.getHost() == null) {
-            return Mono.error(
-                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
-        }
-        return FluxUtil.withContext(context -> service.getWhitespace(this.client.getHost(), context));
-    }
+    Mono<Response<String>> getWhitespaceWithResponseAsync();
 
     /**
      * Get string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for
      * all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time
      *     for all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<String> getWhitespaceAsync() {
-        return getWhitespaceWithResponseAsync()
-                .flatMap(
-                        (Response<String> res) -> {
-                            if (res.getValue() != null) {
-                                return Mono.just(res.getValue());
-                            } else {
-                                return Mono.empty();
-                            }
-                        });
-    }
+    Mono<String> getWhitespaceAsync();
 
     /**
      * Get string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for
      * all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time
      *     for all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public String getWhitespace() {
-        return getWhitespaceAsync().block();
-    }
+    String getWhitespace();
 
     /**
      * Set String value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for
      * all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the completion.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<Void>> putWhitespaceWithResponseAsync() {
-        if (this.client.getHost() == null) {
-            return Mono.error(
-                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
-        }
-        final String stringBody = "    Now is the time for all good men to come to the aid of their country    ";
-        return FluxUtil.withContext(context -> service.putWhitespace(this.client.getHost(), stringBody, context));
-    }
+    Mono<Response<Void>> putWhitespaceWithResponseAsync();
 
     /**
      * Set String value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for
      * all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the completion.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Void> putWhitespaceAsync() {
-        return putWhitespaceWithResponseAsync().flatMap((Response<Void> res) -> Mono.empty());
-    }
+    Mono<Void> putWhitespaceAsync();
 
     /**
      * Set String value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for
      * all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public void putWhitespace() {
-        putWhitespaceAsync().block();
-    }
+    void putWhitespace();
 
     /**
      * Get String value when no string value is sent in response payload.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return string value when no string value is sent in response payload.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<String>> getNotProvidedWithResponseAsync() {
-        if (this.client.getHost() == null) {
-            return Mono.error(
-                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
-        }
-        return FluxUtil.withContext(context -> service.getNotProvided(this.client.getHost(), context));
-    }
+    Mono<Response<String>> getNotProvidedWithResponseAsync();
 
     /**
      * Get String value when no string value is sent in response payload.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return string value when no string value is sent in response payload.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<String> getNotProvidedAsync() {
-        return getNotProvidedWithResponseAsync()
-                .flatMap(
-                        (Response<String> res) -> {
-                            if (res.getValue() != null) {
-                                return Mono.just(res.getValue());
-                            } else {
-                                return Mono.empty();
-                            }
-                        });
-    }
+    Mono<String> getNotProvidedAsync();
 
     /**
      * Get String value when no string value is sent in response payload.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return string value when no string value is sent in response payload.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public String getNotProvided() {
-        return getNotProvidedAsync().block();
-    }
+    String getNotProvided();
 
     /**
      * Get value that is base64 encoded.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return value that is base64 encoded.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<byte[]>> getBase64EncodedWithResponseAsync() {
-        if (this.client.getHost() == null) {
-            return Mono.error(
-                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
-        }
-        return FluxUtil.withContext(context -> service.getBase64Encoded(this.client.getHost(), context));
-    }
+    Mono<Response<byte[]>> getBase64EncodedWithResponseAsync();
 
     /**
      * Get value that is base64 encoded.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return value that is base64 encoded.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<byte[]> getBase64EncodedAsync() {
-        return getBase64EncodedWithResponseAsync()
-                .flatMap(
-                        (Response<byte[]> res) -> {
-                            if (res.getValue() != null) {
-                                return Mono.just(res.getValue());
-                            } else {
-                                return Mono.empty();
-                            }
-                        });
-    }
+    Mono<byte[]> getBase64EncodedAsync();
 
     /**
      * Get value that is base64 encoded.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return value that is base64 encoded.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public byte[] getBase64Encoded() {
-        return getBase64EncodedAsync().block();
-    }
+    byte[] getBase64Encoded();
 
     /**
      * Get value that is base64url encoded.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return value that is base64url encoded.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<byte[]>> getBase64UrlEncodedWithResponseAsync() {
-        if (this.client.getHost() == null) {
-            return Mono.error(
-                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
-        }
-        return FluxUtil.withContext(context -> service.getBase64UrlEncoded(this.client.getHost(), context));
-    }
+    Mono<Response<byte[]>> getBase64UrlEncodedWithResponseAsync();
 
     /**
      * Get value that is base64url encoded.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return value that is base64url encoded.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<byte[]> getBase64UrlEncodedAsync() {
-        return getBase64UrlEncodedWithResponseAsync()
-                .flatMap(
-                        (Response<byte[]> res) -> {
-                            if (res.getValue() != null) {
-                                return Mono.just(res.getValue());
-                            } else {
-                                return Mono.empty();
-                            }
-                        });
-    }
+    Mono<byte[]> getBase64UrlEncodedAsync();
 
     /**
      * Get value that is base64url encoded.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return value that is base64url encoded.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public byte[] getBase64UrlEncoded() {
-        return getBase64UrlEncodedAsync().block();
-    }
+    byte[] getBase64UrlEncoded();
 
     /**
      * Put value that is base64url encoded.
      *
      * @param stringBody string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the completion.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<Void>> putBase64UrlEncodedWithResponseAsync(byte[] stringBody) {
-        if (this.client.getHost() == null) {
-            return Mono.error(
-                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
-        }
-        if (stringBody == null) {
-            return Mono.error(new IllegalArgumentException("Parameter stringBody is required and cannot be null."));
-        }
-        Base64Url stringBodyConverted = Base64Url.encode(stringBody);
-        return FluxUtil.withContext(
-                context -> service.putBase64UrlEncoded(this.client.getHost(), stringBodyConverted, context));
-    }
+    Mono<Response<Void>> putBase64UrlEncodedWithResponseAsync(byte[] stringBody);
 
     /**
      * Put value that is base64url encoded.
      *
      * @param stringBody string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the completion.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Void> putBase64UrlEncodedAsync(byte[] stringBody) {
-        return putBase64UrlEncodedWithResponseAsync(stringBody).flatMap((Response<Void> res) -> Mono.empty());
-    }
+    Mono<Void> putBase64UrlEncodedAsync(byte[] stringBody);
 
     /**
      * Put value that is base64url encoded.
      *
      * @param stringBody string body.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public void putBase64UrlEncoded(byte[] stringBody) {
-        putBase64UrlEncodedAsync(stringBody).block();
-    }
+    void putBase64UrlEncoded(byte[] stringBody);
 
     /**
      * Get null value that is expected to be base64url encoded.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null value that is expected to be base64url encoded.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<byte[]>> getNullBase64UrlEncodedWithResponseAsync() {
-        if (this.client.getHost() == null) {
-            return Mono.error(
-                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
-        }
-        return FluxUtil.withContext(context -> service.getNullBase64UrlEncoded(this.client.getHost(), context));
-    }
+    Mono<Response<byte[]>> getNullBase64UrlEncodedWithResponseAsync();
 
     /**
      * Get null value that is expected to be base64url encoded.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null value that is expected to be base64url encoded.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<byte[]> getNullBase64UrlEncodedAsync() {
-        return getNullBase64UrlEncodedWithResponseAsync()
-                .flatMap(
-                        (Response<byte[]> res) -> {
-                            if (res.getValue() != null) {
-                                return Mono.just(res.getValue());
-                            } else {
-                                return Mono.empty();
-                            }
-                        });
-    }
+    Mono<byte[]> getNullBase64UrlEncodedAsync();
 
     /**
      * Get null value that is expected to be base64url encoded.
      *
-     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws fixtures.bodystring.models.ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return null value that is expected to be base64url encoded.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public byte[] getNullBase64UrlEncoded() {
-        return getNullBase64UrlEncodedAsync().block();
-    }
+    byte[] getNullBase64UrlEncoded();
 }

--- a/vanilla-tests/src/main/java/fixtures/bodystring/implementation/AutoRestSwaggerBATServiceImpl.java
+++ b/vanilla-tests/src/main/java/fixtures/bodystring/implementation/AutoRestSwaggerBATServiceImpl.java
@@ -1,0 +1,114 @@
+package fixtures.bodystring.implementation;
+
+import com.azure.core.http.HttpPipeline;
+import com.azure.core.http.HttpPipelineBuilder;
+import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.RetryPolicy;
+import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
+import fixtures.bodystring.AutoRestSwaggerBATService;
+import fixtures.bodystring.Enums;
+import fixtures.bodystring.StringOperations;
+
+/** Initializes a new instance of the AutoRestSwaggerBATService type. */
+public final class AutoRestSwaggerBATServiceImpl implements AutoRestSwaggerBATService {
+    /** server parameter. */
+    private final String host;
+
+    /**
+     * Gets server parameter.
+     *
+     * @return the host value.
+     */
+    public String getHost() {
+        return this.host;
+    }
+
+    /** The HTTP pipeline to send requests through. */
+    private final HttpPipeline httpPipeline;
+
+    /**
+     * Gets The HTTP pipeline to send requests through.
+     *
+     * @return the httpPipeline value.
+     */
+    public HttpPipeline getHttpPipeline() {
+        return this.httpPipeline;
+    }
+
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
+    /** The StringOperations object to access its operations. */
+    private final StringOperations stringOperations;
+
+    /**
+     * Gets the StringOperations object to access its operations.
+     *
+     * @return the StringOperations object.
+     */
+    public StringOperations getStringOperations() {
+        return this.stringOperations;
+    }
+
+    /** The Enums object to access its operations. */
+    private final Enums enums;
+
+    /**
+     * Gets the Enums object to access its operations.
+     *
+     * @return the Enums object.
+     */
+    public Enums getEnums() {
+        return this.enums;
+    }
+
+    /**
+     * Initializes an instance of AutoRestSwaggerBATService client.
+     *
+     * @param host server parameter.
+     */
+    AutoRestSwaggerBATServiceImpl(String host) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
+                host);
+    }
+
+    /**
+     * Initializes an instance of AutoRestSwaggerBATService client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param host server parameter.
+     */
+    AutoRestSwaggerBATServiceImpl(HttpPipeline httpPipeline, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    }
+
+    /**
+     * Initializes an instance of AutoRestSwaggerBATService client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     * @param host server parameter.
+     */
+    AutoRestSwaggerBATServiceImpl(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
+        this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
+        this.host = host;
+        this.stringOperations = new StringOperationsImpl(this);
+        this.enums = new EnumsImpl(this);
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/bodystring/implementation/AutoRestSwaggerBATServiceImplBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodystring/implementation/AutoRestSwaggerBATServiceImplBuilder.java
@@ -1,4 +1,4 @@
-package fixtures.bodystring;
+package fixtures.bodystring.implementation;
 
 import com.azure.core.annotation.ServiceClientBuilder;
 import com.azure.core.http.HttpClient;
@@ -15,21 +15,22 @@ import com.azure.core.util.Configuration;
 import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
+import fixtures.bodystring.AutoRestSwaggerBATService;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 /** A builder for creating a new instance of the AutoRestSwaggerBATService type. */
-@ServiceClientBuilder(serviceClients = {AutoRestSwaggerBATService.class})
-public final class AutoRestSwaggerBATServiceBuilder {
+@ServiceClientBuilder(serviceClients = {AutoRestSwaggerBATServiceImpl.class})
+public final class AutoRestSwaggerBATServiceImplBuilder {
     private static final String SDK_NAME = "name";
 
     private static final String SDK_VERSION = "version";
 
     private final Map<String, String> properties = new HashMap<>();
 
-    public AutoRestSwaggerBATServiceBuilder() {
+    public AutoRestSwaggerBATServiceImplBuilder() {
         this.pipelinePolicies = new ArrayList<>();
     }
 
@@ -42,9 +43,9 @@ public final class AutoRestSwaggerBATServiceBuilder {
      * Sets server parameter.
      *
      * @param host the host value.
-     * @return the AutoRestSwaggerBATServiceBuilder.
+     * @return the AutoRestSwaggerBATServiceImplBuilder.
      */
-    public AutoRestSwaggerBATServiceBuilder host(String host) {
+    public AutoRestSwaggerBATServiceImplBuilder host(String host) {
         this.host = host;
         return this;
     }
@@ -58,9 +59,9 @@ public final class AutoRestSwaggerBATServiceBuilder {
      * Sets The HTTP pipeline to send requests through.
      *
      * @param pipeline the pipeline value.
-     * @return the AutoRestSwaggerBATServiceBuilder.
+     * @return the AutoRestSwaggerBATServiceImplBuilder.
      */
-    public AutoRestSwaggerBATServiceBuilder pipeline(HttpPipeline pipeline) {
+    public AutoRestSwaggerBATServiceImplBuilder pipeline(HttpPipeline pipeline) {
         this.pipeline = pipeline;
         return this;
     }
@@ -74,9 +75,9 @@ public final class AutoRestSwaggerBATServiceBuilder {
      * Sets The serializer to serialize an object into a string.
      *
      * @param serializerAdapter the serializerAdapter value.
-     * @return the AutoRestSwaggerBATServiceBuilder.
+     * @return the AutoRestSwaggerBATServiceImplBuilder.
      */
-    public AutoRestSwaggerBATServiceBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+    public AutoRestSwaggerBATServiceImplBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
         this.serializerAdapter = serializerAdapter;
         return this;
     }
@@ -90,9 +91,9 @@ public final class AutoRestSwaggerBATServiceBuilder {
      * Sets The HTTP client used to send the request.
      *
      * @param httpClient the httpClient value.
-     * @return the AutoRestSwaggerBATServiceBuilder.
+     * @return the AutoRestSwaggerBATServiceImplBuilder.
      */
-    public AutoRestSwaggerBATServiceBuilder httpClient(HttpClient httpClient) {
+    public AutoRestSwaggerBATServiceImplBuilder httpClient(HttpClient httpClient) {
         this.httpClient = httpClient;
         return this;
     }
@@ -107,9 +108,9 @@ public final class AutoRestSwaggerBATServiceBuilder {
      * Sets The configuration store that is used during construction of the service client.
      *
      * @param configuration the configuration value.
-     * @return the AutoRestSwaggerBATServiceBuilder.
+     * @return the AutoRestSwaggerBATServiceImplBuilder.
      */
-    public AutoRestSwaggerBATServiceBuilder configuration(Configuration configuration) {
+    public AutoRestSwaggerBATServiceImplBuilder configuration(Configuration configuration) {
         this.configuration = configuration;
         return this;
     }
@@ -123,9 +124,9 @@ public final class AutoRestSwaggerBATServiceBuilder {
      * Sets The logging configuration for HTTP requests and responses.
      *
      * @param httpLogOptions the httpLogOptions value.
-     * @return the AutoRestSwaggerBATServiceBuilder.
+     * @return the AutoRestSwaggerBATServiceImplBuilder.
      */
-    public AutoRestSwaggerBATServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+    public AutoRestSwaggerBATServiceImplBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
         return this;
     }
@@ -139,9 +140,9 @@ public final class AutoRestSwaggerBATServiceBuilder {
      * Sets The service API version that is used when making API requests.
      *
      * @param serviceVersion the serviceVersion value.
-     * @return the AutoRestSwaggerBATServiceBuilder.
+     * @return the AutoRestSwaggerBATServiceImplBuilder.
      */
-    public AutoRestSwaggerBATServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
+    public AutoRestSwaggerBATServiceImplBuilder serviceVersion(ServiceVersion serviceVersion) {
         this.serviceVersion = serviceVersion;
         return this;
     }
@@ -156,9 +157,9 @@ public final class AutoRestSwaggerBATServiceBuilder {
      * Sets The retry policy that will attempt to retry failed requests, if applicable.
      *
      * @param retryPolicy the retryPolicy value.
-     * @return the AutoRestSwaggerBATServiceBuilder.
+     * @return the AutoRestSwaggerBATServiceImplBuilder.
      */
-    public AutoRestSwaggerBATServiceBuilder retryPolicy(RetryPolicy retryPolicy) {
+    public AutoRestSwaggerBATServiceImplBuilder retryPolicy(RetryPolicy retryPolicy) {
         this.retryPolicy = retryPolicy;
         return this;
     }
@@ -172,9 +173,9 @@ public final class AutoRestSwaggerBATServiceBuilder {
      * Adds a custom Http pipeline policy.
      *
      * @param customPolicy The custom Http pipeline policy to add.
-     * @return the AutoRestSwaggerBATServiceBuilder.
+     * @return the AutoRestSwaggerBATServiceImplBuilder.
      */
-    public AutoRestSwaggerBATServiceBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+    public AutoRestSwaggerBATServiceImplBuilder addPolicy(HttpPipelinePolicy customPolicy) {
         pipelinePolicies.add(customPolicy);
         return this;
     }
@@ -194,7 +195,7 @@ public final class AutoRestSwaggerBATServiceBuilder {
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
         }
-        AutoRestSwaggerBATService client = new AutoRestSwaggerBATService(pipeline, serializerAdapter, host);
+        AutoRestSwaggerBATServiceImpl client = new AutoRestSwaggerBATServiceImpl(pipeline, serializerAdapter, host);
         return client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodystring/implementation/EnumsImpl.java
+++ b/vanilla-tests/src/main/java/fixtures/bodystring/implementation/EnumsImpl.java
@@ -1,0 +1,374 @@
+package fixtures.bodystring.implementation;
+
+import com.azure.core.annotation.BodyParam;
+import com.azure.core.annotation.ExpectedResponses;
+import com.azure.core.annotation.Get;
+import com.azure.core.annotation.Host;
+import com.azure.core.annotation.HostParam;
+import com.azure.core.annotation.Put;
+import com.azure.core.annotation.ReturnType;
+import com.azure.core.annotation.ServiceInterface;
+import com.azure.core.annotation.ServiceMethod;
+import com.azure.core.annotation.UnexpectedResponseExceptionType;
+import com.azure.core.http.rest.Response;
+import com.azure.core.http.rest.RestProxy;
+import com.azure.core.util.Context;
+import com.azure.core.util.FluxUtil;
+import fixtures.bodystring.Enums;
+import fixtures.bodystring.models.Colors;
+import fixtures.bodystring.models.ErrorException;
+import fixtures.bodystring.models.RefColorConstant;
+import reactor.core.publisher.Mono;
+
+/** An instance of this class provides access to all the operations defined in Enums. */
+public final class EnumsImpl implements Enums {
+    /** The proxy service used to perform REST calls. */
+    private final EnumsService service;
+
+    /** The service client containing this operation class. */
+    private final AutoRestSwaggerBATServiceImpl client;
+
+    /**
+     * Initializes an instance of EnumsImpl.
+     *
+     * @param client the instance of the service client containing this operation class.
+     */
+    EnumsImpl(AutoRestSwaggerBATServiceImpl client) {
+        this.service = RestProxy.create(EnumsService.class, client.getHttpPipeline(), client.getSerializerAdapter());
+        this.client = client;
+    }
+
+    /**
+     * The interface defining all the services for AutoRestSwaggerBATServiceEnums to be used by the proxy service to
+     * perform REST calls.
+     */
+    @Host("{$host}")
+    @ServiceInterface(name = "AutoRestSwaggerBATSe")
+    private interface EnumsService {
+        @Get("/string/enum/notExpandable")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<Colors>> getNotExpandable(@HostParam("$host") String host, Context context);
+
+        @Put("/string/enum/notExpandable")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<Void>> putNotExpandable(
+                @HostParam("$host") String host, @BodyParam("application/json") Colors stringBody, Context context);
+
+        @Get("/string/enum/Referenced")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<Colors>> getReferenced(@HostParam("$host") String host, Context context);
+
+        @Put("/string/enum/Referenced")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<Void>> putReferenced(
+                @HostParam("$host") String host, @BodyParam("application/json") Colors enumStringBody, Context context);
+
+        @Get("/string/enum/ReferencedConstant")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<RefColorConstant>> getReferencedConstant(@HostParam("$host") String host, Context context);
+
+        @Put("/string/enum/ReferencedConstant")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<Void>> putReferencedConstant(
+                @HostParam("$host") String host,
+                @BodyParam("application/json") RefColorConstant enumStringBody,
+                Context context);
+    }
+
+    /**
+     * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Colors>> getNotExpandableWithResponseAsync() {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return FluxUtil.withContext(context -> service.getNotExpandable(this.client.getHost(), context));
+    }
+
+    /**
+     * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Colors> getNotExpandableAsync() {
+        return getNotExpandableWithResponseAsync()
+                .flatMap(
+                        (Response<Colors> res) -> {
+                            if (res.getValue() != null) {
+                                return Mono.just(res.getValue());
+                            } else {
+                                return Mono.empty();
+                            }
+                        });
+    }
+
+    /**
+     * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Colors getNotExpandable() {
+        return getNotExpandableAsync().block();
+    }
+
+    /**
+     * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @param stringBody string body.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putNotExpandableWithResponseAsync(Colors stringBody) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (stringBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter stringBody is required and cannot be null."));
+        }
+        return FluxUtil.withContext(context -> service.putNotExpandable(this.client.getHost(), stringBody, context));
+    }
+
+    /**
+     * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @param stringBody string body.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putNotExpandableAsync(Colors stringBody) {
+        return putNotExpandableWithResponseAsync(stringBody).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @param stringBody string body.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void putNotExpandable(Colors stringBody) {
+        putNotExpandableAsync(stringBody).block();
+    }
+
+    /**
+     * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Colors>> getReferencedWithResponseAsync() {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return FluxUtil.withContext(context -> service.getReferenced(this.client.getHost(), context));
+    }
+
+    /**
+     * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Colors> getReferencedAsync() {
+        return getReferencedWithResponseAsync()
+                .flatMap(
+                        (Response<Colors> res) -> {
+                            if (res.getValue() != null) {
+                                return Mono.just(res.getValue());
+                            } else {
+                                return Mono.empty();
+                            }
+                        });
+    }
+
+    /**
+     * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Colors getReferenced() {
+        return getReferencedAsync().block();
+    }
+
+    /**
+     * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @param enumStringBody enum string body.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putReferencedWithResponseAsync(Colors enumStringBody) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (enumStringBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter enumStringBody is required and cannot be null."));
+        }
+        return FluxUtil.withContext(context -> service.putReferenced(this.client.getHost(), enumStringBody, context));
+    }
+
+    /**
+     * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @param enumStringBody enum string body.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putReferencedAsync(Colors enumStringBody) {
+        return putReferencedWithResponseAsync(enumStringBody).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
+     *
+     * @param enumStringBody enum string body.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void putReferenced(Colors enumStringBody) {
+        putReferencedAsync(enumStringBody).block();
+    }
+
+    /**
+     * Get value 'green-color' from the constant.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return value 'green-color' from the constant.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<RefColorConstant>> getReferencedConstantWithResponseAsync() {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return FluxUtil.withContext(context -> service.getReferencedConstant(this.client.getHost(), context));
+    }
+
+    /**
+     * Get value 'green-color' from the constant.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return value 'green-color' from the constant.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<RefColorConstant> getReferencedConstantAsync() {
+        return getReferencedConstantWithResponseAsync()
+                .flatMap(
+                        (Response<RefColorConstant> res) -> {
+                            if (res.getValue() != null) {
+                                return Mono.just(res.getValue());
+                            } else {
+                                return Mono.empty();
+                            }
+                        });
+    }
+
+    /**
+     * Get value 'green-color' from the constant.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return value 'green-color' from the constant.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public RefColorConstant getReferencedConstant() {
+        return getReferencedConstantAsync().block();
+    }
+
+    /**
+     * Sends value 'green-color' from a constant.
+     *
+     * @param enumStringBody enum string body.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putReferencedConstantWithResponseAsync(RefColorConstant enumStringBody) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (enumStringBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter enumStringBody is required and cannot be null."));
+        } else {
+            enumStringBody.validate();
+        }
+        return FluxUtil.withContext(
+                context -> service.putReferencedConstant(this.client.getHost(), enumStringBody, context));
+    }
+
+    /**
+     * Sends value 'green-color' from a constant.
+     *
+     * @param enumStringBody enum string body.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putReferencedConstantAsync(RefColorConstant enumStringBody) {
+        return putReferencedConstantWithResponseAsync(enumStringBody).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Sends value 'green-color' from a constant.
+     *
+     * @param enumStringBody enum string body.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void putReferencedConstant(RefColorConstant enumStringBody) {
+        putReferencedConstantAsync(enumStringBody).block();
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/bodystring/implementation/StringOperationsImpl.java
+++ b/vanilla-tests/src/main/java/fixtures/bodystring/implementation/StringOperationsImpl.java
@@ -1,0 +1,755 @@
+package fixtures.bodystring.implementation;
+
+import com.azure.core.annotation.BodyParam;
+import com.azure.core.annotation.ExpectedResponses;
+import com.azure.core.annotation.Get;
+import com.azure.core.annotation.Host;
+import com.azure.core.annotation.HostParam;
+import com.azure.core.annotation.Put;
+import com.azure.core.annotation.ReturnType;
+import com.azure.core.annotation.ReturnValueWireType;
+import com.azure.core.annotation.ServiceInterface;
+import com.azure.core.annotation.ServiceMethod;
+import com.azure.core.annotation.UnexpectedResponseExceptionType;
+import com.azure.core.http.rest.Response;
+import com.azure.core.http.rest.RestProxy;
+import com.azure.core.util.Base64Url;
+import com.azure.core.util.Context;
+import com.azure.core.util.FluxUtil;
+import fixtures.bodystring.StringOperations;
+import fixtures.bodystring.models.ErrorException;
+import reactor.core.publisher.Mono;
+
+/** An instance of this class provides access to all the operations defined in StringOperations. */
+public final class StringOperationsImpl implements StringOperations {
+    /** The proxy service used to perform REST calls. */
+    private final StringOperationsService service;
+
+    /** The service client containing this operation class. */
+    private final AutoRestSwaggerBATServiceImpl client;
+
+    /**
+     * Initializes an instance of StringOperationsImpl.
+     *
+     * @param client the instance of the service client containing this operation class.
+     */
+    StringOperationsImpl(AutoRestSwaggerBATServiceImpl client) {
+        this.service =
+                RestProxy.create(
+                        StringOperationsService.class, client.getHttpPipeline(), client.getSerializerAdapter());
+        this.client = client;
+    }
+
+    /**
+     * The interface defining all the services for AutoRestSwaggerBATServiceStringOperations to be used by the proxy
+     * service to perform REST calls.
+     */
+    @Host("{$host}")
+    @ServiceInterface(name = "AutoRestSwaggerBATSe")
+    private interface StringOperationsService {
+        @Get("/string/null")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<String>> getNull(@HostParam("$host") String host, Context context);
+
+        @Put("/string/null")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<Void>> putNull(
+                @HostParam("$host") String host, @BodyParam("application/json") String stringBody, Context context);
+
+        @Get("/string/empty")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<String>> getEmpty(@HostParam("$host") String host, Context context);
+
+        @Put("/string/empty")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<Void>> putEmpty(
+                @HostParam("$host") String host, @BodyParam("application/json") String stringBody, Context context);
+
+        @Get("/string/mbcs")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<String>> getMbcs(@HostParam("$host") String host, Context context);
+
+        @Put("/string/mbcs")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<Void>> putMbcs(
+                @HostParam("$host") String host, @BodyParam("application/json") String stringBody, Context context);
+
+        @Get("/string/whitespace")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<String>> getWhitespace(@HostParam("$host") String host, Context context);
+
+        @Put("/string/whitespace")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<Void>> putWhitespace(
+                @HostParam("$host") String host, @BodyParam("application/json") String stringBody, Context context);
+
+        @Get("/string/notProvided")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<String>> getNotProvided(@HostParam("$host") String host, Context context);
+
+        @Get("/string/base64Encoding")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<byte[]>> getBase64Encoded(@HostParam("$host") String host, Context context);
+
+        @Get("/string/base64UrlEncoding")
+        @ExpectedResponses({200})
+        @ReturnValueWireType(Base64Url.class)
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<byte[]>> getBase64UrlEncoded(@HostParam("$host") String host, Context context);
+
+        @Put("/string/base64UrlEncoding")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<Void>> putBase64UrlEncoded(
+                @HostParam("$host") String host, @BodyParam("application/json") Base64Url stringBody, Context context);
+
+        @Get("/string/nullBase64UrlEncoding")
+        @ExpectedResponses({200})
+        @ReturnValueWireType(Base64Url.class)
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<byte[]>> getNullBase64UrlEncoded(@HostParam("$host") String host, Context context);
+    }
+
+    /**
+     * Get null string value value.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null string value value.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> getNullWithResponseAsync() {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return FluxUtil.withContext(context -> service.getNull(this.client.getHost(), context));
+    }
+
+    /**
+     * Get null string value value.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null string value value.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> getNullAsync() {
+        return getNullWithResponseAsync()
+                .flatMap(
+                        (Response<String> res) -> {
+                            if (res.getValue() != null) {
+                                return Mono.just(res.getValue());
+                            } else {
+                                return Mono.empty();
+                            }
+                        });
+    }
+
+    /**
+     * Get null string value value.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null string value value.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public String getNull() {
+        return getNullAsync().block();
+    }
+
+    /**
+     * Set string value null.
+     *
+     * @param stringBody string body.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putNullWithResponseAsync(String stringBody) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return FluxUtil.withContext(context -> service.putNull(this.client.getHost(), stringBody, context));
+    }
+
+    /**
+     * Set string value null.
+     *
+     * @param stringBody string body.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putNullAsync(String stringBody) {
+        return putNullWithResponseAsync(stringBody).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Set string value null.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putNullAsync() {
+        final String stringBody = null;
+        return putNullWithResponseAsync(stringBody).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Set string value null.
+     *
+     * @param stringBody string body.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void putNull(String stringBody) {
+        putNullAsync(stringBody).block();
+    }
+
+    /**
+     * Set string value null.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void putNull() {
+        final String stringBody = null;
+        putNullAsync(stringBody).block();
+    }
+
+    /**
+     * Get empty string value value ''.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return empty string value value ''.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> getEmptyWithResponseAsync() {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return FluxUtil.withContext(context -> service.getEmpty(this.client.getHost(), context));
+    }
+
+    /**
+     * Get empty string value value ''.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return empty string value value ''.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> getEmptyAsync() {
+        return getEmptyWithResponseAsync()
+                .flatMap(
+                        (Response<String> res) -> {
+                            if (res.getValue() != null) {
+                                return Mono.just(res.getValue());
+                            } else {
+                                return Mono.empty();
+                            }
+                        });
+    }
+
+    /**
+     * Get empty string value value ''.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return empty string value value ''.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public String getEmpty() {
+        return getEmptyAsync().block();
+    }
+
+    /**
+     * Set string value empty ''.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putEmptyWithResponseAsync() {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String stringBody = "";
+        return FluxUtil.withContext(context -> service.putEmpty(this.client.getHost(), stringBody, context));
+    }
+
+    /**
+     * Set string value empty ''.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putEmptyAsync() {
+        return putEmptyWithResponseAsync().flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Set string value empty ''.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void putEmpty() {
+        putEmptyAsync().block();
+    }
+
+    /**
+     * Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> getMbcsWithResponseAsync() {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return FluxUtil.withContext(context -> service.getMbcs(this.client.getHost(), context));
+    }
+
+    /**
+     * Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> getMbcsAsync() {
+        return getMbcsWithResponseAsync()
+                .flatMap(
+                        (Response<String> res) -> {
+                            if (res.getValue() != null) {
+                                return Mono.just(res.getValue());
+                            } else {
+                                return Mono.empty();
+                            }
+                        });
+    }
+
+    /**
+     * Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public String getMbcs() {
+        return getMbcsAsync().block();
+    }
+
+    /**
+     * Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putMbcsWithResponseAsync() {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String stringBody = "啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€";
+        return FluxUtil.withContext(context -> service.putMbcs(this.client.getHost(), stringBody, context));
+    }
+
+    /**
+     * Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putMbcsAsync() {
+        return putMbcsWithResponseAsync().flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void putMbcs() {
+        putMbcsAsync().block();
+    }
+
+    /**
+     * Get string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for
+     * all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time
+     *     for all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> getWhitespaceWithResponseAsync() {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return FluxUtil.withContext(context -> service.getWhitespace(this.client.getHost(), context));
+    }
+
+    /**
+     * Get string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for
+     * all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time
+     *     for all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> getWhitespaceAsync() {
+        return getWhitespaceWithResponseAsync()
+                .flatMap(
+                        (Response<String> res) -> {
+                            if (res.getValue() != null) {
+                                return Mono.just(res.getValue());
+                            } else {
+                                return Mono.empty();
+                            }
+                        });
+    }
+
+    /**
+     * Get string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for
+     * all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time
+     *     for all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public String getWhitespace() {
+        return getWhitespaceAsync().block();
+    }
+
+    /**
+     * Set String value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for
+     * all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putWhitespaceWithResponseAsync() {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String stringBody = "    Now is the time for all good men to come to the aid of their country    ";
+        return FluxUtil.withContext(context -> service.putWhitespace(this.client.getHost(), stringBody, context));
+    }
+
+    /**
+     * Set String value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for
+     * all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putWhitespaceAsync() {
+        return putWhitespaceWithResponseAsync().flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Set String value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for
+     * all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void putWhitespace() {
+        putWhitespaceAsync().block();
+    }
+
+    /**
+     * Get String value when no string value is sent in response payload.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return string value when no string value is sent in response payload.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> getNotProvidedWithResponseAsync() {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return FluxUtil.withContext(context -> service.getNotProvided(this.client.getHost(), context));
+    }
+
+    /**
+     * Get String value when no string value is sent in response payload.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return string value when no string value is sent in response payload.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> getNotProvidedAsync() {
+        return getNotProvidedWithResponseAsync()
+                .flatMap(
+                        (Response<String> res) -> {
+                            if (res.getValue() != null) {
+                                return Mono.just(res.getValue());
+                            } else {
+                                return Mono.empty();
+                            }
+                        });
+    }
+
+    /**
+     * Get String value when no string value is sent in response payload.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return string value when no string value is sent in response payload.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public String getNotProvided() {
+        return getNotProvidedAsync().block();
+    }
+
+    /**
+     * Get value that is base64 encoded.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return value that is base64 encoded.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<byte[]>> getBase64EncodedWithResponseAsync() {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return FluxUtil.withContext(context -> service.getBase64Encoded(this.client.getHost(), context));
+    }
+
+    /**
+     * Get value that is base64 encoded.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return value that is base64 encoded.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<byte[]> getBase64EncodedAsync() {
+        return getBase64EncodedWithResponseAsync()
+                .flatMap(
+                        (Response<byte[]> res) -> {
+                            if (res.getValue() != null) {
+                                return Mono.just(res.getValue());
+                            } else {
+                                return Mono.empty();
+                            }
+                        });
+    }
+
+    /**
+     * Get value that is base64 encoded.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return value that is base64 encoded.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public byte[] getBase64Encoded() {
+        return getBase64EncodedAsync().block();
+    }
+
+    /**
+     * Get value that is base64url encoded.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return value that is base64url encoded.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<byte[]>> getBase64UrlEncodedWithResponseAsync() {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return FluxUtil.withContext(context -> service.getBase64UrlEncoded(this.client.getHost(), context));
+    }
+
+    /**
+     * Get value that is base64url encoded.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return value that is base64url encoded.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<byte[]> getBase64UrlEncodedAsync() {
+        return getBase64UrlEncodedWithResponseAsync()
+                .flatMap(
+                        (Response<byte[]> res) -> {
+                            if (res.getValue() != null) {
+                                return Mono.just(res.getValue());
+                            } else {
+                                return Mono.empty();
+                            }
+                        });
+    }
+
+    /**
+     * Get value that is base64url encoded.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return value that is base64url encoded.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public byte[] getBase64UrlEncoded() {
+        return getBase64UrlEncodedAsync().block();
+    }
+
+    /**
+     * Put value that is base64url encoded.
+     *
+     * @param stringBody string body.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> putBase64UrlEncodedWithResponseAsync(byte[] stringBody) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (stringBody == null) {
+            return Mono.error(new IllegalArgumentException("Parameter stringBody is required and cannot be null."));
+        }
+        Base64Url stringBodyConverted = Base64Url.encode(stringBody);
+        return FluxUtil.withContext(
+                context -> service.putBase64UrlEncoded(this.client.getHost(), stringBodyConverted, context));
+    }
+
+    /**
+     * Put value that is base64url encoded.
+     *
+     * @param stringBody string body.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> putBase64UrlEncodedAsync(byte[] stringBody) {
+        return putBase64UrlEncodedWithResponseAsync(stringBody).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Put value that is base64url encoded.
+     *
+     * @param stringBody string body.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void putBase64UrlEncoded(byte[] stringBody) {
+        putBase64UrlEncodedAsync(stringBody).block();
+    }
+
+    /**
+     * Get null value that is expected to be base64url encoded.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null value that is expected to be base64url encoded.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<byte[]>> getNullBase64UrlEncodedWithResponseAsync() {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return FluxUtil.withContext(context -> service.getNullBase64UrlEncoded(this.client.getHost(), context));
+    }
+
+    /**
+     * Get null value that is expected to be base64url encoded.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null value that is expected to be base64url encoded.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<byte[]> getNullBase64UrlEncodedAsync() {
+        return getNullBase64UrlEncodedWithResponseAsync()
+                .flatMap(
+                        (Response<byte[]> res) -> {
+                            if (res.getValue() != null) {
+                                return Mono.just(res.getValue());
+                            } else {
+                                return Mono.empty();
+                            }
+                        });
+    }
+
+    /**
+     * Get null value that is expected to be base64url encoded.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return null value that is expected to be base64url encoded.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public byte[] getNullBase64UrlEncoded() {
+        return getNullBase64UrlEncodedAsync().block();
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/bodystring/implementation/package-info.java
+++ b/vanilla-tests/src/main/java/fixtures/bodystring/implementation/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Package containing the implementations for AutoRestSwaggerBATService. Test Infrastructure for AutoRest Swagger BAT.
+ */
+package fixtures.bodystring.implementation;

--- a/vanilla-tests/src/test/java/fixtures/bodystring/EnumOperationsTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodystring/EnumOperationsTests.java
@@ -1,5 +1,6 @@
 package fixtures.bodystring;
 
+import fixtures.bodystring.implementation.AutoRestSwaggerBATServiceImplBuilder;
 import fixtures.bodystring.models.Colors;
 import fixtures.bodystring.models.RefColorConstant;
 import org.junit.Assert;
@@ -14,7 +15,7 @@ public class EnumOperationsTests {
 
     @BeforeClass
     public static void setup() {
-        client = new AutoRestSwaggerBATServiceBuilder().buildClient();
+        client = new AutoRestSwaggerBATServiceImplBuilder().buildClient();
     }
 
     @Test

--- a/vanilla-tests/src/test/java/fixtures/bodystring/StringOperationsTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodystring/StringOperationsTests.java
@@ -1,6 +1,7 @@
 package fixtures.bodystring;
 
 import com.azure.core.exception.HttpResponseException;
+import fixtures.bodystring.implementation.AutoRestSwaggerBATServiceImplBuilder;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -19,7 +20,7 @@ public class StringOperationsTests {
 
     @BeforeClass
     public static void setup() {
-        client = new AutoRestSwaggerBATServiceBuilder().buildClient();
+        client = new AutoRestSwaggerBATServiceImplBuilder().buildClient();
     }
 
     @Test


### PR DESCRIPTION
`--generate-client-interfaces` seems broken for quite some time. Attempt to bring it back to life.

sample interface
```
/** An instance of this class provides access to all the operations defined in ResourceGroupsClient. */
public interface ResourceGroupsClient {
    /**
     * Checks whether a resource group exists.
     *
     * @param resourceGroupName The name of the resource group to check. The name is case insensitive.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     * @return whether resource exists.
     */
    @ServiceMethod(returns = ReturnType.SINGLE)
    Mono<Response<Boolean>> checkExistenceWithResponseAsync(String resourceGroupName);

    /**
     * Checks whether a resource group exists.
     *
     * @param resourceGroupName The name of the resource group to check. The name is case insensitive.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     * @return whether resource exists.
     */
    @ServiceMethod(returns = ReturnType.SINGLE)
    Mono<Boolean> checkExistenceAsync(String resourceGroupName);
```

```
/** The interface for ResourceManagementClient class. */
public interface ResourceManagementClient {
    /**
     * Gets The ID of the target subscription.
     *
     * @return the subscriptionId value.
     */
    String getSubscriptionId();

    /**
     * Gets server parameter.
     *
     * @return the endpoint value.
     */
    String getEndpoint();

    /**
     * Gets Api Version.
     *
     * @return the apiVersion value.
     */
    String getApiVersion();

    /**
     * Gets The HTTP pipeline to send requests through.
     *
     * @return the httpPipeline value.
     */
    HttpPipeline getHttpPipeline();

    /**
     * Gets The default poll interval for long-running operation.
     *
     * @return the defaultPollInterval value.
     */
    Duration getDefaultPollInterval();

    /**
     * Gets the OperationsClient object to access its operations.
     *
     * @return the OperationsClient object.
     */
    OperationsClient getOperations();

    /**
     * Gets the DeploymentsClient object to access its operations.
     *
     * @return the DeploymentsClient object.
     */
    DeploymentsClient getDeployments();
```