### PR TITLE
v4 fluentlite, use fullname for Manager in impl

### DIFF
--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/method/FluentConstructorByInner.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/method/FluentConstructorByInner.java
@@ -26,11 +26,11 @@ import java.util.stream.Collectors;
 public class FluentConstructorByInner extends FluentMethod {
 
     private final List<MethodParameter> pathParameters;
-    private final IType managerType;
+    private final ClassType managerType;
 
     public FluentConstructorByInner(FluentResourceModel model, FluentMethodType type,
                                     List<MethodParameter> pathParameters, ResourceLocalVariables resourceLocalVariables,
-                                    IType managerType, UrlPathSegments urlPathSegments) {
+                                    ClassType managerType, UrlPathSegments urlPathSegments) {
         super(model, type);
 
         this.pathParameters = pathParameters;
@@ -74,7 +74,7 @@ public class FluentConstructorByInner extends FluentMethod {
         return String.format("%1$s(%2$s %3$s, %4$s %5$s)",
                 implementationReturnValue.getType().toString(),
                 fluentResourceModel.getInnerModel().getName(), ModelNaming.MODEL_PROPERTY_INNER,
-                managerType.toString(), ModelNaming.MODEL_PROPERTY_MANAGER);
+                managerType.getFullName(), ModelNaming.MODEL_PROPERTY_MANAGER);
     }
 
     @Override
@@ -91,7 +91,9 @@ public class FluentConstructorByInner extends FluentMethod {
     public void addImportsTo(Set<String> imports, boolean includeImplementationImports) {
         if (includeImplementationImports) {
             pathParameters.forEach(p -> p.getClientMethodParameter().addImportsTo(imports, false));
+            /* use full name for FooManager, to avoid naming conflict
             managerType.addImportsTo(imports, false);
+             */
         }
     }
 }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/method/FluentConstructorByName.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/method/FluentConstructorByName.java
@@ -9,6 +9,7 @@ import com.azure.autorest.fluent.model.clientmodel.FluentResourceModel;
 import com.azure.autorest.fluent.model.clientmodel.ModelNaming;
 import com.azure.autorest.fluent.model.clientmodel.fluentmodel.LocalVariable;
 import com.azure.autorest.fluent.model.clientmodel.fluentmodel.ResourceLocalVariables;
+import com.azure.autorest.model.clientmodel.ClassType;
 import com.azure.autorest.model.clientmodel.IType;
 import com.azure.autorest.model.clientmodel.ReturnValue;
 import com.azure.autorest.model.javamodel.JavaJavadocComment;
@@ -21,15 +22,15 @@ public class FluentConstructorByName extends FluentMethod {
 
     private final boolean constantResourceName; // resource name is constant, "name" is not needed
     private final IType resourceNameType;
-    private final IType managerType;
+    private final ClassType managerType;
 
     public static FluentConstructorByName constructorMethodWithConstantResourceName(
-            FluentResourceModel model, FluentMethodType type, IType managerType, ResourceLocalVariables resourceLocalVariables) {
+            FluentResourceModel model, FluentMethodType type, ClassType managerType, ResourceLocalVariables resourceLocalVariables) {
         return new FluentConstructorByName(model, type, null, null, managerType, resourceLocalVariables);
     }
 
     public FluentConstructorByName(FluentResourceModel model, FluentMethodType type,
-                                   IType resourceNameType, String propertyNameForResourceName, IType managerType,
+                                   IType resourceNameType, String propertyNameForResourceName, ClassType managerType,
                                    ResourceLocalVariables resourceLocalVariables) {
         super(model, type);
 
@@ -64,12 +65,12 @@ public class FluentConstructorByName extends FluentMethod {
         if (constantResourceName) {
             return String.format("%1$s(%2$s %3$s)",
                     implementationReturnValue.getType().toString(),
-                    managerType.toString(), ModelNaming.MODEL_PROPERTY_MANAGER);
+                    managerType.getFullName(), ModelNaming.MODEL_PROPERTY_MANAGER);
         } else {
             return String.format("%1$s(%2$s name, %3$s %4$s)",
                     implementationReturnValue.getType().toString(),
                     resourceNameType.toString(),
-                    managerType.toString(), ModelNaming.MODEL_PROPERTY_MANAGER);
+                    managerType.getFullName(), ModelNaming.MODEL_PROPERTY_MANAGER);
         }
     }
 
@@ -89,7 +90,9 @@ public class FluentConstructorByName extends FluentMethod {
             if (resourceNameType != null) {
                 resourceNameType.addImportsTo(imports, false);
             }
+            /* use full name for FooManager, to avoid naming conflict
             managerType.addImportsTo(imports, false);
+             */
         }
     }
 }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentResourceCollectionImplementationTemplate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentResourceCollectionImplementationTemplate.java
