### PR TITLE
v4 fluent, update reactor via azure-core

### DIFF
--- a/azure-tests/pom.xml
+++ b/azure-tests/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
-      <version>1.12.0</version>
+      <version>${azure-core.version}</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>

--- a/azure-tests/src/main/java/fixtures/lro/implementation/LROsClientImpl.java
+++ b/azure-tests/src/main/java/fixtures/lro/implementation/LROsClientImpl.java
@@ -443,7 +443,7 @@ public final class LROsClientImpl implements LROsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.put200Succeeded(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -660,7 +660,7 @@ public final class LROsClientImpl implements LROsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.put201Succeeded(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -872,7 +872,7 @@ public final class LROsClientImpl implements LROsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.post202List(this.client.getEndpoint(), accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -1055,7 +1055,7 @@ public final class LROsClientImpl implements LROsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.put200SucceededNoState(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -1273,7 +1273,7 @@ public final class LROsClientImpl implements LROsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.put202Retry200(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -1492,7 +1492,7 @@ public final class LROsClientImpl implements LROsClient {
         return FluxUtil
             .withContext(
                 context -> service.put201CreatingSucceeded200(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -1726,7 +1726,7 @@ public final class LROsClientImpl implements LROsClient {
         return FluxUtil
             .withContext(
                 context -> service.put200UpdatingSucceeded204(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -1960,7 +1960,7 @@ public final class LROsClientImpl implements LROsClient {
         return FluxUtil
             .withContext(
                 context -> service.put201CreatingFailed200(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -2193,7 +2193,7 @@ public final class LROsClientImpl implements LROsClient {
         return FluxUtil
             .withContext(
                 context -> service.put200Acceptedcanceled200(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -2425,7 +2425,7 @@ public final class LROsClientImpl implements LROsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.putNoHeaderInRetry(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -2644,7 +2644,7 @@ public final class LROsClientImpl implements LROsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.putAsyncRetrySucceeded(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -2875,7 +2875,7 @@ public final class LROsClientImpl implements LROsClient {
         return FluxUtil
             .withContext(
                 context -> service.putAsyncNoRetrySucceeded(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -3108,7 +3108,7 @@ public final class LROsClientImpl implements LROsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.putAsyncRetryFailed(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -3339,7 +3339,7 @@ public final class LROsClientImpl implements LROsClient {
         return FluxUtil
             .withContext(
                 context -> service.putAsyncNoRetrycanceled(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -3571,7 +3571,7 @@ public final class LROsClientImpl implements LROsClient {
         return FluxUtil
             .withContext(
                 context -> service.putAsyncNoHeaderInRetry(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -3790,7 +3790,7 @@ public final class LROsClientImpl implements LROsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.putNonResource(this.client.getEndpoint(), sku, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -3993,7 +3993,7 @@ public final class LROsClientImpl implements LROsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.putAsyncNonResource(this.client.getEndpoint(), sku, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -4196,7 +4196,7 @@ public final class LROsClientImpl implements LROsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.putSubResource(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -4401,7 +4401,7 @@ public final class LROsClientImpl implements LROsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.putAsyncSubResource(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -4607,7 +4607,7 @@ public final class LROsClientImpl implements LROsClient {
             .withContext(
                 context ->
                     service.deleteProvisioning202Accepted200Succeeded(this.client.getEndpoint(), accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -4791,7 +4791,7 @@ public final class LROsClientImpl implements LROsClient {
         return FluxUtil
             .withContext(
                 context -> service.deleteProvisioning202DeletingFailed200(this.client.getEndpoint(), accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -4972,7 +4972,7 @@ public final class LROsClientImpl implements LROsClient {
         return FluxUtil
             .withContext(
                 context -> service.deleteProvisioning202Deletingcanceled200(this.client.getEndpoint(), accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -5153,7 +5153,7 @@ public final class LROsClientImpl implements LROsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.delete204Succeeded(this.client.getEndpoint(), accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -5306,7 +5306,7 @@ public final class LROsClientImpl implements LROsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.delete202Retry200(this.client.getEndpoint(), accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -5472,7 +5472,7 @@ public final class LROsClientImpl implements LROsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.delete202NoRetry204(this.client.getEndpoint(), accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -5638,7 +5638,7 @@ public final class LROsClientImpl implements LROsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.deleteNoHeaderInRetry(this.client.getEndpoint(), accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -5800,7 +5800,7 @@ public final class LROsClientImpl implements LROsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.deleteAsyncNoHeaderInRetry(this.client.getEndpoint(), accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -5962,7 +5962,7 @@ public final class LROsClientImpl implements LROsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.deleteAsyncRetrySucceeded(this.client.getEndpoint(), accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -6124,7 +6124,7 @@ public final class LROsClientImpl implements LROsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.deleteAsyncNoRetrySucceeded(this.client.getEndpoint(), accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -6286,7 +6286,7 @@ public final class LROsClientImpl implements LROsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.deleteAsyncRetryFailed(this.client.getEndpoint(), accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -6448,7 +6448,7 @@ public final class LROsClientImpl implements LROsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.deleteAsyncRetrycanceled(this.client.getEndpoint(), accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -6610,7 +6610,7 @@ public final class LROsClientImpl implements LROsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.post200WithPayload(this.client.getEndpoint(), accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -6781,7 +6781,7 @@ public final class LROsClientImpl implements LROsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.post202Retry200(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -6991,7 +6991,7 @@ public final class LROsClientImpl implements LROsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.post202NoRetry204(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -7204,7 +7204,7 @@ public final class LROsClientImpl implements LROsClient {
         return FluxUtil
             .withContext(
                 context -> service.postDoubleHeadersFinalLocationGet(this.client.getEndpoint(), accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -7374,7 +7374,7 @@ public final class LROsClientImpl implements LROsClient {
         return FluxUtil
             .withContext(
                 context -> service.postDoubleHeadersFinalAzureHeaderGet(this.client.getEndpoint(), accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -7547,7 +7547,7 @@ public final class LROsClientImpl implements LROsClient {
             .withContext(
                 context ->
                     service.postDoubleHeadersFinalAzureHeaderGetDefault(this.client.getEndpoint(), accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -7736,7 +7736,7 @@ public final class LROsClientImpl implements LROsClient {
         return FluxUtil
             .withContext(
                 context -> service.postAsyncRetrySucceeded(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -7969,7 +7969,7 @@ public final class LROsClientImpl implements LROsClient {
         return FluxUtil
             .withContext(
                 context -> service.postAsyncNoRetrySucceeded(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -8202,7 +8202,7 @@ public final class LROsClientImpl implements LROsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.postAsyncRetryFailed(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -8425,7 +8425,7 @@ public final class LROsClientImpl implements LROsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.postAsyncRetrycanceled(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**

--- a/azure-tests/src/main/java/fixtures/lro/implementation/LROsImpl.java
+++ b/azure-tests/src/main/java/fixtures/lro/implementation/LROsImpl.java
@@ -3,7 +3,6 @@ package fixtures.lro.implementation;
 import com.azure.core.util.Context;
 import com.azure.core.util.logging.ClientLogger;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import fixtures.lro.LroManager;
 import fixtures.lro.fluent.LROsClient;
 import fixtures.lro.fluent.models.ProductInner;
 import fixtures.lro.fluent.models.SkuInner;
@@ -21,9 +20,9 @@ public final class LROsImpl implements LROs {
 
     private final LROsClient innerClient;
 
-    private final LroManager serviceManager;
+    private final fixtures.lro.LroManager serviceManager;
 
-    public LROsImpl(LROsClient innerClient, LroManager serviceManager) {
+    public LROsImpl(LROsClient innerClient, fixtures.lro.LroManager serviceManager) {
         this.innerClient = innerClient;
         this.serviceManager = serviceManager;
     }
@@ -875,7 +874,7 @@ public final class LROsImpl implements LROs {
         return this.innerClient;
     }
 
-    private LroManager manager() {
+    private fixtures.lro.LroManager manager() {
         return this.serviceManager;
     }
 }

--- a/azure-tests/src/main/java/fixtures/lro/implementation/LroRetrysClientImpl.java
+++ b/azure-tests/src/main/java/fixtures/lro/implementation/LroRetrysClientImpl.java
@@ -144,7 +144,7 @@ public final class LroRetrysClientImpl implements LroRetrysClient {
         return FluxUtil
             .withContext(
                 context -> service.put201CreatingSucceeded200(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -378,7 +378,7 @@ public final class LroRetrysClientImpl implements LroRetrysClient {
         return FluxUtil
             .withContext(
                 context -> service.putAsyncRelativeRetrySucceeded(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -609,7 +609,7 @@ public final class LroRetrysClientImpl implements LroRetrysClient {
             .withContext(
                 context ->
                     service.deleteProvisioning202Accepted200Succeeded(this.client.getEndpoint(), accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -791,7 +791,7 @@ public final class LroRetrysClientImpl implements LroRetrysClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.delete202Retry200(this.client.getEndpoint(), accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -954,7 +954,7 @@ public final class LroRetrysClientImpl implements LroRetrysClient {
         return FluxUtil
             .withContext(
                 context -> service.deleteAsyncRelativeRetrySucceeded(this.client.getEndpoint(), accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -1123,7 +1123,7 @@ public final class LroRetrysClientImpl implements LroRetrysClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.post202Retry200(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -1335,7 +1335,7 @@ public final class LroRetrysClientImpl implements LroRetrysClient {
         return FluxUtil
             .withContext(
                 context -> service.postAsyncRelativeRetrySucceeded(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**

--- a/azure-tests/src/main/java/fixtures/lro/implementation/LroRetrysImpl.java
+++ b/azure-tests/src/main/java/fixtures/lro/implementation/LroRetrysImpl.java
@@ -3,7 +3,6 @@ package fixtures.lro.implementation;
 import com.azure.core.util.Context;
 import com.azure.core.util.logging.ClientLogger;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import fixtures.lro.LroManager;
 import fixtures.lro.fluent.LroRetrysClient;
 import fixtures.lro.fluent.models.ProductInner;
 import fixtures.lro.models.LroRetrys;
@@ -14,9 +13,9 @@ public final class LroRetrysImpl implements LroRetrys {
 
     private final LroRetrysClient innerClient;
 
-    private final LroManager serviceManager;
+    private final fixtures.lro.LroManager serviceManager;
 
-    public LroRetrysImpl(LroRetrysClient innerClient, LroManager serviceManager) {
+    public LroRetrysImpl(LroRetrysClient innerClient, fixtures.lro.LroManager serviceManager) {
         this.innerClient = innerClient;
         this.serviceManager = serviceManager;
     }
@@ -137,7 +136,7 @@ public final class LroRetrysImpl implements LroRetrys {
         return this.innerClient;
     }
 
-    private LroManager manager() {
+    private fixtures.lro.LroManager manager() {
         return this.serviceManager;
     }
 }

--- a/azure-tests/src/main/java/fixtures/lro/implementation/LrosCustomHeadersClientImpl.java
+++ b/azure-tests/src/main/java/fixtures/lro/implementation/LrosCustomHeadersClientImpl.java
@@ -122,7 +122,7 @@ public final class LrosCustomHeadersClientImpl implements LrosCustomHeadersClien
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.putAsyncRetrySucceeded(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -365,7 +365,7 @@ public final class LrosCustomHeadersClientImpl implements LrosCustomHeadersClien
         return FluxUtil
             .withContext(
                 context -> service.put201CreatingSucceeded200(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -609,7 +609,7 @@ public final class LrosCustomHeadersClientImpl implements LrosCustomHeadersClien
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.post202Retry200(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -833,7 +833,7 @@ public final class LrosCustomHeadersClientImpl implements LrosCustomHeadersClien
         return FluxUtil
             .withContext(
                 context -> service.postAsyncRetrySucceeded(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**

--- a/azure-tests/src/main/java/fixtures/lro/implementation/LrosCustomHeadersImpl.java
+++ b/azure-tests/src/main/java/fixtures/lro/implementation/LrosCustomHeadersImpl.java
@@ -3,7 +3,6 @@ package fixtures.lro.implementation;
 import com.azure.core.util.Context;
 import com.azure.core.util.logging.ClientLogger;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import fixtures.lro.LroManager;
 import fixtures.lro.fluent.LrosCustomHeadersClient;
 import fixtures.lro.fluent.models.ProductInner;
 import fixtures.lro.models.LrosCustomHeaders;
@@ -14,9 +13,9 @@ public final class LrosCustomHeadersImpl implements LrosCustomHeaders {
 
     private final LrosCustomHeadersClient innerClient;
 
-    private final LroManager serviceManager;
+    private final fixtures.lro.LroManager serviceManager;
 
-    public LrosCustomHeadersImpl(LrosCustomHeadersClient innerClient, LroManager serviceManager) {
+    public LrosCustomHeadersImpl(LrosCustomHeadersClient innerClient, fixtures.lro.LroManager serviceManager) {
         this.innerClient = innerClient;
         this.serviceManager = serviceManager;
     }
@@ -103,7 +102,7 @@ public final class LrosCustomHeadersImpl implements LrosCustomHeaders {
         return this.innerClient;
     }
 
-    private LroManager manager() {
+    private fixtures.lro.LroManager manager() {
         return this.serviceManager;
     }
 }

--- a/azure-tests/src/main/java/fixtures/lro/implementation/LrosaDsClientImpl.java
+++ b/azure-tests/src/main/java/fixtures/lro/implementation/LrosaDsClientImpl.java
@@ -315,7 +315,7 @@ public final class LrosaDsClientImpl implements LrosaDsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.putNonRetry400(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -521,7 +521,7 @@ public final class LrosaDsClientImpl implements LrosaDsClient {
         return FluxUtil
             .withContext(
                 context -> service.putNonRetry201Creating400(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -733,7 +733,7 @@ public final class LrosaDsClientImpl implements LrosaDsClient {
             .withContext(
                 context ->
                     service.putNonRetry201Creating400InvalidJson(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -949,7 +949,7 @@ public final class LrosaDsClientImpl implements LrosaDsClient {
         return FluxUtil
             .withContext(
                 context -> service.putAsyncRelativeRetry400(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -1164,7 +1164,7 @@ public final class LrosaDsClientImpl implements LrosaDsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.deleteNonRetry400(this.client.getEndpoint(), accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -1316,7 +1316,7 @@ public final class LrosaDsClientImpl implements LrosaDsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.delete202NonRetry400(this.client.getEndpoint(), accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -1469,7 +1469,7 @@ public final class LrosaDsClientImpl implements LrosaDsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.deleteAsyncRelativeRetry400(this.client.getEndpoint(), accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -1635,7 +1635,7 @@ public final class LrosaDsClientImpl implements LrosaDsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.postNonRetry400(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -1833,7 +1833,7 @@ public final class LrosaDsClientImpl implements LrosaDsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.post202NonRetry400(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -2034,7 +2034,7 @@ public final class LrosaDsClientImpl implements LrosaDsClient {
         return FluxUtil
             .withContext(
                 context -> service.postAsyncRelativeRetry400(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -2250,7 +2250,7 @@ public final class LrosaDsClientImpl implements LrosaDsClient {
             .withContext(
                 context ->
                     service.putError201NoProvisioningStatePayload(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -2468,7 +2468,7 @@ public final class LrosaDsClientImpl implements LrosaDsClient {
         return FluxUtil
             .withContext(
                 context -> service.putAsyncRelativeRetryNoStatus(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -2704,7 +2704,7 @@ public final class LrosaDsClientImpl implements LrosaDsClient {
             .withContext(
                 context ->
                     service.putAsyncRelativeRetryNoStatusPayload(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -2935,7 +2935,7 @@ public final class LrosaDsClientImpl implements LrosaDsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.delete204Succeeded(this.client.getEndpoint(), accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -3089,7 +3089,7 @@ public final class LrosaDsClientImpl implements LrosaDsClient {
         return FluxUtil
             .withContext(
                 context -> service.deleteAsyncRelativeRetryNoStatus(this.client.getEndpoint(), accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -3257,7 +3257,7 @@ public final class LrosaDsClientImpl implements LrosaDsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.post202NoLocation(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -3458,7 +3458,7 @@ public final class LrosaDsClientImpl implements LrosaDsClient {
         return FluxUtil
             .withContext(
                 context -> service.postAsyncRelativeRetryNoPayload(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -3683,7 +3683,7 @@ public final class LrosaDsClientImpl implements LrosaDsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.put200InvalidJson(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -3891,7 +3891,7 @@ public final class LrosaDsClientImpl implements LrosaDsClient {
             .withContext(
                 context ->
                     service.putAsyncRelativeRetryInvalidHeader(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -4122,7 +4122,7 @@ public final class LrosaDsClientImpl implements LrosaDsClient {
                 context ->
                     service
                         .putAsyncRelativeRetryInvalidJsonPolling(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -4355,7 +4355,7 @@ public final class LrosaDsClientImpl implements LrosaDsClient {
         final String accept = "application/json";
         return FluxUtil
             .withContext(context -> service.delete202RetryInvalidHeader(this.client.getEndpoint(), accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -4518,7 +4518,7 @@ public final class LrosaDsClientImpl implements LrosaDsClient {
         return FluxUtil
             .withContext(
                 context -> service.deleteAsyncRelativeRetryInvalidHeader(this.client.getEndpoint(), accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -4684,7 +4684,7 @@ public final class LrosaDsClientImpl implements LrosaDsClient {
             .withContext(
                 context ->
                     service.deleteAsyncRelativeRetryInvalidJsonPolling(this.client.getEndpoint(), accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -4857,7 +4857,7 @@ public final class LrosaDsClientImpl implements LrosaDsClient {
         return FluxUtil
             .withContext(
                 context -> service.post202RetryInvalidHeader(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -5074,7 +5074,7 @@ public final class LrosaDsClientImpl implements LrosaDsClient {
             .withContext(
                 context ->
                     service.postAsyncRelativeRetryInvalidHeader(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**
@@ -5298,7 +5298,7 @@ public final class LrosaDsClientImpl implements LrosaDsClient {
                 context ->
                     service
                         .postAsyncRelativeRetryInvalidJsonPolling(this.client.getEndpoint(), product, accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**

--- a/azure-tests/src/main/java/fixtures/lro/implementation/LrosaDsImpl.java
+++ b/azure-tests/src/main/java/fixtures/lro/implementation/LrosaDsImpl.java
@@ -3,7 +3,6 @@ package fixtures.lro.implementation;
 import com.azure.core.util.Context;
 import com.azure.core.util.logging.ClientLogger;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import fixtures.lro.LroManager;
 import fixtures.lro.fluent.LrosaDsClient;
 import fixtures.lro.fluent.models.ProductInner;
 import fixtures.lro.models.LrosaDs;
@@ -14,9 +13,9 @@ public final class LrosaDsImpl implements LrosaDs {
 
     private final LrosaDsClient innerClient;
 
-    private final LroManager serviceManager;
+    private final fixtures.lro.LroManager serviceManager;
 
-    public LrosaDsImpl(LrosaDsClient innerClient, LroManager serviceManager) {
+    public LrosaDsImpl(LrosaDsClient innerClient, fixtures.lro.LroManager serviceManager) {
         this.innerClient = innerClient;
         this.serviceManager = serviceManager;
     }
@@ -455,7 +454,7 @@ public final class LrosaDsImpl implements LrosaDs {
         return this.innerClient;
     }
 
-    private LroManager manager() {
+    private fixtures.lro.LroManager manager() {
         return this.serviceManager;
     }
 }

--- a/azure-tests/src/main/java/fixtures/lro/implementation/ProductImpl.java
+++ b/azure-tests/src/main/java/fixtures/lro/implementation/ProductImpl.java
@@ -1,6 +1,5 @@
 package fixtures.lro.implementation;
 
-import fixtures.lro.LroManager;
 import fixtures.lro.fluent.models.ProductInner;
 import fixtures.lro.models.Product;
 import fixtures.lro.models.ProductPropertiesProvisioningStateValues;
@@ -10,9 +9,9 @@ import java.util.Map;
 public final class ProductImpl implements Product {
     private ProductInner innerObject;
 
-    private final LroManager serviceManager;
+    private final fixtures.lro.LroManager serviceManager;
 
-    ProductImpl(ProductInner innerObject, LroManager serviceManager) {
+    ProductImpl(ProductInner innerObject, fixtures.lro.LroManager serviceManager) {
         this.innerObject = innerObject;
         this.serviceManager = serviceManager;
     }
@@ -54,7 +53,7 @@ public final class ProductImpl implements Product {
         return this.innerObject;
     }
 
-    private LroManager manager() {
+    private fixtures.lro.LroManager manager() {
         return this.serviceManager;
     }
 }

--- a/azure-tests/src/main/java/fixtures/lro/implementation/SkuImpl.java
+++ b/azure-tests/src/main/java/fixtures/lro/implementation/SkuImpl.java
@@ -1,15 +1,14 @@
 package fixtures.lro.implementation;
 
-import fixtures.lro.LroManager;
 import fixtures.lro.fluent.models.SkuInner;
 import fixtures.lro.models.Sku;
 
 public final class SkuImpl implements Sku {
     private SkuInner innerObject;
 
-    private final LroManager serviceManager;
+    private final fixtures.lro.LroManager serviceManager;
 
-    SkuImpl(SkuInner innerObject, LroManager serviceManager) {
+    SkuImpl(SkuInner innerObject, fixtures.lro.LroManager serviceManager) {
         this.innerObject = innerObject;
         this.serviceManager = serviceManager;
     }
@@ -26,7 +25,7 @@ public final class SkuImpl implements Sku {
         return this.innerObject;
     }
 
-    private LroManager manager() {
+    private fixtures.lro.LroManager manager() {
         return this.serviceManager;
     }
 }

--- a/azure-tests/src/main/java/fixtures/lro/implementation/SubProductImpl.java
+++ b/azure-tests/src/main/java/fixtures/lro/implementation/SubProductImpl.java
@@ -1,6 +1,5 @@
 package fixtures.lro.implementation;
 
-import fixtures.lro.LroManager;
 import fixtures.lro.fluent.models.SubProductInner;
 import fixtures.lro.models.SubProduct;
 import fixtures.lro.models.SubProductPropertiesProvisioningStateValues;
@@ -8,9 +7,9 @@ import fixtures.lro.models.SubProductPropertiesProvisioningStateValues;
 public final class SubProductImpl implements SubProduct {
     private SubProductInner innerObject;
 
-    private final LroManager serviceManager;
+    private final fixtures.lro.LroManager serviceManager;
 
-    SubProductImpl(SubProductInner innerObject, LroManager serviceManager) {
+    SubProductImpl(SubProductInner innerObject, fixtures.lro.LroManager serviceManager) {
         this.innerObject = innerObject;
         this.serviceManager = serviceManager;
     }
@@ -31,7 +30,7 @@ public final class SubProductImpl implements SubProduct {
         return this.innerObject;
     }
 
-    private LroManager manager() {
+    private fixtures.lro.LroManager manager() {
         return this.serviceManager;
     }
 }

--- a/azure-tests/src/main/java/fixtures/lro/implementation/Utils.java
+++ b/azure-tests/src/main/java/fixtures/lro/implementation/Utils.java
@@ -1,11 +1,19 @@
 package fixtures.lro.implementation;
 
+import com.azure.core.http.rest.PagedFlux;
+import com.azure.core.http.rest.PagedIterable;
+import com.azure.core.http.rest.PagedResponse;
+import com.azure.core.http.rest.PagedResponseBase;
 import com.azure.core.util.CoreUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import reactor.core.publisher.Flux;
 
 final class Utils {
     static String getValueFromIdByName(String id, String name) {
@@ -59,5 +67,134 @@ final class Utils {
             }
         }
         return null;
+    }
+
+    static <T, S> PagedIterable<S> mapPage(PagedIterable<T> pageIterable, Function<T, S> mapper) {
+        return new PagedIterableImpl<T, S>(pageIterable, mapper);
+    }
+
+    private static final class PagedIterableImpl<T, S> extends PagedIterable<S> {
+
+        private final PagedIterable<T> pagedIterable;
+        private final Function<T, S> mapper;
+        private final Function<PagedResponse<T>, PagedResponse<S>> pageMapper;
+
+        private PagedIterableImpl(PagedIterable<T> pagedIterable, Function<T, S> mapper) {
+            super(
+                PagedFlux
+                    .create(
+                        () ->
+                            (continuationToken, pageSize) ->
+                                Flux.fromStream(pagedIterable.streamByPage().map(getPageMapper(mapper)))));
+            this.pagedIterable = pagedIterable;
+            this.mapper = mapper;
+            this.pageMapper = getPageMapper(mapper);
+        }
+
+        private static <T, S> Function<PagedResponse<T>, PagedResponse<S>> getPageMapper(Function<T, S> mapper) {
+            return page ->
+                new PagedResponseBase<Void, S>(
+                    page.getRequest(),
+                    page.getStatusCode(),
+                    page.getHeaders(),
+                    page.getElements().stream().map(mapper).collect(Collectors.toList()),
+                    page.getContinuationToken(),
+                    null);
+        }
+
+        @Override
+        public Stream<S> stream() {
+            return pagedIterable.stream().map(mapper);
+        }
+
+        @Override
+        public Stream<PagedResponse<S>> streamByPage() {
+            return pagedIterable.streamByPage().map(pageMapper);
+        }
+
+        @Override
+        public Stream<PagedResponse<S>> streamByPage(String continuationToken) {
+            return pagedIterable.streamByPage(continuationToken).map(pageMapper);
+        }
+
+        @Override
+        public Stream<PagedResponse<S>> streamByPage(int preferredPageSize) {
+            return pagedIterable.streamByPage(preferredPageSize).map(pageMapper);
+        }
+
+        @Override
+        public Stream<PagedResponse<S>> streamByPage(String continuationToken, int preferredPageSize) {
+            return pagedIterable.streamByPage(continuationToken, preferredPageSize).map(pageMapper);
+        }
+
+        @Override
+        public Iterator<S> iterator() {
+            return new IteratorImpl<T, S>(pagedIterable.iterator(), mapper);
+        }
+
+        @Override
+        public Iterable<PagedResponse<S>> iterableByPage() {
+            return new IterableImpl<PagedResponse<T>, PagedResponse<S>>(pagedIterable.iterableByPage(), pageMapper);
+        }
+
+        @Override
+        public Iterable<PagedResponse<S>> iterableByPage(String continuationToken) {
+            return new IterableImpl<PagedResponse<T>, PagedResponse<S>>(
+                pagedIterable.iterableByPage(continuationToken), pageMapper);
+        }
+
+        @Override
+        public Iterable<PagedResponse<S>> iterableByPage(int preferredPageSize) {
+            return new IterableImpl<PagedResponse<T>, PagedResponse<S>>(
+                pagedIterable.iterableByPage(preferredPageSize), pageMapper);
+        }
+
+        @Override
+        public Iterable<PagedResponse<S>> iterableByPage(String continuationToken, int preferredPageSize) {
+            return new IterableImpl<PagedResponse<T>, PagedResponse<S>>(
+                pagedIterable.iterableByPage(continuationToken, preferredPageSize), pageMapper);
+        }
+    }
+
+    private static final class IteratorImpl<T, S> implements Iterator<S> {
+
+        private final Iterator<T> iterator;
+        private final Function<T, S> mapper;
+
+        private IteratorImpl(Iterator<T> iterator, Function<T, S> mapper) {
+            this.iterator = iterator;
+            this.mapper = mapper;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return iterator.hasNext();
+        }
+
+        @Override
+        public S next() {
+            return mapper.apply(iterator.next());
+        }
+
+        @Override
+        public void remove() {
+            iterator.remove();
+        }
+    }
+
+    private static final class IterableImpl<T, S> implements Iterable<S> {
+
+        private final Iterable<T> iterable;
+        private final Function<T, S> mapper;
+
+        private IterableImpl(Iterable<T> iterable, Function<T, S> mapper) {
+            this.iterable = iterable;
+            this.mapper = mapper;
+        }
+
+        @Override
+        public Iterator<S> iterator() {
+            return new IteratorImpl<T, S>(iterable.iterator(), mapper);
+        }
     }
 }

--- a/azure-tests/src/main/java/fixtures/lroparameterizedendpoints/implementation/ResourceProvidersClientImpl.java
+++ b/azure-tests/src/main/java/fixtures/lroparameterizedendpoints/implementation/ResourceProvidersClientImpl.java
@@ -85,7 +85,7 @@ public final class ResourceProvidersClientImpl implements ResourceProvidersClien
         return FluxUtil
             .withContext(
                 context -> service.pollWithParameterizedEndpoints(accountName, this.client.getHost(), accept, context))
-            .subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext())));
+            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
     }
 
     /**

--- a/azure-tests/src/main/java/fixtures/lroparameterizedendpoints/implementation/ResourceProvidersImpl.java
+++ b/azure-tests/src/main/java/fixtures/lroparameterizedendpoints/implementation/ResourceProvidersImpl.java
@@ -3,7 +3,6 @@ package fixtures.lroparameterizedendpoints.implementation;
 import com.azure.core.util.Context;
 import com.azure.core.util.logging.ClientLogger;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import fixtures.lroparameterizedendpoints.LroparameterizedendpointsManager;
 import fixtures.lroparameterizedendpoints.fluent.ResourceProvidersClient;
 import fixtures.lroparameterizedendpoints.models.ResourceProviders;
 
@@ -12,9 +11,11 @@ public final class ResourceProvidersImpl implements ResourceProviders {
 
     private final ResourceProvidersClient innerClient;
 
-    private final LroparameterizedendpointsManager serviceManager;
+    private final fixtures.lroparameterizedendpoints.LroparameterizedendpointsManager serviceManager;
 
-    public ResourceProvidersImpl(ResourceProvidersClient innerClient, LroparameterizedendpointsManager serviceManager) {
+    public ResourceProvidersImpl(
+        ResourceProvidersClient innerClient,
+        fixtures.lroparameterizedendpoints.LroparameterizedendpointsManager serviceManager) {
         this.innerClient = innerClient;
         this.serviceManager = serviceManager;
     }
@@ -31,7 +32,7 @@ public final class ResourceProvidersImpl implements ResourceProviders {
         return this.innerClient;
     }
 
-    private LroparameterizedendpointsManager manager() {
+    private fixtures.lroparameterizedendpoints.LroparameterizedendpointsManager manager() {
         return this.serviceManager;
     }
 }

--- a/azure-tests/src/main/java/fixtures/lroparameterizedendpoints/implementation/Utils.java
+++ b/azure-tests/src/main/java/fixtures/lroparameterizedendpoints/implementation/Utils.java
@@ -1,11 +1,19 @@
 package fixtures.lroparameterizedendpoints.implementation;
 
+import com.azure.core.http.rest.PagedFlux;
+import com.azure.core.http.rest.PagedIterable;
+import com.azure.core.http.rest.PagedResponse;
+import com.azure.core.http.rest.PagedResponseBase;
 import com.azure.core.util.CoreUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import reactor.core.publisher.Flux;
 
 final class Utils {
     static String getValueFromIdByName(String id, String name) {
@@ -59,5 +67,134 @@ final class Utils {
             }
         }
         return null;
+    }
+
+    static <T, S> PagedIterable<S> mapPage(PagedIterable<T> pageIterable, Function<T, S> mapper) {
+        return new PagedIterableImpl<T, S>(pageIterable, mapper);
+    }
+
+    private static final class PagedIterableImpl<T, S> extends PagedIterable<S> {
+
+        private final PagedIterable<T> pagedIterable;
+        private final Function<T, S> mapper;
+        private final Function<PagedResponse<T>, PagedResponse<S>> pageMapper;
+
+        private PagedIterableImpl(PagedIterable<T> pagedIterable, Function<T, S> mapper) {
+            super(
+                PagedFlux
+                    .create(
+                        () ->
+                            (continuationToken, pageSize) ->
+                                Flux.fromStream(pagedIterable.streamByPage().map(getPageMapper(mapper)))));
+            this.pagedIterable = pagedIterable;
+            this.mapper = mapper;
+            this.pageMapper = getPageMapper(mapper);
+        }
+
+        private static <T, S> Function<PagedResponse<T>, PagedResponse<S>> getPageMapper(Function<T, S> mapper) {
+            return page ->
+                new PagedResponseBase<Void, S>(
+                    page.getRequest(),
+                    page.getStatusCode(),
+                    page.getHeaders(),
+                    page.getElements().stream().map(mapper).collect(Collectors.toList()),
+                    page.getContinuationToken(),
+                    null);
+        }
+
+        @Override
+        public Stream<S> stream() {
+            return pagedIterable.stream().map(mapper);
+        }
+
+        @Override
+        public Stream<PagedResponse<S>> streamByPage() {
+            return pagedIterable.streamByPage().map(pageMapper);
+        }
+
+        @Override
+        public Stream<PagedResponse<S>> streamByPage(String continuationToken) {
+            return pagedIterable.streamByPage(continuationToken).map(pageMapper);
+        }
+
+        @Override
+        public Stream<PagedResponse<S>> streamByPage(int preferredPageSize) {
+            return pagedIterable.streamByPage(preferredPageSize).map(pageMapper);
+        }
+
+        @Override
+        public Stream<PagedResponse<S>> streamByPage(String continuationToken, int preferredPageSize) {
+            return pagedIterable.streamByPage(continuationToken, preferredPageSize).map(pageMapper);
+        }
+
+        @Override
+        public Iterator<S> iterator() {
+            return new IteratorImpl<T, S>(pagedIterable.iterator(), mapper);
+        }
+
+        @Override
+        public Iterable<PagedResponse<S>> iterableByPage() {
+            return new IterableImpl<PagedResponse<T>, PagedResponse<S>>(pagedIterable.iterableByPage(), pageMapper);
+        }
+
+        @Override
+        public Iterable<PagedResponse<S>> iterableByPage(String continuationToken) {
+            return new IterableImpl<PagedResponse<T>, PagedResponse<S>>(
+                pagedIterable.iterableByPage(continuationToken), pageMapper);
+        }
+
+        @Override
+        public Iterable<PagedResponse<S>> iterableByPage(int preferredPageSize) {
+            return new IterableImpl<PagedResponse<T>, PagedResponse<S>>(
+                pagedIterable.iterableByPage(preferredPageSize), pageMapper);
+        }
+
+        @Override
+        public Iterable<PagedResponse<S>> iterableByPage(String continuationToken, int preferredPageSize) {
+            return new IterableImpl<PagedResponse<T>, PagedResponse<S>>(
+                pagedIterable.iterableByPage(continuationToken, preferredPageSize), pageMapper);
+        }
+    }
+
+    private static final class IteratorImpl<T, S> implements Iterator<S> {
+
+        private final Iterator<T> iterator;
+        private final Function<T, S> mapper;
+
+        private IteratorImpl(Iterator<T> iterator, Function<T, S> mapper) {
+            this.iterator = iterator;
+            this.mapper = mapper;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return iterator.hasNext();
+        }
+
+        @Override
+        public S next() {
+            return mapper.apply(iterator.next());
+        }
+
+        @Override
+        public void remove() {
+            iterator.remove();
+        }
+    }
+
+    private static final class IterableImpl<T, S> implements Iterable<S> {
+
+        private final Iterable<T> iterable;
+        private final Function<T, S> mapper;
+
+        private IterableImpl(Iterable<T> iterable, Function<T, S> mapper) {
+            this.iterable = iterable;
+            this.mapper = mapper;
+        }
+
+        @Override
+        public Iterator<S> iterator() {
+            return new IteratorImpl<T, S>(iterable.iterator(), mapper);
+        }
     }
 }

--- a/fluent-tests/pom.xml
+++ b/fluent-tests/pom.xml
@@ -120,7 +120,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
-      <version>1.12.0</version>
+      <version>${azure-core.version}</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>

--- a/fluent-tests/src/test/java/com/azure/mgmttest/RuntimeTests.java
+++ b/fluent-tests/src/test/java/com/azure/mgmttest/RuntimeTests.java
@@ -24,7 +24,7 @@ import com.azure.identity.EnvironmentCredentialBuilder;
 import com.azure.mgmtlitetest.advisor.AdvisorManager;
 import com.azure.mgmtlitetest.advisor.models.ResourceRecommendationBase;
 import com.azure.mgmtlitetest.advisor.models.SuppressionContract;
-import com.azure.mgmtlitetest.mediaservices.MediaservicesManager;
+import com.azure.mgmtlitetest.mediaservices.MediaServicesManager;
 import com.azure.mgmtlitetest.mediaservices.models.MediaService;
 import com.azure.mgmtlitetest.mediaservices.models.StorageAccountType;
 import com.azure.mgmtlitetest.resources.ResourceManager;
@@ -208,7 +208,7 @@ public class RuntimeTests {
     }
 
     private void testMediaServices(StorageAccount storageAccount) {
-        MediaservicesManager mediaservicesManager = authenticateMediaServicesManager();
+        MediaServicesManager mediaservicesManager = authenticateMediaServicesManager();
 
         String rgName = "rg1-weidxu-fluentlite";
         String msName = "ms1weidxulite";
@@ -291,8 +291,8 @@ public class RuntimeTests {
                 .authenticate(new EnvironmentCredentialBuilder().build(), new AzureProfile(AzureEnvironment.AZURE));
     }
 
-    private MediaservicesManager authenticateMediaServicesManager() {
-        return MediaservicesManager.configure()
+    private MediaServicesManager authenticateMediaServicesManager() {
+        return MediaServicesManager.configure()
                 .withLogOptions(new HttpLogOptions().setLogLevel(HttpLogDetailLevel.BODY_AND_HEADERS))
                 .authenticate(new EnvironmentCredentialBuilder().build(), new AzureProfile(AzureEnvironment.AZURE));
     }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/projectmodel/Project.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/projectmodel/Project.java
@@ -40,7 +40,7 @@ public class Project {
 
     public static class PackageVersions {
         private String azureClientSdkParentVersion = "1.7.0";
-        private String azureCoreVersion = "1.14.0";
+        private String azureCoreVersion = "1.14.1";
         private String azureCoreManagementVersion = "1.2.0";
         private String jacocoMavenPlugin = "0.8.5";
 

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentClientMethodTemplate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentClientMethodTemplate.java
@@ -110,7 +110,7 @@ public class FluentClientMethodTemplate extends ClientMethodTemplate {
                         }
                     });
                     if (addContextParameter) {
-                        function.line(String.format(".subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(%s.getContext())));", clientMethod.getClientReference()));
+                        function.line(String.format(".contextWrite(context -> context.putAll(FluxUtil.toReactorContext(%s.getContext()).readOnly()));", clientMethod.getClientReference()));
                     }
                 });
             });
@@ -189,7 +189,7 @@ public class FluentClientMethodTemplate extends ClientMethodTemplate {
                         }
                     });
                     if (addContextParameter) {
-                        function.line(String.format(".subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(%s.getContext())));", clientMethod.getClientReference()));
+                        function.line(String.format(".contextWrite(context -> context.putAll(FluxUtil.toReactorContext(%s.getContext()).readOnly()));", clientMethod.getClientReference()));
                     }
                 });
             });
@@ -216,7 +216,7 @@ public class FluentClientMethodTemplate extends ClientMethodTemplate {
                 function.line(String.format("return FluxUtil.withContext(context -> %s)",
                         serviceMethodCall));
                 function.indent(() -> {
-                    function.line(String.format(".subscriberContext(context -> context.putAll(FluxUtil.toReactorContext(%s.getContext())));", clientMethod.getClientReference()));
+                    function.line(String.format(".contextWrite(context -> context.putAll(FluxUtil.toReactorContext(%s.getContext()).readOnly()));", clientMethod.getClientReference()));
                 });
             } else {
                 function.methodReturn(serviceMethodCall);

--- a/fluentnamer/pom.xml
+++ b/fluentnamer/pom.xml
@@ -29,6 +29,12 @@
 
     <dependency>
       <groupId>com.azure</groupId>
+      <artifactId>azure-core</artifactId>
+      <version>${azure-core.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.azure</groupId>
       <artifactId>azure-core-management</artifactId>
       <version>${azure-core-management.version}</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <azure-core.version>1.14.1</azure-core.version>
     <azure-core-management.version>1.2.0</azure-core-management.version>
   </properties>
 


### PR DESCRIPTION
Some method used in fluentgen is marked as deprecated in current reactor used by SDK repo. Need to update them.