### PR TITLE
v4, throw error when no shared common parent found for pagination operation

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -75,6 +75,10 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
             // Mono<SimpleResponse<Page>>
             Schema responseBodySchema = SchemaUtil.getLowestCommonParent(
                     operation.getResponses().stream().map(Response::getSchema).filter(Objects::nonNull).collect(Collectors.toList()));
+            if (!(responseBodySchema instanceof ObjectSchema)) {
+                throw new IllegalArgumentException(String.format("[JavaCheck/SchemaError] no common parent found for client models %s",
+                        operation.getResponses().stream().map(Response::getSchema).filter(Objects::nonNull).map(s -> s.getLanguage().getJava().getName()).collect(Collectors.toList())));
+            }
             ClientModel responseBodyModel = Mappers.getModelMapper().map((ObjectSchema) responseBodySchema);
             Optional<ClientModelProperty> itemPropertyOpt = responseBodyModel.getProperties().stream()
                     .filter(p -> p.getSerializedName().equals(operation.getExtensions().getXmsPageable().getItemName()))


### PR DESCRIPTION
Likely caused by error in schema, already asked service to fix ("400" should be "default").
https://github.com/Azure/azure-rest-api-specs/blob/master/specification/authorization/resource-manager/Microsoft.Authorization/preview/2020-04-01-preview/authorization-RoleAssignmentsCalls.json#L132-L145

Alternative we can add additional logic to exclude 4xx for pagination schema, but I think it probably better to just let it fail with improved message.

Hence add code to have a proper Exception for this case.