@@ -39,8 +39,10 @@ public class FluentResourceCollectionImplementationTemplate implements IJavaTemp
         // ClientLogger
         imports.add(JsonIgnore.class.getName());
         ClassType.ClientLogger.addImportsTo(imports, false);
+        /* use full name for FooManager, to avoid naming conflict
         // manager
         imports.add(managerType.getFullName());
+         */
         // resource collection
         collection.addImportsTo(imports, true);
         if (collection.getResourceCreates() != null) {
@@ -61,10 +63,10 @@ public class FluentResourceCollectionImplementationTemplate implements IJavaTemp
             classBlock.privateFinalMemberVariable(collection.getInnerClientType().getName(), ModelNaming.COLLECTION_PROPERTY_INNER);
 
             // variable for manager
-            classBlock.privateFinalMemberVariable(managerType.getName(), ModelNaming.COLLECTION_PROPERTY_MANAGER);
+            classBlock.privateFinalMemberVariable(managerType.getFullName(), ModelNaming.COLLECTION_PROPERTY_MANAGER);
 
             // constructor
-            classBlock.publicConstructor(String.format("%1$s(%2$s %3$s, %4$s %5$s)", collection.getImplementationType().getName(), collection.getInnerClientType().getName(), ModelNaming.COLLECTION_PROPERTY_INNER, managerType.getName(), ModelNaming.MODEL_PROPERTY_MANAGER), methodBlock -> {
+            classBlock.publicConstructor(String.format("%1$s(%2$s %3$s, %4$s %5$s)", collection.getImplementationType().getName(), collection.getInnerClientType().getName(), ModelNaming.COLLECTION_PROPERTY_INNER, managerType.getFullName(), ModelNaming.MODEL_PROPERTY_MANAGER), methodBlock -> {
                 methodBlock.line(String.format("this.%1$s = %2$s;", ModelNaming.COLLECTION_PROPERTY_INNER, ModelNaming.COLLECTION_PROPERTY_INNER));
                 methodBlock.line(String.format("this.%1$s = %2$s;", ModelNaming.COLLECTION_PROPERTY_MANAGER, ModelNaming.COLLECTION_PROPERTY_MANAGER));
             });
@@ -78,7 +80,7 @@ public class FluentResourceCollectionImplementationTemplate implements IJavaTemp
             });
 
             // method for manager
-            classBlock.privateMethod(String.format("%1$s %2$s()", managerType.getName(), FluentUtils.getGetterName(ModelNaming.METHOD_MANAGER)), methodBlock -> {
+            classBlock.privateMethod(String.format("%1$s %2$s()", managerType.getFullName(), FluentUtils.getGetterName(ModelNaming.METHOD_MANAGER)), methodBlock -> {
                 methodBlock.methodReturn(String.format("this.%s", ModelNaming.MODEL_PROPERTY_MANAGER));
             });
 

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentResourceModelImplementationTemplate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentResourceModelImplementationTemplate.java
@@ -40,7 +40,10 @@ public class FluentResourceModelImplementationTemplate implements IJavaTemplate<
         methodTemplates.addAll(model.getAdditionalMethods());
 
         Set<String> imports = new HashSet<>();
+        /* use full name for FooManager, to avoid naming conflict
+        // manager
         imports.add(managerType.getFullName());
+         */
         model.addImportsTo(imports, true);
         javaFile.declareImport(imports);
 
@@ -58,12 +61,12 @@ public class FluentResourceModelImplementationTemplate implements IJavaTemplate<
             classBlock.privateMemberVariable(model.getInnerModel().getName(), ModelNaming.MODEL_PROPERTY_INNER);
 
             // variable for manager
-            classBlock.privateFinalMemberVariable(managerType.getName(), ModelNaming.MODEL_PROPERTY_MANAGER);
+            classBlock.privateFinalMemberVariable(managerType.getFullName(), ModelNaming.MODEL_PROPERTY_MANAGER);
 
             // if resource is updatable, use the constructor from resourceUpdate
             if (model.getCategory() == ModelCategory.IMMUTABLE || model.getResourceUpdate() == null) {
                 // constructor
-                classBlock.packagePrivateConstructor(String.format("%1$s(%2$s %3$s, %4$s %5$s)", model.getImplementationType().getName(), model.getInnerModel().getName(), ModelNaming.MODEL_PROPERTY_INNER, managerType.getName(), ModelNaming.MODEL_PROPERTY_MANAGER), methodBlock -> {
+                classBlock.packagePrivateConstructor(String.format("%1$s(%2$s %3$s, %4$s %5$s)", model.getImplementationType().getName(), model.getInnerModel().getName(), ModelNaming.MODEL_PROPERTY_INNER, managerType.getFullName(), ModelNaming.MODEL_PROPERTY_MANAGER), methodBlock -> {
                     methodBlock.line(String.format("this.%1$s = %2$s;", ModelNaming.MODEL_PROPERTY_INNER, ModelNaming.MODEL_PROPERTY_INNER));
                     methodBlock.line(String.format("this.%1$s = %2$s;", ModelNaming.MODEL_PROPERTY_MANAGER, ModelNaming.MODEL_PROPERTY_MANAGER));
                 });
@@ -78,7 +81,7 @@ public class FluentResourceModelImplementationTemplate implements IJavaTemplate<
             });
 
             // method for manager
-            classBlock.privateMethod(String.format("%1$s %2$s()", managerType.getName(), FluentUtils.getGetterName(ModelNaming.METHOD_MANAGER)), methodBlock -> {
+            classBlock.privateMethod(String.format("%1$s %2$s()", managerType.getFullName(), FluentUtils.getGetterName(ModelNaming.METHOD_MANAGER)), methodBlock -> {
                 methodBlock.methodReturn(String.format("this.%s", ModelNaming.MODEL_PROPERTY_MANAGER));
             });
 

--- a/fluentgen/src/test/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/FluentMethodTests.java
+++ b/fluentgen/src/test/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/FluentMethodTests.java
@@ -67,7 +67,7 @@ public class FluentMethodTests {
                 lockUpdate.getPathParameters(), lockUpdate.getResourceLocalVariables(),
                 FluentStatic.getFluentManager().getType(), lockUpdate.getUrlPathSegments());
 
-        Assertions.assertEquals("ManagementLockObjectImpl(ManagementLockObjectInner innerObject, ManagementLockManager serviceManager)", constructor.getImplementationMethodSignature());
+        Assertions.assertEquals("ManagementLockObjectImpl(ManagementLockObjectInner innerObject, com.azure.resourcemanager.mock.ManagementLockManager serviceManager)", constructor.getImplementationMethodSignature());
 
         String methodContent = TestUtils.getMethodTemplateContent(constructor.getMethodTemplate());
         Assertions.assertTrue(methodContent.contains("this.innerObject = innerObject;"));
@@ -79,7 +79,7 @@ public class FluentMethodTests {
                 ClassType.String, "lockName",
                 FluentStatic.getFluentManager().getType(), lockCreate.getResourceLocalVariables());
 
-        Assertions.assertEquals("ManagementLockObjectImpl(String name, ManagementLockManager serviceManager)", constructor.getImplementationMethodSignature());
+        Assertions.assertEquals("ManagementLockObjectImpl(String name, com.azure.resourcemanager.mock.ManagementLockManager serviceManager)", constructor.getImplementationMethodSignature());
 
         methodContent = TestUtils.getMethodTemplateContent(constructor.getMethodTemplate());
         Assertions.assertTrue(methodContent.contains("new ManagementLockObjectInner();"));
@@ -90,7 +90,7 @@ public class FluentMethodTests {
         constructor = FluentConstructorByName.constructorMethodWithConstantResourceName(lockModel, FluentMethodType.CONSTRUCTOR,
                 FluentStatic.getFluentManager().getType(), lockCreate.getResourceLocalVariables());
 
-        Assertions.assertEquals("ManagementLockObjectImpl(ManagementLockManager serviceManager)", constructor.getImplementationMethodSignature());
+        Assertions.assertEquals("ManagementLockObjectImpl(com.azure.resourcemanager.mock.ManagementLockManager serviceManager)", constructor.getImplementationMethodSignature());
 
         methodContent = TestUtils.getMethodTemplateContent(constructor.getMethodTemplate());
         Assertions.assertTrue(methodContent.contains("new ManagementLockObjectInner();"));


### PR DESCRIPTION
To avoid conflict of e.g. `NetworkManager` with a resource called `NetworkManager`.