### PR TITLE
Make service version configurable and fix property name collision

### DIFF
--- a/azure-tests/src/main/java/fixtures/azurespecials/AutoRestAzureSpecialParametersTestClient.java
+++ b/azure-tests/src/main/java/fixtures/azurespecials/AutoRestAzureSpecialParametersTestClient.java
@@ -176,15 +176,17 @@ public final class AutoRestAzureSpecialParametersTestClient {
      * @param subscriptionId The subscription id, which appears in the path, always modeled in credentials. The value is
      *     always '1234-5678-9012-3456'.
      * @param host server parameter.
+     * @param apiVersion Api Version.
      */
-    AutoRestAzureSpecialParametersTestClient(String subscriptionId, String host) {
+    AutoRestAzureSpecialParametersTestClient(String subscriptionId, String host, String apiVersion) {
         this(
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
                 JacksonAdapter.createDefaultSerializerAdapter(),
                 subscriptionId,
-                host);
+                host,
+                apiVersion);
     }
 
     /**
@@ -194,9 +196,11 @@ public final class AutoRestAzureSpecialParametersTestClient {
      * @param subscriptionId The subscription id, which appears in the path, always modeled in credentials. The value is
      *     always '1234-5678-9012-3456'.
      * @param host server parameter.
+     * @param apiVersion Api Version.
      */
-    AutoRestAzureSpecialParametersTestClient(HttpPipeline httpPipeline, String subscriptionId, String host) {
-        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), subscriptionId, host);
+    AutoRestAzureSpecialParametersTestClient(
+            HttpPipeline httpPipeline, String subscriptionId, String host, String apiVersion) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), subscriptionId, host, apiVersion);
     }
 
     /**
@@ -207,14 +211,19 @@ public final class AutoRestAzureSpecialParametersTestClient {
      * @param subscriptionId The subscription id, which appears in the path, always modeled in credentials. The value is
      *     always '1234-5678-9012-3456'.
      * @param host server parameter.
+     * @param apiVersion Api Version.
      */
     AutoRestAzureSpecialParametersTestClient(
-            HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String subscriptionId, String host) {
+            HttpPipeline httpPipeline,
+            SerializerAdapter serializerAdapter,
+            String subscriptionId,
+            String host,
+            String apiVersion) {
         this.httpPipeline = httpPipeline;
         this.serializerAdapter = serializerAdapter;
         this.subscriptionId = subscriptionId;
         this.host = host;
-        this.apiVersion = "2015-07-01-preview";
+        this.apiVersion = apiVersion;
         this.xMsClientRequestIds = new XMsClientRequestIds(this);
         this.subscriptionInCredentials = new SubscriptionInCredentials(this);
         this.subscriptionInMethods = new SubscriptionInMethods(this);

--- a/azure-tests/src/main/java/fixtures/azurespecials/AutoRestAzureSpecialParametersTestClientBuilder.java
+++ b/azure-tests/src/main/java/fixtures/azurespecials/AutoRestAzureSpecialParametersTestClientBuilder.java
@@ -68,6 +68,22 @@ public final class AutoRestAzureSpecialParametersTestClientBuilder {
     }
 
     /*
+     * Api Version
+     */
+    private String apiVersion;
+
+    /**
+     * Sets Api Version.
+     *
+     * @param apiVersion the apiVersion value.
+     * @return the AutoRestAzureSpecialParametersTestClientBuilder.
+     */
+    public AutoRestAzureSpecialParametersTestClientBuilder apiVersion(String apiVersion) {
+        this.apiVersion = apiVersion;
+        return this;
+    }
+
+    /*
      * The HTTP pipeline to send requests through
      */
     private HttpPipeline pipeline;
@@ -190,6 +206,9 @@ public final class AutoRestAzureSpecialParametersTestClientBuilder {
         if (host == null) {
             this.host = "http://localhost:3000";
         }
+        if (apiVersion == null) {
+            this.apiVersion = "2015-07-01-preview";
+        }
         if (pipeline == null) {
             this.pipeline = createHttpPipeline();
         }
@@ -197,7 +216,8 @@ public final class AutoRestAzureSpecialParametersTestClientBuilder {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
         }
         AutoRestAzureSpecialParametersTestClient client =
-                new AutoRestAzureSpecialParametersTestClient(pipeline, serializerAdapter, subscriptionId, host);
+                new AutoRestAzureSpecialParametersTestClient(
+                        pipeline, serializerAdapter, subscriptionId, host, apiVersion);
         return client;
     }
 

--- a/azure-tests/src/main/java/fixtures/subscriptionidapiversion/MicrosoftAzureTestUrl.java
+++ b/azure-tests/src/main/java/fixtures/subscriptionidapiversion/MicrosoftAzureTestUrl.java
@@ -87,15 +87,17 @@ public final class MicrosoftAzureTestUrl {
      *
      * @param subscriptionId Subscription Id.
      * @param host server parameter.
+     * @param apiVersion Api Version.
      */
-    MicrosoftAzureTestUrl(String subscriptionId, String host) {
+    MicrosoftAzureTestUrl(String subscriptionId, String host, String apiVersion) {
         this(
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
                 JacksonAdapter.createDefaultSerializerAdapter(),
                 subscriptionId,
-                host);
+                host,
+                apiVersion);
     }
 
     /**
@@ -104,9 +106,10 @@ public final class MicrosoftAzureTestUrl {
      * @param httpPipeline The HTTP pipeline to send requests through.
      * @param subscriptionId Subscription Id.
      * @param host server parameter.
+     * @param apiVersion Api Version.
      */
-    MicrosoftAzureTestUrl(HttpPipeline httpPipeline, String subscriptionId, String host) {
-        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), subscriptionId, host);
+    MicrosoftAzureTestUrl(HttpPipeline httpPipeline, String subscriptionId, String host, String apiVersion) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), subscriptionId, host, apiVersion);
     }
 
     /**
@@ -116,14 +119,19 @@ public final class MicrosoftAzureTestUrl {
      * @param serializerAdapter The serializer to serialize an object into a string.
      * @param subscriptionId Subscription Id.
      * @param host server parameter.
+     * @param apiVersion Api Version.
      */
     MicrosoftAzureTestUrl(
-            HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String subscriptionId, String host) {
+            HttpPipeline httpPipeline,
+            SerializerAdapter serializerAdapter,
+            String subscriptionId,
+            String host,
+            String apiVersion) {
         this.httpPipeline = httpPipeline;
         this.serializerAdapter = serializerAdapter;
         this.subscriptionId = subscriptionId;
         this.host = host;
-        this.apiVersion = "2014-04-01-preview";
+        this.apiVersion = apiVersion;
         this.groups = new Groups(this);
     }
 }

