### PR TITLE
Fix header collection prefix params

### DIFF
--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/CodeModelCustomConstructor.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/CodeModelCustomConstructor.java
@@ -256,6 +256,14 @@ public class CodeModelCustomConstructor extends Constructor {
                                         keyNode.getEndMark(),
                                         keyNode.getScalarStyle()),
                                         extension.getValueNode()));
+                            } else if ("x-ms-header-collection-prefix".equals(keyNode.getValue())) {
+                                actualValues.add(new NodeTuple(new ScalarNode(
+                                        keyNode.getTag(),
+                                        "xmsHeaderCollectionPrefix",
+                                        keyNode.getStartMark(),
+                                        keyNode.getEndMark(),
+                                        keyNode.getScalarStyle()),
+                                        extension.getValueNode()));
                             }
                         }
                         value.setValue(actualValues);

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Value.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Value.java
@@ -182,6 +182,17 @@ public class Value extends Metadata {
     }
 
     public void setSchema(Schema schema) {
+        // This should ideally be done by the modeler if the header collection prefix is set.
+        // The schema should be of type dictionary
+        // TODO: remove this when modeler is fixed.
+        if (this.getExtensions() != null
+                && this.getExtensions().getXmsHeaderCollectionPrefix() != null
+                && schema instanceof StringSchema) {
+            DictionarySchema dictionarySchema = new DictionarySchema();
+            dictionarySchema.setElementType(schema);
+            this.schema = dictionarySchema;
+            return;
+        }
         this.schema = schema;
     }
 

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/extensionmodel/XmsExtensions.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/extensionmodel/XmsExtensions.java
@@ -1,6 +1,7 @@
 package com.azure.autorest.extension.base.model.extensionmodel;
 
 import java.util.List;
+import java.util.Map;
 
 public class XmsExtensions {
     private XmsEnum xmsEnum;
@@ -20,6 +21,8 @@ public class XmsExtensions {
     private boolean xmsAzureResource;
 
     private List<String> xmsMutability;
+
+    private String xmsHeaderCollectionPrefix;
 
     public XmsEnum getXmsEnum() {
         return xmsEnum;
@@ -91,5 +94,13 @@ public class XmsExtensions {
 
     public void setXmsMutability(List<String> xmsMutability) {
         this.xmsMutability = xmsMutability;
+    }
+
+    public String getXmsHeaderCollectionPrefix() {
+        return xmsHeaderCollectionPrefix;
+    }
+
+    public void setXmsHeaderCollectionPrefix(String xmsHeaderCollectionPrefix) {
+        this.xmsHeaderCollectionPrefix = xmsHeaderCollectionPrefix;
     }
 }

--- a/javagen/src/main/java/com/azure/autorest/mapper/CustomProxyParameterMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/CustomProxyParameterMapper.java
@@ -38,6 +38,13 @@ public class CustomProxyParameterMapper implements IMapper<Parameter, ProxyMetho
                 .isRequired(parameter.isRequired())
                 .isNullable(parameter.isNullable());
 
+        String headerCollectionPrefix = null;
+        if (parameter.getExtensions() != null && parameter.getExtensions().getXmsHeaderCollectionPrefix() != null) {
+            headerCollectionPrefix = parameter.getExtensions().getXmsHeaderCollectionPrefix();
+        }
+        builder.headerCollectionPrefix(headerCollectionPrefix);
+
+
         Schema parameterJvWireType = parameter.getSchema();
 
         IType wireType = Mappers.getSchemaMapper().map(parameterJvWireType);

--- a/javagen/src/main/java/com/azure/autorest/mapper/ModelPropertyMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ModelPropertyMapper.java
@@ -96,7 +96,11 @@ public class ModelPropertyMapper implements IMapper<Property, ClientModelPropert
         }
         builder.annotationArguments(String.join(", ", annotationArgumentList));
 
-//        String headerCollectionPrefix = property.Extensions?.GetValue<string>(SwaggerExtensions.HeaderCollectionPrefix);
+        String headerCollectionPrefix = null;
+        if (property.getExtensions() != null && property.getExtensions().getXmsHeaderCollectionPrefix() != null) {
+            headerCollectionPrefix = property.getExtensions().getXmsHeaderCollectionPrefix();
+        }
+        builder.headerCollectionPrefix(headerCollectionPrefix);
 
         IType propertyWireType = Mappers.getSchemaMapper().map(property.getSchema());
         if (propertyWireType != null && property.isNullable()) {

--- a/javagen/src/main/java/com/azure/autorest/mapper/ProxyParameterMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ProxyParameterMapper.java
@@ -36,8 +36,11 @@ public class ProxyParameterMapper implements IMapper<Parameter, ProxyMethodParam
                 .isRequired(parameter.isRequired())
                 .isNullable(parameter.isNullable());
 
-        //TODO: HeaderCollectionPrefix
-//        String parameterHeaderCollectionPrefix = parameter.Extensions.GetValue<string>(SwaggerExtensions.HeaderCollectionPrefix);
+        String headerCollectionPrefix = null;
+        if (parameter.getExtensions() != null && parameter.getExtensions().getXmsHeaderCollectionPrefix() != null) {
+            headerCollectionPrefix = parameter.getExtensions().getXmsHeaderCollectionPrefix();
+        }
+        builder.headerCollectionPrefix(headerCollectionPrefix);
 
         Schema ParameterJvWireType = parameter.getSchema();
         IType wireType = Mappers.getSchemaMapper().map(ParameterJvWireType);


### PR DESCRIPTION
Fixes https://github.com/Azure/autorest.java/issues/877

This PR fixes the header param that is annotated with `x-ms-header-collection-prefix`. The generated `@HeaderParam` should use the prefix instead of the name when this extension is included in the swagger definition. Also, the parameter schema should be `DictionarySchema` instead of `StringSchema` when this extension is set. The fix should be done in the modeler but this PR is to temporarily unblock storage.

## Before

### Proxy method
```java
        @Put("/{queueName}")
        @ExpectedResponses({201, 204})
        @UnexpectedResponseExceptionType(StorageErrorException.class)
        Mono<QueuesCreateResponse> create(
                @HostParam("url") String url,
                @PathParam("queueName") String queueName,
                @QueryParam("timeout") Integer timeout,
                @HeaderParam("x-ms-meta") String metadata,
                @HeaderParam("x-ms-version") String version,
                @HeaderParam("x-ms-client-request-id") String requestId,
                @HeaderParam("Accept") String accept,
                Context context);
```

### Client method
```java
@ServiceMethod(returns = ReturnType.SINGLE)
public Mono<QueuesCreateResponse> createWithResponseAsync(
            String queueName, Integer timeout, String metadata, String requestId, Context context) 
```


## After

### Proxy method
```java
        @Put("/{queueName}")
        @ExpectedResponses({201, 204})
        @UnexpectedResponseExceptionType(StorageErrorException.class)
        Mono<QueuesCreateResponse> create(
                @HostParam("url") String url,
                @PathParam("queueName") String queueName,
                @QueryParam("timeout") Integer timeout,
                @HeaderParam("x-ms-meta-") Map<String, String> metadata,
                @HeaderParam("x-ms-version") String version,
                @HeaderParam("x-ms-client-request-id") String requestId,
                @HeaderParam("Accept") String accept,
                Context context);
```
  
### Client method

```java
@ServiceMethod(returns = ReturnType.SINGLE)
public Mono<QueuesCreateResponse> createWithResponseAsync(
            String queueName, Integer timeout, Map<String, String> metadata, String requestId, Context context) 
```