### PR TITLE
v4 fluentlite, deduplicate method name on generic type of same erasure

### DIFF
--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/method/FluentMethodParameterMethod.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/method/FluentMethodParameterMethod.java
@@ -72,4 +72,8 @@ public class FluentMethodParameterMethod extends FluentMethod {
             return false;
         }
     }
+
+    public ClientMethodParameter getMethodParameter() {
+        return methodParameter;
+    }
 }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/method/FluentModelPropertyMethod.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/method/FluentModelPropertyMethod.java
@@ -95,4 +95,8 @@ public class FluentModelPropertyMethod extends FluentMethod {
             return false;
         }
     }
+
+    public ClientModelProperty getModelProperty() {
+        return modelProperty;
+    }
 }


### PR DESCRIPTION
sample code
```
    public DataLakeStoreAccountImpl withFirewallRules(List<CreateFirewallRuleWithAccountParameters> firewallRules) {
        this.createParameters.withFirewallRules(firewallRules);
        return this;
    }

    public DataLakeStoreAccountImpl withFirewallRulesForUpdate(
        List<UpdateFirewallRuleWithAccountParameters> firewallRules) {
        this.updateParameters.withFirewallRules(firewallRules);
        return this;
    }
```