--- a/azure-tests/src/main/java/fixtures/subscriptionidapiversion/MicrosoftAzureTestUrlBuilder.java
+++ b/azure-tests/src/main/java/fixtures/subscriptionidapiversion/MicrosoftAzureTestUrlBuilder.java
@@ -66,6 +66,22 @@ public final class MicrosoftAzureTestUrlBuilder {
     }
 
     /*
+     * Api Version
+     */
+    private String apiVersion;
+
+    /**
+     * Sets Api Version.
+     *
+     * @param apiVersion the apiVersion value.
+     * @return the MicrosoftAzureTestUrlBuilder.
+     */
+    public MicrosoftAzureTestUrlBuilder apiVersion(String apiVersion) {
+        this.apiVersion = apiVersion;
+        return this;
+    }
+
+    /*
      * The HTTP pipeline to send requests through
      */
     private HttpPipeline pipeline;
@@ -188,13 +204,17 @@ public final class MicrosoftAzureTestUrlBuilder {
         if (host == null) {
             this.host = "http://localhost:3000";
         }
+        if (apiVersion == null) {
+            this.apiVersion = "2014-04-01-preview";
+        }
         if (pipeline == null) {
             this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
         }
-        MicrosoftAzureTestUrl client = new MicrosoftAzureTestUrl(pipeline, serializerAdapter, subscriptionId, host);
+        MicrosoftAzureTestUrl client =
+                new MicrosoftAzureTestUrl(pipeline, serializerAdapter, subscriptionId, host, apiVersion);
         return client;
     }
 

--- a/customization-tests/src/main/java/fixtures/bodycomplex/AutoRestComplexTestServiceBuilder.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/AutoRestComplexTestServiceBuilder.java
@@ -75,6 +75,22 @@ public final class AutoRestComplexTestServiceBuilder {
     }
 
     /*
+     * Api Version
+     */
+    private String apiVersion;
+
+    /**
+     * Sets Api Version.
+     *
+     * @param apiVersion the apiVersion value.
+     * @return the AutoRestComplexTestServiceBuilder.
+     */
+    public AutoRestComplexTestServiceBuilder apiVersion(String apiVersion) {
+        this.apiVersion = apiVersion;
+        return this;
+    }
+
+    /*
      * The HTTP pipeline to send requests through
      */
     private HttpPipeline pipeline;
