### PR TITLE
Fix constant params in model

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -325,7 +325,7 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
         while (parentModel != null && !lastParentName.equals(parentModel.getName())) {
             List<ClientModelProperty> ctorArgs =
                 parentModel.getProperties().stream().filter(ClientModelProperty::isRequired)
-                        .filter(property -> !property.getIsConstant())
+                    .filter(property -> !property.getIsConstant())
                     .collect(Collectors.toList());
             // this will be reversed again, so, it will be in the right order if a
             // super class has multiple ctor args
@@ -340,7 +340,6 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
             .isEmpty())) {
 
             String requiredCtorArgs = requiredProperties.stream()
-                    .filter(property -> !property.getIsConstant())
                 .map(property -> String.format("@JsonProperty(%1$s )%2$s %3$s", property.getAnnotationArguments(),
                     property.getClientType().toString(), property.getName())).collect(Collectors.joining(", "));
 

--- a/preprocessor/readme.md
+++ b/preprocessor/readme.md
@@ -6,7 +6,7 @@ pass-thru:
   - subset-reducer
 
 use-extension:
-  "@autorest/modelerfour": "4.18.0"
+  "@autorest/modelerfour": "4.18.1"
 
 pipeline:
 


### PR DESCRIPTION
Constant properties in models were generated with setters and constructor args. This PR prevents the constant property from being settable.