### PR TITLE
Generate better default credential scopes

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/mapper/ServiceClientMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ServiceClientMapper.java
@@ -22,6 +22,8 @@ import com.azure.autorest.util.CodeNamer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -57,6 +59,8 @@ public class ServiceClientMapper implements IMapper<CodeModel, ServiceClient> {
                 .filter(og -> og.getLanguage().getJava().getName() == null || og.getLanguage().getJava().getName().isEmpty())
                 .flatMap(og -> og.getOperations().stream())
                 .collect(Collectors.toList());
+
+        Proxy proxy = null;
         if (!codeModelRestAPIMethods.isEmpty()) {
             // TODO: Assume all operations share the same base url
             Proxy.Builder proxyBuilder = new Proxy.Builder()
@@ -72,7 +76,8 @@ public class ServiceClientMapper implements IMapper<CodeModel, ServiceClient> {
                 restAPIMethods.addAll(Mappers.getProxyMethodMapper().map(codeModelRestAPIMethod).values());
             }
             proxyBuilder.methods(restAPIMethods);
-            builder.proxy(proxyBuilder.build());
+            proxy = proxyBuilder.build();
+            builder.proxy(proxy);
             builder.clientMethods(codeModelRestAPIMethods.stream()
                     .flatMap(m -> Mappers.getClientMethodMapper().map(m).stream())
                     .collect(Collectors.toList()));
@@ -92,17 +97,20 @@ public class ServiceClientMapper implements IMapper<CodeModel, ServiceClient> {
         boolean usesCredentials = false;
 
         List<ServiceClientProperty> serviceClientProperties = new ArrayList<>();
-        for (Parameter p : Stream.concat(codeModel.getGlobalParameters().stream(),
+        List<Parameter> clientParameters = Stream.concat(codeModel.getGlobalParameters().stream(),
                 codeModel.getOperationGroups().stream()
                         .flatMap(og -> og.getOperations().stream())
                         .flatMap(o -> o.getRequests().stream())
                         .flatMap(r -> r.getParameters().stream()))
                 .filter(p -> p.getImplementation() == Parameter.ImplementationLocation.CLIENT)
                 .distinct()
-                .collect(Collectors.toList())) {
+                .collect(Collectors.toList());
+        for (Parameter p : clientParameters) {
             String serviceClientPropertyDescription = p.getDescription() != null ? p.getDescription() : p.getLanguage().getJava().getDescription();
 
             String serviceClientPropertyName = CodeNamer.getPropertyName(p.getLanguage().getJava().getName());
+
+            String serviceClientPropertySerializedName = p.getLanguage().getJava().getSerializedName();
 
             IType serviceClientPropertyClientType = Mappers.getSchemaMapper().map(p.getSchema());
             if (p.isNullable() && serviceClientPropertyClientType != null) {
@@ -119,8 +127,11 @@ public class ServiceClientMapper implements IMapper<CodeModel, ServiceClient> {
                 usesCredentials = true;
             } else {
                 ServiceClientProperty serviceClientProperty =
-                        new ServiceClientProperty(serviceClientPropertyDescription, serviceClientPropertyClientType,
-                                serviceClientPropertyName, serviceClientPropertyIsReadOnly, serviceClientPropertyDefaultValueExpression);
+                        new ServiceClientProperty(serviceClientPropertyDescription,
+                                serviceClientPropertyClientType,
+                                serviceClientPropertyName,
+                                serviceClientPropertyIsReadOnly,
+                                serviceClientPropertyDefaultValueExpression);
                 if (!serviceClientProperties.contains(serviceClientProperty)) {
                     // Ignore duplicate client property.
                     serviceClientProperties.add(serviceClientProperty);
@@ -180,6 +191,38 @@ public class ServiceClientMapper implements IMapper<CodeModel, ServiceClient> {
                         ? Arrays.asList(ClassType.NonNull)
                         : new ArrayList<>())
                 .build();
+
+        if (settings.getCredentialTypes().contains(JavaSettings.CredentialType.TOKEN_CREDENTIAL)) {
+            Set<String> scopes = JavaSettings.getInstance().getCredentialScopes();
+            String scopeParams;
+            if (scopes != null && !scopes.isEmpty()) {
+                scopeParams = "DEFAULT_SCOPES";
+            } else {
+                // Remove trailing / and all relative paths
+                if (proxy == null) {
+                    proxy = serviceClientMethodGroupClients.get(0).getProxy();
+                }
+                String host = proxy.getBaseURL().replaceAll("/+$", "").replaceAll("(?<!/)[/][^/]+", "");
+                List<String> parameters = new ArrayList<>();
+                int start = host.indexOf("{");
+                while (start >= 0) {
+                    int end = host.indexOf("}", start);
+                    String serializedName = host.substring(start + 1, end);
+                    Optional<Parameter> hostParam = clientParameters.stream().filter(p -> serializedName.equals(p.getLanguage().getJava().getSerializedName())).findFirst();
+                    if (hostParam.isPresent()) {
+                        parameters.add(hostParam.get().getLanguage().getJava().getName());
+                        host = host.substring(0, start) + "%s" + host.substring(end + 1);
+                    }
+                    start = host.indexOf("{", start + 1);
+                }
+                if (parameters.isEmpty()) {
+                    scopeParams = String.format("\"%s/.default\"", host);
+                } else {
+                    scopeParams = String.format("String.format(\"%s/.default\", %s)", host, String.join(", ", parameters));
+                }
+            }
+            builder.defaultCredentialScopes(scopeParams);
+        }
 
         List<Constructor> serviceClientConstructors = new ArrayList<>();
 

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ServiceClient.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ServiceClient.java
@@ -67,6 +67,8 @@ public class ServiceClient {
 
     private String clientBaseName;
 
+    private String defaultCredentialScopes;
+
     /**
      * Create a new ServiceClient with the provided properties.
      * @param packageName The package that this service client belongs to.
@@ -84,7 +86,7 @@ public class ServiceClient {
      * @param defaultPollIntervalParameter The default poll interval parameter.
      */
     private ServiceClient(String packageName, String className, String interfaceName, Proxy proxy, List<MethodGroupClient> methodGroupClients, List<ServiceClientProperty> properties, List<Constructor> constructors, List<ClientMethod> clientMethods,
-                          ClientMethodParameter azureEnvironmentParameter, ClientMethodParameter tokenCredentialParameter, ClientMethodParameter httpPipelineParameter, ClientMethodParameter serializerAdapterParameter, ClientMethodParameter defaultPollIntervalParameter) {
+                          ClientMethodParameter azureEnvironmentParameter, ClientMethodParameter tokenCredentialParameter, ClientMethodParameter httpPipelineParameter, ClientMethodParameter serializerAdapterParameter, ClientMethodParameter defaultPollIntervalParameter, String defaultCredentialScopes) {
         this.packageName = packageName;
         this.className = className;
         this.interfaceName = interfaceName;
@@ -99,6 +101,7 @@ public class ServiceClient {
         this.serializerAdapterParameter = serializerAdapterParameter;
         this.defaultPollIntervalParameter = defaultPollIntervalParameter;
         this.clientBaseName = className.endsWith("Impl") ? className.substring(0, className.length() - 4) : className;
+        this.defaultCredentialScopes = defaultCredentialScopes;
     }
 
     public final String getPackage() {
@@ -155,6 +158,10 @@ public class ServiceClient {
 
     public final String getClientBaseName() {
         return clientBaseName;
+    }
+
+    public final String getDefaultCredentialScopes() {
+        return defaultCredentialScopes;
     }
 
     /**
@@ -236,6 +243,7 @@ public class ServiceClient {
         private ClientMethodParameter httpPipelineParameter;
         private ClientMethodParameter serializerAdapterParameter;
         private ClientMethodParameter defaultPollIntervalParameter;
+        private String defaultCredentialScopes;
 
         /**
          * Sets the package that this service client belongs to.
@@ -367,6 +375,16 @@ public class ServiceClient {
             return this;
         }
 
+        /**
+         * Sets the defaultCredentialScopes parameter.
+         * @param defaultCredentialScopes the default credential scopes
+         * @return the Builder itself
+         */
+        public Builder defaultCredentialScopes(String defaultCredentialScopes) {
+            this.defaultCredentialScopes = defaultCredentialScopes;
+            return this;
+        }
+
         public ServiceClient build() {
             return new ServiceClient(packageName,
                     className,
@@ -380,7 +398,8 @@ public class ServiceClient {
                     tokenCredentialParameter,
                     httpPipelineParameter,
                     serializerAdapterParameter,
-                    defaultPollIntervalParameter);
+                    defaultPollIntervalParameter,
+                    defaultCredentialScopes);
         }
     }
 }


### PR DESCRIPTION
Today if a client does not have an `endpoint` property, the `tokenCredential` is ignored and not added to the pipeline.

This code adds logic to detect the host parameters and build a default scope based on the host. 

### Example 1
Swagger:
```
...
  "host": "quantum.azure.com",
...
```

Java:
```java
        if (host == null) {
            this.host = "https://quantum.azure.com";
        }
...
        if (tokenCredential != null) {
            policies.add(new BearerTokenAuthenticationPolicy(tokenCredential, String.format("%s/.default", host)));
        }
```

### Example 2
Swagger:
```
  "x-ms-parameterized-host": {
    "hostTemplate": "{Endpoint}/text/analytics/v3.0",
    "useSchemePrefix": false,
    "parameters": [
      {
        "$ref": "#/parameters/Endpoint"
      }
    ]
  },
```

Java:
```java
        if (tokenCredential != null) {
            policies.add(new BearerTokenAuthenticationPolicy(tokenCredential, String.format("%s/.default", endpoint)));
        }
```

### Example 3
Swagger:
```
  "x-ms-parameterized-host": {
    "hostTemplate": "https://{searchServiceName}.{searchDnsSuffix}/indexes('{indexName}')",
    "useSchemePrefix": false,
    "parameters": [
      {
        "$ref": "#/parameters/SearchServiceNameParameter"
      },
      {
        "$ref": "#/parameters/SearchDnsSuffixParameter"
      },
      {
        "$ref": "#/parameters/IndexNameParameter"
      }
    ]
  },
```

Java:
```java
        if (searchDnsSuffix == null) {
            this.searchDnsSuffix = "search.windows.net";
        }
...
        if (tokenCredential != null) {
            policies.add(
                    new BearerTokenAuthenticationPolicy(
                            tokenCredential,
                            String.format("https://%s.%s/.default", searchServiceName, searchDnsSuffix)));
        }
```