### PR TITLE
v4 fluentlite, support deleteById

### DIFF
--- a/fluent-tests/src/test/java/com/azure/mgmttest/RuntimeTests.java
+++ b/fluent-tests/src/test/java/com/azure/mgmttest/RuntimeTests.java
@@ -26,6 +26,7 @@ import com.azure.mgmtlitetest.resources.models.ResourceGroup;
 import com.azure.mgmtlitetest.storage.StorageManager;
 import com.azure.mgmtlitetest.storage.models.AccessTier;
 import com.azure.mgmtlitetest.storage.models.BlobContainer;
+import com.azure.mgmtlitetest.storage.models.BlobContainers;
 import com.azure.mgmtlitetest.storage.models.Kind;
 import com.azure.mgmtlitetest.storage.models.PublicAccess;
 import com.azure.mgmtlitetest.storage.models.Sku;
@@ -155,10 +156,13 @@ public class RuntimeTests {
 
             blobContainer.refresh();
 
-            BlobContainer blobContainer2 = storageManager.blobContainers().get(rgName, saName, blobContainerName);
+            BlobContainer blobContainer2 = storageManager.blobContainers().getById(blobContainer.id());
             blobContainer2.update()
                     .withPublicAccess(PublicAccess.NONE)
                     .apply(new Context("key", "value"));
+
+            storageManager.blobContainers().deleteById(blobContainer.id());
+            storageManager.storageAccounts().deleteById(storageAccount.id());
         } finally {
             resourceManager.resourceGroups().delete(rgName);
         }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentResourceCollection.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentResourceCollection.java
@@ -7,6 +7,8 @@ package com.azure.autorest.fluent.model.clientmodel;
 
 import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.fluent.model.clientmodel.fluentmodel.create.ResourceCreate;
+import com.azure.autorest.fluent.model.clientmodel.fluentmodel.delete.ResourceDelete;
+import com.azure.autorest.fluent.model.clientmodel.fluentmodel.get.ResourceRefresh;
 import com.azure.autorest.fluent.model.clientmodel.fluentmodel.update.ResourceUpdate;
 import com.azure.autorest.fluent.util.FluentUtils;
 import com.azure.autorest.model.clientmodel.ClassType;
