### PR TITLE
v4, move exception on parent name conflict to template

### DIFF
--- a/fluentnamer/readme.md
+++ b/fluentnamer/readme.md
@@ -6,7 +6,7 @@ pass-thru:
   - subset-reducer
 
 use-extension:
-  "@autorest/modelerfour": "4.15.447"
+  "@autorest/modelerfour": "4.15.448"
 
 pipeline:
 

--- a/fluentnamer/readme.md
+++ b/fluentnamer/readme.md
@@ -6,7 +6,7 @@ pass-thru:
   - subset-reducer
 
 use-extension:
-  "@autorest/modelerfour": "4.15.448"
+  "@autorest/modelerfour": "4.15.447"
 
 pipeline:
 

--- a/javagen/src/main/java/com/azure/autorest/mapper/ModelMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ModelMapper.java
@@ -81,9 +81,6 @@ public class ModelMapper implements IMapper<ObjectSchema, ClientModel> {
                     modelImports.add(parentType.getPackage() + "." + parentModelName);
                 }
             }
-            if (parentModelName != null && parentModelName.equals(modelName)) {
-                throw new IllegalStateException("Parent model name is same as model name: " + modelName);
-            }
             builder.parentModelName(parentModelName);
 
             List<Property> compositeTypeProperties = compositeType.getProperties()

--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -45,6 +45,10 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
     }
 
     public final void write(ClientModel model, JavaFile javaFile) {
+        if (model.getParentModelName() != null && model.getParentModelName().equals(model.getName())) {
+            throw new IllegalStateException("Parent model name is same as model name: " + model.getName());
+        }
+
         JavaSettings settings = JavaSettings.getInstance();
         Set<String> imports = new HashSet<String>();
         if (settings.shouldClientSideValidations() && settings.shouldClientLogger()) {


### PR DESCRIPTION
It is too early to fail in `ModelMapper`. Some model will be flattened and hence not generated, hence it would not hurt if they having problem. Therefore move to `ModelTemplate` which should break since it writes to file (and such Java file will not compile pass).