### PR TITLE
Enable customizing the method body when changing return type

### DIFF
--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Cat.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Cat.java
@@ -6,6 +6,7 @@ package fixtures.bodycomplex.implementation.models;
 
 import com.azure.core.annotation.Fluent;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.UnsupportedEncodingException;
 import java.util.List;
 
 /** The Cat model. */
@@ -28,8 +29,14 @@ public class Cat extends Pet {
      *
      * @return the color value.
      */
-    public String getColor() {
-        return this.color;
+    public byte[] getColor() {
+        String returnValue = this.color;
+        String colorStr = returnValue;
+        try {
+            return colorStr.getBytes("UTF-8");
+        } catch (UnsupportedEncodingException ex) {
+            return colorStr.getBytes();
+        }
     }
 
     /**

--- a/customization-tests/swagger/src/main/java/fixtures/bodycomplex/customization/BodyComplexCustomization.java
+++ b/customization-tests/swagger/src/main/java/fixtures/bodycomplex/customization/BodyComplexCustomization.java
@@ -34,5 +34,9 @@ public class BodyComplexCustomization extends Customization {
                 .changeMethodReturnType("putValid", "ArrayClient", "this");
         arrayClient.classJavadoc().setDescription("The sync client containing Array operations.");
         arrayClient.methodJavadoc("putValid").setReturn("The ArrayClient itself");
+
+        ClassCustomization cat = implementationModels.getClass("Cat")
+                .changeMethodReturnType("getColor", "byte[]", "String colorStr = %s; try { return colorStr.getBytes" +
+                        "(\"UTF-8\"); } catch (UnsupportedEncodingException ex) { return colorStr.getBytes(); }", true);
     }
 }


### PR DESCRIPTION
When customizing a method's return type, there are cases where we may need to replace the implementation completely and not just format the return value.  This PR enables replacing the entire method with custom logic. 

In the example below, the original generated code returns a `String` value. If the return type has to be changed to a `byte[]` with a special encoding, the `getBytes()` in `String` class throws a checked `UnsupportedEncodingException`. With just the formatter, changing the return type will not be possible as the try-catch block cannot be included in `return String.format(formattedString, returnValue);`

Before:
```java
public String getColor() {
     return this.color;
}
```

After:
```java
public byte[] getColor() {
    String returnValue = this.color;
    String colorStr = returnValue;
    try {
        return colorStr.getBytes("UTF-8");
    } catch (UnsupportedEncodingException ex) {
        return colorStr.getBytes();
    }
}
```