### PR TITLE
v4, add ClientMethod.getMethodInputParameters

### DIFF
--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentCollectionMethod.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentCollectionMethod.java
@@ -58,7 +58,7 @@ public class FluentCollectionMethod {
 
     // method invocation
     public String getMethodInvocation() {
-        List<ClientMethodParameter> methodParameters = method.getOnlyRequiredParameters() ? method.getMethodRequiredParameters() : method.getMethodParameters();
+        List<ClientMethodParameter> methodParameters = method.getMethodInputParameters();
         String argumentsLine = methodParameters.stream().map(ClientMethodParameter::getName).collect(Collectors.joining(", "));
         return String.format("%1$s(%2$s)", method.getName(), argumentsLine);
     }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/method/FluentActionMethod.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/method/FluentActionMethod.java
@@ -56,7 +56,7 @@ public class FluentActionMethod extends FluentMethod {
 
         // remove path parameters from input parameter, as they are provided by the variables of resource model
         ClientMethod method = collectionMethod.getInnerClientMethod();
-        List<ClientMethodParameter> parameters = method.getOnlyRequiredParameters() ? method.getMethodRequiredParameters() : method.getMethodParameters();
+        List<ClientMethodParameter> parameters = method.getMethodInputParameters();
         ResourceLocalVariables resourceLocalVariables = new ResourceLocalVariables(collectionMethod.getInnerClientMethod());
         parameters.removeAll(resourceLocalVariables.getLocalVariablesMap().entrySet().stream()
                 .filter(e -> e.getValue().getParameterLocation() == RequestParameterLocation.Path)
@@ -81,7 +81,7 @@ public class FluentActionMethod extends FluentMethod {
 
         // method invocation
         Set<ClientMethodParameter> parametersSet = new HashSet<>(parameters);
-        List<ClientMethodParameter> methodParameters = method.getOnlyRequiredParameters() ? method.getMethodRequiredParameters() : method.getMethodParameters();;
+        List<ClientMethodParameter> methodParameters = method.getMethodInputParameters();
         String argumentsLine = methodParameters.stream()
                 .map(p -> FluentUtils.getLocalMethodArgument(p, parametersSet, resourceLocalVariables, model, collectionMethod, resourceLocalVariablesDefinedInClass))
                 .collect(Collectors.joining(", "));

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/method/FluentBaseMethod.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/method/FluentBaseMethod.java
@@ -66,7 +66,7 @@ abstract public class FluentBaseMethod extends FluentMethod {
 
         // method invocation
         Set<ClientMethodParameter> parametersSet = new HashSet<>(parameters);
-        List<ClientMethodParameter> methodParameters = collectionMethod.getInnerClientMethod().getOnlyRequiredParameters() ? collectionMethod.getInnerClientMethod().getMethodRequiredParameters() : collectionMethod.getInnerClientMethod().getMethodParameters();
+        List<ClientMethodParameter> methodParameters = collectionMethod.getInnerClientMethod().getMethodInputParameters();
         String argumentsLine = methodParameters.stream()
                 .map(p -> FluentUtils.getLocalMethodArgument(p, parametersSet, resourceLocalVariables, model, collectionMethod, resourceLocalVariablesDefinedInClass))
                 .collect(Collectors.joining(", "));

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/util/FluentUtils.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/util/FluentUtils.java
@@ -18,7 +18,6 @@ import com.azure.autorest.fluent.model.clientmodel.fluentmodel.LocalVariable;
 import com.azure.autorest.fluent.model.clientmodel.fluentmodel.ResourceLocalVariables;
 import com.azure.autorest.fluent.template.UtilsTemplate;
 import com.azure.autorest.model.clientmodel.ClassType;
-import com.azure.autorest.model.clientmodel.ClientMethod;
 import com.azure.autorest.model.clientmodel.ClientMethodParameter;
 import com.azure.autorest.model.clientmodel.ClientModel;
 import com.azure.autorest.model.clientmodel.ClientModelProperty;

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/util/FluentUtils.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/util/FluentUtils.java
@@ -18,6 +18,7 @@ import com.azure.autorest.fluent.model.clientmodel.fluentmodel.LocalVariable;
 import com.azure.autorest.fluent.model.clientmodel.fluentmodel.ResourceLocalVariables;
 import com.azure.autorest.fluent.template.UtilsTemplate;
 import com.azure.autorest.model.clientmodel.ClassType;
+import com.azure.autorest.model.clientmodel.ClientMethod;
 import com.azure.autorest.model.clientmodel.ClientMethodParameter;
 import com.azure.autorest.model.clientmodel.ClientModel;
 import com.azure.autorest.model.clientmodel.ClientModelProperty;

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientMethod.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientMethod.java
@@ -185,6 +185,13 @@ public class ClientMethod {
         return getProxyMethod().getName() + "WithResponseAsync";
     }
 
+    /**
+     * Get the input parameters of the client method, taking configure of onlyRequiredParameters.
+     */
+    public final List<ClientMethodParameter> getMethodInputParameters() {
+        return getOnlyRequiredParameters() ? getMethodRequiredParameters() : getMethodParameters();
+    }
+
     public final List<ClientMethodParameter> getMethodParameters() {
         return getParameters().stream().filter(parameter -> parameter != null && !parameter.getFromClient() &&
                 parameter.getName() != null && !parameter.getName().trim().isEmpty())
@@ -192,7 +199,7 @@ public class ClientMethod {
                 .collect(Collectors.toList());
     }
 
-    public final List<ClientMethodParameter> getMethodNonConstantParameters() {
+    private final List<ClientMethodParameter> getMethodNonConstantParameters() {
         return getMethodParameters().stream().filter(parameter -> !parameter.getIsConstant())
                 .sorted((p1, p2) -> Boolean.compare(!p1.getIsRequired(), !p2.getIsRequired()))
                 .collect(Collectors.toList());

--- a/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
@@ -511,9 +511,7 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
      */
     public static void generateJavadoc(ClientMethod clientMethod, JavaJavadocComment commentBlock, ProxyMethod restAPIMethod, boolean useFullClassName) {
         commentBlock.description(clientMethod.getDescription());
-        List<ClientMethodParameter> methodParameters = clientMethod.getOnlyRequiredParameters()
-                ? clientMethod.getMethodRequiredParameters()
-                : clientMethod.getMethodParameters();
+        List<ClientMethodParameter> methodParameters = clientMethod.getMethodInputParameters();
         for (ClientMethodParameter parameter : methodParameters) {
             commentBlock.param(parameter.getName(), parameterDescriptionOrDefault(parameter));
         }

--- a/javagen/src/main/java/com/azure/autorest/template/WrapperClientMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/WrapperClientMethodTemplate.java
@@ -58,9 +58,7 @@ public class WrapperClientMethodTemplate implements IJavaTemplate<ClientMethod, 
         }
       }
 
-      List<ClientMethodParameter> parameters = clientMethod.getOnlyRequiredParameters()
-          ? clientMethod.getMethodRequiredParameters()
-          : clientMethod.getMethodParameters();
+      List<ClientMethodParameter> parameters = clientMethod.getMethodInputParameters();
       function
           .line((shouldReturn ? "return " : "" ) + "this.serviceClient.%1$s(%2$s);", clientMethod.getName(),
               parameters.stream().map(ClientMethodParameter::getName).collect(Collectors.joining(", ")));
@@ -70,9 +68,7 @@ public class WrapperClientMethodTemplate implements IJavaTemplate<ClientMethod, 
   protected void generateJavadoc(ClientMethod clientMethod, JavaType typeBlock, ProxyMethod restAPIMethod) {
     typeBlock.javadocComment(comment -> {
       comment.description(clientMethod.getDescription());
-      List<ClientMethodParameter> methodParameters = clientMethod.getOnlyRequiredParameters()
-          ? clientMethod.getMethodRequiredParameters()
-          : clientMethod.getMethodParameters();
+      List<ClientMethodParameter> methodParameters = clientMethod.getMethodInputParameters();
       for (ClientMethodParameter parameter : methodParameters) {
         comment.param(parameter.getName(), parameter.getDescription());
       }


### PR DESCRIPTION
Add a convenient method `ClientMethod.getMethodInputParameters` (for getting parameters used as method input. When onlyRequiredParameters=true, this excludes optional parameters), as the same pattern is used multiple places, and seems better to add as a class method.

Currently method name in `ClientMethod` might not be very clear. It is hard to tell the difference of `getParameters` and `getMethodParameters` without looking at the source code. Hope adding this `getMethodInputParameters` does not increase this problem.