### PR TITLE
Remove service version from the builder

### DIFF
--- a/azure-tests/src/main/java/fixtures/azurereport/AutoRestReportServiceForAzureBuilder.java
+++ b/azure-tests/src/main/java/fixtures/azurereport/AutoRestReportServiceForAzureBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import java.util.ArrayList;
@@ -127,22 +126,6 @@ public final class AutoRestReportServiceForAzureBuilder {
      */
     public AutoRestReportServiceForAzureBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the AutoRestReportServiceForAzureBuilder.
-     */
-    public AutoRestReportServiceForAzureBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 

--- a/azure-tests/src/main/java/fixtures/paging/AutoRestPagingTestServiceBuilder.java
+++ b/azure-tests/src/main/java/fixtures/paging/AutoRestPagingTestServiceBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import java.util.ArrayList;
@@ -127,22 +126,6 @@ public final class AutoRestPagingTestServiceBuilder {
      */
     public AutoRestPagingTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the AutoRestPagingTestServiceBuilder.
-     */
-    public AutoRestPagingTestServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 

--- a/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
@@ -325,8 +325,6 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ServiceClient
 
             commonProperties.add(new ServiceClientProperty("The logging configuration for HTTP requests and "
                     + "responses.", ClassType.HttpLogOptions, "httpLogOptions", false, null));
-            commonProperties.add(new ServiceClientProperty("The service API version that is used when making "
-                    + "API requests.", ClassType.ServiceVersion, "serviceVersion", false, null));
             commonProperties.add(new ServiceClientProperty("The retry policy that will attempt to retry failed "
                     + "requests, if applicable.", ClassType.RetryPolicy, "retryPolicy", false, null));
 

--- a/preprocessor/src/main/java/com/azure/autorest/preprocessor/tranformer/Transformer.java
+++ b/preprocessor/src/main/java/com/azure/autorest/preprocessor/tranformer/Transformer.java
@@ -234,11 +234,7 @@ public class Transformer {
                 .forEach(param -> {
                   nextOperation.getRequests().get(0).getSignatureParameters().add(param);
                 });
-
-
       }
-
-
       operation.getExtensions().getXmsPageable().setNextOperation(nextOperation);
       nextOperation.getExtensions().getXmsPageable().setNextOperation(nextOperation);
       operationGroup.getOperations().add(nextOperation);

--- a/vanilla-tests/src/main/java/fixtures/additionalproperties/AdditionalPropertiesClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/additionalproperties/AdditionalPropertiesClientBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import java.util.ArrayList;
@@ -127,22 +126,6 @@ public final class AdditionalPropertiesClientBuilder {
      */
     public AdditionalPropertiesClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the AdditionalPropertiesClientBuilder.
-     */
-    public AdditionalPropertiesClientBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodyarray/AutoRestSwaggerBATArrayServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyarray/AutoRestSwaggerBATArrayServiceBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import java.util.ArrayList;
@@ -127,22 +126,6 @@ public final class AutoRestSwaggerBATArrayServiceBuilder {
      */
     public AutoRestSwaggerBATArrayServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the AutoRestSwaggerBATArrayServiceBuilder.
-     */
-    public AutoRestSwaggerBATArrayServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodyboolean/AutoRestBoolTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyboolean/AutoRestBoolTestServiceBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import java.util.ArrayList;
@@ -127,22 +126,6 @@ public final class AutoRestBoolTestServiceBuilder {
      */
     public AutoRestBoolTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the AutoRestBoolTestServiceBuilder.
-     */
-    public AutoRestBoolTestServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodyboolean/quirks/AutoRestBoolTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyboolean/quirks/AutoRestBoolTestServiceBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import java.util.ArrayList;
@@ -127,22 +126,6 @@ public final class AutoRestBoolTestServiceBuilder {
      */
     public AutoRestBoolTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the AutoRestBoolTestServiceBuilder.
-     */
-    public AutoRestBoolTestServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodybyte/AutoRestSwaggerBATByteServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodybyte/AutoRestSwaggerBATByteServiceBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import java.util.ArrayList;
@@ -127,22 +126,6 @@ public final class AutoRestSwaggerBATByteServiceBuilder {
      */
     public AutoRestSwaggerBATByteServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the AutoRestSwaggerBATByteServiceBuilder.
-     */
-    public AutoRestSwaggerBATByteServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/AutoRestComplexTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/AutoRestComplexTestServiceBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import java.util.ArrayList;
@@ -127,22 +126,6 @@ public final class AutoRestComplexTestServiceBuilder {
      */
     public AutoRestComplexTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the AutoRestComplexTestServiceBuilder.
-     */
-    public AutoRestComplexTestServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodydate/AutoRestDateTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydate/AutoRestDateTestServiceBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import java.util.ArrayList;
@@ -127,22 +126,6 @@ public final class AutoRestDateTestServiceBuilder {
      */
     public AutoRestDateTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the AutoRestDateTestServiceBuilder.
-     */
-    public AutoRestDateTestServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodydatetime/AutoRestDateTimeTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydatetime/AutoRestDateTimeTestServiceBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import java.util.ArrayList;
@@ -127,22 +126,6 @@ public final class AutoRestDateTimeTestServiceBuilder {
      */
     public AutoRestDateTimeTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the AutoRestDateTimeTestServiceBuilder.
-     */
-    public AutoRestDateTimeTestServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodydatetimerfc1123/AutoRestRFC1123DateTimeTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydatetimerfc1123/AutoRestRFC1123DateTimeTestServiceBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import java.util.ArrayList;
@@ -127,22 +126,6 @@ public final class AutoRestRFC1123DateTimeTestServiceBuilder {
      */
     public AutoRestRFC1123DateTimeTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the AutoRestRFC1123DateTimeTestServiceBuilder.
-     */
-    public AutoRestRFC1123DateTimeTestServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodydictionary/AutoRestSwaggerBATDictionaryServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydictionary/AutoRestSwaggerBATDictionaryServiceBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import fixtures.bodydictionary.implementation.AutoRestSwaggerBATDictionaryServiceImpl;
@@ -132,22 +131,6 @@ public final class AutoRestSwaggerBATDictionaryServiceBuilder {
      */
     public AutoRestSwaggerBATDictionaryServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the AutoRestSwaggerBATDictionaryServiceBuilder.
-     */
-    public AutoRestSwaggerBATDictionaryServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodyduration/AutoRestDurationTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyduration/AutoRestDurationTestServiceBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import java.util.ArrayList;
@@ -127,22 +126,6 @@ public final class AutoRestDurationTestServiceBuilder {
      */
     public AutoRestDurationTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the AutoRestDurationTestServiceBuilder.
-     */
-    public AutoRestDurationTestServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodyfile/AutoRestSwaggerBATFileServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyfile/AutoRestSwaggerBATFileServiceBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import java.util.ArrayList;
@@ -127,22 +126,6 @@ public final class AutoRestSwaggerBATFileServiceBuilder {
      */
     public AutoRestSwaggerBATFileServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the AutoRestSwaggerBATFileServiceBuilder.
-     */
-    public AutoRestSwaggerBATFileServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodyinteger/AutoRestIntegerTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyinteger/AutoRestIntegerTestServiceBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import java.util.ArrayList;
@@ -127,22 +126,6 @@ public final class AutoRestIntegerTestServiceBuilder {
      */
     public AutoRestIntegerTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the AutoRestIntegerTestServiceBuilder.
-     */
-    public AutoRestIntegerTestServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodynumber/AutoRestNumberTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodynumber/AutoRestNumberTestServiceBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import java.util.ArrayList;
@@ -127,22 +126,6 @@ public final class AutoRestNumberTestServiceBuilder {
      */
     public AutoRestNumberTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the AutoRestNumberTestServiceBuilder.
-     */
-    public AutoRestNumberTestServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/bodystring/implementation/AutoRestSwaggerBATServiceImplBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodystring/implementation/AutoRestSwaggerBATServiceImplBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import fixtures.bodystring.AutoRestSwaggerBATService;
@@ -128,22 +127,6 @@ public final class AutoRestSwaggerBATServiceImplBuilder {
      */
     public AutoRestSwaggerBATServiceImplBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the AutoRestSwaggerBATServiceImplBuilder.
-     */
-    public AutoRestSwaggerBATServiceImplBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/custombaseuri/AutoRestParameterizedHostTestClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/custombaseuri/AutoRestParameterizedHostTestClientBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import java.util.ArrayList;
@@ -127,22 +126,6 @@ public final class AutoRestParameterizedHostTestClientBuilder {
      */
     public AutoRestParameterizedHostTestClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the AutoRestParameterizedHostTestClientBuilder.
-     */
-    public AutoRestParameterizedHostTestClientBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/custombaseuri/moreoptions/AutoRestParameterizedCustomHostTestClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/custombaseuri/moreoptions/AutoRestParameterizedCustomHostTestClientBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import java.util.ArrayList;
@@ -144,22 +143,6 @@ public final class AutoRestParameterizedCustomHostTestClientBuilder {
      */
     public AutoRestParameterizedCustomHostTestClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the AutoRestParameterizedCustomHostTestClientBuilder.
-     */
-    public AutoRestParameterizedCustomHostTestClientBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/discriminatorflattening/MonitorManagementClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/discriminatorflattening/MonitorManagementClientBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import java.util.ArrayList;
@@ -127,22 +126,6 @@ public final class MonitorManagementClientBuilder {
      */
     public MonitorManagementClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the MonitorManagementClientBuilder.
-     */
-    public MonitorManagementClientBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/extensibleenums/PetStoreIncBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/extensibleenums/PetStoreIncBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import java.util.ArrayList;
@@ -127,22 +126,6 @@ public final class PetStoreIncBuilder {
      */
     public PetStoreIncBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the PetStoreIncBuilder.
-     */
-    public PetStoreIncBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/head/AutoRestHeadTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/head/AutoRestHeadTestServiceBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import java.util.ArrayList;
@@ -127,22 +126,6 @@ public final class AutoRestHeadTestServiceBuilder {
      */
     public AutoRestHeadTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the AutoRestHeadTestServiceBuilder.
-     */
-    public AutoRestHeadTestServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/header/AutoRestSwaggerBATHeaderServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/header/AutoRestSwaggerBATHeaderServiceBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import java.util.ArrayList;
@@ -127,22 +126,6 @@ public final class AutoRestSwaggerBATHeaderServiceBuilder {
      */
     public AutoRestSwaggerBATHeaderServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the AutoRestSwaggerBATHeaderServiceBuilder.
-     */
-    public AutoRestSwaggerBATHeaderServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/headexceptions/AutoRestHeadExceptionTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/headexceptions/AutoRestHeadExceptionTestServiceBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import java.util.ArrayList;
@@ -127,22 +126,6 @@ public final class AutoRestHeadExceptionTestServiceBuilder {
      */
     public AutoRestHeadExceptionTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the AutoRestHeadExceptionTestServiceBuilder.
-     */
-    public AutoRestHeadExceptionTestServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/httpinfrastructure/AutoRestHttpInfrastructureTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/httpinfrastructure/AutoRestHttpInfrastructureTestServiceBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import java.util.ArrayList;
@@ -127,22 +126,6 @@ public final class AutoRestHttpInfrastructureTestServiceBuilder {
      */
     public AutoRestHttpInfrastructureTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the AutoRestHttpInfrastructureTestServiceBuilder.
-     */
-    public AutoRestHttpInfrastructureTestServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClientBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import java.util.ArrayList;
@@ -127,22 +126,6 @@ public final class MediaTypesClientBuilder {
      */
     public MediaTypesClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the MediaTypesClientBuilder.
-     */
-    public MediaTypesClientBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/modelflattening/AutoRestResourceFlatteningTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/modelflattening/AutoRestResourceFlatteningTestServiceBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import java.util.ArrayList;
@@ -127,22 +126,6 @@ public final class AutoRestResourceFlatteningTestServiceBuilder {
      */
     public AutoRestResourceFlatteningTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the AutoRestResourceFlatteningTestServiceBuilder.
-     */
-    public AutoRestResourceFlatteningTestServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/multipleinheritance/MultipleInheritanceServiceClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/multipleinheritance/MultipleInheritanceServiceClientBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import java.util.ArrayList;
@@ -127,22 +126,6 @@ public final class MultipleInheritanceServiceClientBuilder {
      */
     public MultipleInheritanceServiceClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the MultipleInheritanceServiceClientBuilder.
-     */
-    public MultipleInheritanceServiceClientBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/nonstringenum/NonStringEnumsClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/nonstringenum/NonStringEnumsClientBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import java.util.ArrayList;
@@ -127,22 +126,6 @@ public final class NonStringEnumsClientBuilder {
      */
     public NonStringEnumsClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the NonStringEnumsClientBuilder.
-     */
-    public NonStringEnumsClientBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/parameterflattening/AutoRestParameterFlatteningBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/parameterflattening/AutoRestParameterFlatteningBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import java.util.ArrayList;
@@ -127,22 +126,6 @@ public final class AutoRestParameterFlatteningBuilder {
      */
     public AutoRestParameterFlatteningBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the AutoRestParameterFlatteningBuilder.
-     */
-    public AutoRestParameterFlatteningBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/report/AutoRestReportServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/report/AutoRestReportServiceBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import java.util.ArrayList;
@@ -127,22 +126,6 @@ public final class AutoRestReportServiceBuilder {
      */
     public AutoRestReportServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the AutoRestReportServiceBuilder.
-     */
-    public AutoRestReportServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/requiredoptional/AutoRestRequiredOptionalTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/requiredoptional/AutoRestRequiredOptionalTestServiceBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import java.util.ArrayList;
@@ -175,22 +174,6 @@ public final class AutoRestRequiredOptionalTestServiceBuilder {
      */
     public AutoRestRequiredOptionalTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the AutoRestRequiredOptionalTestServiceBuilder.
-     */
-    public AutoRestRequiredOptionalTestServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/url/AutoRestUrlTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/url/AutoRestUrlTestServiceBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import java.util.ArrayList;
@@ -159,22 +158,6 @@ public final class AutoRestUrlTestServiceBuilder {
      */
     public AutoRestUrlTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the AutoRestUrlTestServiceBuilder.
-     */
-    public AutoRestUrlTestServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/url/multi/AutoRestUrlMutliCollectionFormatTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/url/multi/AutoRestUrlMutliCollectionFormatTestServiceBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import java.util.ArrayList;
@@ -127,22 +126,6 @@ public final class AutoRestUrlMutliCollectionFormatTestServiceBuilder {
      */
     public AutoRestUrlMutliCollectionFormatTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the AutoRestUrlMutliCollectionFormatTestServiceBuilder.
-     */
-    public AutoRestUrlMutliCollectionFormatTestServiceBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/validation/AutoRestValidationTestBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/validation/AutoRestValidationTestBuilder.java
@@ -12,7 +12,6 @@ import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.util.Configuration;
-import com.azure.core.util.ServiceVersion;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import java.util.ArrayList;
@@ -143,22 +142,6 @@ public final class AutoRestValidationTestBuilder {
      */
     public AutoRestValidationTestBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
         this.httpLogOptions = httpLogOptions;
-        return this;
-    }
-
-    /*
-     * The service API version that is used when making API requests.
-     */
-    private ServiceVersion serviceVersion;
-
-    /**
-     * Sets The service API version that is used when making API requests.
-     *
-     * @param serviceVersion the serviceVersion value.
-     * @return the AutoRestValidationTestBuilder.
-     */
-    public AutoRestValidationTestBuilder serviceVersion(ServiceVersion serviceVersion) {
-        this.serviceVersion = serviceVersion;
         return this;
     }
 


### PR DESCRIPTION
This PR removes setter method for service version from the generated client builder as the version is currently hardcoded to the one specified in swagger. So, the service version on the builder cannot be used to create the client. This will result in spotbugs issue complaining that the field is unused.

```
Unread field: com.azure.digitaltwins.core.implementation.AzureDigitalTwinsAPIImplBuilder.serviceVersion [com.azure.digitaltwins.core.implementation.AzureDigitalTwinsAPIImplBuilder] At AzureDigitalTwinsAPIImplBuilder.java:[line 149] URF_UNREAD_FIELD 
```