### PR TITLE
v4, module-info support

### DIFF
--- a/fluent-tests/prepare-tests.bat
+++ b/fluent-tests/prepare-tests.bat
@@ -7,8 +7,8 @@ REM print java version
 java -version
 
 REM re-generate code
-RMDIR /S /Q "src/main/java/com/azure/mgmttest"
-RMDIR /S /Q "src/main/java/com/azure/mgmtlitetest"
+RMDIR /S /Q "src\main\java\com\azure\mgmttest"
+RMDIR /S /Q "src\main\java\com\azure\mgmtlitetest"
 
 SET AUTOREST_CORE_VERSION=3.0.6324
 SET MODELERFOUR_ARGUMENTS=--pipeline.modelerfour.additional-checks=false --pipeline.modelerfour.lenient-model-deduplication=true
@@ -39,4 +39,4 @@ REM CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENTLITE_ARGUMENTS% --pay
 REM CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENTLITE_ARGUMENTS% --payload-flattening-threshold=0 https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/compute/resource-manager/readme.md --tag=package-2020-06-30 --java.namespace=com.azure.mgmtlitetest.compute --pom-file=pom_generated_compute.xml
 
 REM delete module-info as fluent-test is on java8
-DEL "src/main/java/module-info.java"
+DEL "src\main\java\module-info.java"

--- a/fluent-tests/prepare-tests.bat
+++ b/fluent-tests/prepare-tests.bat
@@ -37,3 +37,6 @@ CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENTLITE_ARGUMENTS% --payload
 
 REM CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENTLITE_ARGUMENTS% --payload-flattening-threshold=0 https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/network/resource-manager/readme.md --tag=package-2020-06 --java.namespace=com.azure.mgmtlitetest.network --pom-file=pom_generated_network.xml
 REM CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENTLITE_ARGUMENTS% --payload-flattening-threshold=0 https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/compute/resource-manager/readme.md --tag=package-2020-06-30 --java.namespace=com.azure.mgmtlitetest.compute --pom-file=pom_generated_compute.xml
