### PR TITLE
Add ConstructorCustomization

### DIFF
--- a/customization-base/src/main/java/com/azure/autorest/customization/ClassCustomization.java
+++ b/customization-base/src/main/java/com/azure/autorest/customization/ClassCustomization.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * The class level customization for an AutoRest generated class.
@@ -33,6 +34,14 @@ public final class ClassCustomization {
      * spaces and an opening '{'.
      */
     private static final Pattern METHOD_SIGNATURE_PATTERN =
+        Pattern.compile("^\\s*([^/*][\\w\\s]+\\([\\w\\s\\.]+\\))\\s*\\{?$", Pattern.MULTILINE);
+
+    /*
+     * This pattern attempts to find the first line of a constructor string that doesn't have a first non-space
+     * character of '*' or '/', effectively the first non-Javadoc line. From there it captures all word and space
+     * characters before and inside '( )' ignoring any trailing spaces and an opening '{'.
+     */
+    private static final Pattern CONSTRUCTOR_SIGNATURE_PATTERN =
         Pattern.compile("^\\s*([^/*][\\w\\s]+\\([\\w\\s\\.]+\\))\\s*\\{?$", Pattern.MULTILINE);
 
     private final EclipseLanguageClient languageClient;
@@ -101,6 +110,59 @@ public final class ClassCustomization {
     }
 
     /**
+     * Gets the constructor level customization for a constructor in the class.
+     * <p>
+     * If only the constructor name is passed and the class has multiple constructors an error will be thrown to prevent
+     * ambiguous runtime behavior.
+     *
+     * @param constructorNameOrSignature The constructor name or signature.
+     * @return The constructor level customization.
+     * @throws IllegalStateException If only the constructor name is passed and the class has multiple constructors.
+     */
+    public ConstructorCustomization getConstructor(String constructorNameOrSignature) {
+        String constructorName;
+        String constructorSignature = null;
+        if (constructorNameOrSignature.contains("(")) {
+            // method signature
+            constructorSignature = constructorNameOrSignature.replaceFirst("\\) *\\{", "")
+                .replaceFirst(" *public ", "")
+                .replaceFirst(" *private ", "");
+            String returnTypeAndMethodName = constructorNameOrSignature.split("\\(")[0];
+            if (returnTypeAndMethodName.contains(" ")) {
+                constructorName = returnTypeAndMethodName.replaceAll(".* ", "");
+            } else {
+                constructorName = returnTypeAndMethodName;
+            }
+        } else {
+            constructorName = constructorNameOrSignature;
+        }
+
+        List<SymbolInformation> constructorSymbol = languageClient.listDocumentSymbols(fileUri)
+            .stream().filter(si -> si.getName().replaceFirst("\\(.*\\)", "").equals(constructorName)
+                && si.getKind() == SymbolKind.CONSTRUCTOR)
+            .filter(si -> editor.getFileLine(fileName, si.getLocation().getRange().getStart().getLine())
+                .contains(constructorNameOrSignature))
+            .collect(Collectors.toList());
+
+        if (constructorSymbol.size() > 1) {
+            throw new IllegalStateException("Multiple instances of " + constructorNameOrSignature + " exist in the "
+                + "class. Use a more specific constructor signature.");
+        }
+
+        if (constructorSymbol.size() == 0) {
+            throw new IllegalArgumentException("Constructor " + constructorNameOrSignature + " does not exist in class "
+                + className);
+        }
+
+        if (constructorSignature == null) {
+            constructorSignature = editor.getFileLine(fileName, constructorSymbol.get(0).getLocation().getRange().getStart().getLine())
+                .replaceFirst("\\) *\\{", "").replaceFirst(" *public ", "").replaceFirst(" *private ", "");
+        }
+        return new ConstructorCustomization(editor, languageClient, packageName, className, constructorSignature,
+            constructorSymbol.get(0));
+    }
+
+    /**
      * Gets the property level customization for a property in the class.
      *
      * @param propertyName the property name
@@ -121,10 +183,70 @@ public final class ClassCustomization {
     }
 
     /**
+     * Adds a constructor to this class.
+     *
+     * @param constructor The entire constructor as a literal string.
+     * @return The constructor level customization for the added constructor.
+     */
+    public ConstructorCustomization addConstructor(String constructor) {
+        // Get the signature of the constructor.
+        Matcher constructorSignatureMatcher = CONSTRUCTOR_SIGNATURE_PATTERN.matcher(constructor);
+        String constructorSignature = null;
+        if (constructorSignatureMatcher.find()) {
+            constructorSignature = constructorSignatureMatcher.group(1);
+        }
+
+        // Find all constructor and field symbols.
+        List<SymbolInformation> constructorLocationFinder = languageClient.listDocumentSymbols(fileUri).stream()
+            .filter(symbol -> symbol.getKind() == SymbolKind.FIELD || symbol.getKind() == SymbolKind.CONSTRUCTOR)
+            .collect(Collectors.toList());
+
+        // If no constructors or fields exist in the class place the constructor after the class declaration line.
+        // Otherwise place the constructor after the last constructor or field.
+        int constructorStartLine;
+        if (Utils.isNullOrEmpty(constructorLocationFinder)) {
+            constructorStartLine = classSymbol.getLocation().getRange().getStart().getLine();
+        } else {
+            SymbolInformation symbol = constructorLocationFinder.get(constructorLocationFinder.size() - 1);
+
+            // If the last symbol before the new constructor is a field only a new line needs to be inserted.
+            // Otherwise if the last symbol is a constructor its closing '}' needs to be found and then a new line
+            // needs to be inserted.
+            if (symbol.getKind() == SymbolKind.FIELD) {
+                constructorStartLine = symbol.getLocation().getRange().getStart().getLine();
+            } else {
+                constructorStartLine = symbol.getLocation().getRange().getStart().getLine();
+
+                List<String> fileLines = editor.getFileLines(fileName);
+                String currentLine = fileLines.get(constructorStartLine);
+                String constructorIdent = currentLine.replaceAll("\\w.*$", "");
+                while (!currentLine.endsWith("}") || !currentLine.equals(constructorIdent + "}")) {
+                    currentLine = fileLines.get(++constructorStartLine);
+                }
+            }
+        }
+
+        editor.insertBlankLine(fileName, ++constructorStartLine, false);
+        Position constructorPosition = editor.insertBlankLine(fileName, ++constructorStartLine, false);
+
+        editor.replace(fileName, constructorPosition, constructorPosition, constructor);
+        FileEvent fileEvent = new FileEvent();
+        fileEvent.setUri(fileUri);
+        fileEvent.setType(FileChangeType.CHANGED);
+
+        languageClient.notifyWatchedFilesChanged(Collections.singletonList(fileEvent));
+
+        if (constructorSignature == null) {
+            constructorSignature = editor.getFileLine(fileName, constructorStartLine);
+        }
+        return getConstructor(constructorSignature);
+    }
+
+    /**
      * Adds a method to this class.
      *
-     * @param method the entire literal string of the method
-     * @return the method level customization for the added method
+     * @param method The entire method as a literal string.
+     * @return The method level customization for the added method.
      */
     public MethodCustomization addMethod(String method) {
         // Get the signature of the method.
@@ -220,10 +342,8 @@ public final class ClassCustomization {
         languageClient.listDocumentSymbols(classSymbol.getLocation().getUri())
             .stream().filter(si -> si.getName().equals(className) && si.getKind() == SymbolKind.CLASS)
             .findFirst()
-            .ifPresent(symbolInformation ->
-                Utils.replaceModifier(symbolInformation, editor, languageClient, (oldLine, newModifiers) ->
-                        oldLine.replaceFirst("\\w.* class " + className, newModifiers + " class " + className),
-                    Modifier.classModifiers(), modifiers));
+            .ifPresent(symbolInformation -> Utils.replaceModifier(symbolInformation, editor, languageClient,
+                "(?:.+ )?class " + className, "class " + className, Modifier.classModifiers(), modifiers));
 
         return refreshSymbol();
     }
@@ -239,7 +359,6 @@ public final class ClassCustomization {
             annotation = "@" + annotation;
         }
 
-        URI fileUri = classSymbol.getLocation().getUri();
         Optional<SymbolInformation> symbol = languageClient.listDocumentSymbols(fileUri)
             .stream().filter(si -> si.getKind() == SymbolKind.CLASS)
             .findFirst();

--- a/customization-base/src/main/java/com/azure/autorest/customization/ConstructorCustomization.java
+++ b/customization-base/src/main/java/com/azure/autorest/customization/ConstructorCustomization.java
@@ -1,0 +1,210 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.autorest.customization;
+
+import com.azure.autorest.customization.implementation.Utils;
+import com.azure.autorest.customization.implementation.ls.EclipseLanguageClient;
+import com.azure.autorest.customization.implementation.ls.models.FileChangeType;
+import com.azure.autorest.customization.implementation.ls.models.FileEvent;
+import com.azure.autorest.customization.implementation.ls.models.SymbolInformation;
+import com.azure.autorest.customization.implementation.ls.models.SymbolKind;
+import com.azure.autorest.customization.models.Position;
+
+import java.lang.reflect.Modifier;
+import java.net.URI;
+import java.util.Collections;
+import java.util.Optional;
+
+/**
+ * The constructor level customization for an AutoRest generated constructor.
+ */
+public final class ConstructorCustomization {
+    private final EclipseLanguageClient languageClient;
+    private final Editor editor;
+    private final String packageName;
+    private final String className;
+    private final URI fileUri;
+    private final String fileName;
+    private final String constructorSignature;
+    private final SymbolInformation symbol;
+
+    ConstructorCustomization(Editor editor, EclipseLanguageClient languageClient, String packageName, String className,
+        String constructorSignature, SymbolInformation symbol) {
+        this.editor = editor;
+        this.languageClient = languageClient;
+        this.packageName = packageName;
+        this.className = className;
+        this.fileUri = symbol.getLocation().getUri();
+        int i = fileUri.toString().indexOf("src/main/java/");
+        this.fileName = fileUri.toString().substring(i);
+        this.constructorSignature = constructorSignature;
+        this.symbol = symbol;
+    }
+
+    /**
+     * Gets the name of the class containing the constructor.
+     *
+     * @return The name of the class containing the constructor.
+     */
+    public String getClassName() {
+        return className;
+    }
+
+    /**
+     * Gets the Javadoc customization for this constructor.
+     *
+     * @return The Javadoc customization for this constructor.
+     */
+    public JavadocCustomization getJavadoc() {
+        String packagePath = packageName.replace(".", "/");
+        return new JavadocCustomization(editor, languageClient, packagePath, className,
+            symbol.getLocation().getRange().getStart().getLine());
+    }
+
+    /**
+     * Add an annotation to the constructor.
+     *
+     * @param annotation The annotation to add to the constructor. The leading @ can be omitted.
+     * @return A new ConstructorCustomization representing the updated constructor.
+     */
+    public ConstructorCustomization addAnnotation(String annotation) {
+        Utils.addAnnotation(annotation, editor, fileName, symbol, fileUri, languageClient);
+
+        return new ConstructorCustomization(editor, languageClient, packageName, className, constructorSignature,
+            refreshSymbol());
+    }
+
+    /**
+     * Remove an annotation from the constructor.
+     *
+     * @param annotation The annotation to remove from the constructor. The leading @ can be omitted.
+     * @return A new ConstructorCustomization representing the updated constructor.
+     */
+    public ConstructorCustomization removeAnnotation(String annotation) {
+        Utils.removeAnnotation(annotation, editor, fileName, symbol, fileUri, languageClient);
+
+        return new ConstructorCustomization(editor, languageClient, packageName, className, constructorSignature,
+            refreshSymbol());
+    }
+
+    /**
+     * Replace the modifier for this constructor.
+     * <p>
+     * For compound modifiers such as {@code public abstract} use bitwise OR ({@code |}) of multiple Modifiers, {@code
+     * Modifier.PUBLIC | Modifier.ABSTRACT}.
+     * <p>
+     * Pass {@code 0} for {@code modifiers} to indicate that the constructor has no modifiers.
+     *
+     * @param modifiers The {@link Modifier Modifiers} for the constructor.
+     * @return A new ConstructorCustomization representing the updated constructor.
+     * @throws IllegalArgumentException If the {@code modifier} is less than to {@code 0} or any {@link Modifier}
+     * included in the bitwise OR isn't a valid constructor {@link Modifier}.
+     */
+    public ConstructorCustomization setModifier(int modifiers) {
+        Utils.replaceModifier(symbol, editor, languageClient, "(?:.+ )?" + className + "\\(", className + "(",
+            Modifier.constructorModifiers(), modifiers);
+
+        return new ConstructorCustomization(editor, languageClient, packageName, className, constructorSignature,
+            refreshSymbol());
+    }
+
+    /**
+     * Replace the parameters of the constructor.
+     *
+     * @param newParameters New constructor parameters.
+     * @return A new ConstructorCustomization representing the updated constructor.
+     */
+    public ConstructorCustomization replaceParameters(String newParameters) {
+        // Beginning line of the symbol.
+        int line = symbol.getLocation().getRange().getStart().getLine();
+        String parametersPositionFinder = editor.getFileLine(fileName, line);
+
+        // First find the starting location of the parameters.
+        // The beginning of the parameters may not be on the same line as the start of the signature.
+        while (!parametersPositionFinder.contains("(")) {
+            parametersPositionFinder = editor.getFileLine(fileName, ++line);
+        }
+
+        // Now that the line where the parameters begin is found create its position.
+        int parametersStartCharacter = parametersPositionFinder.indexOf("(");
+
+        // Starting character is inclusive of the character offset, so increment the index one.
+        Position parametersStart = new Position(line, parametersStartCharacter + 1);
+
+        // Then find where the parameters end.
+        // The ending of the parameters may not be on the same line as the start of the parameters.
+        while (!parametersPositionFinder.contains(")")) {
+            parametersPositionFinder = editor.getFileLine(fileName, ++line);
+        }
+
+        // Now that the line where the parameters end is found gets create its position.
+        int parametersEndCharacter = parametersPositionFinder.indexOf(")");
+
+        // Ending character is exclusive of the character offset, so use the index as is.
+        Position parametersEnd = new Position(line, parametersEndCharacter);
+
+        editor.replace(fileName, parametersStart, parametersEnd, newParameters);
+        FileEvent fileEvent = new FileEvent();
+        fileEvent.setUri(fileUri);
+        fileEvent.setType(FileChangeType.CHANGED);
+        languageClient.notifyWatchedFilesChanged(Collections.singletonList(fileEvent));
+
+        return new PackageCustomization(editor, languageClient, packageName)
+            .getClass(className)
+            .getConstructor(String.format("%s(%s)", className, newParameters));
+    }
+
+    /**
+     * Replace the body of the constructor.
+     *
+     * @param newBody New constructor body.
+     * @return A new ConstructorCustomization representing the updated constructor.
+     */
+    public ConstructorCustomization replaceBody(String newBody) {
+        // Beginning line of the symbol.
+        int line = symbol.getLocation().getRange().getStart().getLine();
+        String bodyPositionFinder = editor.getFileLine(fileName, line);
+        String methodIndent = bodyPositionFinder.replaceAll("\\w.*$", "");
+
+        // Loop until the line containing the body start is found.
+        while (!bodyPositionFinder.matches(".*\\{\\s*")) {
+            bodyPositionFinder = editor.getFileLine(fileName, ++line);
+        }
+
+        // Then determine the base indentation level for the body.
+        String bodyIdent = editor.getFileLine(fileName, line + 1).replaceAll("\\w.*$", "");
+        Position oldBodyStart = new Position(line + 1, bodyIdent.length());
+        int lastLineLength = bodyIdent.length();
+
+        // Then continue iterating over lines until the body close line is found.
+        while (!bodyPositionFinder.matches(methodIndent + "}\\s*")) {
+            lastLineLength = bodyPositionFinder.length();
+            bodyPositionFinder = editor.getFileLine(fileName, ++line);
+        }
+        Position oldBodyEnd = new Position(line - 1, lastLineLength);
+
+        editor.replace(fileName, oldBodyStart, oldBodyEnd, newBody);
+        FileEvent fileEvent = new FileEvent();
+        fileEvent.setUri(fileUri);
+        fileEvent.setType(FileChangeType.CHANGED);
+        languageClient.notifyWatchedFilesChanged(Collections.singletonList(fileEvent));
+
+        return new ConstructorCustomization(editor, languageClient, packageName, className, constructorSignature,
+            refreshSymbol());
+    }
+
+    private SymbolInformation refreshSymbol() {
+        Optional<SymbolInformation> methodSymbol = languageClient.listDocumentSymbols(fileUri)
+            .stream().filter(si -> si.getName().replaceFirst("\\(.*\\)", "").equals(className)
+                && si.getKind() == SymbolKind.CONSTRUCTOR)
+            .filter(si -> editor.getFileLine(fileName, si.getLocation().getRange().getStart().getLine())
+                .contains(constructorSignature))
+            .findFirst();
+        if (!methodSymbol.isPresent()) {
+            throw new IllegalArgumentException("Constructor " + constructorSignature + " does not exist in class "
+                + className);
+        }
+        return methodSymbol.get();
+    }
+}

--- a/customization-base/src/main/java/com/azure/autorest/customization/ConstructorCustomization.java
+++ b/customization-base/src/main/java/com/azure/autorest/customization/ConstructorCustomization.java
@@ -57,8 +57,7 @@ public final class ConstructorCustomization {
      * @return The Javadoc customization for this constructor.
      */
     public JavadocCustomization getJavadoc() {
-        String packagePath = packageName.replace(".", "/");
-        return new JavadocCustomization(editor, languageClient, packagePath, className,
+        return new JavadocCustomization(editor, languageClient, fileUri, fileName,
             symbol.getLocation().getRange().getStart().getLine());
     }
 

--- a/customization-base/src/main/java/com/azure/autorest/customization/MethodCustomization.java
+++ b/customization-base/src/main/java/com/azure/autorest/customization/MethodCustomization.java
@@ -75,8 +75,8 @@ public final class MethodCustomization {
      * @return the Javadoc customization
      */
     public JavadocCustomization getJavadoc() {
-        String packagePath = packageName.replace(".", "/");
-        return new JavadocCustomization(editor, languageClient, packagePath, className, symbol.getLocation().getRange().getStart().getLine());
+        return new JavadocCustomization(editor, languageClient, fileUri, fileName,
+            symbol.getLocation().getRange().getStart().getLine());
     }
 
     /**

--- a/customization-base/src/main/java/com/azure/autorest/customization/implementation/Utils.java
+++ b/customization-base/src/main/java/com/azure/autorest/customization/implementation/Utils.java
@@ -2,11 +2,13 @@ package com.azure.autorest.customization.implementation;
 
 import com.azure.autorest.customization.Editor;
 import com.azure.autorest.customization.implementation.ls.EclipseLanguageClient;
+import com.azure.autorest.customization.implementation.ls.models.CodeActionKind;
 import com.azure.autorest.customization.implementation.ls.models.FileChangeType;
 import com.azure.autorest.customization.implementation.ls.models.FileEvent;
 import com.azure.autorest.customization.implementation.ls.models.SymbolInformation;
 import com.azure.autorest.customization.implementation.ls.models.TextEdit;
 import com.azure.autorest.customization.implementation.ls.models.WorkspaceEdit;
+import com.azure.autorest.customization.implementation.ls.models.WorkspaceEditCommand;
 import com.azure.autorest.customization.models.Position;
 import com.azure.autorest.customization.models.Range;
 
@@ -18,7 +20,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -68,6 +69,10 @@ public class Utils {
         directoryToBeDeleted.delete();
     }
 
+    public static boolean isNullOrEmpty(CharSequence charSequence) {
+        return charSequence == null || charSequence.length() == 0;
+    }
+
     public static <T> boolean isNullOrEmpty(T[] array) {
         return array == null || array.length == 0;
     }
@@ -91,8 +96,19 @@ public class Utils {
         }
     }
 
+    /**
+     * Replaces the modifier for a given symbol.
+     *
+     * @param symbol The symbol having its modifier replaced.
+     * @param editor The editor containing information about the symbol.
+     * @param languageClient The language client handling replacement of the modifiers.
+     * @param replaceTarget A string regex that determines how the modifiers are replaced.
+     * @param modifierReplaceBase A string that determines the base modifier replacement.
+     * @param validaTypeModifiers The modifier bit flag used to validate the new modifiers.
+     * @param newModifiers The new modifiers for the symbol.
+     */
     public static void replaceModifier(SymbolInformation symbol, Editor editor, EclipseLanguageClient languageClient,
-        BiFunction<String, String, String> replacer, int validaTypeModifiers, int newModifiers) {
+        String replaceTarget, String modifierReplaceBase, int validaTypeModifiers, int newModifiers) {
         validateModifiers(validaTypeModifiers, newModifiers);
 
         URI fileUri = symbol.getLocation().getUri();
@@ -103,7 +119,12 @@ public class Utils {
         Position start = new Position(line, 0);
         String oldLineContent = editor.getFileLine(fileName, line);
         Position end = new Position(line, oldLineContent.length());
-        String newLineContent = replacer.apply(oldLineContent, Modifier.toString(newModifiers));
+
+        String newModifiersString = Modifier.toString(newModifiers);
+        String newLineContent = (isNullOrEmpty(newModifiersString))
+            ? oldLineContent.replaceFirst(replaceTarget, modifierReplaceBase)
+            : oldLineContent.replaceFirst(replaceTarget, newModifiersString + " " + modifierReplaceBase);
+
         TextEdit textEdit = new TextEdit();
         textEdit.setNewText(newLineContent);
         textEdit.setRange(new Range(start, end));
@@ -132,5 +153,73 @@ public class Utils {
         stringBuilder.append(text).append(System.lineSeparator());
     }
 
-    private Utils() {}
+    public static void addAnnotation(String annotation, Editor editor, String fileName, SymbolInformation symbol,
+        URI fileUri, EclipseLanguageClient languageClient) {
+        if (!annotation.startsWith("@")) {
+            annotation = "@" + annotation;
+        }
+
+        if (editor.getContents().containsKey(fileName)) {
+            int line = symbol.getLocation().getRange().getStart().getLine();
+            Position position = editor.insertBlankLine(fileName, line, true);
+            editor.replace(fileName, position, position, annotation);
+
+            FileEvent fileEvent = new FileEvent();
+            fileEvent.setUri(fileUri);
+            fileEvent.setType(FileChangeType.CHANGED);
+            languageClient.notifyWatchedFilesChanged(Collections.singletonList(fileEvent));
+
+            languageClient.listCodeActions(fileUri, symbol.getLocation().getRange())
+                .stream().filter(ca -> ca.getKind().equals(CodeActionKind.SOURCE_ORGANIZEIMPORTS.toString()))
+                .findFirst()
+                .ifPresent(action -> {
+                    if (action.getCommand() instanceof WorkspaceEditCommand) {
+                        ((WorkspaceEditCommand) action.getCommand()).getArguments().forEach(workspaceEdit ->
+                            Utils.applyWorkspaceEdit(workspaceEdit, editor, languageClient));
+                    }
+                });
+        }
+    }
+
+    public static void removeAnnotation(String annotation, Editor editor, String fileName, SymbolInformation symbol,
+        URI fileUri, EclipseLanguageClient languageClient) {
+        if (!annotation.startsWith("@")) {
+            annotation = "@" + annotation;
+        }
+
+        if (editor.getContents().containsKey(fileName)) {
+            int line = symbol.getLocation().getRange().getStart().getLine();
+            int annotationLine = -1;
+            String lineContent = editor.getFileLine(fileName, line);
+            while (!lineContent.trim().isEmpty()) {
+                if (lineContent.trim().startsWith(annotation)) {
+                    annotationLine = line;
+                }
+                lineContent = editor.getFileLine(fileName, --line);
+            }
+            if (annotationLine != -1) {
+                Position start = new Position(annotationLine, 0);
+                Position end = new Position(annotationLine + 1, 0);
+                editor.replace(fileName, start, end, "");
+
+                FileEvent fileEvent = new FileEvent();
+                fileEvent.setUri(fileUri);
+                fileEvent.setType(FileChangeType.CHANGED);
+                languageClient.notifyWatchedFilesChanged(Collections.singletonList(fileEvent));
+
+                languageClient.listCodeActions(fileUri, new Range(start, end))
+                    .stream().filter(ca -> ca.getKind().equals(CodeActionKind.SOURCE_ORGANIZEIMPORTS.toString()))
+                    .findFirst()
+                    .ifPresent(action -> {
+                        if (action.getCommand() instanceof WorkspaceEditCommand) {
+                            ((WorkspaceEditCommand) action.getCommand()).getArguments().forEach(workspaceEdit ->
+                                Utils.applyWorkspaceEdit(workspaceEdit, editor, languageClient));
+                        }
+                    });
+            }
+        }
+    }
+
+    private Utils() {
+    }
 }


### PR DESCRIPTION
Fixes #946 

This PR adds `ConstructorCustomization` which is capable of performing constructor level customizations. Additionally, `addConstructor` and `getConstructor` APIs were added to `ClassCustomization` to enable accessing or creating a `ConstructorCustomization`.