### PR TITLE
v4, update jackson to 2.11.3 to fix security alert

### DIFF
--- a/customization-base/pom.xml
+++ b/customization-base/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.1</version>
+      <version>2.11.3</version>
     </dependency>
     <dependency>
       <groupId>com.azure.tools</groupId>

--- a/customization-base/pom.xml
+++ b/customization-base/pom.xml
@@ -27,13 +27,6 @@
   </repositories>
 
   <dependencies>
-    <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.10.2</version>
-    </dependency>
-
     <dependency>
       <groupId>com.azure.tools</groupId>
       <artifactId>azure-autorest-extension</artifactId>

--- a/customization-base/pom.xml
+++ b/customization-base/pom.xml
@@ -28,6 +28,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.12.1</version>
+    </dependency>
+    <dependency>
       <groupId>com.azure.tools</groupId>
       <artifactId>azure-autorest-extension</artifactId>
       <version>1.0.0-beta.1</version>

--- a/extension-base/pom.xml
+++ b/extension-base/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.10.2</version>
+      <version>2.12.1</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>

--- a/extension-base/pom.xml
+++ b/extension-base/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.10.2</version>
+      <version>2.12.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/extension-base/pom.xml
+++ b/extension-base/pom.xml
@@ -37,12 +37,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.12.1</version>
+      <version>2.11.3</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.1</version>
+      <version>2.11.3</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>

--- a/javagen/pom.xml
+++ b/javagen/pom.xml
@@ -22,12 +22,6 @@
   </repositories>
 
   <dependencies>
-    <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.10.2</version>
-    </dependency>
     <dependency>
       <groupId>com.azure.tools</groupId>
       <artifactId>azure-autorest-extension</artifactId>

--- a/javagen/pom.xml
+++ b/javagen/pom.xml
@@ -23,6 +23,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.12.1</version>
+    </dependency>
+    <dependency>
       <groupId>com.azure.tools</groupId>
       <artifactId>azure-autorest-extension</artifactId>
       <version>1.0.0-beta.1</version>

--- a/javagen/pom.xml
+++ b/javagen/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.1</version>
+      <version>2.11.3</version>
     </dependency>
     <dependency>
       <groupId>com.azure.tools</groupId>

--- a/postprocessor/pom.xml
+++ b/postprocessor/pom.xml
@@ -23,13 +23,6 @@
   </repositories>
 
   <dependencies>
-    <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.10.2</version>
-    </dependency>
-
     <dependency>
       <groupId>com.azure.tools</groupId>
       <artifactId>azure-autorest-extension</artifactId>

--- a/postprocessor/pom.xml
+++ b/postprocessor/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.1</version>
+      <version>2.11.3</version>
     </dependency>
     <dependency>
       <groupId>com.azure.tools</groupId>

--- a/postprocessor/pom.xml
+++ b/postprocessor/pom.xml
@@ -24,6 +24,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.12.1</version>
+    </dependency>
+    <dependency>
       <groupId>com.azure.tools</groupId>
       <artifactId>azure-autorest-extension</artifactId>
       <version>1.0.0-beta.1</version>

--- a/postprocessor/src/main/resources/readme/pom.xml
+++ b/postprocessor/src/main/resources/readme/pom.xml
@@ -16,6 +16,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <dependencies>
+    <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
     <dependency>
       <groupId>com.azure.tools</groupId>
       <artifactId>azure-autorest-customization</artifactId>

--- a/postprocessor/src/main/resources/readme/pom.xml
+++ b/postprocessor/src/main/resources/readme/pom.xml
@@ -16,7 +16,6 @@
   <modelVersion>4.0.0</modelVersion>
 
   <dependencies>
-    <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
     <dependency>
       <groupId>com.azure.tools</groupId>
       <artifactId>azure-autorest-customization</artifactId>

--- a/preprocessor/pom.xml
+++ b/preprocessor/pom.xml
@@ -18,6 +18,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.12.1</version>
+    </dependency>
+    <dependency>
       <groupId>com.azure.tools</groupId>
       <artifactId>azure-autorest-extension</artifactId>
       <version>1.0.0-beta.1</version>

--- a/preprocessor/pom.xml
+++ b/preprocessor/pom.xml
@@ -17,13 +17,6 @@
 
 
   <dependencies>
-    <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.10.2</version>
-    </dependency>
-
     <dependency>
       <groupId>com.azure.tools</groupId>
       <artifactId>azure-autorest-extension</artifactId>

--- a/preprocessor/pom.xml
+++ b/preprocessor/pom.xml
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.1</version>
+      <version>2.11.3</version>
     </dependency>
     <dependency>
       <groupId>com.azure.tools</groupId>


### PR DESCRIPTION
core is currently using 2.11, and Alan is planning to upgrade to 2.12.