### PR TITLE
v4, fluentlite, init integration with azure-sdk-for-java

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# default
+/                           @srnagar
+
+# fluentgen
+/fluentnamer                @ChenTanyi @weidongxu-microsoft @yungezz @xccc-msft
+/fluentgen                  @ChenTanyi @weidongxu-microsoft @yungezz @xccc-msft
+/fluent-tests               @ChenTanyi @weidongxu-microsoft @yungezz @xccc-msft

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
@@ -13,7 +13,7 @@ import com.azure.autorest.fluent.checker.JavaFormatter;
 import com.azure.autorest.fluent.mapper.FluentMapper;
 import com.azure.autorest.fluent.mapper.FluentMapperFactory;
 import com.azure.autorest.fluent.mapper.PomMapper;
-import com.azure.autorest.fluent.model.Project;
+import com.azure.autorest.fluent.model.projectmodel.Project;
 import com.azure.autorest.fluent.model.clientmodel.FluentClient;
 import com.azure.autorest.fluent.model.clientmodel.FluentResourceCollection;
 import com.azure.autorest.fluent.model.clientmodel.FluentResourceModel;

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
@@ -181,8 +181,9 @@ public class FluentGen extends NewPlugin {
                 FluentStatic.setClient(client);
 
                 FluentClient fluentClient = fluentMapper.map(codeModel, client);
+
                 // project
-                fluentClient.setProject(new Project(fluentClient));
+                Project project = new Project(fluentClient);
 
                 // Fluent manager
                 javaPackage.addFluentManager(fluentClient.getManager());
@@ -200,7 +201,7 @@ public class FluentGen extends NewPlugin {
                 javaPackage.addUtils();
 
                 // POM
-                Pom pom = new PomMapper().map(fluentClient);
+                Pom pom = new PomMapper().map(project);
                 javaPackage.addPom(fluentJavaSettings.getPomFilename(), pom);
             }
 

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
@@ -177,10 +177,11 @@ public class FluentGen extends NewPlugin {
 
             // Fluent Lite
             if (javaSettings.isFluentLite()) {
-                FluentStatic.setClient(client);
                 FluentStatic.setFluentJavaSettings(fluentJavaSettings);
+                FluentStatic.setClient(client);
 
                 FluentClient fluentClient = fluentMapper.map(codeModel, client);
+                // project
                 fluentClient.setProject(new Project(fluentClient));
 
                 // Fluent manager

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
@@ -13,6 +13,7 @@ import com.azure.autorest.fluent.checker.JavaFormatter;
 import com.azure.autorest.fluent.mapper.FluentMapper;
 import com.azure.autorest.fluent.mapper.FluentMapperFactory;
 import com.azure.autorest.fluent.mapper.PomMapper;
+import com.azure.autorest.fluent.model.Project;
 import com.azure.autorest.fluent.model.clientmodel.FluentClient;
 import com.azure.autorest.fluent.model.clientmodel.FluentResourceCollection;
 import com.azure.autorest.fluent.model.clientmodel.FluentResourceModel;
@@ -177,8 +178,10 @@ public class FluentGen extends NewPlugin {
             // Fluent Lite
             if (javaSettings.isFluentLite()) {
                 FluentStatic.setClient(client);
+                FluentStatic.setFluentJavaSettings(fluentJavaSettings);
 
                 FluentClient fluentClient = fluentMapper.map(codeModel, client);
+                fluentClient.setProject(new Project(fluentClient));
 
                 // Fluent manager
                 javaPackage.addFluentManager(fluentClient.getManager());
@@ -196,7 +199,7 @@ public class FluentGen extends NewPlugin {
                 javaPackage.addUtils();
 
                 // POM
-                Pom pom = new PomMapper().map(codeModel, fluentClient);
+                Pom pom = new PomMapper().map(fluentClient);
                 javaPackage.addPom(fluentJavaSettings.getPomFilename(), pom);
             }
 

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/PomMapper.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/PomMapper.java
@@ -5,7 +5,7 @@
 
 package com.azure.autorest.fluent.mapper;
 
-import com.azure.autorest.fluent.model.clientmodel.FluentClient;
+import com.azure.autorest.fluent.model.Project;
 import com.azure.autorest.fluent.model.clientmodel.FluentStatic;
 import com.azure.autorest.model.clientmodel.Pom;
 
@@ -13,16 +13,14 @@ import java.util.Arrays;
 
 public class PomMapper {
 
-    public Pom map(FluentClient fluentClient) {
-        String serviceName = fluentClient.getProject().getServiceName();
-
+    public Pom map(Project project) {
         Pom pom = new Pom();
-        pom.setGroupId(fluentClient.getProject().getGroupId());
-        pom.setArtifactId(fluentClient.getProject().getArtifactId());
-        pom.setVersion(fluentClient.getProject().getVersion());
+        pom.setGroupId(project.getGroupId());
+        pom.setArtifactId(project.getArtifactId());
+        pom.setVersion(project.getVersion());
 
-        pom.setServiceName(serviceName);
-        pom.setServiceDescription(fluentClient.getInnerClient().getClientDescription());
+        pom.setServiceName(project.getServiceName());
+        pom.setServiceDescription(project.getServiceDescription());
 
         pom.setDependencyIdentifiers(Arrays.asList(
                 "com.azure:azure-core-management:1.0.0"

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/PomMapper.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/PomMapper.java
@@ -5,25 +5,21 @@
 
 package com.azure.autorest.fluent.mapper;
 
-import com.azure.autorest.extension.base.model.codemodel.CodeModel;
 import com.azure.autorest.fluent.model.clientmodel.FluentClient;
-import com.azure.autorest.fluent.util.FluentUtils;
-import com.azure.autorest.fluent.util.Utils;
+import com.azure.autorest.fluent.model.clientmodel.FluentStatic;
 import com.azure.autorest.model.clientmodel.Pom;
 
 import java.util.Arrays;
-import java.util.Locale;
 
 public class PomMapper {
 
-    public Pom map(CodeModel codeModel, FluentClient fluentClient) {
-        String clientName = Utils.getJavaName(codeModel);
-        String serviceName = FluentUtils.getServiceName(clientName);
+    public Pom map(FluentClient fluentClient) {
+        String serviceName = fluentClient.getProject().getServiceName();
 
         Pom pom = new Pom();
-        pom.setGroupId("com.azure.resourcemanager");
-        pom.setArtifactId(String.format("azure-resourcemanager-%1$s-generated", serviceName.toLowerCase(Locale.ROOT)));
-        pom.setVersion("1.0.0-beta");
+        pom.setGroupId(fluentClient.getProject().getGroupId());
+        pom.setArtifactId(fluentClient.getProject().getArtifactId());
+        pom.setVersion(fluentClient.getProject().getVersion());
 
         pom.setServiceName(serviceName);
         pom.setServiceDescription(fluentClient.getInnerClient().getClientDescription());
@@ -31,6 +27,11 @@ public class PomMapper {
         pom.setDependencyIdentifiers(Arrays.asList(
                 "com.azure:azure-core-management:1.0.0"
         ));
+
+        if (FluentStatic.getFluentJavaSettings().isSdkIntegration()) {
+            pom.setParentIdentifier("com.azure:azure-client-sdk-parent:1.7.0");
+            pom.setParentRelativePath("../../parents/azure-client-sdk-parent");
+        }
 
         return pom;
     }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/PomMapper.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/PomMapper.java
@@ -5,7 +5,7 @@
 
 package com.azure.autorest.fluent.mapper;
 
-import com.azure.autorest.fluent.model.Project;
+import com.azure.autorest.fluent.model.projectmodel.Project;
 import com.azure.autorest.fluent.model.clientmodel.FluentStatic;
 import com.azure.autorest.model.clientmodel.Pom;
 

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/Project.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/Project.java
@@ -14,6 +14,7 @@ import java.util.Locale;
 public class Project {
 
     private final String serviceName;
+    private final String serviceDescription;
 
     private final String namespace;
     private final String groupId = "com.azure.resourcemanager";
@@ -26,10 +27,16 @@ public class Project {
         this.artifactId = String.format("azure-resourcemanager-%1$s-generated", serviceName.toLowerCase(Locale.ROOT));
 
         FluentStatic.getFluentJavaSettings().getArtifactVersion().ifPresent(version -> this.version = version);
+
+        this.serviceDescription = fluentClient.getInnerClient().getClientDescription();
     }
 
     public String getServiceName() {
         return serviceName;
+    }
+
+    public String getServiceDescription() {
+        return serviceDescription;
     }
 
     public String getNamespace() {

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/Project.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/Project.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.azure.autorest.fluent.model;
+
+import com.azure.autorest.extension.base.plugin.JavaSettings;
+import com.azure.autorest.fluent.model.clientmodel.FluentClient;
+import com.azure.autorest.fluent.model.clientmodel.FluentStatic;
+
+import java.util.Locale;
+
+public class Project {
+
+    private final String serviceName;
+
+    private final String namespace;
+    private final String groupId = "com.azure.resourcemanager";
+    private final String artifactId;
+    private String version = "1.0.0-beta.1";
+
+    public Project(FluentClient fluentClient) {
+        this.serviceName = fluentClient.getManager().getServiceName();
+        this.namespace = JavaSettings.getInstance().getPackage();
+        this.artifactId = String.format("azure-resourcemanager-%1$s-generated", serviceName.toLowerCase(Locale.ROOT));
+
+        FluentStatic.getFluentJavaSettings().getArtifactVersion().ifPresent(version -> this.version = version);
+    }
+
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+}

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentClient.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentClient.java
@@ -10,6 +10,9 @@ import com.azure.autorest.model.clientmodel.Client;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Model for all Fluent lite related models.
+ */
 public class FluentClient {
 
     private final Client client;

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentClient.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentClient.java
@@ -5,6 +5,7 @@
 
 package com.azure.autorest.fluent.model.clientmodel;
 
+import com.azure.autorest.fluent.model.Project;
 import com.azure.autorest.model.clientmodel.Client;
 
 import java.util.ArrayList;
@@ -19,6 +20,8 @@ public class FluentClient {
     private final List<FluentResourceModel> resourceModels = new ArrayList<>();
 
     private final List<FluentResourceCollection> resourceCollections = new ArrayList<>();
+
+    private Project project;
 
     public FluentClient(Client client) {
         this.client = client;
@@ -38,6 +41,14 @@ public class FluentClient {
 
     public void setManager(FluentManager manager) {
         this.manager = manager;
+    }
+
+    public Project getProject() {
+        return project;
+    }
+
+    public void setProject(Project project) {
+        this.project = project;
     }
 
     public Client getInnerClient() {

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentClient.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentClient.java
@@ -5,7 +5,6 @@
 
 package com.azure.autorest.fluent.model.clientmodel;
 
-import com.azure.autorest.fluent.model.Project;
 import com.azure.autorest.model.clientmodel.Client;
 
 import java.util.ArrayList;
@@ -20,8 +19,6 @@ public class FluentClient {
     private final List<FluentResourceModel> resourceModels = new ArrayList<>();
 
     private final List<FluentResourceCollection> resourceCollections = new ArrayList<>();
-
-    private Project project;
 
     public FluentClient(Client client) {
         this.client = client;
@@ -41,14 +38,6 @@ public class FluentClient {
 
     public void setManager(FluentManager manager) {
         this.manager = manager;
-    }
-
-    public Project getProject() {
-        return project;
-    }
-
-    public void setProject(Project project) {
-        this.project = project;
     }
 
     public Client getInnerClient() {

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentManager.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentManager.java
@@ -14,6 +14,9 @@ import com.azure.autorest.util.CodeNamer;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Model for Manager.
+ */
 public class FluentManager {
 
     private final Client client;

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentManager.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentManager.java
@@ -20,6 +20,8 @@ public class FluentManager {
 
     private final ClassType type;
 
+    private final String serviceName;
+
     private final List<FluentManagerProperty> properties = new ArrayList<>();
 
     public FluentManager(Client client, String clientName) {
@@ -27,9 +29,11 @@ public class FluentManager {
 
         this.client = client;
 
+        this.serviceName = CodeNamer.toPascalCase(FluentUtils.getServiceName(clientName));
+
         this.type = new ClassType.Builder()
                 .packageName(settings.getPackage())
-                .name(CodeNamer.toPascalCase(FluentUtils.getServiceName(clientName)) + "Manager")
+                .name(this.serviceName + "Manager")
                 .build();
     }
 
@@ -43,6 +47,10 @@ public class FluentManager {
 
     public String getDescription() {
         return String.format("Entry point to %1$s.\n%2$s", this.getType().getName(), client.getClientDescription());
+    }
+
+    public String getServiceName() {
+        return serviceName;
     }
 
     public List<FluentManagerProperty> getProperties() {

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentResourceCollection.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentResourceCollection.java
@@ -20,6 +20,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+/**
+ * Model for Azure resource collection.
+ */
 // Fluent resource collection API. E.g. StorageAccounts.
 public class FluentResourceCollection {
 

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentResourceModel.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentResourceModel.java
@@ -23,6 +23,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * Model for Azure resource instance.
+ */
 // Fluent resource instance. E.g. StorageAccount.
 // Also include some simple wrapper class.
 public class FluentResourceModel {

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentStatic.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentStatic.java
@@ -8,6 +8,11 @@ package com.azure.autorest.fluent.model.clientmodel;
 import com.azure.autorest.fluent.util.FluentJavaSettings;
 import com.azure.autorest.model.clientmodel.Client;
 
+/**
+ * Convenient class for global variables.
+ *
+ * Avoid using it unless no better solution.
+ */
 public class FluentStatic {
 
     private static Client client;
@@ -17,7 +22,6 @@ public class FluentStatic {
     private static FluentJavaSettings fluentJavaSettings;
 
     private FluentStatic() {
-
     }
 
     /**

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentStatic.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentStatic.java
@@ -5,6 +5,7 @@
 
 package com.azure.autorest.fluent.model.clientmodel;
 
+import com.azure.autorest.fluent.util.FluentJavaSettings;
 import com.azure.autorest.model.clientmodel.Client;
 
 public class FluentStatic {
@@ -12,6 +13,8 @@ public class FluentStatic {
     private static Client client;
 
     private static FluentClient fluentClient;
+
+    private static FluentJavaSettings fluentJavaSettings;
 
     private FluentStatic() {
 
@@ -37,5 +40,16 @@ public class FluentStatic {
 
     public static void setFluentClient(FluentClient fluentClient) {
         FluentStatic.fluentClient = fluentClient;
+    }
+
+    /**
+     * @return settings for Fluent.
+     */
+    public static FluentJavaSettings getFluentJavaSettings() {
+        return fluentJavaSettings;
+    }
+
+    public static void setFluentJavaSettings(FluentJavaSettings fluentJavaSettings) {
+        FluentStatic.fluentJavaSettings = fluentJavaSettings;
     }
 }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/projectmodel/Project.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/projectmodel/Project.java
@@ -3,7 +3,7 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  */
 
-package com.azure.autorest.fluent.model;
+package com.azure.autorest.fluent.model.projectmodel;
 
 import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.fluent.model.clientmodel.FluentClient;

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentPomTemplate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentPomTemplate.java
@@ -5,6 +5,7 @@
 
 package com.azure.autorest.fluent.template;
 
+import com.azure.autorest.fluent.model.clientmodel.FluentStatic;
 import com.azure.autorest.model.clientmodel.Pom;
 import com.azure.autorest.model.xmlmodel.XmlBlock;
 import com.azure.autorest.template.PomTemplate;
@@ -24,14 +25,27 @@ public class FluentPomTemplate extends PomTemplate {
     protected void writeBuildBlock(XmlBlock projectBlock, Pom pom) {
         projectBlock.block("build", buildBlock -> {
             buildBlock.block("plugins", pluginsBlock -> {
-                pluginsBlock.block("plugin", pluginBlock -> {
-                    pluginBlock.tag("groupId", "org.apache.maven.plugins");
-                    pluginBlock.tag("artifactId", "maven-compiler-plugin");
-                    pluginBlock.tag("version", "3.8.1");
-                    pluginBlock.block("configuration", configurationBlock -> {
-                        configurationBlock.tag("release", "11");
+                if (FluentStatic.getFluentJavaSettings().isSdkIntegration()) {
+                    // jacoco-maven-plugin
+                    pluginsBlock.block("plugin", pluginBlock -> {
+                        pluginBlock.tag("groupId", "org.jacoco");
+                        pluginBlock.tag("artifactId", "jacoco-maven-plugin");
+                        pluginBlock.tag("version", "0.8.5");
+                        pluginBlock.block("configuration", configurationBlock -> {
+                            configurationBlock.tag("skip", "true");
+                        });
                     });
-                });
+                } else {
+                    // maven-compiler-plugin
+                    pluginsBlock.block("plugin", pluginBlock -> {
+                        pluginBlock.tag("groupId", "org.apache.maven.plugins");
+                        pluginBlock.tag("artifactId", "maven-compiler-plugin");
+                        pluginBlock.tag("version", "3.8.1");
+                        pluginBlock.block("configuration", configurationBlock -> {
+                            configurationBlock.tag("release", "11");
+                        });
+                    });
+                }
             });
         });
     }

--- a/fluentnamer/readme.md
+++ b/fluentnamer/readme.md
@@ -4,6 +4,8 @@
 | ----------- | ----------- |
 | `--fluent` | Enum. `LITE` for Fluent Lite; `PREMIUM` for Fluent Premium. Case insensitive. Default to `PREMIUM` if provided as other values. |
 | `--pom-file` | String. Name for Maven POM file. Default to `pom.xml` |
+| `--artifact-version` | String. Version number for Maven artifact. Default to `1.0.0-beta.1` |
+| `--sdk-integration` | Boolean. Integrate to `azure-sdk-for-java` |
 | `--track1-naming` | Boolean. Use track1 naming style (`withFoo` / `foo` as setter / getter). |
 | `--add-inner` | CSV. Treat as inner class (append `Inner` to class name). |
 | `--remove-inner` | CSV. Exclude from inner classes. |

--- a/fluentnamer/src/main/java/com/azure/autorest/fluent/util/FluentJavaSettings.java
+++ b/fluentnamer/src/main/java/com/azure/autorest/fluent/util/FluentJavaSettings.java
@@ -56,6 +56,10 @@ public class FluentJavaSettings {
 
     private String pomFilename = "pom.xml";
 
+    private Optional<String> artifactVersion = Optional.empty();
+
+    private boolean sdkIntegration = false;
+
     public FluentJavaSettings(NewPlugin host) {
         Objects.requireNonNull(host);
         this.host = host;
@@ -91,6 +95,14 @@ public class FluentJavaSettings {
         return pomFilename;
     }
 
+    public Optional<String> getArtifactVersion() {
+        return artifactVersion;
+    }
+
+    public boolean isSdkIntegration() {
+        return sdkIntegration;
+    }
+
     private void loadSettings() {
         String addInnerSetting = host.getStringValue("add-inner");
         if (addInnerSetting != null && !addInnerSetting.isEmpty()) {
@@ -118,6 +130,9 @@ public class FluentJavaSettings {
         loadStringSetting("name-for-ungrouped-operations", s -> nameForUngroupedOperations = Optional.of(s) );
 
         loadStringSetting("pom-file", s -> pomFilename = s );
+        loadStringSetting("artifact-version", s -> artifactVersion = Optional.of(s) );
+
+        loadBooleanSetting("sdk-integration", b -> sdkIntegration = b );
 
         Map<String, String> namingOverride = host.getValue(new TypeReference<Map<String, String>>() {}.getType(), "pipeline.fluentnamer.naming.override");
         if (namingOverride != null) {

--- a/javagen/src/main/java/com/azure/autorest/template/PomTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/PomTemplate.java
@@ -47,7 +47,7 @@ public class PomTemplate implements IXmlTemplate<Pom, XmlFile> {
                     String parentVersion = parts[2];
                     parentBlock.tag("groupId", parentGroupId);
                     parentBlock.tag("artifactId", parentArtifactId);
-                    parentBlock.tag("parentVersion", parentVersion);
+                    parentBlock.tag("version", parentVersion);
                     parentBlock.tag("relativePath", pom.getParentRelativePath());
                 });
             }


### PR DESCRIPTION
sample command
```
SET AUTOREST_CORE_VERSION=3.0.6324
SET MODELERFOUR_ARGUMENTS=--pipeline.modelerfour.additional-checks=false --pipeline.modelerfour.lenient-model-deduplication=true
SET FLUENTLITE_ARGUMENTS=--java --use:"C:\github_fork\autorest.java" %MODELERFOUR_ARGUMENTS% --azure-arm --fluent=lite --license-header=MICROSOFT_MIT_SMALL --generate-client-interfaces --sync-methods=all --required-parameter-client-methods --add-context-parameter --context-client-method-parameter --track1-naming --client-side-validations --client-logger

CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENTLITE_ARGUMENTS% --output-folder="sdk/resources/azure-resourcemanager-resource" --sdk-integration --payload-flattening-threshold=0 https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/resources/resource-manager/readme.md --tag=package-resources-2020-06 --java.namespace=com.azure.resourcemanager.resources.generated
```