### PR TITLE
v4, add common class/annotation of azure-core to reserved words

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/mapper/ChoiceMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ChoiceMapper.java
@@ -41,7 +41,6 @@ public class ChoiceMapper implements IMapper<ChoiceSchema, IType> {
         if (enumTypeName == null || enumTypeName.isEmpty() || enumTypeName.equals("enum")) {
             _itype = ClassType.String;
         } else {
-            enumTypeName = CodeNamer.getTypeName(enumTypeName);
             String enumSubpackage = settings.getModelsSubpackage();
             if (settings.isCustomType(enumTypeName)) {
                 enumSubpackage = settings.getCustomTypesSubpackage();

--- a/javagen/src/main/java/com/azure/autorest/mapper/SealedChoiceMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/SealedChoiceMapper.java
@@ -41,7 +41,6 @@ public class SealedChoiceMapper implements IMapper<SealedChoiceSchema, IType> {
         if (enumTypeName == null || enumTypeName.isEmpty() || enumTypeName.equals("enum")) {
             _itype = ClassType.String;
         } else {
-            enumTypeName = CodeNamer.getTypeName(enumTypeName);
             String enumSubpackage = settings.getModelsSubpackage();
             if (settings.isCustomType(enumTypeName)) {
                 enumSubpackage = settings.getCustomTypesSubpackage();

--- a/javagen/src/main/java/com/azure/autorest/util/CodeNamer.java
+++ b/javagen/src/main/java/com/azure/autorest/util/CodeNamer.java
@@ -196,13 +196,6 @@ public class CodeNamer {
         return correctName;
     }
 
-    public static String getTypeName(String name) {
-        if (name == null || name.trim().isEmpty()) {
-            return name;
-        }
-        return toPascalCase(removeInvalidCharacters(getEscapedReservedName(name, "Model")));
-    }
-
     public static String getPropertyName(String name) {
         if (name == null || name.trim().isEmpty()) {
             return name;

--- a/javagen/src/main/java/com/azure/autorest/util/CodeNamer.java
+++ b/javagen/src/main/java/com/azure/autorest/util/CodeNamer.java
@@ -59,7 +59,7 @@ public class CodeNamer {
         put((char) 125, "RightCurlyBracket");
         put((char) 126, "Tilde");
     }};
-    private static final List<String> RESERVED_WORDS = Arrays.asList(
+    private static final Set<String> RESERVED_WORDS = new HashSet<>(Arrays.asList(
             "abstract", "assert", "boolean", "Boolean", "break",
             "byte", "Byte", "case", "catch", "char",
             "Character", "class", "Class", "const", "continue",
@@ -75,7 +75,7 @@ public class CodeNamer {
             "Void", "volatile", "while", "Date", "Datetime",
             "OffsetDateTime", "Duration", "Period", "Stream",
             "String", "Object", "header", "_"
-    );
+    ));
 
     private static NamerFactory factory = new DefaultNamerFactory();
 

--- a/preprocessor/src/main/java/com/azure/autorest/preprocessor/namer/CodeNamer.java
+++ b/preprocessor/src/main/java/com/azure/autorest/preprocessor/namer/CodeNamer.java
@@ -5,9 +5,11 @@ import org.atteo.evo.inflector.English;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class CodeNamer {
@@ -55,7 +57,7 @@ public class CodeNamer {
         put((char) 125, "RightCurlyBracket");
         put((char) 126, "Tilde");
     }};
-    private static final List<String> RESERVED_WORDS = Arrays.asList(
+    private static final Set<String> RESERVED_WORDS = new HashSet<>(Arrays.asList(
             "abstract", "assert", "boolean", "Boolean", "break",
             "byte", "Byte", "case", "catch", "char",
             "Character", "class", "Class", "const", "continue",
@@ -70,14 +72,20 @@ public class CodeNamer {
             "throws", "transient", "true", "try", "void",
             "Void", "volatile", "while", "Date", "Datetime",
             "OffsetDateTime", "Duration", "Period", "Stream",
-            "String", "Object", "header", "_",
-            // following are commonly used classes/annotations in service client, from azure-core
-            "Host", "ServiceInterface", "ServiceMethod", "ReturnType",
-            "Get", "Put", "Post", "Patch", "Delete", "Headers",
-            "ExpectedResponses", "UnexpectedResponseExceptionType", "UnexpectedResponseExceptionTypes",
-            "HostParam", "PathParam", "QueryParam", "HeaderParam", "FormParam",
-            "Fluent", "Immutable", "JsonFlatten"
-    );
+            "String", "Object", "header", "_"
+    ));
+
+    private static final Set<String> RESERVED_WORDS_CLASSES = new HashSet<>(RESERVED_WORDS);
+    static {
+        RESERVED_WORDS_CLASSES.addAll(Arrays.asList(
+                // following are commonly used classes/annotations in service client, from azure-core
+                "Host", "ServiceInterface", "ServiceMethod", "ReturnType",
+                "Get", "Put", "Post", "Patch", "Delete", "Headers",
+                "ExpectedResponses", "UnexpectedResponseExceptionType", "UnexpectedResponseExceptionTypes",
+                "HostParam", "PathParam", "QueryParam", "HeaderParam", "FormParam",
+                "Fluent", "Immutable", "JsonFlatten"
+        ));
+    }
 
     private CodeNamer() {
     }
@@ -184,7 +192,7 @@ public class CodeNamer {
         if (name == null || name.trim().isEmpty()) {
             return name;
         }
-        return toPascalCase(removeInvalidCharacters(getEscapedReservedName(name, "Model")));
+        return toPascalCase(removeInvalidCharacters(getEscapedReservedNameAndClasses(name, "Model")));
     }
 
     public static String getParameterName(String name) {
@@ -226,6 +234,17 @@ public class CodeNamer {
         Objects.requireNonNull(appendValue);
 
         if (RESERVED_WORDS.contains(name)) {
+            name += appendValue;
+        }
+
+        return name;
+    }
+
+    protected static String getEscapedReservedNameAndClasses(String name, String appendValue) {
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(appendValue);
+
+        if (RESERVED_WORDS_CLASSES.contains(name)) {
             name += appendValue;
         }
 

--- a/preprocessor/src/main/java/com/azure/autorest/preprocessor/namer/CodeNamer.java
+++ b/preprocessor/src/main/java/com/azure/autorest/preprocessor/namer/CodeNamer.java
@@ -75,7 +75,7 @@ public class CodeNamer {
             "Host", "ServiceInterface", "ServiceMethod", "ReturnType",
             "Get", "Put", "Post", "Patch", "Delete", "Headers",
             "ExpectedResponses", "UnexpectedResponseExceptionType", "UnexpectedResponseExceptionTypes",
-            "HostParam", "PathParam", "QueryParam", "HeaderParam",
+            "HostParam", "PathParam", "QueryParam", "HeaderParam", "FormParam",
             "Fluent", "Immutable", "JsonFlatten"
     );
 

--- a/preprocessor/src/main/java/com/azure/autorest/preprocessor/namer/CodeNamer.java
+++ b/preprocessor/src/main/java/com/azure/autorest/preprocessor/namer/CodeNamer.java
@@ -70,7 +70,13 @@ public class CodeNamer {
             "throws", "transient", "true", "try", "void",
             "Void", "volatile", "while", "Date", "Datetime",
             "OffsetDateTime", "Duration", "Period", "Stream",
-            "String", "Object", "header", "_"
+            "String", "Object", "header", "_",
+            // following are commonly used classes/annotations in service client, from azure-core
+            "Host", "ServiceInterface", "ServiceMethod", "ReturnType",
+            "Get", "Put", "Post", "Patch", "Delete", "Headers",
+            "ExpectedResponses", "UnexpectedResponseExceptionType", "UnexpectedResponseExceptionTypes",
+            "HostParam", "PathParam", "QueryParam", "HeaderParam",
+            "Fluent", "Immutable", "JsonFlatten"
     );
 
     private CodeNamer() {


### PR DESCRIPTION
It might not be all. I didn't add less used ones like `HeaderCollection` and `ResumeOperation`, or more confined ones like `ServiceClient` and `ServiceClientBuilder`.