### PR TITLE
Code Customization Performance Improvement and Ability to Replace Method Parameters

### DIFF
--- a/customization-base/src/main/java/com/azure/autorest/customization/Editor.java
+++ b/customization-base/src/main/java/com/azure/autorest/customization/Editor.java
@@ -70,9 +70,10 @@ public final class Editor {
         boolean fileCreated;
         try {
             fileCreated = newFile.createNewFile();
-            BufferedWriter writer = Files.newBufferedWriter(newFile.toPath());
-            writer.write(content);
-            writer.close();
+
+            try (BufferedWriter writer = Files.newBufferedWriter(newFile.toPath())) {
+                writer.write(content);
+            }
         } catch (IOException e) {
             throw new RuntimeException();
         }

--- a/customization-base/src/main/java/com/azure/autorest/customization/Editor.java
+++ b/customization-base/src/main/java/com/azure/autorest/customization/Editor.java
@@ -4,13 +4,10 @@ import com.azure.autorest.customization.implementation.Utils;
 import com.azure.autorest.customization.models.Position;
 import com.azure.autorest.customization.models.Range;
 
+import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -20,6 +17,8 @@ import java.util.Map;
 import java.util.Scanner;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import static com.azure.autorest.customization.implementation.Utils.writeLine;
 
 /**
  * The raw editor containing the current files being customized.
@@ -71,9 +70,9 @@ public final class Editor {
         boolean fileCreated;
         try {
             fileCreated = newFile.createNewFile();
-            FileOutputStream stream = new FileOutputStream(newFile);
-            stream.write(content.getBytes(StandardCharsets.UTF_8));
-            stream.close();
+            BufferedWriter writer = Files.newBufferedWriter(newFile.toPath());
+            writer.write(content);
+            writer.close();
         } catch (IOException e) {
             throw new RuntimeException();
         }
@@ -158,29 +157,40 @@ public final class Editor {
      * @param newContent the new content to replace the chunk
      */
     public void replace(String fileName, Position start, Position end, String newContent) {
-        StringWriter stringWriter = new StringWriter();
-        PrintWriter printWriter = new PrintWriter(stringWriter);
+        StringBuilder stringBuilder = new StringBuilder(4096);
         List<String> lineContent = lines.get(fileName);
+
+        // Copy lines until the start of the change is reached.
         for (int i = 0; i != start.getLine(); i++) {
-            printWriter.println(lineContent.get(i));
+            writeLine(stringBuilder, lineContent.get(i));
         }
-        printWriter.print(lineContent.get(start.getLine()).substring(0, start.getCharacter()));
+
+        // Copy until the start of the change.
+        stringBuilder.append(lineContent.get(start.getLine()), 0, start.getCharacter());
+
         List<String> replacementLineContent = splitContentIntoLines(newContent);
+
+        // Add the change.
         if (replacementLineContent.size() > 0) {
             for (int i = 0; i != replacementLineContent.size() - 1; i++) {
-                printWriter.println(replacementLineContent.get(i));
+                writeLine(stringBuilder, replacementLineContent.get(i));
             }
-            printWriter.print(replacementLineContent.get(replacementLineContent.size() - 1));
+
+            stringBuilder.append(replacementLineContent.get(replacementLineContent.size() - 1));
         }
-        printWriter.println(lineContent.get(end.getLine()).substring(end.getCharacter()));
+
+        writeLine(stringBuilder, lineContent.get(end.getLine()).substring(end.getCharacter()));
+
+        // Copy the rest of the file until its end.
         for (int i = end.getLine() + 1; i != lineContent.size(); i++) {
-            printWriter.println(lineContent.get(i));
+            writeLine(stringBuilder, lineContent.get(i));
         }
-        contents.put(fileName, stringWriter.toString());
+
+        contents.put(fileName, stringBuilder.toString());
         lines.put(fileName, splitContentIntoLines(contents.get(fileName)));
-        try (PrintWriter fileWriter = new PrintWriter(paths.get(fileName).toFile())) {
-            fileWriter.print(contents.get(fileName));
-        } catch (FileNotFoundException e) {
+        try (BufferedWriter fileWriter = Files.newBufferedWriter(paths.get(fileName))) {
+            fileWriter.write(contents.get(fileName));
+        } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
@@ -255,8 +265,7 @@ public final class Editor {
      * @return the text in the range
      */
     public String getTextInRange(String fileName, Range range, String delimiter) {
-        StringWriter stringWriter = new StringWriter();
-        PrintWriter printWriter = new PrintWriter(stringWriter);
+        StringBuilder stringBuilder = new StringBuilder(4096);
         for (int line = range.getStart().getLine(); line <= range.getEnd().getLine(); line++) {
             String lineContent = getFileLine(fileName, line);
             int truncateIndex = 0;
@@ -268,13 +277,12 @@ public final class Editor {
                 lineContent = lineContent.substring(0, range.getEnd().getCharacter() - truncateIndex);
             }
             if (delimiter == null) {
-                printWriter.println(lineContent);
+                writeLine(stringBuilder, lineContent);
             } else {
-                printWriter.print(lineContent);
-                printWriter.print(delimiter);
+                stringBuilder.append(lineContent).append(delimiter);
             }
         }
-        return stringWriter.toString();
+        return stringBuilder.toString();
     }
 
     private static List<String> splitContentIntoLines(String content) {

--- a/customization-base/src/main/java/com/azure/autorest/customization/MethodCustomization.java
+++ b/customization-base/src/main/java/com/azure/autorest/customization/MethodCustomization.java
@@ -93,7 +93,10 @@ public final class MethodCustomization {
         if (!newMethodSymbol.isPresent()) {
             throw new IllegalArgumentException("Renamed failed with new method " + newName + " not found.");
         }
-        return new MethodCustomization(editor, languageClient, packageName, className, newName, methodSignature.replace(methodName + "(", newName + "("), newMethodSymbol.get());
+
+        return new PackageCustomization(editor, languageClient, packageName)
+            .getClass(className)
+            .getMethod(methodSignature.replace(methodName + "(", newName + "("));
     }
 
     /**
@@ -282,9 +285,8 @@ public final class MethodCustomization {
         fileEvent.setType(FileChangeType.CHANGED);
         languageClient.notifyWatchedFilesChanged(Collections.singletonList(fileEvent));
 
-        return new PackageCustomization(editor, languageClient, packageName)
-            .getClass(className)
-            .getMethod(methodSignature);
+        return new MethodCustomization(editor, languageClient, packageName, className, methodName, methodSignature,
+            refreshSymbol());
     }
 
     /**
@@ -402,9 +404,12 @@ public final class MethodCustomization {
                         Utils.applyWorkspaceEdit(importEdit, editor, languageClient));
                 }
             });
+
         String newMethodSignature = methodSignature.replace(oldReturnType + " " + methodName, newReturnType + " " + methodName);
-        return new MethodCustomization(editor, languageClient, packageName, className, methodName, newMethodSignature,
-            refreshSymbol());
+
+        return new PackageCustomization(editor, languageClient, packageName)
+            .getClass(className)
+            .getMethod(newMethodSignature);
     }
 
     private SymbolInformation refreshSymbol() {

--- a/customization-base/src/main/java/com/azure/autorest/customization/implementation/Utils.java
+++ b/customization-base/src/main/java/com/azure/autorest/customization/implementation/Utils.java
@@ -128,5 +128,9 @@ public class Utils {
             : orElse.get();
     }
 
+    public static void writeLine(StringBuilder stringBuilder, String text) {
+        stringBuilder.append(text).append(System.lineSeparator());
+    }
+
     private Utils() {}
 }

--- a/customization-base/src/main/java/com/azure/autorest/customization/implementation/ls/EclipseLanguageClient.java
+++ b/customization-base/src/main/java/com/azure/autorest/customization/implementation/ls/EclipseLanguageClient.java
@@ -1,6 +1,5 @@
 package com.azure.autorest.customization.implementation.ls;
 
-import com.azure.autorest.extension.base.jsonrpc.Connection;
 import com.azure.autorest.customization.implementation.ls.models.ClientCapabilities;
 import com.azure.autorest.customization.implementation.ls.models.CodeAction;
 import com.azure.autorest.customization.implementation.ls.models.CodeActionClientCapabilities;
@@ -19,8 +18,6 @@ import com.azure.autorest.customization.implementation.ls.models.FormattingOptio
 import com.azure.autorest.customization.implementation.ls.models.InitializeParams;
 import com.azure.autorest.customization.implementation.ls.models.InitializeResponse;
 import com.azure.autorest.customization.implementation.ls.models.JavaCodeActionKind;
-import com.azure.autorest.customization.models.Position;
-import com.azure.autorest.customization.models.Range;
 import com.azure.autorest.customization.implementation.ls.models.RenameParams;
 import com.azure.autorest.customization.implementation.ls.models.ServerCapabilities;
 import com.azure.autorest.customization.implementation.ls.models.SymbolInformation;
@@ -37,6 +34,9 @@ import com.azure.autorest.customization.implementation.ls.models.WorkspaceCapabi
 import com.azure.autorest.customization.implementation.ls.models.WorkspaceEdit;
 import com.azure.autorest.customization.implementation.ls.models.WorkspaceFolder;
 import com.azure.autorest.customization.implementation.ls.models.WorkspaceSymbolClientCapabilities;
+import com.azure.autorest.customization.models.Position;
+import com.azure.autorest.customization.models.Range;
+import com.azure.autorest.extension.base.jsonrpc.Connection;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.jna.Library;
 import com.sun.jna.Native;
@@ -152,7 +152,7 @@ public class EclipseLanguageClient {
 
     public void notifyFileOpened(URI fileUri, String content, int version) {
         if (serverCapabilities.getTextDocumentSync() != null
-                && serverCapabilities.getTextDocumentSync().isOpenClose()) {
+            && serverCapabilities.getTextDocumentSync().isOpenClose()) {
             DidOpenTextDocumentParams params = new DidOpenTextDocumentParams();
             TextDocumentItem item = new TextDocumentItem();
             item.setUri(fileUri);
@@ -165,7 +165,7 @@ public class EclipseLanguageClient {
 
     public void notifyFileClosed(URI fileUri) {
         if (serverCapabilities.getTextDocumentSync() != null
-                && serverCapabilities.getTextDocumentSync().isOpenClose()) {
+            && serverCapabilities.getTextDocumentSync().isOpenClose()) {
             DidCloseTextDocumentParams params = new DidCloseTextDocumentParams();
             TextDocumentIdentifier item = new TextDocumentIdentifier(fileUri);
             params.setTextDocument(item);
@@ -175,7 +175,7 @@ public class EclipseLanguageClient {
 
     public void notifyFileChanged(URI fileUri, String newContent, List<TextEdit> textEdits, int version) {
         if (serverCapabilities.getTextDocumentSync() != null
-                && serverCapabilities.getTextDocumentSync().getChange() != 0) {
+            && serverCapabilities.getTextDocumentSync().getChange() != 0) {
             DidChangeTextDocumentParams params = new DidChangeTextDocumentParams();
             VersionedTextDocumentIdentifier item = new VersionedTextDocumentIdentifier(fileUri);
             item.setVersion(version);
@@ -204,7 +204,7 @@ public class EclipseLanguageClient {
 
     public void notifyFileToSave(URI fileUri) {
         if (serverCapabilities.getTextDocumentSync() != null
-                && serverCapabilities.getTextDocumentSync().isWillSave()) {
+            && serverCapabilities.getTextDocumentSync().isWillSave()) {
             WillSaveTextDocumentParams params = new WillSaveTextDocumentParams();
             TextDocumentIdentifier identifier = new TextDocumentIdentifier(fileUri);
             params.setTextDocument(identifier);
@@ -214,7 +214,7 @@ public class EclipseLanguageClient {
 
     public void notifyFileSaved(URI fileUri, String content) {
         if (serverCapabilities.getTextDocumentSync() != null
-                && serverCapabilities.getTextDocumentSync().getSave() != null) {
+            && serverCapabilities.getTextDocumentSync().getSave() != null) {
             DidSaveTextDocumentParams params = new DidSaveTextDocumentParams();
             TextDocumentIdentifier identifier = new TextDocumentIdentifier(fileUri);
             params.setTextDocument(identifier);
@@ -251,7 +251,7 @@ public class EclipseLanguageClient {
         codeActionParams.put("range", range);
         codeActionParams.put("context", Collections.singletonMap("diagnostics", new ArrayList<Object>()));
 
-        return connection.requestWithObject(OBJECT_MAPPER.getTypeFactory().constructCollectionLikeType(List.class, CodeAction.class), "textDocument/codeAction",  codeActionParams);
+        return connection.requestWithObject(OBJECT_MAPPER.getTypeFactory().constructCollectionLikeType(List.class, CodeAction.class), "textDocument/codeAction", codeActionParams);
     }
 
     public void exit() {
@@ -268,6 +268,7 @@ public class EclipseLanguageClient {
 
     private interface CLibrary extends Library {
         CLibrary INSTANCE = (CLibrary) Native.loadLibrary("c", CLibrary.class);
+
         int getpid();
     }
 }

--- a/customization-base/src/main/java/com/azure/autorest/customization/implementation/ls/EclipseLanguageServerFacade.java
+++ b/customization-base/src/main/java/com/azure/autorest/customization/implementation/ls/EclipseLanguageServerFacade.java
@@ -12,9 +12,9 @@ public class EclipseLanguageServerFacade {
         Runtime.getRuntime().addShutdownHook(new Thread(this::shutdown));
         try {
             String command = "java -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=1044 " +
-                    "-Declipse.application=org.eclipse.jdt.ls.core.id1 -Dosgi.bundles.defaultStartLevel=4 " +
-                    "-Declipse.product=org.eclipse.jdt.ls.core.product -Dlog.protocol=true -Dlog.level=ALL " +
-                    "-noverify -Xmx1G -jar ./plugins/org.eclipse.equinox.launcher_1.5.700.v20200207-2156.jar ";
+                "-Declipse.application=org.eclipse.jdt.ls.core.id1 -Dosgi.bundles.defaultStartLevel=4 " +
+                "-Declipse.product=org.eclipse.jdt.ls.core.product -Dlog.protocol=true -Dlog.level=ALL " +
+                "-noverify -Xmx1G -jar ./plugins/org.eclipse.equinox.launcher_1.5.700.v20200207-2156.jar ";
             double version = Double.parseDouble(System.getProperty("java.specification.version"));
             if (version >= 9) {
                 command += "--add-modules=ALL-SYSTEM --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED ";
@@ -26,8 +26,8 @@ public class EclipseLanguageServerFacade {
             } else {
                 command += "-configuration ./config_linux";
             }
-            server = Runtime.getRuntime().exec(command, new String[] { "CLIENT_PORT=" + port },
-                    Paths.get(System.getProperty("user.dir"), "jdt-language-server").toFile());
+            server = Runtime.getRuntime().exec(command, new String[]{"CLIENT_PORT=" + port},
+                Paths.get(System.getProperty("user.dir"), "jdt-language-server").toFile());
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
This PR makes the following changes:

**Performance Improvements**

Some code locations that were using `StringWriter` and `PrintWriter` were replaced with using `StringBuilder`. These locations used the writers in a localized and thread-safe manner which meant there was unneeded overhead as they use synchronization to support thread safety. Now, these locations are using `StringBuilder` which isn't thread safe as isn't doesn't synchronize. This results in performance improvements around synchronization and the ability for the operation to leverage better memory locality.

**Ability to Replace Method Parameters**

The ability to replace a methods parameters was added. This API only replaces the method parameters and doesn't update its `@param` Javadocs, so when it is used if the parameter name is change or parameters are being added or removed the Javadoc will need to be updated in an additional step.

**Other Changes**

Additionally, a minor bug was fixed with Javadoc parsing where `@deprecated` wasn't using the correct offset (it accidentally changed to using `@see`).