### PR TITLE
v4 fluent rename unnamed type

### DIFF
--- a/fluent-tests/report.md
+++ b/fluent-tests/report.md
@@ -1,5 +1,5 @@
 # Java Codegen Report
-Generated at 2020-12-22T19:38:37.516035
+Generated at 2020-12-23T04:36:54.986528
 ## Success
 <details>
 <summary>RP count: 152</summary>
@@ -308,7 +308,7 @@ INFORMATION (FluentJavaSettings): Option, string, base-folder : .
 INFORMATION (FluentJavaSettings): Option, string, output-folder : /home/runner/work/autorest.java/autorest.java/fluent_generated/azure-resourcemanager-authorization
 INFORMATION (FluentJavaSettings): Option, string, azure-libraries-for-java-folder : null
 INFORMATION (FluentGen): Map code model to client model
-INFORMATION (FluentMapper): Add Inner to response types: [DenyAssignment, Error, RoleAssignment, RoleDefinition, ClassicAdministrator, Permission, ProviderOperationsMetadata]
+INFORMATION (FluentMapper): Add Inner to response types: [RoleAssignment, RoleDefinition, Permission, ClassicAdministrator, Error, ProviderOperationsMetadata, DenyAssignment]
 
 ```
 **stderr**
@@ -1439,7 +1439,7 @@ INFORMATION (FluentJavaSettings): Option, string, base-folder : .
 INFORMATION (FluentJavaSettings): Option, string, output-folder : /home/runner/work/autorest.java/autorest.java/fluent_generated/azure-resourcemanager-intune
 INFORMATION (FluentJavaSettings): Option, string, azure-libraries-for-java-folder : null
 INFORMATION (FluentGen): Map code model to client model
-INFORMATION (FluentMapper): Add Inner to response types: [OperationResult, GroupItem, Location, AndroidMamPolicy, FlaggedUser, IOsmamPolicy, Device, WipeDeviceOperationResult, Application, FlaggedEnrolledApp]
+INFORMATION (FluentMapper): Add Inner to response types: [Location, OperationResult, IOsmamPolicy, FlaggedUser, FlaggedEnrolledApp, GroupItem, Device, WipeDeviceOperationResult, AndroidMamPolicy, Application]
 
 ```
 **stderr**
@@ -1746,7 +1746,7 @@ INFORMATION (FluentJavaSettings): Option, string, base-folder : .
 INFORMATION (FluentJavaSettings): Option, string, output-folder : /home/runner/work/autorest.java/autorest.java/fluent_generated/azure-resourcemanager-recoveryservicessiterecovery
 INFORMATION (FluentJavaSettings): Option, string, azure-libraries-for-java-folder : null
 INFORMATION (FluentGen): Map code model to client model
-INFORMATION (FluentMapper): Add Inner to response types: [TargetComputeSize, MigrationItem, Network, MigrationRecoveryPoint, RecoveryPoint, Fabric, ProtectionContainerMapping, StorageClassification, VaultHealthDetails, Event, VaultSetting, SupportedOperatingSystems, LogicalNetwork, ProtectableItem, RecoveryServicesProvider, VCenter, StorageClassificationMapping, ReplicationProtectionIntent, NetworkMapping, ProtectionContainer, RecoveryPlan, OperationsDiscovery, Alert, Job, ReplicationEligibilityResults, ReplicationProtectedItem, ReplicationEligibilityResultsCollection, Policy]
+INFORMATION (FluentMapper): Add Inner to response types: [ProtectionContainer, Fabric, Alert, ReplicationProtectionIntent, RecoveryServicesProvider, ReplicationEligibilityResults, Event, ReplicationProtectedItem, OperationsDiscovery, SupportedOperatingSystems, VaultHealthDetails, StorageClassificationMapping, ProtectionContainerMapping, Network, ReplicationEligibilityResultsCollection, VaultSetting, VCenter, RecoveryPoint, MigrationRecoveryPoint, ProtectableItem, Job, RecoveryPlan, NetworkMapping, Policy, LogicalNetwork, TargetComputeSize, StorageClassification, MigrationItem]
 INFORMATION (FluentGen): Java template for client model
 INFORMATION (FluentGen): Process for Fluent Lite, SDK integration disabled
 INFORMATION (ResourceCreate): ResourceCreate: Fluent model 'Alert', method reference 'create', body parameter 'ConfigureAlertRequest'
@@ -1997,11 +1997,16 @@ INFORMATION (FluentJavaSettings): Option, string, output-folder : generated
 INFORMATION (FluentJavaSettings): Option, string, azure-libraries-for-java-folder : null
 INFORMATION (FluentNamer): Transform code model
 INFORMATION (SchemaNameNormalization): Override default name, from 'ETag' to 'Etag'
