### PR TITLE
v4 fluentlite, bug fix for edge case that parameter got same name as model property

### DIFF
--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/method/FluentMethodParameterMethod.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/method/FluentMethodParameterMethod.java
@@ -44,6 +44,29 @@ public class FluentMethodParameterMethod extends FluentMethod {
                 .build();
     }
 
+    public FluentMethodParameterMethod(FluentResourceModel model, FluentMethodType type,
+                                       FluentInterfaceStage stage,
+                                       ClientMethodParameter methodParameter, LocalVariable localVariable,
+                                       String name) {
+        super(model, type);
+
+        this.methodParameter = methodParameter;
+        this.localVariable = localVariable;
+
+        this.name = name;
+        this.description = String.format("Specifies the %1$s property: %2$s.", methodParameter.getName(), methodParameter.getDescription());
+        this.interfaceReturnValue = new ReturnValue("the next definition stage.", new ClassType.Builder().name(stage.getNextStage().getName()).build());
+        this.implementationReturnValue = new ReturnValue("", model.getImplementationType());
+
+        this.implementationMethodTemplate = MethodTemplate.builder()
+                .methodSignature(this.getImplementationMethodSignature())
+                .method(block -> {
+                    block.line("this.%1$s = %2$s;", localVariable.getName(), methodParameter.getName());
+                    block.methodReturn("this");
+                })
+                .build();
+    }
+
     @Override
     protected String getBaseMethodSignature() {
         return String.format("%1$s(%2$s %3$s)",

--- a/fluentgen/src/test/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/FluentMethodTests.java
+++ b/fluentgen/src/test/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/FluentMethodTests.java
@@ -210,5 +210,8 @@ public class FluentMethodTests {
 
         FluentMethodParameterMethod parameterMethod = new FluentMethodParameterMethod(lockModel, FluentMethodType.CREATE_WITH, stage, lockParameter, variable);
         Assertions.assertEquals("WithCreate withLockName(String lockName)", parameterMethod.getInterfaceMethodSignature());
+
+        parameterMethod = new FluentMethodParameterMethod(lockModel, FluentMethodType.CREATE_WITH, stage, lockParameter, variable, "withLockNameParameter");
+        Assertions.assertEquals("WithCreate withLockNameParameter(String lockName)", parameterMethod.getInterfaceMethodSignature());
     }
 }


### PR DESCRIPTION
case https://github.com/Azure/azure-rest-api-specs/blob/master/specification/applicationinsights/resource-manager/Microsoft.Insights/stable/2020-10-20/workbooks_API.json#L234

parameter got `sourceId`, and `Workbook` model got `sourceId` as well.