### PR TITLE
v4, bug fix, should use property.getWireType().getClientType() if available

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -290,7 +290,11 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                 if (!parentProperty.getIsReadOnly() && !(settings.isRequiredFieldsAsConstructorArgs() && parentProperty.isRequired())) {
                     classBlock.javadocComment(JavaJavadocComment::inheritDoc);
                     classBlock.annotation("Override");
-                    classBlock.publicMethod(String.format("%s %s(%s %s)", model.getName(), parentProperty.getSetterName(), parentProperty.getClientType(), parentProperty.getName()),
+                    classBlock.publicMethod(String.format("%s %s(%s %s)",
+                            model.getName(),
+                            parentProperty.getSetterName(),
+                            parentProperty.getWireType() == null ? parentProperty.getClientType() : parentProperty.getWireType().getClientType(),
+                            parentProperty.getName()),
                             methodBlock -> {
                                 methodBlock.line(String.format("super.%1$s(%2$s);", parentProperty.getSetterName(), parentProperty.getName()));
                                 methodBlock.methodReturn("this");


### PR DESCRIPTION
Follow model property here https://github.com/Azure/autorest.java/blob/v4/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java#L197-L208