@@ -197,13 +213,17 @@ public final class AutoRestComplexTestServiceBuilder {
         if (host == null) {
             this.host = "http://localhost:3000";
         }
+        if (apiVersion == null) {
+            this.apiVersion = "2016-02-29";
+        }
         if (pipeline == null) {
             this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
         }
-        AutoRestComplexTestServiceImpl client = new AutoRestComplexTestServiceImpl(pipeline, serializerAdapter, host);
+        AutoRestComplexTestServiceImpl client =
+                new AutoRestComplexTestServiceImpl(pipeline, serializerAdapter, host, apiVersion);
         return client;
     }
 

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/AutoRestComplexTestServiceImpl.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/AutoRestComplexTestServiceImpl.java
@@ -174,14 +174,16 @@ public final class AutoRestComplexTestServiceImpl {
      * Initializes an instance of AutoRestComplexTestService client.
      *
      * @param host server parameter.
+     * @param apiVersion Api Version.
      */
-    public AutoRestComplexTestServiceImpl(String host) {
+    public AutoRestComplexTestServiceImpl(String host, String apiVersion) {
         this(
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
                 JacksonAdapter.createDefaultSerializerAdapter(),
-                host);
+                host,
+                apiVersion);
     }
 
     /**
@@ -189,9 +191,10 @@ public final class AutoRestComplexTestServiceImpl {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      * @param host server parameter.
+     * @param apiVersion Api Version.
      */
-    public AutoRestComplexTestServiceImpl(HttpPipeline httpPipeline, String host) {
-        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    public AutoRestComplexTestServiceImpl(HttpPipeline httpPipeline, String host, String apiVersion) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host, apiVersion);
     }
 
     /**
@@ -200,12 +203,14 @@ public final class AutoRestComplexTestServiceImpl {
      * @param httpPipeline The HTTP pipeline to send requests through.
      * @param serializerAdapter The serializer to serialize an object into a string.
      * @param host server parameter.
+     * @param apiVersion Api Version.
      */