-INFORMATION (SchemaNameNormalization): Rename schema from 'Enum3' to 'SettingsSettingName', based on operation group 'Settings'
-INFORMATION (SchemaNameNormalization): Rename schema from 'Enum15' to 'TasksTaskUpdateActionType', based on operation group 'Tasks'
-INFORMATION (SchemaNameNormalization): Rename schema from 'Enum17' to 'InformationProtectionPoliciesInformationProtectionPolicyName', based on operation group 'InformationProtectionPolicies'
-INFORMATION (SchemaNameNormalization): Rename schema from 'Enum37' to 'AdaptiveApplicationControlsIncludePathRecommendations', based on operation group 'AdaptiveApplicationControls'
-INFORMATION (SchemaNameNormalization): Rename schema from 'Enum38' to 'AdaptiveApplicationControlsSummary', based on operation group 'AdaptiveApplicationControls'
+
+WARNING (SchemaNameNormalization): Rename schema from 'Enum3' to 'SettingsSettingName', based on operation group 'Settings'
+
+WARNING (SchemaNameNormalization): Rename schema from 'Enum15' to 'TasksTaskUpdateActionType', based on operation group 'Tasks'
+
+WARNING (SchemaNameNormalization): Rename schema from 'Enum17' to 'InformationProtectionPoliciesInformationProtectionPolicyName', based on operation group 'InformationProtectionPolicies'
+
+WARNING (SchemaNameNormalization): Rename schema from 'Enum37' to 'AdaptiveApplicationControlsIncludePathRecommendations', based on operation group 'AdaptiveApplicationControls'
+
+WARNING (SchemaNameNormalization): Rename schema from 'Enum38' to 'AdaptiveApplicationControlsSummary', based on operation group 'AdaptiveApplicationControls'
 
 WARNING (NamingConflictResolver): Name conflict of choice with object 'protocol'
 INFORMATION (NamingConflictResolver): Rename choice from 'protocol' to 'protocolValue'
@@ -2093,7 +2098,7 @@ INFORMATION (FluentJavaSettings): Option, string, base-folder : .
 INFORMATION (FluentJavaSettings): Option, string, output-folder : /home/runner/work/autorest.java/autorest.java/fluent_generated/azure-resourcemanager-security
 INFORMATION (FluentJavaSettings): Option, string, azure-libraries-for-java-folder : null
 INFORMATION (FluentGen): Map code model to client model
