### PR TITLE
v4 fluentlite, getById convenient method for Azure resource

### DIFF
--- a/fluent-tests/src/test/java/com/azure/mgmttest/RuntimeTests.java
+++ b/fluent-tests/src/test/java/com/azure/mgmttest/RuntimeTests.java
@@ -143,7 +143,7 @@ public class RuntimeTests {
 
             storageAccount.refresh();
 
-            StorageAccount storageAccount2 = storageManager.storageAccounts().getByResourceGroup(rgName, saName);
+            StorageAccount storageAccount2 = storageManager.storageAccounts().getById(storageAccount.id());
             storageAccount2.update()
                     .withAccessTier(AccessTier.COOL)
                     .apply();

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/method/CollectionMethodOperationByIdTemplate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/method/CollectionMethodOperationByIdTemplate.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.azure.autorest.fluent.model.clientmodel.fluentmodel.method;
+
+import com.azure.autorest.extension.base.model.codemodel.RequestParameterLocation;
+import com.azure.autorest.fluent.model.arm.UrlPathSegments;
+import com.azure.autorest.fluent.model.clientmodel.FluentCollectionMethod;
+import com.azure.autorest.fluent.model.clientmodel.FluentResourceModel;
+import com.azure.autorest.fluent.model.clientmodel.MethodParameter;
+import com.azure.autorest.fluent.model.clientmodel.ModelNaming;
+import com.azure.autorest.fluent.model.clientmodel.fluentmodel.LocalVariable;
+import com.azure.autorest.fluent.model.clientmodel.fluentmodel.ResourceLocalVariables;
+import com.azure.autorest.fluent.model.clientmodel.immutablemodel.ImmutableMethod;
+import com.azure.autorest.fluent.util.Utils;
+import com.azure.autorest.model.clientmodel.ClassType;
+import com.azure.autorest.model.clientmodel.ClientMethod;
+import com.azure.autorest.model.clientmodel.ClientMethodParameter;
+import com.azure.autorest.model.clientmodel.GenericType;
+import com.azure.autorest.model.clientmodel.IType;
+import com.azure.autorest.model.clientmodel.PrimitiveType;
+import com.azure.autorest.model.clientmodel.ReturnValue;
+import com.azure.autorest.template.ClientMethodTemplate;
+import com.azure.autorest.template.prototype.MethodTemplate;
+import com.azure.core.http.rest.Response;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class CollectionMethodOperationByIdTemplate implements ImmutableMethod {
+
+    private final MethodTemplate methodTemplate;
+    private final String name;
+
+    public CollectionMethodOperationByIdTemplate(FluentResourceModel model, String name,
+                                                 List<MethodParameter> pathParameters, UrlPathSegments urlPathSegments, boolean includeContextParameter,
+                                                 ResourceLocalVariables resourceLocalVariables,
+                                                 FluentCollectionMethod collectionMethod) {
+        if (includeContextParameter) {
+            name += Utils.METHOD_POSTFIX_WITH_RESPONSE;
+        }
+        this.name = name;
+
+        final boolean removeResponse = !includeContextParameter;
+        final IType returnType = getReturnType(removeResponse, collectionMethod.getFluentReturnType());
+
+        final List<ClientMethodParameter> parameters = new ArrayList<>();
+        // id parameter
+        parameters.add(new ClientMethodParameter.Builder()
+                .name("id")
+                .description("the id of the resource.")
+                .wireType(ClassType.String)
+                .annotations(new ArrayList<>())
+                .isConstant(false)
+                .defaultValue(null)
+                .fromClient(false)
+                .isFinal(false)
+                .isRequired(true)
+                .build());
+        if (includeContextParameter) {
+            // optional parameters
+            Set<String> pathParameterNames = pathParameters.stream()
+                    .map(p -> p.getClientMethodParameter().getName())
+                    .collect(Collectors.toSet());
+            parameters.addAll(collectionMethod.getInnerClientMethod().getParameters().stream()
+                    .filter(p -> !pathParameterNames.contains(p.getName()))
+                    .collect(Collectors.toList()));
+        }
+
+        // method invocation
+        Set<ClientMethodParameter> parametersSet = new HashSet<>(parameters);
+        List<ClientMethodParameter> methodParameters = collectionMethod.getInnerClientMethod().getMethodParameters();
+        String argumentsLine = methodParameters.stream()
+                .map(p -> {
+                    if (parametersSet.contains(p)) {
+                        return p.getName();
+                    } else if (model.getInnerModel().getName().equals(p.getClientType().toString())) {
+                        return ModelNaming.MODEL_PROPERTY_INNER;
+                    } else if (ClassType.Context == p.getClientType()) {
+                        return "Context.NONE";
+                    } else {
+                        LocalVariable localVariable = resourceLocalVariables.getLocalVariableByMethodParameter(p);
+                        if (localVariable == null) {
+                            throw new IllegalStateException(String.format("local variable not found for method %1$s, model %2$s, parameter %3$s, available local variables %4$s",
+                                    collectionMethod.getInnerClientMethod().getName(),
+                                    model.getName(),
+                                    p.getName(),
+                                    resourceLocalVariables.getLocalVariablesMap().entrySet().stream().collect(Collectors.toMap(e -> e.getKey().getName(), e -> e.getValue().getName()))));
+                        }
+                        return localVariable.getName();
+                    }
+                })
+                .collect(Collectors.joining(", "));
+        String methodInvocation = String.format("%1$s(%2$s)", collectionMethod.getInnerClientMethod().getName(), argumentsLine);
+
+        List<UrlPathSegments.ParameterSegment> segments = urlPathSegments.getReverseParameterSegments();
+        Collections.reverse(segments);
+        Map<String, String> urlSegmentNameByParameterName = urlPathSegments.getReverseParameterSegments().stream()
+                .collect(Collectors.toMap(UrlPathSegments.ParameterSegment::getParameterName, UrlPathSegments.ParameterSegment::getSegmentName));
+
+        String afterInvocationCode = removeResponse ? ".getValue()" : "";
+
+        // a dummy client method only for generating javadoc
+        ClientMethod dummyClientMethodForJavadoc = new ClientMethod.Builder()
+                .proxyMethod(collectionMethod.getInnerProxyMethod())
+                .name(name)
+                .returnValue(new ReturnValue(collectionMethod.getInnerClientMethod().getReturnValue().getDescription(), returnType))
+                .parameters(parameters)
+                .description(collectionMethod.getInnerClientMethod().getDescription())
+                .build();
+
+        methodTemplate = MethodTemplate.builder()
+                .comment(commentBlock -> ClientMethodTemplate.generateJavadoc(dummyClientMethodForJavadoc, commentBlock, dummyClientMethodForJavadoc.getProxyMethod(), true))
+                .methodSignature(this.getMethodSignature(returnType, parameters))
+                .method(block -> {
+                    // init path parameters from resource id
+                    pathParameters.forEach(p -> {
+                        String valueFromIdText = String.format("Utils.getValueFromIdByName(id, \"%1$s\")", urlSegmentNameByParameterName.get(p.getSerializedName()));
+                        if (p.getClientMethodParameter().getClientType() != ClassType.String) {
+                            valueFromIdText = String.format("%1$s.fromString(%2$s)", p.getClientMethodParameter().getClientType().toString(), valueFromIdText);
+                        }
+                        LocalVariable var = resourceLocalVariables.getLocalVariableByMethodParameter(p.getClientMethodParameter());
+                        block.line(String.format("%1$s %2$s = %3$s;", var.getVariableType().toString(), var.getName(), valueFromIdText));
+                    });
+
+                    if (!includeContextParameter) {
+                        // init local variables to default value
+                        for (LocalVariable var : resourceLocalVariables.getLocalVariablesMap().values()) {
+                            if (var.getParameterLocation() == RequestParameterLocation.Query) {
+                                block.line(String.format("%1$s %2$s = %3$s;", var.getVariableType().toString(), var.getName(), var.getInitializeExpression()));
+                            }
+                        }
+                    }
+
+                    if (returnType == PrimitiveType.Void) {
+                        block.line(String.format("this.%1$s%2$s;",
+                                methodInvocation,
+                                afterInvocationCode));
+                    } else {
+                        block.methodReturn(String.format("this.%1$s%2$s",
+                                methodInvocation,
+                                afterInvocationCode));
+                    }
+                })
+                .build();
+    }
+
+    @Override
+    public MethodTemplate getMethodTemplate() {
+        return methodTemplate;
+    }
+
+    private static IType getReturnType(boolean removeResponse, IType collectionMethodReturnType) {
+        IType returnType;
+        if (removeResponse) {
+            if (collectionMethodReturnType instanceof GenericType && Response.class.getSimpleName().equals(((GenericType) collectionMethodReturnType).getName())) {
+                returnType = ((GenericType) collectionMethodReturnType).getTypeArguments()[0];
+                if (returnType == ClassType.Void) {
+                    returnType = PrimitiveType.Void;
+                }
+            } else {
+                throw new IllegalStateException("type error, return type should be of type Response<T>");
+            }
+        } else {
+            returnType = collectionMethodReturnType;
+        }
+        return returnType;
+    }
+
+    private String getMethodSignature(IType returnType, List<ClientMethodParameter> parameters) {
+        String parameterText = parameters.stream()
+                .map(p -> String.format("%1$s %2$s", p.getClientType().toString(), p.getName()))
+                .collect(Collectors.joining(", "));
+        return String.format("%1$s %2$s(%3$s)",
+                returnType.toString(), this.name, parameterText);
+    }
+}

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/method/FluentBaseMethod.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/method/FluentBaseMethod.java
@@ -49,43 +49,43 @@ abstract public class FluentBaseMethod extends FluentMethod {
         IType returnType = collectionMethod.getInnerClientMethod().getReturnValue().getType();
         final boolean returnIsResponseType = returnType instanceof GenericType && Response.class.getSimpleName().equals(((GenericType) returnType).getName());
 
+        // resource collection from manager
+        String innerClientGetMethod = FluentStatic.getFluentManager().getProperties().stream()
+                .filter(p -> p.getFluentType().getName().equals(collection.getInterfaceType().getName()))
+                .map(FluentManagerProperty::getInnerClientGetMethod)
+                .findFirst().get();
+
+        // method invocation
+        Set<ClientMethodParameter> parametersSet = new HashSet<>(parameters);
+        List<ClientMethodParameter> methodParameters = collectionMethod.getInnerClientMethod().getMethodParameters();
+        String argumentsLine = methodParameters.stream()
+                .map(p -> {
+                    if (parametersSet.contains(p)) {
+                        return p.getName();
+                    } else if (fluentResourceModel.getInnerModel().getName().equals(p.getClientType().toString())) {
+                        return ModelNaming.MODEL_PROPERTY_INNER;
+                    } else if (ClassType.Context == p.getClientType()) {
+                        return "Context.NONE";
+                    } else {
+                        LocalVariable localVariable = resourceLocalVariables.getLocalVariableByMethodParameter(p);
+                        if (localVariable == null) {
+                            throw new IllegalStateException(String.format("local variable not found for method %1$s, model %2$s, parameter %3$s, available local variables %4$s",
+                                    collectionMethod.getInnerClientMethod().getName(),
+                                    model.getName(),
+                                    p.getName(),
+                                    resourceLocalVariables.getLocalVariablesMap().entrySet().stream().collect(Collectors.toMap(e -> e.getKey().getName(), e -> e.getValue().getName()))));
+                        }
+                        return localVariable.getName();
+                    }
+                })
+                .collect(Collectors.joining(", "));
+        String methodInvocation = String.format("%1$s(%2$s)", collectionMethod.getInnerClientMethod().getName(), argumentsLine);
+
+        String afterInvocationCode = returnIsResponseType ? ".getValue()" : "";
+
         this.implementationMethodTemplate = MethodTemplate.builder()
                 .methodSignature(this.getImplementationMethodSignature())
                 .method(block -> {
-                    // resource collection from manager
-                    String innerClientGetMethod = FluentStatic.getFluentManager().getProperties().stream()
-                            .filter(p -> p.getFluentType().getName().equals(collection.getInterfaceType().getName()))
-                            .map(FluentManagerProperty::getInnerClientGetMethod)
-                            .findFirst().get();
-
-                    // method invocation
-                    Set<ClientMethodParameter> parametersSet = new HashSet<>(parameters);
-                    List<ClientMethodParameter> methodParameters = collectionMethod.getInnerClientMethod().getMethodParameters();
-                    String argumentsLine = methodParameters.stream()
-                            .map(p -> {
-                                if (parametersSet.contains(p)) {
-                                    return p.getName();
-                                } else if (fluentResourceModel.getInnerModel().getName().equals(p.getClientType().toString())) {
-                                    return ModelNaming.MODEL_PROPERTY_INNER;
-                                } else if (ClassType.Context == p.getClientType()) {
-                                    return "Context.NONE";
-                                } else {
-                                    LocalVariable localVariable = resourceLocalVariables.getLocalVariableByMethodParameter(p);
-                                    if (localVariable == null) {
-                                        throw new IllegalStateException(String.format("local variable not found for method %1$s, model %2$s, parameter %3$s, available local variables %4$s",
-                                                collectionMethod.getInnerClientMethod().getName(),
-                                                model.getName(),
-                                                p.getName(),
-                                                resourceLocalVariables.getLocalVariablesMap().entrySet().stream().collect(Collectors.toMap(e -> e.getKey().getName(), e -> e.getValue().getName()))));
-                                    }
-                                    return localVariable.getName();
-                                }
-                            })
-                            .collect(Collectors.joining(", "));
-                    String methodInvocation = String.format("%1$s(%2$s)", collectionMethod.getInnerClientMethod().getName(), argumentsLine);
-
-                    String afterInvocationCode = returnIsResponseType ? ".getValue()" : "";
-
                     if (initLocalVariables) {
                         for (LocalVariable var : resourceLocalVariables.getLocalVariablesMap().values()) {
                             if (var.getParameterLocation() == RequestParameterLocation.Query) {

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/method/FluentBaseMethod.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/method/FluentBaseMethod.java
@@ -14,7 +14,7 @@ import com.azure.autorest.fluent.model.clientmodel.FluentStatic;
 import com.azure.autorest.fluent.model.clientmodel.ModelNaming;
 import com.azure.autorest.fluent.model.clientmodel.fluentmodel.LocalVariable;
 import com.azure.autorest.fluent.model.clientmodel.fluentmodel.ResourceLocalVariables;
-import com.azure.autorest.model.clientmodel.ClassType;
+import com.azure.autorest.fluent.util.FluentUtils;
 import com.azure.autorest.model.clientmodel.ClientMethodParameter;
 import com.azure.autorest.model.clientmodel.GenericType;
 import com.azure.autorest.model.clientmodel.IType;
@@ -59,25 +59,7 @@ abstract public class FluentBaseMethod extends FluentMethod {
         Set<ClientMethodParameter> parametersSet = new HashSet<>(parameters);
         List<ClientMethodParameter> methodParameters = collectionMethod.getInnerClientMethod().getMethodParameters();
         String argumentsLine = methodParameters.stream()
-                .map(p -> {
-                    if (parametersSet.contains(p)) {
-                        return p.getName();
-                    } else if (fluentResourceModel.getInnerModel().getName().equals(p.getClientType().toString())) {
-                        return ModelNaming.MODEL_PROPERTY_INNER;
-                    } else if (ClassType.Context == p.getClientType()) {
-                        return "Context.NONE";
-                    } else {
-                        LocalVariable localVariable = resourceLocalVariables.getLocalVariableByMethodParameter(p);
-                        if (localVariable == null) {
-                            throw new IllegalStateException(String.format("local variable not found for method %1$s, model %2$s, parameter %3$s, available local variables %4$s",
-                                    collectionMethod.getInnerClientMethod().getName(),
-                                    model.getName(),
-                                    p.getName(),
-                                    resourceLocalVariables.getLocalVariablesMap().entrySet().stream().collect(Collectors.toMap(e -> e.getKey().getName(), e -> e.getValue().getName()))));
-                        }
-                        return localVariable.getName();
-                    }
-                })
+                .map(p -> FluentUtils.getLocalMethodArgument(p, parametersSet, resourceLocalVariables, model, collectionMethod))
                 .collect(Collectors.joining(", "));
         String methodInvocation = String.format("%1$s(%2$s)", collectionMethod.getInnerClientMethod().getName(), argumentsLine);
 

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentResourceCollectionImplementationTemplate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentResourceCollectionImplementationTemplate.java
@@ -60,7 +60,7 @@ public class FluentResourceCollectionImplementationTemplate implements IJavaTemp
             });
 
             // method for properties
-            methodTemplates.forEach(m -> m.writeMethod(classBlock));
+            methodTemplates.forEach(m -> m.writeMethodWithoutJavadoc(classBlock));
 
             // method for inner model
             classBlock.privateMethod(collection.getInnerMethodSignature(), methodBlock -> {

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentResourceModelInterfaceTemplate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentResourceModelInterfaceTemplate.java
@@ -28,7 +28,7 @@ public class FluentResourceModelInterfaceTemplate implements IJavaTemplate<Fluen
     @Override
     public void write(FluentResourceModel model, JavaFile javaFile) {
         Set<String> imports = new HashSet<>();
-        imports.add(Immutable.class.getName());
+        //imports.add(Immutable.class.getName());
         model.addImportsTo(imports, false);
         javaFile.declareImport(imports);
 
@@ -36,7 +36,7 @@ public class FluentResourceModelInterfaceTemplate implements IJavaTemplate<Fluen
             comment.description(model.getDescription());
         });
 
-        javaFile.annotation("Immutable");
+        //javaFile.annotation("Immutable");
         javaFile.publicInterface(model.getInterfaceType().getName(), interfaceBlock -> {
             // method for properties
             model.getProperties().forEach(property -> {

--- a/fluentnamer/src/main/java/com/azure/autorest/fluent/util/Utils.java
+++ b/fluentnamer/src/main/java/com/azure/autorest/fluent/util/Utils.java
@@ -15,6 +15,8 @@ import java.lang.reflect.Field;
 
 public class Utils {
 
+    public final static String METHOD_POSTFIX_WITH_RESPONSE = "WithResponse";
+
     public static String getDefaultName(Metadata m) {
         return m.getLanguage().getDefault().getName();
     }

--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,7 @@ Following settings only works when `fluent` option is specified.
 | `--pom-file` | String. Name for Maven POM file. Default is `pom.xml`. |
 | `--package-version` | String. Version number for Maven artifact. Default is `1.0.0-beta.1`. |
 | `--service-name` | String. Service name used in Manager class and other documentations. If not provided, service name is deduced from `title` configure (from swagger or readme). |
-| `--sdk-integration` | Boolean. Integrate to `azure-sdk-for-java`. Default is `false`. |
+| `--sdk-integration` | Boolean. Integrate to [azure-sdk-for-java](https://github.com/Azure/azure-sdk-for-java/). Default is `false`. |
 | `--track1-naming` | Boolean. Use track1 naming style (`withFoo` / `foo` as setter / getter). Default is `true`. |
 | `--add-inner` | CSV. Treat as inner class (move to `fluent.models` namespace, append `Inner` to class name). |
 | `--remove-inner` | CSV. Exclude from inner classes. |


### PR DESCRIPTION
sample code

```
    /**
     * Gets properties of a specified container.
     *
     * @param id the id of the resource.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     * @return properties of a specified container.
     */
    public BlobContainer getById(String id) {
        String resourceGroupName = Utils.getValueFromIdByName(id, "resourceGroups");
        String accountName = Utils.getValueFromIdByName(id, "storageAccounts");
        String containerName = Utils.getValueFromIdByName(id, "containers");
        return this.getWithResponse(resourceGroupName, accountName, containerName, Context.NONE).getValue();
    }

    /**
     * Gets properties of a specified container.
     *
     * @param id the id of the resource.
     * @param context The context to associate with this operation.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     * @return properties of a specified container.
     */
    public Response<BlobContainer> getByIdWithResponse(String id, Context context) {
        String resourceGroupName = Utils.getValueFromIdByName(id, "resourceGroups");
        String accountName = Utils.getValueFromIdByName(id, "storageAccounts");
        String containerName = Utils.getValueFromIdByName(id, "containers");
        return this.getWithResponse(resourceGroupName, accountName, containerName, context);
    }

    /**
     * Gets the existing immutability policy along with the corresponding ETag in response headers and body.
     *
     * @param id the id of the resource.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     * @return the existing immutability policy along with the corresponding ETag in response headers and body.
     */
    public ImmutabilityPolicy getImmutabilityPolicyById(String id) {
        String resourceGroupName = Utils.getValueFromIdByName(id, "resourceGroups");
        String accountName = Utils.getValueFromIdByName(id, "storageAccounts");
        String containerName = Utils.getValueFromIdByName(id, "containers");
        String localIfMatch = null;
        return this
            .getImmutabilityPolicyWithResponse(
                resourceGroupName, accountName, containerName, localIfMatch, Context.NONE)
            .getValue();
    }

    /**
     * Gets the existing immutability policy along with the corresponding ETag in response headers and body.
     *
     * @param id the id of the resource.
     * @param ifMatch The entity state (ETag) version of the immutability policy to update. A value of "*" can be used
     *     to apply the operation only if the immutability policy already exists. If omitted, this operation will always
     *     be applied.
     * @param context The context to associate with this operation.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws com.azure.core.management.exception.ManagementException thrown if the request is rejected by server.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     * @return the existing immutability policy along with the corresponding ETag in response headers and body.
     */
    public Response<ImmutabilityPolicy> getImmutabilityPolicyByIdWithResponse(
        String id, String ifMatch, Context context) {
        String resourceGroupName = Utils.getValueFromIdByName(id, "resourceGroups");
        String accountName = Utils.getValueFromIdByName(id, "storageAccounts");
        String containerName = Utils.getValueFromIdByName(id, "containers");
        return this.getImmutabilityPolicyWithResponse(resourceGroupName, accountName, containerName, ifMatch, context);
    }
```