### PR TITLE
v4, rename option to service-name

### DIFF
--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
@@ -92,7 +92,7 @@ public class JavaSettings
                     host.getBooleanValue("regenerate-pom", false),
                     _header,
                     80,
-                    host.getStringValue("serviceName"),
+                    host.getStringValue("service-name"),
                     host.getStringValue("namespace", "").toLowerCase(),
                     host.getBooleanValue("enable-xml", false),
                     host.getBooleanValue("non-null-annotations", false),

--- a/fluentnamer/readme.md
+++ b/fluentnamer/readme.md
@@ -5,6 +5,7 @@
 | `--fluent` | Enum. `LITE` for Fluent Lite; `PREMIUM` for Fluent Premium. Case insensitive. Default to `PREMIUM` if provided as other values. |
 | `--pom-file` | String. Name for Maven POM file. Default to `pom.xml`. |
 | `--package-version` | String. Version number for Maven artifact. Default to `1.0.0-beta.1`. |
+| `--service-name` | String. Service name used in Manager class and other documentations. If not provided, service name is deduced from `title` configure (from swagger or readme). |
 | `--sdk-integration` | Boolean. Integrate to `azure-sdk-for-java`.  Default to `false`. |
 | `--track1-naming` | Boolean. Use track1 naming style (`withFoo` / `foo` as setter / getter). Default to `true`. |
 | `--add-inner` | CSV. Treat as inner class (append `Inner` to class name). |


### PR DESCRIPTION
the `getServiceName` method currently is only used in fluent lite. so it is safe to change without affect data-plane.