-INFORMATION (FluentMapper): Add Inner to response types: [IotRecommendationModel, InformationProtectionPolicy, SecuritySolution, IoTSecuritySolutionAnalyticsModelList, PricingList, Scan, SecurityAssessment, JitNetworkAccessPolicy, AdvancedThreatProtectionSetting, AdaptiveApplicationControlGroup, SecureScoreControlDefinitionItem, RegulatoryComplianceAssessment, AdaptiveNetworkHardening, AdaptiveApplicationControlGroups, Automation, ConnectorSetting, PackageDownloads, JitNetworkAccessRequest, Compliance, ScanResults, IotSensorsList, IotSensorsModel, RegulatoryComplianceControl, AllowedConnectionsResource, IoTSecuritySolutionModel, ScanResult, TopologyResource, AscLocation, IoTSecurityAggregatedAlert, IotAlertType, IotSitesList, DeviceSecurityGroup, IoTSecurityAggregatedRecommendation, IotDefenderSettingsModel, SecuritySolutionsReferenceDataList, OnPremiseIotSensorsList, IotRecommendationTypeList, ServerVulnerabilityAssessment, RuleResults, Setting, Scans, Device, Pricing, SecuritySubAssessment, ComplianceResult, SecurityTask, WorkspaceSetting, SecureScoreControlDetails, Alert, AutomationValidationStatus, ServerVulnerabilityAssessmentsList, Operation, SecurityContact, AutoProvisioningSetting, SecureScoreItem, DiscoveredSecuritySolution, IotAlertTypeList, RulesResults, IotAlertModel, AlertsSuppressionRule, IotDefenderSettingsList, IotRecommendation, ExternalSecuritySolution, RegulatoryComplianceStandard, IotSitesModel, IoTSecuritySolutionAnalyticsModel, IotAlert, OnPremiseIotSensor, SecurityAssessmentMetadata, IotRecommendationType]
+INFORMATION (FluentMapper): Add Inner to response types: [IotSensorsList, Alert, ExternalSecuritySolution, IotSitesList, IoTSecuritySolutionModel, IotRecommendationModel, WorkspaceSetting, SecureScoreItem, SecuritySolutionsReferenceDataList, OnPremiseIotSensor, RegulatoryComplianceStandard, ConnectorSetting, SecurityAssessmentMetadata, RegulatoryComplianceControl, RegulatoryComplianceAssessment, ServerVulnerabilityAssessmentsList, AllowedConnectionsResource, Scan, Setting, IoTSecurityAggregatedRecommendation, AlertsSuppressionRule, Compliance, IotDefenderSettingsList, IotAlertType, TopologyResource, IotDefenderSettingsModel, Operation, DeviceSecurityGroup, JitNetworkAccessRequest, IotAlert, ScanResult, AscLocation, ServerVulnerabilityAssessment, IotSensorsModel, AdaptiveNetworkHardening, SecurityTask, PackageDownloads, IoTSecuritySolutionAnalyticsModelList, IotSitesModel, AdaptiveApplicationControlGroup, SecuritySolution, SecurityContact, RuleResults, Device, Automation, OnPremiseIotSensorsList, PricingList, IotRecommendationType, ComplianceResult, ScanResults, AdvancedThreatProtectionSetting, DiscoveredSecuritySolution, Pricing, IotAlertTypeList, SecurityAssessment, SecuritySubAssessment, AutomationValidationStatus, SecureScoreControlDefinitionItem, AdaptiveApplicationControlGroups, Scans, IotAlertModel, IotRecommendation, IoTSecurityAggregatedAlert, InformationProtectionPolicy, AutoProvisioningSetting, RulesResults, SecureScoreControlDetails, IoTSecuritySolutionAnalyticsModel, JitNetworkAccessPolicy, IotRecommendationTypeList]
 INFORMATION (FluentMapper): Add Inner for type 'SecureScoreControlDefinitionItem': []
 
 ```
@@ -2295,6 +2300,12 @@ WARNING (EnumInsteadOfBoolean/R3018/ARMViolation): Booleans are not descriptive 
 WARNING (EnumInsteadOfBoolean/R3018/ARMViolation): Booleans are not descriptive and make them hard to use. Consider using string enums with allowed set of values defined. Property: live
     - file:///home/runner/work/autorest.java/autorest.java/azure-rest-api-specs/specification/service-map/resource-manager/Microsoft.OperationalInsights/preview/2015-11-01-preview/arm-service-map.json:1:1
 
+WARNING (OperationIdNounVerb/R1001/SDKViolation): Per the Noun_Verb convention for Operation Ids, the noun 'Machines' should not appear after the underscore. Note: If you have already shipped an SDK on top of this spec, fixing this warning may introduce a breaking change.
+    - file:///home/runner/work/autorest.java/autorest.java/azure-rest-api-specs/specification/service-map/resource-manager/Microsoft.OperationalInsights/preview/2015-11-01-preview/arm-service-map.json:1:1
+
+WARNING (PutInOperationName/R1006/SDKViolation): 'PUT' operation 'MachineGroups_Update' should use method name 'Create'. Note: If you have already shipped an SDK on top of this spec, fixing this warning may introduce a breaking change.
+    - file:///home/runner/work/autorest.java/autorest.java/azure-rest-api-specs/specification/service-map/resource-manager/Microsoft.OperationalInsights/preview/2015-11-01-preview/arm-service-map.json:1:1
+
 WARNING (XmsEnumValidation/R2018/SDKViolation): The enum types should have x-ms-enum type extension set with appropriate options. Property name: kind
     - file:///home/runner/work/autorest.java/autorest.java/azure-rest-api-specs/specification/service-map/resource-manager/Microsoft.OperationalInsights/preview/2015-11-01-preview/arm-service-map.json:1:1
 
@@ -2339,12 +2350,6 @@ WARNING (EnumInsteadOfBoolean/R3018/ARMViolation): Booleans are not descriptive 
 
 WARNING (EnumInsteadOfBoolean/R3018/ARMViolation): Booleans are not descriptive and make them hard to use. Consider using string enums with allowed set of values defined. Property: filterProcesses
     - file:///home/runner/work/autorest.java/autorest.java/azure-rest-api-specs/specification/service-map/resource-manager/Microsoft.OperationalInsights/preview/2015-11-01-preview/arm-service-map.json:1:1
-
-WARNING (OperationIdNounVerb/R1001/SDKViolation): Per the Noun_Verb convention for Operation Ids, the noun 'Machines' should not appear after the underscore. Note: If you have already shipped an SDK on top of this spec, fixing this warning may introduce a breaking change.
-    - file:///home/runner/work/autorest.java/autorest.java/azure-rest-api-specs/specification/service-map/resource-manager/Microsoft.OperationalInsights/preview/2015-11-01-preview/arm-service-map.json:1:1
-
-WARNING (PutInOperationName/R1006/SDKViolation): 'PUT' operation 'MachineGroups_Update' should use method name 'Create'. Note: If you have already shipped an SDK on top of this spec, fixing this warning may introduce a breaking change.
-    - file:///home/runner/work/autorest.java/autorest.java/azure-rest-api-specs/specification/service-map/resource-manager/Microsoft.OperationalInsights/preview/2015-11-01-preview/arm-service-map.json:1:1
 INFORMATION (FluentNamer): Load fluent settings
 INFORMATION (FluentJavaSettings): Option, string, add-inner : null
 INFORMATION (FluentJavaSettings): Option, string, remove-inner : null
@@ -2381,7 +2386,7 @@ INFORMATION (FluentJavaSettings): Option, string, base-folder : .
 INFORMATION (FluentJavaSettings): Option, string, output-folder : /home/runner/work/autorest.java/autorest.java/fluent_generated/azure-resourcemanager-service-map
 INFORMATION (FluentJavaSettings): Option, string, azure-libraries-for-java-folder : null
 INFORMATION (FluentGen): Map code model to client model
-INFORMATION (FluentMapper): Add Inner to response types: [ClientGroupMembersCount, Connection, Liveness, Process, Port, MachinesSummary, MachineGroup, Machine, ClientGroupMember, ClientGroup, MapResponse]
+INFORMATION (FluentMapper): Add Inner to response types: [Machine, Connection, MachineGroup, Port, MapResponse, ClientGroup, Process, Liveness, ClientGroupMembersCount, ClientGroupMember, MachinesSummary]
 INFORMATION (FluentGen): Java template for client model
 INFORMATION (FluentGen): Process for Fluent Lite, SDK integration disabled
 INFORMATION (FluentGen): Write Java
@@ -2395,12 +2400,12 @@ INFORMATION (FluentGen): Write Text
 ```
 FATAL: Failed validating: 'file:///home/runner/work/autorest.java/autorest.java/azure-rest-api-specs/specification/service-map/resource-manager/Microsoft.OperationalInsights/preview/2015-11-01-preview/arm-service-map.json', error encountered: TypeError: Cannot read property 'properties' of undefined
 FATAL: [object Object]