-    public AutoRestComplexTestServiceImpl(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
+    public AutoRestComplexTestServiceImpl(
+            HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host, String apiVersion) {
         this.httpPipeline = httpPipeline;
         this.serializerAdapter = serializerAdapter;
         this.host = host;
-        this.apiVersion = "2016-02-29";
+        this.apiVersion = apiVersion;
         this.basics = new BasicsImpl(this);
         this.primitives = new PrimitivesImpl(this);
         this.arrays = new ArraysImpl(this);

--- a/javagen/src/main/java/com/azure/autorest/mapper/ServiceClientMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ServiceClientMapper.java
@@ -109,14 +109,16 @@ public class ServiceClientMapper implements IMapper<CodeModel, ServiceClient> {
                 serviceClientPropertyClientType = serviceClientPropertyClientType.asNullable();
             }
 
-            boolean serviceClientPropertyIsReadOnly = p.getSchema() instanceof ConstantSchema;
+            // boolean serviceClientPropertyIsReadOnly = p.getSchema() instanceof ConstantSchema;
 
             String serviceClientPropertyDefaultValueExpression = serviceClientPropertyClientType.defaultValueExpression(p.getClientDefaultValue());
 
             if (serviceClientPropertyClientType == ClassType.TokenCredential) {
                 usesCredentials = true;
             } else {
-                ServiceClientProperty serviceClientProperty = new ServiceClientProperty(serviceClientPropertyDescription, serviceClientPropertyClientType, serviceClientPropertyName, serviceClientPropertyIsReadOnly, serviceClientPropertyDefaultValueExpression);
+                ServiceClientProperty serviceClientProperty =
+                        new ServiceClientProperty(serviceClientPropertyDescription, serviceClientPropertyClientType,
+                                serviceClientPropertyName, false, serviceClientPropertyDefaultValueExpression);
                 if (!serviceClientProperties.contains(serviceClientProperty)) {
                     // Ignore duplicate client property.
                     serviceClientProperties.add(serviceClientProperty);

--- a/javagen/src/main/java/com/azure/autorest/mapper/ServiceClientMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ServiceClientMapper.java
@@ -109,8 +109,10 @@ public class ServiceClientMapper implements IMapper<CodeModel, ServiceClient> {
                 serviceClientPropertyClientType = serviceClientPropertyClientType.asNullable();
             }
 
-            // boolean serviceClientPropertyIsReadOnly = p.getSchema() instanceof ConstantSchema;
-
+            boolean serviceClientPropertyIsReadOnly = p.getSchema() instanceof ConstantSchema;
+            if (!settings.isFluent()) {
+                serviceClientPropertyIsReadOnly = false;
+            }
             String serviceClientPropertyDefaultValueExpression = serviceClientPropertyClientType.defaultValueExpression(p.getClientDefaultValue());
 
             if (serviceClientPropertyClientType == ClassType.TokenCredential) {
@@ -118,7 +120,7 @@ public class ServiceClientMapper implements IMapper<CodeModel, ServiceClient> {
             } else {
                 ServiceClientProperty serviceClientProperty =
                         new ServiceClientProperty(serviceClientPropertyDescription, serviceClientPropertyClientType,
-                                serviceClientPropertyName, false, serviceClientPropertyDefaultValueExpression);
+                                serviceClientPropertyName, serviceClientPropertyIsReadOnly, serviceClientPropertyDefaultValueExpression);
                 if (!serviceClientProperties.contains(serviceClientProperty)) {
                     // Ignore duplicate client property.
                     serviceClientProperties.add(serviceClientProperty);

--- a/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
@@ -195,9 +195,14 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
             if (conditionalAssignment) {
                 function.decreaseIndent();
                 function.line("}");
+
+                String name = transformation.getOutParameter().getName();
+                if (clientMethod.getParameters().stream().anyMatch(param -> param.getName().equals(transformation.getOutParameter().getName()))) {
+                    name = name + "Local";
+                }
                 function.line(String.format("%s %s = %s;",
                         transformation.getOutParameter().getClientType(),
-                        transformation.getOutParameter().getName(),
+                        name,
                         outParameterName));
             }
         }
@@ -552,7 +557,20 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
                 AddOptionalAndConstantVariables(function, clientMethod, restAPIMethod.getParameters(), settings);
                 ApplyParameterTransformations(function, clientMethod, settings);
                 ConvertClientTypesToWireTypes(function, clientMethod, restAPIMethod.getParameters(), clientMethod.getClientReference(), settings);
-                String restAPIMethodArgumentList = String.join(", ", clientMethod.getProxyMethodArguments(settings));
+
+                List<String> serviceMethodArgs = clientMethod.getProxyMethodArguments(settings)
+                        .stream()
+                        .map(argVal -> {
+                            if(clientMethod.getParameters().stream().filter(param -> param.getName().equals(argVal))
+                                    .anyMatch(param -> clientMethod.getMethodTransformationDetails().stream()
+                                            .anyMatch(transformation -> param.getName().equals(transformation.getOutParameter().getName())))) {
+                                return argVal + "Local";
+                            }
+                            return argVal;
+                        })
+                        .collect(Collectors.toList());
+                String restAPIMethodArgumentList = String.join(", ", serviceMethodArgs);
+
                 String serviceMethodCall = String.format("service.%s(%s)", restAPIMethod.getName(), restAPIMethodArgumentList);
                 if (settings.getAddContextParameter()) {
                     if (settings.isContextClientMethodParameter() && contextInParameters(clientMethod)) {
@@ -588,7 +606,21 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
                 AddOptionalAndConstantVariables(function, clientMethod, restAPIMethod.getParameters(), settings);
                 ApplyParameterTransformations(function, clientMethod, settings);
                 ConvertClientTypesToWireTypes(function, clientMethod, restAPIMethod.getParameters(), clientMethod.getClientReference(), settings);
-                String restAPIMethodArgumentList = String.join(", ", clientMethod.getProxyMethodArguments(settings));
+
+                List<String> serviceMethodArgs = clientMethod.getProxyMethodArguments(settings)
+                        .stream()
+                        .map(argVal -> {
+                            if(clientMethod.getParameters().stream().filter(param -> param.getName().equals(argVal))
+                                    .anyMatch(param -> clientMethod.getMethodTransformationDetails().stream()
+                                            .anyMatch(transformation -> param.getName().equals(transformation.getOutParameter().getName())))) {
+                                return argVal + "Local";
+                            }
+                            return argVal;
+                        })
+                        .collect(Collectors.toList());
+
+
+                String restAPIMethodArgumentList = String.join(", ", serviceMethodArgs);
                 String serviceMethodCall = String.format("service.%s(%s)", restAPIMethod.getName(), restAPIMethodArgumentList);
                 if (settings.getAddContextParameter()) {
                     if (settings.isContextClientMethodParameter() && contextInParameters(clientMethod)) {
@@ -628,7 +660,20 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
             AddOptionalAndConstantVariables(function, clientMethod, restAPIMethod.getParameters(), settings);
             ApplyParameterTransformations(function, clientMethod, settings);
             ConvertClientTypesToWireTypes(function, clientMethod, restAPIMethod.getParameters(), clientMethod.getClientReference(), settings);
-            String restAPIMethodArgumentList = String.join(", ", clientMethod.getProxyMethodArguments(settings));
+
+            List<String> serviceMethodArgs = clientMethod.getProxyMethodArguments(settings)
+                    .stream()
+                    .map(argVal -> {
+                        if(clientMethod.getParameters().stream().filter(param -> param.getName().equals(argVal))
+                                .anyMatch(param -> clientMethod.getMethodTransformationDetails().stream()
+                                        .anyMatch(transformation -> param.getName().equals(transformation.getOutParameter().getName())))) {
+                            return argVal + "Local";
+                        }
+                        return argVal;
+                    })
+                    .collect(Collectors.toList());
+
+            String restAPIMethodArgumentList = String.join(", ", serviceMethodArgs);
             String serviceMethodCall = String.format("service.%s(%s)", restAPIMethod.getName(), restAPIMethodArgumentList);
             if (settings.getAddContextParameter()) {
                 if (settings.isContextClientMethodParameter() && contextInParameters(clientMethod)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/java",
-  "version": "4.0.14",
+  "version": "4.0.15",
   "description": "The Java extension for classic generators in AutoRest.",
   "scripts": {
     "autorest": "autorest",

--- a/preprocessor/readme.md
+++ b/preprocessor/readme.md
@@ -6,7 +6,7 @@ pass-thru:
   - subset-reducer
 
 use-extension:
-  "@autorest/modelerfour": "4.15.447"
+  "@autorest/modelerfour": "4.15.452"
 
 pipeline:
 

--- a/preprocessor/readme.md
+++ b/preprocessor/readme.md
@@ -6,7 +6,7 @@ pass-thru:
   - subset-reducer
 
 use-extension:
-  "@autorest/modelerfour": "4.15.452"
+  "@autorest/modelerfour": "4.15.447"
 
 pipeline:
 

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/AutoRestComplexTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/AutoRestComplexTestService.java
@@ -170,14 +170,16 @@ public final class AutoRestComplexTestService {
      * Initializes an instance of AutoRestComplexTestService client.
      *
      * @param host server parameter.
+     * @param apiVersion Api Version.
      */
-    AutoRestComplexTestService(String host) {
+    AutoRestComplexTestService(String host, String apiVersion) {
         this(
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
                 JacksonAdapter.createDefaultSerializerAdapter(),
-                host);
+                host,
+                apiVersion);
     }
 
     /**
@@ -185,9 +187,10 @@ public final class AutoRestComplexTestService {
      *
      * @param httpPipeline The HTTP pipeline to send requests through.
      * @param host server parameter.
+     * @param apiVersion Api Version.
      */
-    AutoRestComplexTestService(HttpPipeline httpPipeline, String host) {
-        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    AutoRestComplexTestService(HttpPipeline httpPipeline, String host, String apiVersion) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host, apiVersion);
     }
 
     /**
@@ -196,12 +199,14 @@ public final class AutoRestComplexTestService {
      * @param httpPipeline The HTTP pipeline to send requests through.
      * @param serializerAdapter The serializer to serialize an object into a string.
      * @param host server parameter.
+     * @param apiVersion Api Version.
      */
-    AutoRestComplexTestService(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
+    AutoRestComplexTestService(
+            HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host, String apiVersion) {
         this.httpPipeline = httpPipeline;
         this.serializerAdapter = serializerAdapter;
         this.host = host;
-        this.apiVersion = "2016-02-29";
+        this.apiVersion = apiVersion;
         this.basics = new Basics(this);
         this.primitives = new Primitives(this);
         this.arrays = new Arrays(this);

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/AutoRestComplexTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/AutoRestComplexTestServiceBuilder.java
@@ -50,6 +50,22 @@ public final class AutoRestComplexTestServiceBuilder {
     }
 
     /*
+     * Api Version
+     */
+    private String apiVersion;
+
+    /**
+     * Sets Api Version.
+     *
+     * @param apiVersion the apiVersion value.
+     * @return the AutoRestComplexTestServiceBuilder.
+     */
+    public AutoRestComplexTestServiceBuilder apiVersion(String apiVersion) {
+        this.apiVersion = apiVersion;
+        return this;
+    }
+
+    /*
      * The HTTP pipeline to send requests through
      */
     private HttpPipeline pipeline;
@@ -172,13 +188,17 @@ public final class AutoRestComplexTestServiceBuilder {
         if (host == null) {
             this.host = "http://localhost:3000";
         }
+        if (apiVersion == null) {
+            this.apiVersion = "2016-02-29";
+        }
         if (pipeline == null) {
             this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
         }
-        AutoRestComplexTestService client = new AutoRestComplexTestService(pipeline, serializerAdapter, host);
+        AutoRestComplexTestService client =
+                new AutoRestComplexTestService(pipeline, serializerAdapter, host, apiVersion);
         return client;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/validation/AutoRestValidationTest.java
+++ b/vanilla-tests/src/main/java/fixtures/validation/AutoRestValidationTest.java
@@ -100,15 +100,17 @@ public final class AutoRestValidationTest {
      *
      * @param subscriptionId Subscription ID.
      * @param host server parameter.
+     * @param apiVersion Api Version.
      */
-    AutoRestValidationTest(String subscriptionId, String host) {
+    AutoRestValidationTest(String subscriptionId, String host, String apiVersion) {
         this(
                 new HttpPipelineBuilder()
                         .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
                         .build(),
                 JacksonAdapter.createDefaultSerializerAdapter(),
                 subscriptionId,
-                host);
+                host,
+                apiVersion);
     }
 
     /**
@@ -117,9 +119,10 @@ public final class AutoRestValidationTest {
      * @param httpPipeline The HTTP pipeline to send requests through.
      * @param subscriptionId Subscription ID.
      * @param host server parameter.
+     * @param apiVersion Api Version.
      */
-    AutoRestValidationTest(HttpPipeline httpPipeline, String subscriptionId, String host) {
-        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), subscriptionId, host);
+    AutoRestValidationTest(HttpPipeline httpPipeline, String subscriptionId, String host, String apiVersion) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), subscriptionId, host, apiVersion);
     }
 
     /**
@@ -129,14 +132,19 @@ public final class AutoRestValidationTest {
      * @param serializerAdapter The serializer to serialize an object into a string.
      * @param subscriptionId Subscription ID.
      * @param host server parameter.
+     * @param apiVersion Api Version.
      */
     AutoRestValidationTest(
-            HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String subscriptionId, String host) {
+            HttpPipeline httpPipeline,
+            SerializerAdapter serializerAdapter,
+            String subscriptionId,
+            String host,
+            String apiVersion) {
         this.httpPipeline = httpPipeline;
         this.serializerAdapter = serializerAdapter;
         this.subscriptionId = subscriptionId;
         this.host = host;
-        this.apiVersion = "1.0.0";
+        this.apiVersion = apiVersion;
         this.service =
                 RestProxy.create(AutoRestValidationTestService.class, this.httpPipeline, this.getSerializerAdapter());
     }

--- a/vanilla-tests/src/main/java/fixtures/validation/AutoRestValidationTestBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/validation/AutoRestValidationTestBuilder.java
@@ -66,6 +66,22 @@ public final class AutoRestValidationTestBuilder {
     }
 
     /*
+     * Api Version
+     */
+    private String apiVersion;
+
+    /**
+     * Sets Api Version.
+     *
+     * @param apiVersion the apiVersion value.
+     * @return the AutoRestValidationTestBuilder.
+     */
+    public AutoRestValidationTestBuilder apiVersion(String apiVersion) {
+        this.apiVersion = apiVersion;
+        return this;
+    }
+
+    /*
      * The HTTP pipeline to send requests through
      */
     private HttpPipeline pipeline;
@@ -188,13 +204,17 @@ public final class AutoRestValidationTestBuilder {
         if (host == null) {
             this.host = "http://localhost:3000";
         }
+        if (apiVersion == null) {
+            this.apiVersion = "1.0.0";
+        }
         if (pipeline == null) {
             this.pipeline = createHttpPipeline();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
         }
-        AutoRestValidationTest client = new AutoRestValidationTest(pipeline, serializerAdapter, subscriptionId, host);
+        AutoRestValidationTest client =
+                new AutoRestValidationTest(pipeline, serializerAdapter, subscriptionId, host, apiVersion);
         return client;
     }
 


### PR DESCRIPTION
This PR makes a couple of changes:
- enables configuring service versions through the builder (fixes #889 )
- Fixes compilation failure of generated code when the parameter group name is the same as the proxy method arg name (fixes #902 )