### PR TITLE
Fix paging APIs to include headers and host params in next page call

### DIFF
--- a/azure-tests/src/main/java/fixtures/paging/Pagings.java
+++ b/azure-tests/src/main/java/fixtures/paging/Pagings.java
@@ -202,73 +202,109 @@ public final class Pagings {
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Mono<Response<ProductResultValue>> getNoItemNamePagesNext(
-                @PathParam(value = "nextLink", encoded = true) String nextLink, Context context);
+                @PathParam(value = "nextLink", encoded = true) String nextLink,
+                @HostParam("$host") String host,
+                Context context);
 
         @Get("{nextLink}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Mono<Response<ProductResult>> getSinglePagesNext(
-                @PathParam(value = "nextLink", encoded = true) String nextLink, Context context);
+                @PathParam(value = "nextLink", encoded = true) String nextLink,
+                @HostParam("$host") String host,
+                Context context);
 
         @Get("{nextLink}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Mono<Response<ProductResult>> getMultiplePagesNext(
-                @PathParam(value = "nextLink", encoded = true) String nextLink, Context context);
+                @PathParam(value = "nextLink", encoded = true) String nextLink,
+                @HostParam("$host") String host,
+                @HeaderParam("client-request-id") String clientRequestId,
+                @HeaderParam("maxresults") Integer maxresults,
+                @HeaderParam("timeout") Integer timeout,
+                Context context);
 
         @Get("{nextLink}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Mono<Response<OdataProductResult>> getOdataMultiplePagesNext(
-                @PathParam(value = "nextLink", encoded = true) String nextLink, Context context);
+                @PathParam(value = "nextLink", encoded = true) String nextLink,
+                @HostParam("$host") String host,
+                @HeaderParam("client-request-id") String clientRequestId,
+                @HeaderParam("maxresults") Integer maxresults,
+                @HeaderParam("timeout") Integer timeout,
+                Context context);
 
         @Get("{nextLink}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Mono<Response<ProductResult>> getMultiplePagesWithOffsetNext(
-                @PathParam(value = "nextLink", encoded = true) String nextLink, Context context);
+                @PathParam(value = "nextLink", encoded = true) String nextLink,
+                @HostParam("$host") String host,
+                @HeaderParam("client-request-id") String clientRequestId,
+                @HeaderParam("maxresults") Integer maxresults,
+                @HeaderParam("timeout") Integer timeout,
+                Context context);
 
         @Get("{nextLink}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Mono<Response<ProductResult>> getMultiplePagesRetryFirstNext(
-                @PathParam(value = "nextLink", encoded = true) String nextLink, Context context);
+                @PathParam(value = "nextLink", encoded = true) String nextLink,
+                @HostParam("$host") String host,
+                Context context);
 
         @Get("{nextLink}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Mono<Response<ProductResult>> getMultiplePagesRetrySecondNext(
-                @PathParam(value = "nextLink", encoded = true) String nextLink, Context context);
+                @PathParam(value = "nextLink", encoded = true) String nextLink,
+                @HostParam("$host") String host,
+                Context context);
 
         @Get("{nextLink}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Mono<Response<ProductResult>> getSinglePagesFailureNext(
-                @PathParam(value = "nextLink", encoded = true) String nextLink, Context context);
+                @PathParam(value = "nextLink", encoded = true) String nextLink,
+                @HostParam("$host") String host,
+                Context context);
 
         @Get("{nextLink}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Mono<Response<ProductResult>> getMultiplePagesFailureNext(
-                @PathParam(value = "nextLink", encoded = true) String nextLink, Context context);
+                @PathParam(value = "nextLink", encoded = true) String nextLink,
+                @HostParam("$host") String host,
+                Context context);
 
         @Get("{nextLink}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Mono<Response<ProductResult>> getMultiplePagesFailureUriNext(
-                @PathParam(value = "nextLink", encoded = true) String nextLink, Context context);
+                @PathParam(value = "nextLink", encoded = true) String nextLink,
+                @HostParam("$host") String host,
+                Context context);
 
         @Get("{nextLink}")
         @ExpectedResponses({202})
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Mono<Response<ProductResult>> getMultiplePagesLRONext(
-                @PathParam(value = "nextLink", encoded = true) String nextLink, Context context);
+                @PathParam(value = "nextLink", encoded = true) String nextLink,
+                @HostParam("$host") String host,
+                @HeaderParam("client-request-id") String clientRequestId,
+                @HeaderParam("maxresults") Integer maxresults,
+                @HeaderParam("timeout") Integer timeout,
+                Context context);
 
         @Get("{nextLink}")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Mono<Response<ProductResultValueWithXMSClientName>> getPagingModelWithItemNameWithXMSClientNameNext(
-                @PathParam(value = "nextLink", encoded = true) String nextLink, Context context);
+                @PathParam(value = "nextLink", encoded = true) String nextLink,
+                @HostParam("$host") String host,
+                Context context);
     }
 
     /**
@@ -480,7 +516,8 @@ public final class Pagings {
             String clientRequestId, PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) {
         return new PagedFlux<>(
                 () -> getMultiplePagesSinglePageAsync(clientRequestId, pagingGetMultiplePagesOptions),
-                nextLink -> getMultiplePagesNextSinglePageAsync(nextLink));
+                nextLink ->
+                        getMultiplePagesNextSinglePageAsync(nextLink, clientRequestId, pagingGetMultiplePagesOptions));
     }
 
     /**
@@ -496,7 +533,8 @@ public final class Pagings {
         final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions = null;
         return new PagedFlux<>(
                 () -> getMultiplePagesSinglePageAsync(clientRequestId, pagingGetMultiplePagesOptions),
-                nextLink -> getMultiplePagesNextSinglePageAsync(nextLink));
+                nextLink ->
+                        getMultiplePagesNextSinglePageAsync(nextLink, clientRequestId, pagingGetMultiplePagesOptions));
     }
 
     /**
@@ -680,7 +718,9 @@ public final class Pagings {
             String clientRequestId, PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) {
         return new PagedFlux<>(
                 () -> getOdataMultiplePagesSinglePageAsync(clientRequestId, pagingGetOdataMultiplePagesOptions),
-                nextLink -> getOdataMultiplePagesNextSinglePageAsync(nextLink));
+                nextLink ->
+                        getOdataMultiplePagesNextSinglePageAsync(
+                                nextLink, clientRequestId, pagingGetOdataMultiplePagesOptions));
     }
 
     /**
@@ -696,7 +736,9 @@ public final class Pagings {
         final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions = null;
         return new PagedFlux<>(
                 () -> getOdataMultiplePagesSinglePageAsync(clientRequestId, pagingGetOdataMultiplePagesOptions),
-                nextLink -> getOdataMultiplePagesNextSinglePageAsync(nextLink));
+                nextLink ->
+                        getOdataMultiplePagesNextSinglePageAsync(
+                                nextLink, clientRequestId, pagingGetOdataMultiplePagesOptions));
     }
 
     /**
@@ -788,7 +830,9 @@ public final class Pagings {
                 () ->
                         getMultiplePagesWithOffsetSinglePageAsync(
                                 pagingGetMultiplePagesWithOffsetOptions, clientRequestId),
-                nextLink -> getMultiplePagesWithOffsetNextSinglePageAsync(nextLink));
+                nextLink ->
+                        getMultiplePagesWithOffsetNextSinglePageAsync(
+                                nextLink, pagingGetMultiplePagesWithOffsetOptions, clientRequestId));
     }
 
     /**
@@ -808,7 +852,9 @@ public final class Pagings {
                 () ->
                         getMultiplePagesWithOffsetSinglePageAsync(
                                 pagingGetMultiplePagesWithOffsetOptions, clientRequestId),
-                nextLink -> getMultiplePagesWithOffsetNextSinglePageAsync(nextLink));
+                nextLink ->
+                        getMultiplePagesWithOffsetNextSinglePageAsync(
+                                nextLink, pagingGetMultiplePagesWithOffsetOptions, clientRequestId));
     }
 
     /**
@@ -1307,7 +1353,9 @@ public final class Pagings {
             String clientRequestId, PagingGetMultiplePagesLroOptions pagingGetMultiplePagesLroOptions) {
         return new PagedFlux<>(
                 () -> getMultiplePagesLROSinglePageAsync(clientRequestId, pagingGetMultiplePagesLroOptions),
-                nextLink -> getMultiplePagesLRONextSinglePageAsync(nextLink));
+                nextLink ->
+                        getMultiplePagesLRONextSinglePageAsync(
+                                nextLink, clientRequestId, pagingGetMultiplePagesLroOptions));
     }
 
     /**
@@ -1323,7 +1371,9 @@ public final class Pagings {
         final PagingGetMultiplePagesLroOptions pagingGetMultiplePagesLroOptions = null;
         return new PagedFlux<>(
                 () -> getMultiplePagesLROSinglePageAsync(clientRequestId, pagingGetMultiplePagesLroOptions),
-                nextLink -> getMultiplePagesLRONextSinglePageAsync(nextLink));
+                nextLink ->
+                        getMultiplePagesLRONextSinglePageAsync(
+                                nextLink, clientRequestId, pagingGetMultiplePagesLroOptions));
     }
 
     /**
@@ -1504,7 +1554,11 @@ public final class Pagings {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
         }
-        return FluxUtil.withContext(context -> service.getNoItemNamePagesNext(nextLink, context))
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return FluxUtil.withContext(context -> service.getNoItemNamePagesNext(nextLink, this.client.getHost(), context))
                 .map(
                         res ->
                                 new PagedResponseBase<>(
@@ -1530,7 +1584,11 @@ public final class Pagings {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
         }
-        return FluxUtil.withContext(context -> service.getSinglePagesNext(nextLink, context))
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return FluxUtil.withContext(context -> service.getSinglePagesNext(nextLink, this.client.getHost(), context))
                 .map(
                         res ->
                                 new PagedResponseBase<>(
@@ -1546,17 +1604,40 @@ public final class Pagings {
      * Get the next page of items.
      *
      * @param nextLink The nextLink parameter.
+     * @param clientRequestId The clientRequestId parameter.
+     * @param pagingGetMultiplePagesOptions Parameter group.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getMultiplePagesNextSinglePageAsync(String nextLink) {
+    public Mono<PagedResponse<Product>> getMultiplePagesNextSinglePageAsync(
+            String nextLink, String clientRequestId, PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
         }
-        return FluxUtil.withContext(context -> service.getMultiplePagesNext(nextLink, context))
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (pagingGetMultiplePagesOptions != null) {
+            pagingGetMultiplePagesOptions.validate();
+        }
+        Integer maxresultsInternal = null;
+        if (pagingGetMultiplePagesOptions != null) {
+            maxresultsInternal = pagingGetMultiplePagesOptions.getMaxresults();
+        }
+        Integer maxresults = maxresultsInternal;
+        Integer timeoutInternal = null;
+        if (pagingGetMultiplePagesOptions != null) {
+            timeoutInternal = pagingGetMultiplePagesOptions.getTimeout();
+        }
+        Integer timeout = timeoutInternal;
+        return FluxUtil.withContext(
+                        context ->
+                                service.getMultiplePagesNext(
+                                        nextLink, this.client.getHost(), clientRequestId, maxresults, timeout, context))
                 .map(
                         res ->
                                 new PagedResponseBase<>(
@@ -1572,17 +1653,42 @@ public final class Pagings {
      * Get the next page of items.
      *
      * @param nextLink The nextLink parameter.
+     * @param clientRequestId The clientRequestId parameter.
+     * @param pagingGetOdataMultiplePagesOptions Parameter group.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getOdataMultiplePagesNextSinglePageAsync(String nextLink) {
+    public Mono<PagedResponse<Product>> getOdataMultiplePagesNextSinglePageAsync(
+            String nextLink,
+            String clientRequestId,
+            PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
         }
-        return FluxUtil.withContext(context -> service.getOdataMultiplePagesNext(nextLink, context))
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (pagingGetOdataMultiplePagesOptions != null) {
+            pagingGetOdataMultiplePagesOptions.validate();
+        }
+        Integer maxresultsInternal = null;
+        if (pagingGetOdataMultiplePagesOptions != null) {
+            maxresultsInternal = pagingGetOdataMultiplePagesOptions.getMaxresults();
+        }
+        Integer maxresults = maxresultsInternal;
+        Integer timeoutInternal = null;
+        if (pagingGetOdataMultiplePagesOptions != null) {
+            timeoutInternal = pagingGetOdataMultiplePagesOptions.getTimeout();
+        }
+        Integer timeout = timeoutInternal;
+        return FluxUtil.withContext(
+                        context ->
+                                service.getOdataMultiplePagesNext(
+                                        nextLink, this.client.getHost(), clientRequestId, maxresults, timeout, context))
                 .map(
                         res ->
                                 new PagedResponseBase<>(
@@ -1598,17 +1704,38 @@ public final class Pagings {
      * Get the next page of items.
      *
      * @param nextLink The nextLink parameter.
+     * @param pagingGetMultiplePagesWithOffsetOptions Parameter group.
+     * @param clientRequestId The clientRequestId parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getMultiplePagesWithOffsetNextSinglePageAsync(String nextLink) {
+    public Mono<PagedResponse<Product>> getMultiplePagesWithOffsetNextSinglePageAsync(
+            String nextLink,
+            PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions,
+            String clientRequestId) {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
         }
-        return FluxUtil.withContext(context -> service.getMultiplePagesWithOffsetNext(nextLink, context))
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (pagingGetMultiplePagesWithOffsetOptions == null) {
+            return Mono.error(
+                    new IllegalArgumentException(
+                            "Parameter pagingGetMultiplePagesWithOffsetOptions is required and cannot be null."));
+        } else {
+            pagingGetMultiplePagesWithOffsetOptions.validate();
+        }
+        Integer maxresults = pagingGetMultiplePagesWithOffsetOptions.getMaxresults();
+        Integer timeout = pagingGetMultiplePagesWithOffsetOptions.getTimeout();
+        return FluxUtil.withContext(
+                        context ->
+                                service.getMultiplePagesWithOffsetNext(
+                                        nextLink, this.client.getHost(), clientRequestId, maxresults, timeout, context))
                 .map(
                         res ->
                                 new PagedResponseBase<>(
@@ -1634,7 +1761,12 @@ public final class Pagings {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
         }
-        return FluxUtil.withContext(context -> service.getMultiplePagesRetryFirstNext(nextLink, context))
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return FluxUtil.withContext(
+                        context -> service.getMultiplePagesRetryFirstNext(nextLink, this.client.getHost(), context))
                 .map(
                         res ->
                                 new PagedResponseBase<>(
@@ -1660,7 +1792,12 @@ public final class Pagings {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
         }
-        return FluxUtil.withContext(context -> service.getMultiplePagesRetrySecondNext(nextLink, context))
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return FluxUtil.withContext(
+                        context -> service.getMultiplePagesRetrySecondNext(nextLink, this.client.getHost(), context))
                 .map(
                         res ->
                                 new PagedResponseBase<>(
@@ -1686,7 +1823,12 @@ public final class Pagings {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
         }
-        return FluxUtil.withContext(context -> service.getSinglePagesFailureNext(nextLink, context))
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return FluxUtil.withContext(
+                        context -> service.getSinglePagesFailureNext(nextLink, this.client.getHost(), context))
                 .map(
                         res ->
                                 new PagedResponseBase<>(
@@ -1712,7 +1854,12 @@ public final class Pagings {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
         }
-        return FluxUtil.withContext(context -> service.getMultiplePagesFailureNext(nextLink, context))
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return FluxUtil.withContext(
+                        context -> service.getMultiplePagesFailureNext(nextLink, this.client.getHost(), context))
                 .map(
                         res ->
                                 new PagedResponseBase<>(
@@ -1738,7 +1885,12 @@ public final class Pagings {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
         }
-        return FluxUtil.withContext(context -> service.getMultiplePagesFailureUriNext(nextLink, context))
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return FluxUtil.withContext(
+                        context -> service.getMultiplePagesFailureUriNext(nextLink, this.client.getHost(), context))
                 .map(
                         res ->
                                 new PagedResponseBase<>(
@@ -1754,17 +1906,42 @@ public final class Pagings {
      * Get the next page of items.
      *
      * @param nextLink The nextLink parameter.
+     * @param clientRequestId The clientRequestId parameter.
+     * @param pagingGetMultiplePagesLroOptions Parameter group.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<PagedResponse<Product>> getMultiplePagesLRONextSinglePageAsync(String nextLink) {
+    public Mono<PagedResponse<Product>> getMultiplePagesLRONextSinglePageAsync(
+            String nextLink,
+            String clientRequestId,
+            PagingGetMultiplePagesLroOptions pagingGetMultiplePagesLroOptions) {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
         }
-        return FluxUtil.withContext(context -> service.getMultiplePagesLRONext(nextLink, context))
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (pagingGetMultiplePagesLroOptions != null) {
+            pagingGetMultiplePagesLroOptions.validate();
+        }
+        Integer maxresultsInternal = null;
+        if (pagingGetMultiplePagesLroOptions != null) {
+            maxresultsInternal = pagingGetMultiplePagesLroOptions.getMaxresults();
+        }
+        Integer maxresults = maxresultsInternal;
+        Integer timeoutInternal = null;
+        if (pagingGetMultiplePagesLroOptions != null) {
+            timeoutInternal = pagingGetMultiplePagesLroOptions.getTimeout();
+        }
+        Integer timeout = timeoutInternal;
+        return FluxUtil.withContext(
+                        context ->
+                                service.getMultiplePagesLRONext(
+                                        nextLink, this.client.getHost(), clientRequestId, maxresults, timeout, context))
                 .map(
                         res ->
                                 new PagedResponseBase<>(
@@ -1791,8 +1968,14 @@ public final class Pagings {
         if (nextLink == null) {
             return Mono.error(new IllegalArgumentException("Parameter nextLink is required and cannot be null."));
         }
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
         return FluxUtil.withContext(
-                        context -> service.getPagingModelWithItemNameWithXMSClientNameNext(nextLink, context))
+                        context ->
+                                service.getPagingModelWithItemNameWithXMSClientNameNext(
+                                        nextLink, this.client.getHost(), context))
                 .map(
                         res ->
                                 new PagedResponseBase<>(


### PR DESCRIPTION
This PR fixes an issue with Java's generated code forpaging APIs. The generated API that retrieves the first page has params to set the host, headers and other params as specified in the swagger as shown below:

 ```java
@Get("/eventroutes")
@ExpectedResponses({200})
@UnexpectedResponseExceptionType(ErrorResponseException.class)
Mono<Response<EventRouteCollection>> list(
        @HostParam("$host") String host,
        @HeaderParam("x-ms-max-item-count") Integer maxItemCount,
        @QueryParam("api-version") String apiVersion,
        Context context);
```
 
The issue is with the API that retrieves the next page using the next link. The API only takes the `nextLink` and doesn't include the host param or the headers. 
 
```java
@Get("{nextLink}")
@ExpectedResponses({200})
@UnexpectedResponseExceptionType(ErrorResponseException.class)
Mono<Response<EventRouteCollection>> listNext(
        @PathParam(value = "nextLink", encoded = true) String nextLink, Context context);
```
 

For some services, the next link returned from first call does not include the hostname and relies on the header to determine the number of items to return in the next page. So, with the current generated code, the call to get the next page (after manually adding hostname to the returned next link) will include all remaining items because the header cannot be set. Looking at .NET and Python implementation, it seems like the host and header params are included for both first and next page APIs. We are planning to do the same for Java too. This will be done only if x-ms-pageable doesn't have `operationName` defined.

 
After the fix: 

```java
@Get("{nextLink}")
@ExpectedResponses({200})
@UnexpectedResponseExceptionType(ErrorResponseException.class)
Mono<Response<EventRouteCollection>> listNext(
        @HostParam("$host") String host,
        @HeaderParam("x-ms-max-item-count") Integer maxItemCount,
        @PathParam(value = "nextLink", encoded = true) String nextLink, Context context);
```