### PR TITLE
[Autorest.Android] Hide direct paging functions in generated Clients

### DIFF
--- a/androidgen/src/main/java/com/azure/autorest/android/mapper/AndroidClientMethodMapper.java
+++ b/androidgen/src/main/java/com/azure/autorest/android/mapper/AndroidClientMethodMapper.java
@@ -313,7 +313,7 @@ public class AndroidClientMethodMapper extends ClientMethodMapper {
                 final ClientMethodParameter callbackCollectionParam = new ClientMethodParameter.Builder()
                         .description("the Callback that receives the response collection.")
                         .wireType(GenericType.AndroidCallback(GenericType.AndroidAsyncPagedDataCollection(elementType)))
-                        .name("collectionCallback")
+                        .name("callback")
                         .annotations(new ArrayList<>())
                         .isConstant(false)
                         .defaultValue(null)

--- a/androidgen/src/main/java/com/azure/autorest/android/template/AndroidServiceAsyncClientTemplate.java
+++ b/androidgen/src/main/java/com/azure/autorest/android/template/AndroidServiceAsyncClientTemplate.java
@@ -2,6 +2,7 @@ package com.azure.autorest.android.template;
 
 import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.model.clientmodel.AsyncSyncClient;
+import com.azure.autorest.model.clientmodel.ClientMethodType;
 import com.azure.autorest.model.clientmodel.MethodGroupClient;
 import com.azure.autorest.model.clientmodel.ServiceClient;
 import com.azure.autorest.model.javamodel.JavaFile;
@@ -77,7 +78,10 @@ public class AndroidServiceAsyncClientTemplate extends ServiceAsyncClientTemplat
             if (wrapServiceClient) {
                 serviceClient.getClientMethods()
                         .stream()
-                        .filter(clientMethod -> clientMethod.getType().name().contains("Async"))
+                        .filter(clientMethod -> clientMethod.getType() == ClientMethodType.SimpleAsyncRestResponse
+                                || clientMethod.getType() == ClientMethodType.SimpleAsync
+                                || (clientMethod.getType() == ClientMethodType.PagingAsync
+                                    && clientMethod.getName().contains("Pages")))
                         .forEach(clientMethod -> {
                             Templates.getWrapperClientMethodTemplate().write(clientMethod, classBlock);
                         });

--- a/androidgen/src/main/java/com/azure/autorest/android/template/AndroidServiceSyncClientTemplate.java
+++ b/androidgen/src/main/java/com/azure/autorest/android/template/AndroidServiceSyncClientTemplate.java
@@ -2,6 +2,7 @@ package com.azure.autorest.android.template;
 
 import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.model.clientmodel.AsyncSyncClient;
+import com.azure.autorest.model.clientmodel.ClientMethodType;
 import com.azure.autorest.model.clientmodel.MethodGroupClient;
 import com.azure.autorest.model.clientmodel.ServiceClient;
 import com.azure.autorest.model.javamodel.JavaFile;
@@ -77,7 +78,9 @@ public class AndroidServiceSyncClientTemplate  extends ServiceSyncClientTemplate
             if (wrapServiceClient) {
                 serviceClient.getClientMethods()
                         .stream()
-                        .filter(clientMethod -> !clientMethod.getType().name().contains("Async"))
+                        .filter(clientMethod -> clientMethod.getType() == ClientMethodType.SimpleSync
+                            || (clientMethod.getType() == ClientMethodType.PagingSync
+                                && clientMethod.getName().contains("WithPage")) )
                         .forEach(clientMethod -> {
                             Templates.getWrapperClientMethodTemplate().write(clientMethod, classBlock);
                         });


### PR DESCRIPTION
Skip writing paging functions that use Callback<Page<data>>. Ensure callback is the last parameter of all functions