### PR TITLE
v4 support multiple exceptions

### DIFF
--- a/fluentgen/src/test/java/com/azure/autorest/MockJavagen.java
+++ b/fluentgen/src/test/java/com/azure/autorest/MockJavagen.java
@@ -7,9 +7,6 @@ package com.azure.autorest;
 
 import com.azure.autorest.extension.base.jsonrpc.Connection;
 import com.azure.autorest.extension.base.model.Message;
-import com.azure.autorest.extension.base.plugin.JavaSettingsAccessor;
-import com.azure.autorest.fluent.model.clientmodel.FluentStatic;
-import com.azure.autorest.fluent.util.FluentJavaSettings;
 
 import java.lang.reflect.Type;
 import java.util.HashMap;
@@ -18,25 +15,10 @@ import java.util.Map;
 public class MockJavagen extends Javagen {
 
     private static final Map<String, Object> DEFAULT_SETTINGS = new HashMap<>();
-    static {
-        DEFAULT_SETTINGS.put("namespace", "com.azure.resourcemanager.mock");
-        DEFAULT_SETTINGS.put("fluent", "lite");
-        DEFAULT_SETTINGS.put("sync-methods", "all");
-        DEFAULT_SETTINGS.put("add-context-parameter", true);
-        DEFAULT_SETTINGS.put("context-client-method-parameter", true);
-        DEFAULT_SETTINGS.put("client-side-validations", true);
-        DEFAULT_SETTINGS.put("client-logger", true);
-        DEFAULT_SETTINGS.put("generate-client-interfaces", true);
-        DEFAULT_SETTINGS.put("required-parameter-client-methods", true);
-    }
 
     public MockJavagen() {
         super(new Connection(System.out, System.in), "dummy", "dummy");
         instance = this;
-
-        JavaSettingsAccessor.setHost(this);
-
-        FluentStatic.setFluentJavaSettings(new FluentJavaSettings(this));
     }
 
     @Override
@@ -46,7 +28,6 @@ public class MockJavagen extends Javagen {
 
     @Override
     public void message(Message message) {
-//            System.out.println(String.format("[%1$s] %2$s", message.getChannel(), message.getText()));
     }
 }
 

--- a/fluentgen/src/test/java/com/azure/autorest/MockJavagen.java
+++ b/fluentgen/src/test/java/com/azure/autorest/MockJavagen.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.azure.autorest;
+
+import com.azure.autorest.extension.base.jsonrpc.Connection;
+import com.azure.autorest.extension.base.model.Message;
+import com.azure.autorest.extension.base.plugin.JavaSettingsAccessor;
+import com.azure.autorest.fluent.model.clientmodel.FluentStatic;
+import com.azure.autorest.fluent.util.FluentJavaSettings;
+
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+
+public class MockJavagen extends Javagen {
+
+    private static final Map<String, Object> DEFAULT_SETTINGS = new HashMap<>();
+    static {
+        DEFAULT_SETTINGS.put("namespace", "com.azure.resourcemanager.mock");
+        DEFAULT_SETTINGS.put("fluent", "lite");
+        DEFAULT_SETTINGS.put("sync-methods", "all");
+        DEFAULT_SETTINGS.put("add-context-parameter", true);
+        DEFAULT_SETTINGS.put("context-client-method-parameter", true);
+        DEFAULT_SETTINGS.put("client-side-validations", true);
+        DEFAULT_SETTINGS.put("client-logger", true);
+        DEFAULT_SETTINGS.put("generate-client-interfaces", true);
+        DEFAULT_SETTINGS.put("required-parameter-client-methods", true);
+    }
+
+    public MockJavagen() {
+        super(new Connection(System.out, System.in), "dummy", "dummy");
+        instance = this;
+
+        JavaSettingsAccessor.setHost(this);
+
+        FluentStatic.setFluentJavaSettings(new FluentJavaSettings(this));
+    }
+
+    @Override
+    public <T> T getValue(Type type, String key) {
+        return (T) DEFAULT_SETTINGS.get(key);
+    }
+
+    @Override
+    public void message(Message message) {
+//            System.out.println(String.format("[%1$s] %2$s", message.getChannel(), message.getText()));
+    }
+}
+

--- a/fluentgen/src/test/java/com/azure/autorest/fluent/TestUtils.java
+++ b/fluentgen/src/test/java/com/azure/autorest/fluent/TestUtils.java
@@ -5,6 +5,8 @@
 
 package com.azure.autorest.fluent;
 
+import com.azure.autorest.Javagen;
+import com.azure.autorest.MockJavagen;
 import com.azure.autorest.extension.base.jsonrpc.Connection;
 import com.azure.autorest.extension.base.model.Message;
 import com.azure.autorest.extension.base.model.codemodel.CodeModel;
@@ -49,6 +51,8 @@ public class TestUtils {
             DEFAULT_SETTINGS.put("required-parameter-client-methods", true);
         }
 
+        private Javagen javagen;
+
         public MockFluentGen() {
             super(new Connection(System.out, System.in), "dummy", "dummy");
             instance = this;
@@ -56,6 +60,8 @@ public class TestUtils {
             JavaSettingsAccessor.setHost(this);
 
             FluentStatic.setFluentJavaSettings(new FluentJavaSettings(this));
+
+            javagen = new MockJavagen();
         }
 
         @Override

--- a/javagen/src/main/java/com/azure/autorest/Javagen.java
+++ b/javagen/src/main/java/com/azure/autorest/Javagen.java
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
 
 public class Javagen extends NewPlugin {
     private final Logger LOGGER = new PluginLogger(this, Javagen.class);
-    private static Javagen instance;
+    static Javagen instance;
 
     public Javagen(Connection connection, String plugin, String sessionId) {
         super(connection, plugin, sessionId);

--- a/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
@@ -191,7 +191,7 @@ public class ProxyMethodMapper implements IMapper<Operation, Map<Request, ProxyM
                 boolean isDefaultError = true;
                 if (exception.getProtocol() != null && exception.getProtocol().getHttp() != null) {
                     List<String> statusCodes = exception.getProtocol().getHttp().getStatusCodes();
-                    if (statusCodes != null && !statusCodes.isEmpty() && exception.getSchema() != null) {
+                    if (statusCodes != null && !statusCodes.isEmpty()) {
                         try {
                             ClassType exceptionType = getExceptionType(exception, settings);
                             List<HttpResponseStatus> statusCodeList = statusCodes.stream()

--- a/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
@@ -184,6 +184,12 @@ public class ProxyMethodMapper implements IMapper<Operation, Map<Request, ProxyM
         ClassType errorType = null;
         Map<ClassType, List<HttpResponseStatus>> errorTypeMap = new HashMap<>();
 
+        /*
+        1. If exception has valid numeric status codes, group them to unexpectedResponseExceptionTypes
+        2. If exception does not have status codes, or have 'default' or invalid number, put the first to unexpectedResponseExceptionType, ignore the rest
+        3. After processing, if no model in unexpectedResponseExceptionType, take any from unexpectedResponseExceptionTypes and put it to unexpectedResponseExceptionType
+         */
+
         if (operation.getExceptions() != null && !operation.getExceptions().isEmpty()) {
             //errorType = (ClassType) Mappers.getSchemaMapper().map(operation.getExceptions().get(0).getSchema());
             for (Response exception : operation.getExceptions()) {

--- a/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
@@ -219,7 +219,7 @@ public class ProxyMethodMapper implements IMapper<Operation, Map<Request, ProxyM
             }
 
             if (errorType == null) {
-                // no default exception, use the 1st to keep backward compatibility
+                // no default error, use the 1st to keep backward compatibility
                 errorType = (ClassType) Mappers.getSchemaMapper().map(operation.getExceptions().get(0).getSchema());
             }
         }

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
@@ -121,6 +121,11 @@ public class ClassType implements IType {
         return Objects.equals(this.name, that.name) && Objects.equals(this.packageName, that.packageName);
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(packageName, name);
+    }
+
     public final IType asNullable() {
         return this;
     }


### PR DESCRIPTION
Sample swagger https://github.com/Azure/azure-sdk-for-java/blob/f25746c19cfa7818f8ade5a4acfedd6f1d3bb68a/sdk/communication/azure-communication-chat/swagger/swagger.json#L52-L80

Sample proxy method (I've tweaked a bit on the 1st method for testing purpose, added a "default" and another different type for "403"; 2nd method is same as swagger above)
```
        @Get("/chat/threads/{chatThreadId}/readReceipts")
        @ExpectedResponses({200})
        @UnexpectedResponseExceptionType(
                value = CommunicationErrorResponse2Exception.class,
                code = {403})
        @UnexpectedResponseExceptionType(
                value = CommunicationErrorResponseException.class,
                code = {401, 429})
        @UnexpectedResponseExceptionType(CommunicationErrorResponseException.class)
        Mono<Response<ChatMessageReadReceiptsCollection>> listChatReadReceipts(
                @HostParam("endpoint") String endpoint,
                @PathParam("chatThreadId") String chatThreadId,
                @QueryParam("maxPageSize") Integer maxPageSize,
                @QueryParam("skip") Integer skip,
                @QueryParam("api-version") String apiVersion,
                @HeaderParam("Accept") String accept,
                Context context);

        @Post("/chat/threads/{chatThreadId}/readReceipts")
        @ExpectedResponses({200})
        @UnexpectedResponseExceptionType(
                value = CommunicationErrorResponseException.class,
                code = {401, 403, 429, 503})
        @UnexpectedResponseExceptionType(CommunicationErrorResponseException.class)
        Mono<Response<Void>> sendChatReadReceipt(
                @HostParam("endpoint") String endpoint,
                @PathParam("chatThreadId") String chatThreadId,
                @QueryParam("api-version") String apiVersion,
                @BodyParam("application/json") SendReadReceiptRequest sendReadReceiptRequest,
                @HeaderParam("Accept") String accept,
                Context context);
```

Sample client method (javadoc changed only)
```
    /**
     * Gets chat message read receipts for a thread.
     *
     * @param chatThreadId Thread id to get the chat message read receipts for.
     * @param maxPageSize The maximum number of chat message read receipts to be returned per page.
     * @param skip Skips chat message read receipts up to a specified position in response.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws CommunicationErrorResponseException thrown if the request is rejected by server.
     * @throws CommunicationErrorResponseException thrown if the request is rejected by server on status code 401, 429.
     * @throws CommunicationErrorResponse2Exception thrown if the request is rejected by server on status code 403.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     * @return chat message read receipts for a thread.
     */
    @ServiceMethod(returns = ReturnType.SINGLE)
    public Mono<PagedResponse<ChatMessageReadReceipt>> listChatReadReceiptsSinglePageAsync(
            String chatThreadId, Integer maxPageSize, Integer skip) {

   ...

    /**
     * Sends a read receipt event to a thread, on behalf of a user.
     *
     * @param chatThreadId Thread id to send the read receipt event to.
     * @param sendReadReceiptRequest Read receipt details.
     * @throws IllegalArgumentException thrown if parameters fail the validation.
     * @throws CommunicationErrorResponseException thrown if the request is rejected by server.
     * @throws CommunicationErrorResponseException thrown if the request is rejected by server on status code 401, 403,
     *     429, 503.
     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
     * @return the completion.
     */
    @ServiceMethod(returns = ReturnType.SINGLE)
    public Mono<Response<Void>> sendChatReadReceiptWithResponseAsync(
            String chatThreadId, SendReadReceiptRequest sendReadReceiptRequest) {

    ```