-(node:23476) UnhandledPromiseRejectionWarning: Error: Plugin model-validator reported failure.
+(node:23777) UnhandledPromiseRejectionWarning: Error: Plugin model-validator reported failure.
     at /home/runner/.autorest/@autorest_core@3.0.6326/node_modules/@autorest/core/dist/lib/pipeline/plugins/external.js:26:19
     at async ScheduleNode (/home/runner/.autorest/@autorest_core@3.0.6326/node_modules/@autorest/core/dist/lib/pipeline/pipeline.js:294:33)
 (Use `node --trace-warnings ...` to show where the warning was created)
-(node:23476) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 60)
-(node:23476) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
+(node:23777) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 60)
+(node:23777) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
   Error: Plugin model-validator reported failure.
 
 ```
@@ -2471,8 +2476,8 @@ FATAL: [object Object]
 [INFO] ------------------------------------------------------------------------
 [INFO] BUILD FAILURE
 [INFO] ------------------------------------------------------------------------
-[INFO] Total time:  4.300 s
-[INFO] Finished at: 2020-12-22T19:23:04Z
+[INFO] Total time:  4.669 s
+[INFO] Finished at: 2020-12-23T04:20:44Z
 [INFO] ------------------------------------------------------------------------
 [ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project azure-resourcemanager-servicefabric-generated: Compilation failure: Compilation failure: 
 [ERROR] /home/runner/work/autorest.java/autorest.java/fluent_generated/azure-resourcemanager-servicefabric/src/main/java/azure/resourcemanager/servicefabric/fluent/OperationsClient.java:[45,41] method list() is already defined in interface azure.resourcemanager.servicefabric.fluent.OperationsClient


### PR DESCRIPTION
This kind of rename will be logged as warning:
```
WARNING (SchemaNameNormalization): Rename schema default name, from 'ComponentsQit0EtSchemasManagedclusterpropertiesPropertiesIdentityprofileAdditionalproperties' to 'ManagedClusterPropertiesIdentityProfile'

WARNING (SchemaNameNormalization): Rename schema default name, from 'Components1Umhcm8SchemasManagedclusteridentityPropertiesUserassignedidentitiesAdditionalproperties' to 'ManagedClusterIdentityUserAssignedIdentities'

WARNING (SchemaNameNormalization): Rename schema default name, from 'Components1Q1Og48SchemasManagedclusterAllof1' to 'BaseManagedCluster'
```

For premium, we might need to use `rename-model` option to maintain backward compatibility.