### PR TITLE
v4, throw exception on same parent name

### DIFF
--- a/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentModelTemplate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentModelTemplate.java
@@ -59,8 +59,9 @@ public class FluentModelTemplate extends ModelTemplate {
     protected List<ClientModelPropertyReference> getClientModelPropertyReferences(ClientModel model) {
         List<ClientModelPropertyReference> propertyReferences = new ArrayList<>();
         if (JavaSettings.getInstance().isOverrideSetterFromSuperclass()) {
+            String lastParentName = model.getName();
             String parentModelName = model.getParentModelName();
-            while (parentModelName != null) {
+            while (parentModelName != null && !lastParentName.equals(parentModelName)) {
                 ClientModel parentModel = ClientModels.Instance.getModel(parentModelName);
                 if (parentModel == null) {
                     parentModel = getPredefinedModel(parentModelName).orElse(null);
@@ -74,6 +75,7 @@ public class FluentModelTemplate extends ModelTemplate {
                     }
                 }
 
+                lastParentName = parentModelName;
                 parentModelName = parentModel == null ? null : parentModel.getParentModelName();
             }
         }

--- a/javagen/src/main/java/com/azure/autorest/mapper/ModelMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ModelMapper.java
@@ -81,6 +81,9 @@ public class ModelMapper implements IMapper<ObjectSchema, ClientModel> {
                     modelImports.add(parentType.getPackage() + "." + parentModelName);
                 }
             }
+            if (parentModelName != null && parentModelName.equals(modelName)) {
+                throw new IllegalStateException("Parent model name is same as model name: " + modelName);
+            }
             builder.parentModelName(parentModelName);
 
             List<Property> compositeTypeProperties = compositeType.getProperties()

--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -53,9 +53,11 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
         }
 
         imports.add("com.fasterxml.jackson.annotation.JsonCreator");
+        String lastParentName = model.getName();
         ClientModel parentModel = ClientModels.Instance.getModel(model.getParentModelName());
-        while (parentModel != null) {
+        while (parentModel != null && !lastParentName.equals(parentModel.getName())) {
             imports.addAll(parentModel.getImports());
+            lastParentName = parentModel.getName();
             parentModel = ClientModels.Instance.getModel(parentModel.getParentModelName());
         }
 
@@ -299,9 +301,10 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
     private void addModelConstructor(ClientModel model, JavaSettings settings, JavaClass classBlock,
         List<ClientModelProperty> constantProperties, List<ClientModelProperty> requiredProperties) {
 
+        String lastParentName = model.getName();
         ClientModel parentModel = ClientModels.Instance.getModel(model.getParentModelName());
         List<ClientModelProperty> requiredParentProperties = new ArrayList<>();
-        while (parentModel != null) {
+        while (parentModel != null && !lastParentName.equals(parentModel.getName())) {
             List<ClientModelProperty> ctorArgs =
                 parentModel.getProperties().stream().filter(ClientModelProperty::isRequired)
                     .collect(Collectors.toList());
@@ -309,6 +312,8 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
             // super class has multiple ctor args
             Collections.reverse(ctorArgs);
             requiredParentProperties.addAll(ctorArgs);
+
+            lastParentName = parentModel.getName();
             parentModel = ClientModels.Instance.getModel(parentModel.getParentModelName());
         }
 
@@ -460,8 +465,9 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
     protected List<ClientModelPropertyReference> getClientModelPropertyReferences(ClientModel model) {
         List<ClientModelPropertyReference> propertyReferences = new ArrayList<>();
         if (JavaSettings.getInstance().isOverrideSetterFromSuperclass()) {
+            String lastParentName = model.getName();
             String parentModelName = model.getParentModelName();
-            while (parentModelName != null) {
+            while (parentModelName != null && !lastParentName.equals(parentModelName)) {
                 ClientModel parentModel = ClientModels.Instance.getModel(parentModelName);
                 if (parentModel != null) {
                     if (parentModel.getProperties() != null) {
@@ -472,6 +478,7 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                     }
                 }
 
+                lastParentName = parentModelName;
                 parentModelName = parentModel == null ? null : parentModel.getParentModelName();
             }
         }


### PR DESCRIPTION
Root cause is naming conflict in preprocessor.

Before fixing the root cause, for now, throw an Exception on this case.

Sample, note that both `OrganizationResource-properties` and `OrganizationResourceProperties` in default get renamed to same `OrganizationResourceProperties` in java.
```
  - &id095
    apiVersions:
    - {version: 2020-03-01-preview}
    extensions: {xmsAzureResource: false, xmsClientFlatten: true, xmsFlattened: true,
      xmsLongRunningOperation: false, xmsSkipUrlEncoding: false}
    language:
      default: {description: Organization resource properties, name: OrganizationResource-properties}
      java: {description: Organization resource properties, name: OrganizationResourceProperties}
    maxProperties: 0.0
    minProperties: 0.0
    parents:
      all:
      - &id098 !!com.azure.autorest.extension.base.model.codemodel.ObjectSchema
        apiVersions:
        - {version: 2020-03-01-preview}
        children:
          all:
          - *id095
          immediate:
          - *id095
        language:
          default: {description: Organization resource property, name: OrganizationResourceProperties}
          java: {description: Organization resource property, name: OrganizationResourceProperties}
```