### PR TITLE
Generate JsonPatchDocument if content type is json-patch+json

### DIFF
--- a/javagen/pom.xml
+++ b/javagen/pom.xml
@@ -19,6 +19,16 @@
       <id>azuresdkmaven</id>
       <url>https://azsdkartifacts.blob.core.windows.net/maven</url>
     </repository>
+    <repository>
+      <id>azure-sdk-for-java</id>
+      <url>https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-java/maven/v1</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
   </repositories>
 
   <dependencies>
@@ -36,7 +46,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
-      <version>1.9.0</version>
+      <version>1.10.0-alpha.20201022.0</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -117,6 +117,15 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
 
             for (Parameter parameter : request.getParameters().stream().filter(p -> !p.isFlattened()).collect(Collectors.toList())) {
                 ClientMethodParameter clientMethodParameter = Mappers.getClientParameterMapper().map(parameter);
+
+                if (request.getProtocol() != null
+                    && request.getProtocol().getHttp() != null
+                    && request.getProtocol().getHttp().getMediaTypes() != null
+                    && request.getProtocol().getHttp().getMediaTypes().stream().anyMatch(mediaType -> mediaType.equals(
+                        "application/json-patch+json"))) {
+                    clientMethodParameter = CustomClientParameterMapper.getInstance().map(parameter);
+                }
+
                 if (request.getSignatureParameters().contains(parameter)) {
                     parameters.add(clientMethodParameter);
                 }

--- a/javagen/src/main/java/com/azure/autorest/mapper/CustomClientParameterMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/CustomClientParameterMapper.java
@@ -1,0 +1,75 @@
+package com.azure.autorest.mapper;
+
+import com.azure.autorest.extension.base.model.codemodel.AnySchema;
+import com.azure.autorest.extension.base.model.codemodel.ArraySchema;
+import com.azure.autorest.extension.base.model.codemodel.ConstantSchema;
+import com.azure.autorest.extension.base.model.codemodel.Parameter;
+import com.azure.autorest.extension.base.plugin.JavaSettings;
+import com.azure.autorest.model.clientmodel.ClassType;
+import com.azure.autorest.model.clientmodel.ClientMethodParameter;
+import com.azure.autorest.model.clientmodel.IType;
+import com.azure.autorest.util.CodeNamer;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class CustomClientParameterMapper implements IMapper<Parameter, ClientMethodParameter> {
+
+    private static CustomClientParameterMapper instance = new CustomClientParameterMapper();
+
+    private CustomClientParameterMapper() {
+    }
+
+    public static CustomClientParameterMapper getInstance() {
+        return instance;
+    }
+
+    @Override
+    public ClientMethodParameter map(Parameter parameter) {
+        String name = parameter.getOriginalParameter() != null && parameter.getLanguage().getJava().getName().equals(parameter.getOriginalParameter().getLanguage().getJava().getName())
+                ? CodeNamer.toCamelCase(parameter.getOriginalParameter().getSchema().getLanguage().getJava().getName()) + CodeNamer.toPascalCase(parameter.getLanguage().getJava().getName())
+                : parameter.getLanguage().getJava().getName();
+
+        JavaSettings settings = JavaSettings.getInstance();
+        ClientMethodParameter.Builder builder = new ClientMethodParameter.Builder()
+                .name(name)
+                .isRequired(parameter.isRequired())
+                .fromClient(parameter.getImplementation() == Parameter.ImplementationLocation.CLIENT);
+
+        IType wireType = Mappers.getSchemaMapper().map(parameter.getSchema());
+        if (parameter.getSchema() instanceof ArraySchema) {
+            ArraySchema arraySchema = (ArraySchema) parameter.getSchema();
+            if (arraySchema.getElementType() instanceof AnySchema) {
+                wireType = ClassType.JsonPatchDocument;
+            }
+        }
+
+        if (parameter.isNullable() || !parameter.isRequired()) {
+            wireType = wireType.asNullable();
+        }
+        builder.wireType(wireType);
+
+        builder.annotations(settings.shouldNonNullAnnotations() && parameter.isRequired() ?
+                Arrays.asList(ClassType.NonNull) : new ArrayList<>());
+
+        boolean isConstant = false;
+        String defaultValue = null;
+        if (parameter.getSchema() instanceof ConstantSchema) {
+            isConstant = true;
+            Object objValue = ((ConstantSchema) parameter.getSchema()).getValue().getValue();
+            defaultValue = objValue == null ? null : String.valueOf(objValue);
+        }
+        builder.isConstant(isConstant).defaultValue(defaultValue);
+
+        if (parameter.getSchema() != null && parameter.getSchema().getLanguage() != null) {
+            String description = parameter.getSchema().getLanguage().getDefault().getDescription();
+            if (description == null || description.isEmpty()) {
+                if (parameter.getLanguage() != null) {
+                    description = parameter.getLanguage().getDefault().getDescription();
+                }
+            }
+            builder.description(description);
+        }
+        return builder.build();
+    }
+}

--- a/javagen/src/main/java/com/azure/autorest/mapper/CustomProxyParameterMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/CustomProxyParameterMapper.java
@@ -1,0 +1,145 @@
+package com.azure.autorest.mapper;
+
+import com.azure.autorest.extension.base.model.codemodel.AnySchema;
+import com.azure.autorest.extension.base.model.codemodel.ArraySchema;
+import com.azure.autorest.extension.base.model.codemodel.ConstantSchema;
+import com.azure.autorest.extension.base.model.codemodel.Parameter;
+import com.azure.autorest.extension.base.model.codemodel.RequestParameterLocation;
+import com.azure.autorest.extension.base.model.codemodel.Schema;
+import com.azure.autorest.extension.base.plugin.JavaSettings;
+import com.azure.autorest.model.clientmodel.ArrayType;
+import com.azure.autorest.model.clientmodel.ClassType;
+import com.azure.autorest.model.clientmodel.IType;
+import com.azure.autorest.model.clientmodel.ListType;
+import com.azure.autorest.model.clientmodel.PrimitiveType;
+import com.azure.autorest.model.clientmodel.ProxyMethodParameter;
+import com.azure.autorest.util.CodeNamer;
+import com.azure.core.util.serializer.CollectionFormat;
+
+public class CustomProxyParameterMapper implements IMapper<Parameter, ProxyMethodParameter> {
+
+    private static CustomProxyParameterMapper instance = new CustomProxyParameterMapper();
+
+    private CustomProxyParameterMapper() {
+    }
+
+    public static CustomProxyParameterMapper getInstance() {
+        return instance;
+    }
+
+
+    @Override
+    public ProxyMethodParameter map(Parameter parameter) {
+        JavaSettings settings = JavaSettings.getInstance();
+
+        ProxyMethodParameter.Builder builder = new ProxyMethodParameter.Builder()
+                .requestParameterName(parameter.getLanguage().getDefault().getSerializedName())
+                .name(parameter.getLanguage().getJava().getName())
+                .isRequired(parameter.isRequired())
+                .isNullable(parameter.isNullable());
+
+        Schema parameterJvWireType = parameter.getSchema();
+
+        IType wireType = Mappers.getSchemaMapper().map(parameterJvWireType);
+
+        if (parameterJvWireType instanceof ArraySchema) {
+            ArraySchema arraySchema = (ArraySchema) parameterJvWireType;
+            if (arraySchema.getElementType() instanceof AnySchema) {
+                wireType = ClassType.JsonPatchDocument;
+            }
+        }
+
+        if (parameter.isNullable() || !parameter.isRequired()) {
+            wireType = wireType.asNullable();
+        }
+        IType clientType = wireType.getClientType();
+        builder.clientType(clientType);
+
+        RequestParameterLocation parameterRequestLocation = parameter.getProtocol().getHttp().getIn();
+        builder.requestParameterLocation(parameterRequestLocation);
+
+        boolean parameterIsServiceClientProperty = parameter.getImplementation() == Parameter.ImplementationLocation.CLIENT;
+        builder.fromClient(parameterIsServiceClientProperty);
+
+        if (wireType instanceof ListType && settings.shouldGenerateXmlSerialization() && parameterRequestLocation == RequestParameterLocation.Body){
+            String parameterTypePackage = settings.getPackage(settings.getImplementationSubpackage());
+            String parameterTypeName = CodeNamer
+                    .toPascalCase(parameterJvWireType.getSerialization().getXml().getName() +
+                            "Wrapper");
+            wireType = new ClassType.Builder()
+                    .packageName(parameterTypePackage)
+                    .name(parameterTypeName)
+                    .build();
+        } else if (wireType == ArrayType.ByteArray) {
+            if (parameterRequestLocation != RequestParameterLocation.Body /*&& parameterRequestLocation != RequestParameterLocation.FormData*/) {
+                wireType = ClassType.String;
+            }
+        } else if (wireType instanceof ListType && parameter.getProtocol().getHttp().getIn() != RequestParameterLocation.Body /*&& parameter.getProtocol().getHttp().getIn() != RequestParameterLocation.FormData*/) {
+            wireType = ClassType.String;
+        }
+        builder.wireType(wireType);
+
+        String parameterDescription = parameter.getDescription();
+        if (parameterDescription == null || parameterDescription.isEmpty()) {
+            parameterDescription = String.format("the %s value", clientType);
+        }
+        builder.description(parameterDescription);
+
+        if (parameter.getExtensions() != null) {
+            builder.alreadyEncoded(parameter.getExtensions().isXmsSkipUrlEncoding());
+        }
+
+        if (parameter.getSchema() instanceof ConstantSchema){
+            builder.isConstant(true);
+            Object objValue = ((ConstantSchema) parameter.getSchema()).getValue().getValue();
+            builder.defaultValue(objValue == null ? null : String.valueOf(objValue));
+        }
+
+        String parameterReference = parameter.getLanguage().getJava().getName();
+        if (Parameter.ImplementationLocation.CLIENT.equals(parameter.getImplementation())) {
+            String operationGroupName = parameter.getOperation().getOperationGroup().getLanguage().getJava().getName();
+            String caller = (operationGroupName == null || operationGroupName.isEmpty()) ? "this" : "this.client";
+            String clientPropertyName = parameter.getLanguage().getJava().getName();
+            if (clientPropertyName != null && !clientPropertyName.isEmpty()) {
+                clientPropertyName = CodeNamer.toPascalCase(CodeNamer.removeInvalidCharacters(clientPropertyName));
+            }
+            String prefix = "get";
+            if (clientType == PrimitiveType.Boolean || clientType == ClassType.Boolean) {
+                prefix = "is";
+                if (CodeNamer.toCamelCase(parameterReference).startsWith(prefix)) {
+                    prefix = "";
+                    clientPropertyName = CodeNamer.toCamelCase(clientPropertyName);
+                }
+            }
+            parameterReference = String.format("%s.%s%s()", caller, prefix, clientPropertyName);
+        }
+        builder.parameterReference(parameterReference);
+
+        CollectionFormat collectionFormat = null;
+        if (parameter.getProtocol().getHttp().getStyle() != null) {
+            switch (parameter.getProtocol().getHttp().getStyle()) {
+                case SIMPLE:
+                    collectionFormat = CollectionFormat.CSV;
+                    break;
+                case SPACE_DELIMITED:
+                    collectionFormat = CollectionFormat.SSV;
+                    break;
+                case PIPE_DELIMITED:
+                    collectionFormat = CollectionFormat.PIPES;
+                    break;
+                case TAB_DELIMITED:
+                    collectionFormat = CollectionFormat.TSV;
+                    break;
+                default:
+                    collectionFormat = CollectionFormat.CSV;
+            }
+        }
+        if (collectionFormat == null && clientType instanceof ListType
+                && ClassType.String == wireType) {
+            collectionFormat = CollectionFormat.CSV;
+        }
+        builder.collectionFormat(collectionFormat);
+
+        return builder.build();
+    }
+}

--- a/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
@@ -136,7 +136,11 @@ public class ProxyMethodMapper implements IMapper<Operation, Map<Request, ProxyM
                     .filter(p -> p.getProtocol() != null && p.getProtocol().getHttp() != null)
                     .collect(Collectors.toList())) {
                 parameter.setOperation(operation);
-                parameters.add(Mappers.getProxyParameterMapper().map(parameter));
+                ProxyMethodParameter proxyMethodParameter = Mappers.getProxyParameterMapper().map(parameter);
+                if (requestContentType.startsWith("application/json-patch+json")) {
+                    proxyMethodParameter = CustomProxyParameterMapper.getInstance().map(parameter);
+                }
+                parameters.add(proxyMethodParameter);
             }
             if (settings.getAddContextParameter()) {
                 ProxyMethodParameter contextParameter = new ProxyMethodParameter.Builder()

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
@@ -57,6 +57,8 @@ public class ClassType implements IType {
     public static final ClassType ServiceVersion = new ClassType.Builder().knownClass(com.azure.core.util.ServiceVersion.class).build();
     public static final ClassType AzureKeyCredential = new ClassType.Builder().knownClass(com.azure.core.credential.AzureKeyCredential.class).build();
     public static final ClassType RetryPolicy = new ClassType.Builder().knownClass(com.azure.core.http.policy.RetryPolicy.class).build();
+    public static final ClassType JsonPatchDocument =
+            new ClassType.Builder().knownClass(com.azure.core.util.JsonPatchDocument.class).build();
 
 
     private final String packageName;

--- a/vanilla-tests/pom.xml
+++ b/vanilla-tests/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
-      <version>1.10.0-alpha.20201022.0</version>
+      <version>1.5.0</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>

--- a/vanilla-tests/pom.xml
+++ b/vanilla-tests/pom.xml
@@ -14,11 +14,28 @@
   <artifactId>autorest-vanilla-tests</artifactId>
   <version>1.0.0-SNAPSHOT</version>
 
+  <repositories>
+    <repository>
+      <id>azuresdkmaven</id>
+      <url>https://azsdkartifacts.blob.core.windows.net/maven</url>
+    </repository>
+    <repository>
+      <id>azure-sdk-for-java</id>
+      <url>https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-java/maven/v1</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
   <dependencies>
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
-      <version>1.5.0</version>
+      <version>1.10.0-alpha.20201022.0</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>


### PR DESCRIPTION
This PR generates APIs that will use `JsonPatchDocument` type introduced in `azure-core` version 2.10.0 if the REST operations have content-type set to `json-patch+json` and the body param is of type `List<Object>`. 