### PR TITLE
v4 fluent, improve model clean up

### DIFF
--- a/fluentnamer/src/main/java/com/azure/autorest/fluent/transformer/ErrorTypeNormalization.java
+++ b/fluentnamer/src/main/java/com/azure/autorest/fluent/transformer/ErrorTypeNormalization.java
@@ -85,7 +85,7 @@ public class ErrorTypeNormalization {
     private void normalizeErrorType(ObjectSchema error, ObjectSchema errorSchema) {
         switch (getErrorType(errorSchema)) {
             case MANAGEMENT_ERROR:
-                logger.info("Rename error from `{}` to `ManagementError`", Utils.getJavaName(error));
+                logger.info("Rename error from '{}' to 'ManagementError'", Utils.getJavaName(error));
 
                 error.getLanguage().getJava().setName(FluentType.ManagementError.getName());
 
@@ -102,7 +102,7 @@ public class ErrorTypeNormalization {
                 break;
 
             case SUBCLASS_MANAGEMENT_ERROR:
-                logger.info("Modify error `{}` as subclass of `ManagementError`", Utils.getJavaName(error));
+                logger.info("Modify error '{}' as subclass of 'ManagementError'", Utils.getJavaName(error));
 
                 error.getLanguage().getJava().setName(Utils.getJavaName(errorSchema));
 
@@ -138,7 +138,7 @@ public class ErrorTypeNormalization {
                 if (schema instanceof ObjectSchema) {
                     ObjectSchema error = (ObjectSchema) schema;
 
-                    logger.info("Modify type `{}` as subclass of `{}`", Utils.getJavaName(error), Utils.getJavaName(errorSchema));
+                    logger.info("Modify type '{}' as subclass of '{}'", Utils.getJavaName(error), Utils.getJavaName(errorSchema));
 
                     filterProperties(error);
                 }

--- a/fluentnamer/src/main/java/com/azure/autorest/fluent/transformer/SchemaCleanup.java
+++ b/fluentnamer/src/main/java/com/azure/autorest/fluent/transformer/SchemaCleanup.java
@@ -135,9 +135,9 @@ public class SchemaCleanup {
 
     private static Schema schemaOrElementInCollection(Schema schema) {
         if (schema instanceof ArraySchema) {
-            return ((ArraySchema) schema).getElementType();
+            return schemaOrElementInCollection(((ArraySchema) schema).getElementType());
         } else if (schema instanceof DictionarySchema) {
-            return ((DictionarySchema) schema).getElementType();
+            return schemaOrElementInCollection(((DictionarySchema) schema).getElementType());
         } else {
             return schema;
         }

--- a/fluentnamer/src/main/java/com/azure/autorest/fluent/transformer/SchemaCleanup.java
+++ b/fluentnamer/src/main/java/com/azure/autorest/fluent/transformer/SchemaCleanup.java
@@ -62,16 +62,8 @@ public class SchemaCleanup {
                     .flatMap(s -> s.getProperties().stream())
 //                    .filter(Utils::nonFlattenedProperty)
                     .map(Property::getSchema)
+                    .map(SchemaCleanup::schemaOrElementInCollection)
                     .filter(Objects::nonNull)
-                    .collect(Collectors.toSet());
-            schemasNotInUse.removeAll(schemasInUse);
-            choicesSchemasNotInUse.removeAll(schemasInUse);
-        }
-        if (!schemasNotInUse.isEmpty()) {
-            // elements of array or dictionary
-            schemasInUse = Stream.concat(
-                    codeModel.getSchemas().getArrays().stream().map(ArraySchema::getElementType),
-                    codeModel.getSchemas().getDictionaries().stream().map(DictionarySchema::getElementType))
                     .collect(Collectors.toSet());
             schemasNotInUse.removeAll(schemasInUse);
             choicesSchemasNotInUse.removeAll(schemasInUse);
@@ -83,6 +75,7 @@ public class SchemaCleanup {
                     .flatMap(o -> o.getRequests().stream())
                     .flatMap(r -> r.getParameters().stream())
                     .map(Parameter::getSchema)
+                    .map(SchemaCleanup::schemaOrElementInCollection)
                     .filter(Objects::nonNull)
                     .collect(Collectors.toSet());
             schemasNotInUse.removeAll(schemasInUse);
@@ -94,6 +87,7 @@ public class SchemaCleanup {
                     .flatMap(og -> og.getOperations().stream())
                     .flatMap(o -> o.getResponses().stream())
                     .map(Response::getSchema)
+                    .map(SchemaCleanup::schemaOrElementInCollection)
                     .filter(Objects::nonNull)
                     .collect(Collectors.toSet());
             schemasNotInUse.removeAll(schemasInUse);
@@ -105,6 +99,7 @@ public class SchemaCleanup {
                     .flatMap(og -> og.getOperations().stream())
                     .flatMap(o -> o.getExceptions().stream())
                     .map(Response::getSchema)
+                    .map(SchemaCleanup::schemaOrElementInCollection)
                     .filter(Objects::nonNull)
                     .collect(Collectors.toSet());
             schemasNotInUse.removeAll(schemasInUse);
@@ -136,6 +131,16 @@ public class SchemaCleanup {
         });
 
         return codeModel;
+    }
+
+    private static Schema schemaOrElementInCollection(Schema schema) {
+        if (schema instanceof ArraySchema) {
+            return ((ArraySchema) schema).getElementType();
+        } else if (schema instanceof DictionarySchema) {
+            return ((DictionarySchema) schema).getElementType();
+        } else {
+            return schema;
+        }
     }
 
 //    private static boolean hasFlattenedExtension(Schema schema) {


### PR DESCRIPTION
This would fix that `ErrorAdditionalInfo` not removed, after the error object is replace by shared `ManagementError` in azure-core-management.