+
+REM delete module-info as fluent-test is on java8
+DEL "src/main/java/module-info.java"

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
@@ -193,17 +193,21 @@ public class FluentGen extends NewPlugin {
                 // Fluent manager
                 javaPackage.addFluentManager(fluentClient.getManager(), project);
 
-                // Fluent resource model
+                // Fluent resource models
                 for (FluentResourceModel model : fluentClient.getResourceModels()) {
                     javaPackage.addFluentResourceModel(model);
                 }
 
+                // Fluent resource collections
                 for (FluentResourceCollection collection : fluentClient.getResourceCollections()) {
                     javaPackage.addFluentResourceCollection(collection);
                 }
 
                 // Utils
                 javaPackage.addUtils();
+
+                // module-info
+                javaPackage.addModuleInfo(fluentClient.getModuleInfo());
 
                 // POM
                 Pom pom = new PomMapper().map(project);

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentMapper.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentMapper.java
@@ -12,6 +12,7 @@ import com.azure.autorest.extension.base.model.codemodel.ObjectSchema;
 import com.azure.autorest.extension.base.model.codemodel.Operation;
 import com.azure.autorest.extension.base.model.codemodel.Response;
 import com.azure.autorest.extension.base.model.codemodel.Value;
+import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.fluent.model.FluentType;
 import com.azure.autorest.fluent.model.clientmodel.FluentClient;
 import com.azure.autorest.fluent.model.clientmodel.FluentManager;
@@ -21,10 +22,13 @@ import com.azure.autorest.fluent.util.FluentJavaSettings;
 import com.azure.autorest.fluent.util.Utils;
 import com.azure.autorest.mapper.Mappers;
 import com.azure.autorest.model.clientmodel.Client;
+import com.azure.autorest.model.clientmodel.ModuleInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -46,6 +50,8 @@ public class FluentMapper {
 
     public FluentClient map(CodeModel codeModel, Client client) {
         FluentClient fluentClient = new FluentClient(client);
+
+        fluentClient.setModuleInfo(moduleInfo());
 
         FluentStatic.setFluentClient(fluentClient);
 
@@ -77,6 +83,27 @@ public class FluentMapper {
                         .collect(Collectors.toList()));
 
         return fluentClient;
+    }
+
+    private static ModuleInfo moduleInfo() {
+        JavaSettings settings = JavaSettings.getInstance();
+        ModuleInfo moduleInfo = new ModuleInfo(settings.getPackage());
+
+        List<ModuleInfo.RequireModule> requireModules = moduleInfo.getRequireModules();
+        requireModules.add(new ModuleInfo.RequireModule("com.azure.resourcemanager.resources", true));
+
+        List<ModuleInfo.ExportModule> exportModules = moduleInfo.getExportModules();
+        exportModules.add(new ModuleInfo.ExportModule(settings.getPackage()));
+        exportModules.add(new ModuleInfo.ExportModule(settings.getPackage(settings.getFluentSubpackage())));
+        exportModules.add(new ModuleInfo.ExportModule(settings.getPackage(settings.getFluentSubpackage(), settings.getModelsSubpackage())));
+        exportModules.add(new ModuleInfo.ExportModule(settings.getPackage(settings.getModelsSubpackage())));
+
+        List<String> openToModules = Arrays.asList("com.azure.core", "com.fasterxml.jackson.databind");
+        List<ModuleInfo.OpenModule> openModules = moduleInfo.getOpenModules();
+        openModules.add(new ModuleInfo.OpenModule(settings.getPackage(settings.getFluentSubpackage(), settings.getModelsSubpackage()), openToModules));
+        openModules.add(new ModuleInfo.OpenModule(settings.getPackage(settings.getModelsSubpackage()), openToModules));
+
+        return moduleInfo;
     }
 
     private void processInnerModel(CodeModel codeModel) {

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentMapper.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentMapper.java
@@ -90,7 +90,7 @@ public class FluentMapper {
         ModuleInfo moduleInfo = new ModuleInfo(settings.getPackage());
 
         List<ModuleInfo.RequireModule> requireModules = moduleInfo.getRequireModules();
-        requireModules.add(new ModuleInfo.RequireModule("com.azure.resourcemanager.resources", true));
+        requireModules.add(new ModuleInfo.RequireModule("com.azure.core.management", true));
 
         List<ModuleInfo.ExportModule> exportModules = moduleInfo.getExportModules();
         exportModules.add(new ModuleInfo.ExportModule(settings.getPackage()));

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentClient.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentClient.java
@@ -6,6 +6,7 @@
 package com.azure.autorest.fluent.model.clientmodel;
 
 import com.azure.autorest.model.clientmodel.Client;
+import com.azure.autorest.model.clientmodel.ModuleInfo;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,6 +19,8 @@ public class FluentClient {
     private final Client client;
 
     private FluentManager manager;
+
+    private ModuleInfo moduleInfo;
 
     private final List<FluentResourceModel> resourceModels = new ArrayList<>();
 
@@ -45,5 +48,13 @@ public class FluentClient {
 
     public Client getInnerClient() {
         return this.client;
+    }
+
+    public ModuleInfo getModuleInfo() {
+        return moduleInfo;
+    }
+
+    public void setModuleInfo(ModuleInfo moduleInfo) {
+        this.moduleInfo = moduleInfo;
     }
 }

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ModuleInfo.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ModuleInfo.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.azure.autorest.model.clientmodel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ModuleInfo {
+    private final String moduleName;
+    private final List<RequireModule> requireModules = new ArrayList<>();
+    private final List<ExportModule> exportModules = new ArrayList<>();
+    private final List<OpenModule> openModules = new ArrayList<>();
+
+    public static class RequireModule {
+        private final String moduleName;
+        private final boolean isTransitive;
+
+        public RequireModule(String moduleName) {
+            this.moduleName = moduleName;
+            this.isTransitive = false;
+        }
+
+        public RequireModule(String moduleName, boolean isTransitive) {
+            this.moduleName = moduleName;
+            this.isTransitive = isTransitive;
+        }
+
+        public String getModuleName() {
+            return moduleName;
+        }
+
+        public boolean isTransitive() {
+            return isTransitive;
+        }
+    }
+
+    public static class ExportModule {
+        private final String moduleName;
+
+        public ExportModule(String moduleName) {
+            this.moduleName = moduleName;
+        }
+
+        public String getModuleName() {
+            return moduleName;
+        }
+    }
+
+    public static class OpenModule {
+        private final String moduleName;
+        private final List<String> openToModules;
+
+        public OpenModule(String moduleName) {
+            this.moduleName = moduleName;
+            this.openToModules = null;
+        }
+
+        public OpenModule(String moduleName, List<String> openToModules) {
+            this.moduleName = moduleName;
+            this.openToModules = openToModules;
+        }
+
+        public String getModuleName() {
+            return moduleName;
+        }
+
+        public List<String> getOpenToModules() {
+            return openToModules;
+        }
+
+        public boolean isOpenTo() {
+            return openToModules != null && !openToModules.isEmpty();
+        }
+    }
+
+    public ModuleInfo(String moduleName) {
+        this.moduleName = moduleName;
+    }
+
+    public String getModuleName() {
+        return moduleName;
+    }
+
+    public List<RequireModule> getRequireModules() {
+        return requireModules;
+    }
+
+    public List<ExportModule> getExportModules() {
+        return exportModules;
+    }
+
+    public List<OpenModule> getOpenModules() {
+        return openModules;
+    }
+}

--- a/javagen/src/main/java/com/azure/autorest/model/javamodel/JavaPackage.java
+++ b/javagen/src/main/java/com/azure/autorest/model/javamodel/JavaPackage.java
@@ -8,6 +8,7 @@ import com.azure.autorest.model.clientmodel.ClientResponse;
 import com.azure.autorest.model.clientmodel.EnumType;
 import com.azure.autorest.model.clientmodel.Manager;
 import com.azure.autorest.model.clientmodel.MethodGroupClient;
+import com.azure.autorest.model.clientmodel.ModuleInfo;
 import com.azure.autorest.model.clientmodel.PackageInfo;
 import com.azure.autorest.model.clientmodel.PageDetails;
 import com.azure.autorest.model.clientmodel.Pom;
@@ -148,6 +149,12 @@ public class JavaPackage {
     public final void addPackageInfo(String package_Keyword, String name, PackageInfo model) {
         JavaFile javaFile = javaFileFactory.createEmptySourceFile(package_Keyword, name);
         Templates.getPackageInfoTemplate().write(model, javaFile);
+        javaFiles.add(javaFile);
+    }
+
+    public final void addModuleInfo(ModuleInfo moduleInfo) {
+        JavaFile javaFile = javaFileFactory.createEmptySourceFile("", "module-info");
+        Templates.getModuleInfoTemplate().write(moduleInfo, javaFile);
         javaFiles.add(javaFile);
     }
 

--- a/javagen/src/main/java/com/azure/autorest/template/DefaultTemplateFactory.java
+++ b/javagen/src/main/java/com/azure/autorest/template/DefaultTemplateFactory.java
@@ -95,4 +95,9 @@ public class DefaultTemplateFactory implements TemplateFactory {
     public PomTemplate getPomTemplate() {
         return PomTemplate.getInstance();
     }
+
+    @Override
+    public ModuleInfoTemplate getModuleInfoTemplate() {
+        return ModuleInfoTemplate.getInstance();
+    }
 }

--- a/javagen/src/main/java/com/azure/autorest/template/ModuleInfoTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModuleInfoTemplate.java
@@ -5,6 +5,7 @@
 
 package com.azure.autorest.template;
 
+import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.model.clientmodel.ModuleInfo;
 import com.azure.autorest.model.javamodel.JavaFile;
 
@@ -20,24 +21,32 @@ public class ModuleInfoTemplate implements IJavaTemplate<ModuleInfo, JavaFile> {
     }
 
     @Override
-    public void write(ModuleInfo model, JavaFile context) {
-        context.line(String.format("module %1$s {", model.getModuleName()));
-        context.indent(() -> {
+    public void write(ModuleInfo model, JavaFile javaFile) {
+        JavaSettings settings = JavaSettings.getInstance();
+        if (settings.getFileHeaderText() != null && !settings.getFileHeaderText().isEmpty()) {
+            javaFile.lineComment(settings.getMaximumJavadocCommentWidth(), comment -> {
+                comment.line(settings.getFileHeaderText());
+            });
+            javaFile.line();
+        }
+
+        javaFile.line(String.format("module %1$s {", model.getModuleName()));
+        javaFile.indent(() -> {
             for (ModuleInfo.RequireModule module : model.getRequireModules()) {
-                context.line(String.format("requires %1$s%2$s;",
+                javaFile.line(String.format("requires %1$s%2$s;",
                         module.isTransitive() ? "transitive " : "",
                         module.getModuleName()));
             }
             for (ModuleInfo.ExportModule module : model.getExportModules()) {
-                context.line(String.format("exports %1$s;",
+                javaFile.line(String.format("exports %1$s;",
                         module.getModuleName()));
             }
             for (ModuleInfo.OpenModule module : model.getOpenModules()) {
-                context.line(String.format("opens %1$s%2$s;",
+                javaFile.line(String.format("opens %1$s%2$s;",
                         module.getModuleName(),
                         module.isOpenTo() ? (" to " + String.join(", ", module.getOpenToModules())) : ""));
             }
         });
-        context.line("}");
+        javaFile.line("}");
     }
 }

--- a/javagen/src/main/java/com/azure/autorest/template/ModuleInfoTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModuleInfoTemplate.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.azure.autorest.template;
+
+import com.azure.autorest.model.clientmodel.ModuleInfo;
+import com.azure.autorest.model.javamodel.JavaFile;
+
+public class ModuleInfoTemplate implements IJavaTemplate<ModuleInfo, JavaFile> {
+
+    private static ModuleInfoTemplate INSTANCE = new ModuleInfoTemplate();
+
+    private ModuleInfoTemplate() {
+    }
+
+    public static ModuleInfoTemplate getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public void write(ModuleInfo model, JavaFile context) {
+        context.line(String.format("module %1$s {", model.getModuleName()));
+        context.indent(() -> {
+            for (ModuleInfo.RequireModule module : model.getRequireModules()) {
+                context.line(String.format("requires %1$s%2$s;",
+                        module.isTransitive() ? "transitive " : "",
+                        module.getModuleName()));
+            }
+            for (ModuleInfo.ExportModule module : model.getExportModules()) {
+                context.line(String.format("exports %1$s;",
+                        module.getModuleName()));
+            }
+            for (ModuleInfo.OpenModule module : model.getOpenModules()) {
+                context.line(String.format("opens %1$s%2$s;",
+                        module.getModuleName(),
+                        module.isOpenTo() ? (" to " + String.join(", ", module.getOpenToModules())) : ""));
+            }
+        });
+        context.line("}");
+    }
+}

--- a/javagen/src/main/java/com/azure/autorest/template/TemplateFactory.java
+++ b/javagen/src/main/java/com/azure/autorest/template/TemplateFactory.java
@@ -39,5 +39,7 @@ public interface TemplateFactory {
     WrapperClientMethodTemplate getWrapperClientMethodTemplate();
 
     PomTemplate getPomTemplate();
+
+    ModuleInfoTemplate getModuleInfoTemplate();
 }
 

--- a/javagen/src/main/java/com/azure/autorest/template/Templates.java
+++ b/javagen/src/main/java/com/azure/autorest/template/Templates.java
@@ -83,11 +83,15 @@ public class Templates {
         return factory.getWrapperClientMethodTemplate();
     }
 
-    public static <ContextT, ModelT> ServiceSyncClientTemplate getServiceSyncClientTemplate() {
+    public static ServiceSyncClientTemplate getServiceSyncClientTemplate() {
         return factory.getServiceSynClientTemplate();
     }
 
     public static PomTemplate getPomTemplate() {
         return factory.getPomTemplate();
+    }
+
+    public static ModuleInfoTemplate getModuleInfoTemplate() {
+        return factory.getModuleInfoTemplate();
     }
 }


### PR DESCRIPTION
data-plane might need it, hence I put the code to javagen (not called in javagen process).

Sample output for Fluent Lite
```
// Copyright (c) Microsoft Corporation. All rights reserved.
// Licensed under the MIT License.
// Code generated by Microsoft (R) AutoRest Code Generator.

module com.azure.resourcemanager.resources.generated {
    requires transitive com.azure.core.management;

    exports com.azure.resourcemanager.resources.generated;
    exports com.azure.resourcemanager.resources.generated.fluent;
    exports com.azure.resourcemanager.resources.generated.fluent.models;
    exports com.azure.resourcemanager.resources.generated.models;

    opens com.azure.resourcemanager.resources.generated.fluent.models to
        com.azure.core,
        com.fasterxml.jackson.databind;
    opens com.azure.resourcemanager.resources.generated.models to
        com.azure.core,
        com.fasterxml.jackson.databind;
}
```