### PR TITLE
v4 fluentlite, put core version to pom as well

### DIFF
--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/PomMapper.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/PomMapper.java
@@ -23,6 +23,7 @@ public class PomMapper {
         pom.setServiceDescription(project.getServiceDescriptionForPom());
 
         pom.setDependencyIdentifiers(Arrays.asList(
+                "com.azure:azure-core:" + project.getPackageVersions().getAzureCoreVersion(),
                 "com.azure:azure-core-management:" + project.getPackageVersions().getAzureCoreManagementVersion()
         ));
 

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/projectmodel/Project.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/projectmodel/Project.java
@@ -40,11 +40,16 @@ public class Project {
 
     public static class PackageVersions {
         private String azureClientSdkParentVersion = "1.7.0";
+        private String azureCoreVersion = "1.13.0";
         private String azureCoreManagementVersion = "1.1.1";
         private String jacocoMavenPlugin = "0.8.5";
 
         public String getAzureClientSdkParentVersion() {
             return azureClientSdkParentVersion;
+        }
+
+        public String getAzureCoreVersion() {
+            return azureCoreVersion;
         }
 
         public String getAzureCoreManagementVersion() {
@@ -164,6 +169,7 @@ public class Project {
         try (BufferedReader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
             reader.lines().forEach(line -> {
                 checkArtifact(line, "org.jacoco:jacoco-maven-plugin").ifPresent(v -> packageVersions.jacocoMavenPlugin = v);
+                checkArtifact(line, "com.azure:azure-core").ifPresent(v -> packageVersions.azureCoreVersion = v);
                 checkArtifact(line, "com.azure:azure-core-management").ifPresent(v -> packageVersions.azureCoreManagementVersion = v);
                 checkArtifact(line, "com.azure:azure-client-sdk-parent").ifPresent(v -> packageVersions.azureClientSdkParentVersion = v);
             });


### PR DESCRIPTION
As azure-core is likely upgrading more frequently than azure-core-management.

sample 

```
    <dependencies>
        <dependency>
            <groupId>com.azure</groupId>
            <artifactId>azure-core</artifactId>
            <version>1.13.0</version> <!-- {x-version-update;com.azure:azure-core;dependency} -->
        </dependency>
        <dependency>
            <groupId>com.azure</groupId>
            <artifactId>azure-core-management</artifactId>
            <version>1.1.1</version> <!-- {x-version-update;com.azure:azure-core-management;dependency} -->
        </dependency>
    </dependencies>
```