### PR TITLE
Add API to list classes and include logger in customization method

### DIFF
--- a/customization-base/src/main/java/com/azure/autorest/customization/Customization.java
+++ b/customization-base/src/main/java/com/azure/autorest/customization/Customization.java
@@ -2,6 +2,7 @@ package com.azure.autorest.customization;
 
 import com.azure.autorest.customization.implementation.Utils;
 import com.azure.autorest.customization.implementation.ls.EclipseLanguageClient;
+import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -19,7 +20,7 @@ public abstract class Customization {
      * @param files the list of files generated in the previous steps in AutoRest
      * @return the list of files after customization
      */
-    public final Map<String, String> run(Map<String, String> files) {
+    public final Map<String, String> run(Map<String, String> files, Logger logger) {
         Path tempDirWithPrefix;
 
         // Populate editor
@@ -40,7 +41,7 @@ public abstract class Customization {
         try {
             languageClient = new EclipseLanguageClient(tempDirWithPrefix.toString());
             languageClient.initialize();
-            customize(new LibraryCustomization(editor, languageClient));
+            customize(new LibraryCustomization(editor, languageClient), logger);
             editor.removeFile("pom.xml");
             return editor.getContents();
         } catch (Exception e) {
@@ -57,5 +58,5 @@ public abstract class Customization {
      * Override this method to customize the client library.
      * @param libraryCustomization the top level customization object
      */
-    public abstract void customize(LibraryCustomization libraryCustomization);
+    public abstract void customize(LibraryCustomization libraryCustomization, Logger logger);
 }

--- a/customization-base/src/main/java/com/azure/autorest/customization/PackageCustomization.java
+++ b/customization-base/src/main/java/com/azure/autorest/customization/PackageCustomization.java
@@ -39,6 +39,10 @@ public final class PackageCustomization {
             () -> new IllegalArgumentException(className + " does not exist in package " + packageName));
     }
 
+    /**
+     * This method lists all the classes in this package.
+     * @return A list of classes that are in this package.
+     */
     public List<ClassCustomization> listClasses() {
         List<ClassCustomization> classCustomizations = languageClient.findWorkspaceSymbol("*")
                 .stream()

--- a/customization-base/src/main/java/com/azure/autorest/customization/PackageCustomization.java
+++ b/customization-base/src/main/java/com/azure/autorest/customization/PackageCustomization.java
@@ -4,7 +4,9 @@ import com.azure.autorest.customization.implementation.Utils;
 import com.azure.autorest.customization.implementation.ls.EclipseLanguageClient;
 import com.azure.autorest.customization.implementation.ls.models.SymbolInformation;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * The package level customization for an AutoRest generated client library.
@@ -35,5 +37,15 @@ public final class PackageCustomization {
         return Utils.returnIfPresentOrThrow(classSymbol,
             symbol -> new ClassCustomization(editor, languageClient, packageName, className, symbol),
             () -> new IllegalArgumentException(className + " does not exist in package " + packageName));
+    }
+
+    public List<ClassCustomization> listClasses() {
+        List<ClassCustomization> classCustomizations = languageClient.findWorkspaceSymbol("*")
+                .stream()
+                .filter(si -> si.getContainerName().equals(packageName))
+                .map(classSymbol -> new ClassCustomization(editor, languageClient, packageName,
+                        classSymbol.getName(), classSymbol))
+                .collect(Collectors.toList());
+        return classCustomizations;
     }
 }

--- a/customization-tests/swagger/src/main/java/BodyComplexCustomization.java
+++ b/customization-tests/swagger/src/main/java/BodyComplexCustomization.java
@@ -2,10 +2,11 @@ import com.azure.autorest.customization.ClassCustomization;
 import com.azure.autorest.customization.Customization;
 import com.azure.autorest.customization.LibraryCustomization;
 import com.azure.autorest.customization.PackageCustomization;
+import org.slf4j.Logger;
 
 public class BodyComplexCustomization extends Customization {
     @Override
-    public void customize(LibraryCustomization customization) {
+    public void customize(LibraryCustomization customization, Logger logger) {
         PackageCustomization implementationModels = customization.getPackage("fixtures.bodycomplex.implementation.models");
         implementationModels.getClass("Goblinshark").rename("GoblinShark");
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/java",
-  "version": "4.0.23",
+  "version": "4.0.24",
   "description": "The Java extension for classic generators in AutoRest.",
   "scripts": {
     "autorest": "autorest",

--- a/postprocessor/src/main/java/com/azure/autorest/postprocessor/Postprocessor.java
+++ b/postprocessor/src/main/java/com/azure/autorest/postprocessor/Postprocessor.java
@@ -110,7 +110,7 @@ public class Postprocessor extends NewPlugin {
       try {
         Customization customization = customizationClass.getConstructor().newInstance();
         logger.info("Running customization, this may take a while...");
-        fileContents = customization.run(fileContents);
+        fileContents = customization.run(fileContents, logger);
       } catch (Exception e) {
         logger.error("Unable to complete customization", e);
         return false;


### PR DESCRIPTION
This PR adds a new API to package customization to list all classes in a package. The abstract customization method is updated to include a logger, so that an debugging information can be printed out to console for debugginer when users are writing customization code.