### PR TITLE
v4 fluent override credential type to string

### DIFF
--- a/fluent-tests/prepare-tests.bat
+++ b/fluent-tests/prepare-tests.bat
@@ -12,8 +12,8 @@ RMDIR /S /Q "src\main\java\com\azure\mgmtlitetest"
 
 SET AUTOREST_CORE_VERSION=3.0.6326
 SET MODELERFOUR_ARGUMENTS=--pipeline.modelerfour.additional-checks=false --pipeline.modelerfour.lenient-model-deduplication=true
-SET COMMON_ARGUMENTS=--java --use=../ --output-folder=./ %MODELERFOUR_ARGUMENTS% --azure-arm --fluent --license-header=MICROSOFT_MIT_SMALL
-SET FLUENTLITE_ARGUMENTS=--java --use=../ --output-folder=./ %MODELERFOUR_ARGUMENTS% --azure-arm --fluent=lite --license-header=MICROSOFT_MIT_SMALL
+SET COMMON_ARGUMENTS=--java --use=../ --java.output-folder=./ %MODELERFOUR_ARGUMENTS% --azure-arm --fluent --java.license-header=MICROSOFT_MIT_SMALL
+SET FLUENTLITE_ARGUMENTS=--java --use=../ --java.output-folder=./ %MODELERFOUR_ARGUMENTS% --azure-arm --fluent=lite --java.fluent=lite --java.license-header=MICROSOFT_MIT_SMALL
 
 REM fluent premium
 CALL autorest --version=%AUTOREST_CORE_VERSION% %COMMON_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/resources/resource-manager/Microsoft.Resources/stable/2019-08-01/resources.json --namespace=com.azure.mgmttest.resources

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentClientMethodMapper.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentClientMethodMapper.java
@@ -12,10 +12,10 @@ import com.azure.autorest.model.javamodel.JavaVisibility;
 
 public class FluentClientMethodMapper extends ClientMethodMapper {
 
-    private static final FluentClientMethodMapper instance = new FluentClientMethodMapper();
+    private static final FluentClientMethodMapper INSTANCE = new FluentClientMethodMapper();
 
     public static FluentClientMethodMapper getInstance() {
-        return instance;
+        return INSTANCE;
     }
 
     @Override

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentExceptionMapper.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentExceptionMapper.java
@@ -15,13 +15,13 @@ import com.azure.autorest.model.clientmodel.ClientException;
 
 public class FluentExceptionMapper extends ExceptionMapper {
 
-    private static final FluentExceptionMapper instance = new FluentExceptionMapper();
+    private static final FluentExceptionMapper INSTANCE = new FluentExceptionMapper();
 
     protected FluentExceptionMapper() {
     }
 
     public static FluentExceptionMapper getInstance() {
-        return instance;
+        return INSTANCE;
     }
 
     protected ClientException buildException(ObjectSchema compositeType, JavaSettings settings) {

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentMapperFactory.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentMapperFactory.java
@@ -10,6 +10,7 @@ import com.azure.autorest.mapper.DefaultMapperFactory;
 import com.azure.autorest.mapper.ExceptionMapper;
 import com.azure.autorest.mapper.MethodGroupMapper;
 import com.azure.autorest.mapper.ObjectMapper;
+import com.azure.autorest.mapper.PrimitiveMapper;
 import com.azure.autorest.mapper.ProxyMethodMapper;
 
 public class FluentMapperFactory extends DefaultMapperFactory {
@@ -37,5 +38,10 @@ public class FluentMapperFactory extends DefaultMapperFactory {
     @Override
     public ClientMethodMapper getClientMethodMapper() {
         return FluentClientMethodMapper.getInstance();
+    }
+
+    @Override
+    public PrimitiveMapper getPrimitiveMapper() {
+        return FluentPrimitiveMapper.getInstance();
     }
 }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentMethodGroupMapper.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentMethodGroupMapper.java
@@ -27,10 +27,10 @@ public class FluentMethodGroupMapper extends MethodGroupMapper {
 
     private static final Logger logger = LoggerFactory.getLogger(FluentMethodGroupMapper.class);
 
-    private static final FluentMethodGroupMapper instance = new FluentMethodGroupMapper();
+    private static final FluentMethodGroupMapper INSTANCE = new FluentMethodGroupMapper();
 
     public static FluentMethodGroupMapper getInstance() {
-        return instance;
+        return INSTANCE;
     }
 
     @Override

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentObjectMapper.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentObjectMapper.java
@@ -20,10 +20,10 @@ import java.util.stream.Collectors;
 
 public class FluentObjectMapper extends ObjectMapper {
 
-    private static final FluentObjectMapper instance = new FluentObjectMapper();
+    private static final FluentObjectMapper INSTANCE = new FluentObjectMapper();
 
     public static FluentObjectMapper getInstance() {
-        return instance;
+        return INSTANCE;
     }
 
     private final Set<ObjectSchema> innerModels = ConcurrentHashMap.newKeySet();

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentPrimitiveMapper.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentPrimitiveMapper.java
@@ -28,6 +28,7 @@ public class FluentPrimitiveMapper extends PrimitiveMapper {
             return parsed.get(primaryType);
         }
         if (primaryType.getType() == Schema.AllSchemaTypes.CREDENTIAL) {
+            // swagger is "format": "password", which mostly serve as a hint
             IType type = ClassType.String;
             parsed.put(primaryType, type);
             return type;

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentPrimitiveMapper.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentPrimitiveMapper.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.azure.autorest.fluent.mapper;
+
+import com.azure.autorest.extension.base.model.codemodel.PrimitiveSchema;
+import com.azure.autorest.extension.base.model.codemodel.Schema;
+import com.azure.autorest.mapper.PrimitiveMapper;
+import com.azure.autorest.model.clientmodel.ClassType;
+import com.azure.autorest.model.clientmodel.IType;
+
+public class FluentPrimitiveMapper extends PrimitiveMapper {
+
+    @Override
+    public IType map(PrimitiveSchema primaryType) {
+        if (primaryType == null) {
+            return null;
+        }
+        if (parsed.containsKey(primaryType)) {
+            return parsed.get(primaryType);
+        }
+        if (primaryType.getType() == Schema.AllSchemaTypes.CREDENTIAL) {
+            IType type = ClassType.String;
+            parsed.put(primaryType, type);
+            return type;
+        } else {
+            return super.map(primaryType);
+        }
+    }
+}

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentPrimitiveMapper.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentPrimitiveMapper.java
@@ -13,6 +13,12 @@ import com.azure.autorest.model.clientmodel.IType;
 
 public class FluentPrimitiveMapper extends PrimitiveMapper {
 
+    private static FluentPrimitiveMapper INSTANCE = new FluentPrimitiveMapper();
+
+    public static FluentPrimitiveMapper getInstance() {
+        return INSTANCE;
+    }
+
     @Override
     public IType map(PrimitiveSchema primaryType) {
         if (primaryType == null) {

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentProxyMethodMapper.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentProxyMethodMapper.java
@@ -18,10 +18,10 @@ import java.util.List;
 
 public class FluentProxyMethodMapper extends ProxyMethodMapper {
 
-    private static final FluentProxyMethodMapper instance = new FluentProxyMethodMapper();
+    private static final FluentProxyMethodMapper INSTANCE = new FluentProxyMethodMapper();
 
     public static FluentProxyMethodMapper getInstance() {
-        return instance;
+        return INSTANCE;
     }
 
     @Override

--- a/javagen/src/main/java/com/azure/autorest/mapper/PrimitiveMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/PrimitiveMapper.java
@@ -14,9 +14,9 @@ import java.util.Map;
 
 public class PrimitiveMapper implements IMapper<PrimitiveSchema, IType> {
     private static PrimitiveMapper instance = new PrimitiveMapper();
-    Map<PrimitiveSchema, IType> parsed = new HashMap<>();
+    protected Map<PrimitiveSchema, IType> parsed = new HashMap<>();
 
-    private PrimitiveMapper() {
+    protected PrimitiveMapper() {
     }
 
     public static PrimitiveMapper getInstance() {


### PR DESCRIPTION
swagger is something like this
```
        "administratorLoginPassword": {
          "type": "string",
          "format": "password",
          "description": "The password of the administrator login."
        }
```