@@ -43,6 +45,8 @@ public class FluentResourceCollection {
     // resource models
     private final List<ResourceCreate> resourceCreates = new ArrayList<>();
     private final List<ResourceUpdate> resourceUpdates = new ArrayList<>();
+    private final List<ResourceRefresh> resourceRefreshes = new ArrayList<>();
+    private final List<ResourceDelete> resourceDeletes = new ArrayList<>();
     private final List<MethodTemplate> additionalMethods = new ArrayList<>();
 
     public FluentResourceCollection(MethodGroupClient groupClient) {
@@ -121,6 +125,14 @@ public class FluentResourceCollection {
 
     public List<ResourceUpdate> getResourceUpdates() {
         return resourceUpdates;
+    }
+
+    public List<ResourceRefresh> getResourceGets() {
+        return resourceRefreshes;
+    }
+
+    public List<ResourceDelete> getResourceDeletes() {
+        return resourceDeletes;
     }
 
     public List<MethodTemplate> getAdditionalMethods() {

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/delete/ResourceDelete.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/delete/ResourceDelete.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.azure.autorest.fluent.model.clientmodel.fluentmodel.delete;
+
+import com.azure.autorest.fluent.model.arm.UrlPathSegments;
+import com.azure.autorest.fluent.model.clientmodel.FluentCollectionMethod;
+import com.azure.autorest.fluent.model.clientmodel.FluentResourceCollection;
+import com.azure.autorest.fluent.model.clientmodel.FluentResourceModel;
+import com.azure.autorest.fluent.model.clientmodel.MethodParameter;
+import com.azure.autorest.fluent.model.clientmodel.fluentmodel.ResourceOperation;
+import com.azure.autorest.fluent.model.clientmodel.fluentmodel.method.CollectionMethodOperationByIdTemplate;
+import com.azure.autorest.fluent.model.clientmodel.fluentmodel.method.FluentMethod;
+import com.azure.autorest.fluent.util.Utils;
+import com.azure.autorest.model.clientmodel.ClientMethodParameter;
+import com.azure.autorest.model.clientmodel.ClientModel;
+import com.azure.autorest.template.prototype.MethodTemplate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public class ResourceDelete extends ResourceOperation {
+
+    private static final Logger logger = LoggerFactory.getLogger(ResourceDelete.class);
+
+    public ResourceDelete(FluentResourceModel resourceModel, FluentResourceCollection resourceCollection,
+                           UrlPathSegments urlPathSegments, String methodName, ClientModel bodyParameterModel) {
+        super(resourceModel, resourceCollection, urlPathSegments, methodName, bodyParameterModel);
+
+        logger.info("ResourceDelete: Fluent model {}, method reference {}",
+                resourceModel.getName(), methodName);
+    }
+
+    @Override
+    public List<FluentMethod> getFluentMethods() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getLocalVariablePrefix() {
+        return "local";
+    }
+
+    public List<MethodTemplate> getDeleteByIdCollectionMethods() {
+        List<MethodTemplate> methods = new ArrayList<>();
+        List<ClientMethodParameter> parameters = new ArrayList<>();
+        Optional<FluentCollectionMethod> methodOpt = this.findMethod(true, parameters);
+        if (methodOpt.isPresent()) {
+            FluentCollectionMethod collectionMethod = methodOpt.get();
+
+            String name = getDeleteByIdMethodName(collectionMethod.getInnerClientMethod().getName());
+            List<MethodParameter> pathParameters = this.getPathParameters();
+
+            methods.add(new CollectionMethodOperationByIdTemplate(
+                    resourceModel, name,
+                    pathParameters, urlPathSegments, false, getResourceLocalVariables(),
+                    collectionMethod)
+                    .getMethodTemplate());
+
+            methods.add(new CollectionMethodOperationByIdTemplate(
+                    resourceModel, name,
+                    pathParameters, urlPathSegments, true, getResourceLocalVariables(),
+                    collectionMethod)
+                    .getMethodTemplate());
+        }
+        return methods;
+    }
+
+    private static String getDeleteByIdMethodName(String methodName) {
+        String getByIdMethodName = methodName;
+        int indexOfBy = methodName.indexOf("By");
+        if (indexOfBy > 0) {
+            getByIdMethodName = methodName.substring(0, indexOfBy);
+        } else if (methodName.endsWith(Utils.METHOD_POSTFIX_WITH_RESPONSE)) {
+            getByIdMethodName = methodName.substring(0, methodName.length() - Utils.METHOD_POSTFIX_WITH_RESPONSE.length());
+        }
+        getByIdMethodName += "ById";
+        return getByIdMethodName;
+    }
+}

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/method/CollectionMethodOperationByIdTemplate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/method/CollectionMethodOperationByIdTemplate.java
@@ -52,6 +52,7 @@ public class CollectionMethodOperationByIdTemplate implements ImmutableMethod {
         final ResourceLocalVariables localVariables = resourceLocalVariables.getDeduplicatedLocalVariables(new HashSet<>(Collections.singleton(ModelNaming.METHOD_PARAMETER_NAME_ID)));
         final boolean removeResponseInReturnType = !includeContextParameter;
         final IType returnType = getReturnType(collectionMethod.getFluentReturnType(), removeResponseInReturnType);
+        final boolean responseInReturnTypeRemoved = returnType != collectionMethod.getFluentReturnType();
 
         final List<ClientMethodParameter> parameters = new ArrayList<>();
         // id parameter
@@ -89,7 +90,7 @@ public class CollectionMethodOperationByIdTemplate implements ImmutableMethod {
         Map<String, String> urlSegmentNameByParameterName = urlPathSegments.getReverseParameterSegments().stream()
                 .collect(Collectors.toMap(UrlPathSegments.ParameterSegment::getParameterName, UrlPathSegments.ParameterSegment::getSegmentName));
 
-        String afterInvocationCode = removeResponseInReturnType ? ".getValue()" : "";
+        String afterInvocationCode = responseInReturnTypeRemoved ? ".getValue()" : "";
 
         // a dummy client method only for generating javadoc
         ClientMethod dummyClientMethodForJavadoc = new ClientMethod.Builder()
@@ -158,7 +159,8 @@ public class CollectionMethodOperationByIdTemplate implements ImmutableMethod {
                     returnType = PrimitiveType.Void;
                 }
             } else {
-                throw new IllegalStateException("type error, return type should be of type Response<T>");
+                // LRO would not have Response<T> for method takes Context, usually happens to delete method
+                returnType = collectionMethodReturnType;
             }
         } else {
             returnType = collectionMethodReturnType;

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/method/CollectionMethodOperationByIdTemplate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/method/CollectionMethodOperationByIdTemplate.java
@@ -96,7 +96,7 @@ public class CollectionMethodOperationByIdTemplate implements ImmutableMethod {
         ClientMethod dummyClientMethodForJavadoc = new ClientMethod.Builder()
                 .proxyMethod(collectionMethod.getInnerProxyMethod())
                 .name(name)
-                .returnValue(new ReturnValue(collectionMethod.getInnerClientMethod().getReturnValue().getDescription(), returnType))
+                .returnValue(new ReturnValue(returnType == PrimitiveType.Void ? "" : collectionMethod.getInnerClientMethod().getReturnValue().getDescription(), returnType))
                 .parameters(parameters)
                 .description(collectionMethod.getInnerClientMethod().getDescription())
                 .build();


### PR DESCRIPTION
sample
```
    public ImmutabilityPolicy getImmutabilityPolicyById(String id) {
        String resourceGroupName = Utils.getValueFromIdByName(id, "resourceGroups");
        if (resourceGroupName == null) {
            throw logger
                .logExceptionAsError(
                    new IllegalArgumentException(
                        String
                            .format("The resource ID '%s' is not valid. Missing path segment 'resourceGroups'.", id)));
        }
        String accountName = Utils.getValueFromIdByName(id, "storageAccounts");
        if (accountName == null) {
            throw logger
                .logExceptionAsError(
                    new IllegalArgumentException(
                        String
                            .format("The resource ID '%s' is not valid. Missing path segment 'storageAccounts'.", id)));
        }
        String containerName = Utils.getValueFromIdByName(id, "containers");
        if (containerName == null) {
            throw logger
                .logExceptionAsError(
                    new IllegalArgumentException(
                        String.format("The resource ID '%s' is not valid. Missing path segment 'containers'.", id)));
        }
        String localIfMatch = null;
        return this
            .getImmutabilityPolicyWithResponse(
                resourceGroupName, accountName, containerName, localIfMatch, Context.NONE)
            .getValue();
    }
```