### PR TITLE
Add support for FormParam

### DIFF
--- a/generate
+++ b/generate
@@ -38,6 +38,7 @@ autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure
 autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/non-string-enum.json --namespace=fixtures.nonstringenum
 autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/multiple-inheritance.json --namespace=fixtures.multipleinheritance
 autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/report.json --namespace=fixtures.report --payload-flattening-threshold=1
+autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/body-formdata-urlencoded.json --namespace=fixtures.bodyformdataurlencoded
 # local swagger
 autorest $VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/discriminator-flattening.json --namespace=fixtures.discriminatorflattening
 

--- a/generate.bat
+++ b/generate.bat
@@ -35,6 +35,8 @@ call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com
 call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/non-string-enum.json --namespace=fixtures.nonstringenum
 call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/multiple-inheritance.json --namespace=fixtures.multipleinheritance
 call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/report.json --namespace=fixtures.report --payload-flattening-threshold=1
+call autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/body-formdata-urlencoded.json --namespace=fixtures.bodyformdataurlencoded
+
 rem local swagger
 call autorest %VANILLA_ARGUMENTS% --input-file=vanilla-tests/swagger/discriminator-flattening.json --namespace=fixtures.discriminatorflattening
 

--- a/generate.bat
+++ b/generate.bat
@@ -35,7 +35,7 @@ call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com
 call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/non-string-enum.json --namespace=fixtures.nonstringenum
 call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/multiple-inheritance.json --namespace=fixtures.multipleinheritance
 call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/report.json --namespace=fixtures.report --payload-flattening-threshold=1
-call autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/body-formdata-urlencoded.json --namespace=fixtures.bodyformdataurlencoded
+call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/body-formdata-urlencoded.json --namespace=fixtures.bodyformdataurlencoded
 
 rem local swagger
 call autorest %VANILLA_ARGUMENTS% --input-file=vanilla-tests/swagger/discriminator-flattening.json --namespace=fixtures.discriminatorflattening

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethod.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethod.java
@@ -9,6 +9,7 @@ package com.azure.autorest.model.clientmodel;
 
 import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.util.CodeNamer;
+import com.azure.core.http.ContentType;
 import com.azure.core.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import java.util.List;
@@ -257,6 +258,10 @@ public class ProxyMethod {
             }
 
             returnType.addImportsTo(imports, includeImplementationImports);
+
+            if (ContentType.APPLICATION_X_WWW_FORM_URLENCODED.equals(this.requestContentType)) {
+                imports.add("com.azure.core.annotation.FormParam");
+            }
 
             for (ProxyMethodParameter parameter : parameters) {
                 parameter.addImportsTo(imports, includeImplementationImports, settings);

--- a/javagen/src/main/java/com/azure/autorest/template/ProxyTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ProxyTemplate.java
@@ -112,7 +112,7 @@ public class ProxyTemplate implements IJavaTemplate<Proxy, JavaClass> {
                                 break;
 
                             case Body:
-                                if (restAPIMethod.getRequestContentType() != null && restAPIMethod.getRequestContentType().equals(ContentType.APPLICATION_X_WWW_FORM_URLENCODED)) {
+                                if (ContentType.APPLICATION_X_WWW_FORM_URLENCODED.equals(restAPIMethod.getRequestContentType())) {
                                     parameterDeclarationBuilder.append(String.format("@FormParam(\"%1$s\") ",
                                             parameter.getRequestParameterName()));
                                     break;

--- a/javagen/src/main/java/com/azure/autorest/template/ProxyTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ProxyTemplate.java
@@ -11,6 +11,7 @@ import com.azure.autorest.model.clientmodel.ProxyMethod;
 import com.azure.autorest.model.clientmodel.ProxyMethodParameter;
 import com.azure.autorest.model.javamodel.JavaClass;
 import com.azure.autorest.util.CodeNamer;
+import com.azure.core.http.ContentType;
 import io.netty.handler.codec.http.HttpResponseStatus;
 
 import java.util.ArrayList;
@@ -111,12 +112,17 @@ public class ProxyTemplate implements IJavaTemplate<Proxy, JavaClass> {
                                 break;
 
                             case Body:
+                                if (restAPIMethod.getRequestContentType() != null && restAPIMethod.getRequestContentType().equals(ContentType.APPLICATION_X_WWW_FORM_URLENCODED)) {
+                                    parameterDeclarationBuilder.append(String.format("@FormParam(\"%1$s\") ",
+                                            parameter.getRequestParameterName()));
+                                    break;
+                                }
                                 parameterDeclarationBuilder.append(String.format("@BodyParam(\"%1$s\") ", restAPIMethod.getRequestContentType()));
                                 break;
 
-//                            case FormData:
-//                                parameterDeclarationBuilder.append(String.format("@FormParam(\"%1$s\") ", parameter.getRequestParameterName()));
-//                                break;
+                           // case FormData:
+                           //     parameterDeclarationBuilder.append(String.format("@FormParam(\"%1$s\") ", parameter.getRequestParameterName()));
+                           //     break;
 
                             default:
                                 if (!restAPIMethod.getIsResumable() && parameter.getWireType() != ClassType.Context) {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   "homepage": "https://github.com/Azure/autorest.java/blob/v4/readme.md",
   "devDependencies": {
     "autorest": "^3.0.0",
-    "@microsoft.azure/autorest.testserver": "^2.10.68"
+    "@microsoft.azure/autorest.testserver": "^3.0.21"
   }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodyformdataurlencoded/BodyFormsDataURLEncoded.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyformdataurlencoded/BodyFormsDataURLEncoded.java
@@ -1,0 +1,98 @@
+package fixtures.bodyformdataurlencoded;
+
+import com.azure.core.http.HttpPipeline;
+import com.azure.core.http.HttpPipelineBuilder;
+import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.RetryPolicy;
+import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
+
+/** Initializes a new instance of the BodyFormsDataURLEncoded type. */
+public final class BodyFormsDataURLEncoded {
+    /** server parameter. */
+    private final String host;
+
+    /**
+     * Gets server parameter.
+     *
+     * @return the host value.
+     */
+    public String getHost() {
+        return this.host;
+    }
+
+    /** The HTTP pipeline to send requests through. */
+    private final HttpPipeline httpPipeline;
+
+    /**
+     * Gets The HTTP pipeline to send requests through.
+     *
+     * @return the httpPipeline value.
+     */
+    public HttpPipeline getHttpPipeline() {
+        return this.httpPipeline;
+    }
+
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
+    /** The Formdataurlencodeds object to access its operations. */
+    private final Formdataurlencodeds formdataurlencodeds;
+
+    /**
+     * Gets the Formdataurlencodeds object to access its operations.
+     *
+     * @return the Formdataurlencodeds object.
+     */
+    public Formdataurlencodeds getFormdataurlencodeds() {
+        return this.formdataurlencodeds;
+    }
+
+    /**
+     * Initializes an instance of BodyFormsDataURLEncoded client.
+     *
+     * @param host server parameter.
+     */
+    BodyFormsDataURLEncoded(String host) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
+                host);
+    }
+
+    /**
+     * Initializes an instance of BodyFormsDataURLEncoded client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param host server parameter.
+     */
+    BodyFormsDataURLEncoded(HttpPipeline httpPipeline, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    }
+
+    /**
+     * Initializes an instance of BodyFormsDataURLEncoded client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     * @param host server parameter.
+     */
+    BodyFormsDataURLEncoded(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
+        this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
+        this.host = host;
+        this.formdataurlencodeds = new Formdataurlencodeds(this);
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/bodyformdataurlencoded/BodyFormsDataURLEncodedBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyformdataurlencoded/BodyFormsDataURLEncodedBuilder.java
@@ -1,0 +1,209 @@
+package fixtures.bodyformdataurlencoded;
+
+import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
+import com.azure.core.http.HttpPipeline;
+import com.azure.core.http.HttpPipelineBuilder;
+import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
+import com.azure.core.http.policy.RetryPolicy;
+import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/** A builder for creating a new instance of the BodyFormsDataURLEncoded type. */
+@ServiceClientBuilder(serviceClients = {BodyFormsDataURLEncoded.class})
+public final class BodyFormsDataURLEncodedBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
+    /** Create an instance of the BodyFormsDataURLEncodedBuilder. */
+    public BodyFormsDataURLEncodedBuilder() {
+        this.pipelinePolicies = new ArrayList<>();
+    }
+
+    /*
+     * server parameter
+     */
+    private String host;
+
+    /**
+     * Sets server parameter.
+     *
+     * @param host the host value.
+     * @return the BodyFormsDataURLEncodedBuilder.
+     */
+    public BodyFormsDataURLEncodedBuilder host(String host) {
+        this.host = host;
+        return this;
+    }
+
+    /*
+     * The HTTP pipeline to send requests through
+     */
+    private HttpPipeline pipeline;
+
+    /**
+     * Sets The HTTP pipeline to send requests through.
+     *
+     * @param pipeline the pipeline value.
+     * @return the BodyFormsDataURLEncodedBuilder.
+     */
+    public BodyFormsDataURLEncodedBuilder pipeline(HttpPipeline pipeline) {
+        this.pipeline = pipeline;
+        return this;
+    }
+
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the BodyFormsDataURLEncodedBuilder.
+     */
+    public BodyFormsDataURLEncodedBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the BodyFormsDataURLEncodedBuilder.
+     */
+    public BodyFormsDataURLEncodedBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the BodyFormsDataURLEncodedBuilder.
+     */
+    public BodyFormsDataURLEncodedBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the BodyFormsDataURLEncodedBuilder.
+     */
+    public BodyFormsDataURLEncodedBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the BodyFormsDataURLEncodedBuilder.
+     */
+    public BodyFormsDataURLEncodedBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private final List<HttpPipelinePolicy> pipelinePolicies;
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the BodyFormsDataURLEncodedBuilder.
+     */
+    public BodyFormsDataURLEncodedBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
+    /**
+     * Builds an instance of BodyFormsDataURLEncoded with the provided parameters.
+     *
+     * @return an instance of BodyFormsDataURLEncoded.
+     */
+    public BodyFormsDataURLEncoded buildClient() {
+        if (host == null) {
+            this.host = "http://localhost:3000";
+        }
+        if (pipeline == null) {
+            this.pipeline = createHttpPipeline();
+        }
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        BodyFormsDataURLEncoded client = new BodyFormsDataURLEncoded(pipeline, serializerAdapter, host);
+        return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        policies.add(
+                new UserAgentPolicy(httpLogOptions.getApplicationId(), clientName, clientVersion, buildConfiguration));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/bodyformdataurlencoded/Formdataurlencodeds.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyformdataurlencoded/Formdataurlencodeds.java
@@ -1,0 +1,173 @@
+package fixtures.bodyformdataurlencoded;
+
+import com.azure.core.annotation.ExpectedResponses;
+import com.azure.core.annotation.FormParam;
+import com.azure.core.annotation.Host;
+import com.azure.core.annotation.HostParam;
+import com.azure.core.annotation.PathParam;
+import com.azure.core.annotation.Post;
+import com.azure.core.annotation.ReturnType;
+import com.azure.core.annotation.ServiceInterface;
+import com.azure.core.annotation.ServiceMethod;
+import com.azure.core.annotation.UnexpectedResponseExceptionType;
+import com.azure.core.exception.HttpResponseException;
+import com.azure.core.http.rest.Response;
+import com.azure.core.http.rest.RestProxy;
+import com.azure.core.util.Context;
+import com.azure.core.util.FluxUtil;
+import fixtures.bodyformdataurlencoded.models.PetFood;
+import fixtures.bodyformdataurlencoded.models.PetType;
+import reactor.core.publisher.Mono;
+
+/** An instance of this class provides access to all the operations defined in Formdataurlencodeds. */
+public final class Formdataurlencodeds {
+    /** The proxy service used to perform REST calls. */
+    private final FormdataurlencodedsService service;
+
+    /** The service client containing this operation class. */
+    private final BodyFormsDataURLEncoded client;
+
+    /**
+     * Initializes an instance of Formdataurlencodeds.
+     *
+     * @param client the instance of the service client containing this operation class.
+     */
+    Formdataurlencodeds(BodyFormsDataURLEncoded client) {
+        this.service =
+                RestProxy.create(
+                        FormdataurlencodedsService.class, client.getHttpPipeline(), client.getSerializerAdapter());
+        this.client = client;
+    }
+
+    /**
+     * The interface defining all the services for BodyFormsDataURLEncodedFormdataurlencodeds to be used by the proxy
+     * service to perform REST calls.
+     */
+    @Host("{$host}")
+    @ServiceInterface(name = "BodyFormsDataURLEnco")
+    private interface FormdataurlencodedsService {
+        // @Multipart not supported by RestProxy
+        @Post("/formsdataurlencoded/pet/add/{petId}")
+        @ExpectedResponses({200, 405})
+        @UnexpectedResponseExceptionType(HttpResponseException.class)
+        Mono<Response<Void>> updatePetWithForm(
+                @HostParam("$host") String host,
+                @PathParam("petId") int petId,
+                @FormParam("pet_type") PetType petType,
+                @FormParam("pet_food") PetFood petFood,
+                @FormParam("pet_age") int petAge,
+                @FormParam("name") String name,
+                @FormParam("status") String status,
+                Context context);
+    }
+
+    /**
+     * Updates a pet in the store with form data.
+     *
+     * @param petId ID of pet that needs to be updated.
+     * @param petType Can take a value of dog, or cat, or fish.
+     * @param petFood Can take a value of meat, or fish, or plant.
+     * @param petAge How many years is it old?.
+     * @param name Updated name of the pet.
+     * @param status Updated status of the pet.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> updatePetWithFormWithResponseAsync(
+            int petId, PetType petType, PetFood petFood, int petAge, String name, String status) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (petType == null) {
+            return Mono.error(new IllegalArgumentException("Parameter petType is required and cannot be null."));
+        }
+        if (petFood == null) {
+            return Mono.error(new IllegalArgumentException("Parameter petFood is required and cannot be null."));
+        }
+        return FluxUtil.withContext(
+                context ->
+                        service.updatePetWithForm(
+                                this.client.getHost(), petId, petType, petFood, petAge, name, status, context));
+    }
+
+    /**
+     * Updates a pet in the store with form data.
+     *
+     * @param petId ID of pet that needs to be updated.
+     * @param petType Can take a value of dog, or cat, or fish.
+     * @param petFood Can take a value of meat, or fish, or plant.
+     * @param petAge How many years is it old?.
+     * @param name Updated name of the pet.
+     * @param status Updated status of the pet.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> updatePetWithFormAsync(
+            int petId, PetType petType, PetFood petFood, int petAge, String name, String status) {
+        return updatePetWithFormWithResponseAsync(petId, petType, petFood, petAge, name, status)
+                .flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Updates a pet in the store with form data.
+     *
+     * @param petId ID of pet that needs to be updated.
+     * @param petType Can take a value of dog, or cat, or fish.
+     * @param petFood Can take a value of meat, or fish, or plant.
+     * @param petAge How many years is it old?.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> updatePetWithFormAsync(int petId, PetType petType, PetFood petFood, int petAge) {
+        final String name = null;
+        final String status = null;
+        return updatePetWithFormWithResponseAsync(petId, petType, petFood, petAge, name, status)
+                .flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Updates a pet in the store with form data.
+     *
+     * @param petId ID of pet that needs to be updated.
+     * @param petType Can take a value of dog, or cat, or fish.
+     * @param petFood Can take a value of meat, or fish, or plant.
+     * @param petAge How many years is it old?.
+     * @param name Updated name of the pet.
+     * @param status Updated status of the pet.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void updatePetWithForm(int petId, PetType petType, PetFood petFood, int petAge, String name, String status) {
+        updatePetWithFormAsync(petId, petType, petFood, petAge, name, status).block();
+    }
+
+    /**
+     * Updates a pet in the store with form data.
+     *
+     * @param petId ID of pet that needs to be updated.
+     * @param petType Can take a value of dog, or cat, or fish.
+     * @param petFood Can take a value of meat, or fish, or plant.
+     * @param petAge How many years is it old?.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void updatePetWithForm(int petId, PetType petType, PetFood petFood, int petAge) {
+        final String name = null;
+        final String status = null;
+        updatePetWithFormAsync(petId, petType, petFood, petAge, name, status).block();
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/bodyformdataurlencoded/models/Paths14Hl8BdFormsdataurlencodedPetAddPetidPostRequestbodyContentApplicationXWwwFormUrlencodedSchema.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyformdataurlencoded/models/Paths14Hl8BdFormsdataurlencodedPetAddPetidPostRequestbodyContentApplicationXWwwFormUrlencodedSchema.java
@@ -1,0 +1,164 @@
+package fixtures.bodyformdataurlencoded.models;
+
+import com.azure.core.annotation.Fluent;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** The Paths14Hl8BdFormsdataurlencodedPetAddPetidPostRequestbodyContentApplicationXWwwFormUrlencodedSchema model. */
+@Fluent
+public final class Paths14Hl8BdFormsdataurlencodedPetAddPetidPostRequestbodyContentApplicationXWwwFormUrlencodedSchema {
+    /*
+     * Can take a value of dog, or cat, or fish
+     */
+    @JsonProperty(value = "pet_type", required = true)
+    private PetType petType;
+
+    /*
+     * Can take a value of meat, or fish, or plant
+     */
+    @JsonProperty(value = "pet_food", required = true)
+    private PetFood petFood;
+
+    /*
+     * How many years is it old?
+     */
+    @JsonProperty(value = "pet_age", required = true)
+    private int petAge;
+
+    /*
+     * Updated name of the pet
+     */
+    @JsonProperty(value = "name")
+    private String name;
+
+    /*
+     * Updated status of the pet
+     */
+    @JsonProperty(value = "status")
+    private String status;
+
+    /**
+     * Get the petType property: Can take a value of dog, or cat, or fish.
+     *
+     * @return the petType value.
+     */
+    public PetType getPetType() {
+        return this.petType;
+    }
+
+    /**
+     * Set the petType property: Can take a value of dog, or cat, or fish.
+     *
+     * @param petType the petType value to set.
+     * @return the Paths14Hl8BdFormsdataurlencodedPetAddPetidPostRequestbodyContentApplicationXWwwFormUrlencodedSchema
+     *     object itself.
+     */
+    public Paths14Hl8BdFormsdataurlencodedPetAddPetidPostRequestbodyContentApplicationXWwwFormUrlencodedSchema
+            setPetType(PetType petType) {
+        this.petType = petType;
+        return this;
+    }
+
+    /**
+     * Get the petFood property: Can take a value of meat, or fish, or plant.
+     *
+     * @return the petFood value.
+     */
+    public PetFood getPetFood() {
+        return this.petFood;
+    }
+
+    /**
+     * Set the petFood property: Can take a value of meat, or fish, or plant.
+     *
+     * @param petFood the petFood value to set.
+     * @return the Paths14Hl8BdFormsdataurlencodedPetAddPetidPostRequestbodyContentApplicationXWwwFormUrlencodedSchema
+     *     object itself.
+     */
+    public Paths14Hl8BdFormsdataurlencodedPetAddPetidPostRequestbodyContentApplicationXWwwFormUrlencodedSchema
+            setPetFood(PetFood petFood) {
+        this.petFood = petFood;
+        return this;
+    }
+
+    /**
+     * Get the petAge property: How many years is it old?.
+     *
+     * @return the petAge value.
+     */
+    public int getPetAge() {
+        return this.petAge;
+    }
+
+    /**
+     * Set the petAge property: How many years is it old?.
+     *
+     * @param petAge the petAge value to set.
+     * @return the Paths14Hl8BdFormsdataurlencodedPetAddPetidPostRequestbodyContentApplicationXWwwFormUrlencodedSchema
+     *     object itself.
+     */
+    public Paths14Hl8BdFormsdataurlencodedPetAddPetidPostRequestbodyContentApplicationXWwwFormUrlencodedSchema
+            setPetAge(int petAge) {
+        this.petAge = petAge;
+        return this;
+    }
+
+    /**
+     * Get the name property: Updated name of the pet.
+     *
+     * @return the name value.
+     */
+    public String getName() {
+        return this.name;
+    }
+
+    /**
+     * Set the name property: Updated name of the pet.
+     *
+     * @param name the name value to set.
+     * @return the Paths14Hl8BdFormsdataurlencodedPetAddPetidPostRequestbodyContentApplicationXWwwFormUrlencodedSchema
+     *     object itself.
+     */
+    public Paths14Hl8BdFormsdataurlencodedPetAddPetidPostRequestbodyContentApplicationXWwwFormUrlencodedSchema setName(
+            String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Get the status property: Updated status of the pet.
+     *
+     * @return the status value.
+     */
+    public String getStatus() {
+        return this.status;
+    }
+
+    /**
+     * Set the status property: Updated status of the pet.
+     *
+     * @param status the status value to set.
+     * @return the Paths14Hl8BdFormsdataurlencodedPetAddPetidPostRequestbodyContentApplicationXWwwFormUrlencodedSchema
+     *     object itself.
+     */
+    public Paths14Hl8BdFormsdataurlencodedPetAddPetidPostRequestbodyContentApplicationXWwwFormUrlencodedSchema
+            setStatus(String status) {
+        this.status = status;
+        return this;
+    }
+
+    /**
+     * Validates the instance.
+     *
+     * @throws IllegalArgumentException thrown if the instance is not valid.
+     */
+    public void validate() {
+        if (getPetType() == null) {
+            throw new IllegalArgumentException(
+                    "Missing required property petType in model Paths14Hl8BdFormsdataurlencodedPetAddPetidPostRequestbodyContentApplicationXWwwFormUrlencodedSchema");
+        }
+        if (getPetFood() == null) {
+            throw new IllegalArgumentException(
+                    "Missing required property petFood in model Paths14Hl8BdFormsdataurlencodedPetAddPetidPostRequestbodyContentApplicationXWwwFormUrlencodedSchema");
+        }
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/bodyformdataurlencoded/models/PetFood.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyformdataurlencoded/models/PetFood.java
@@ -1,0 +1,33 @@
+package fixtures.bodyformdataurlencoded.models;
+
+import com.azure.core.util.ExpandableStringEnum;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.Collection;
+
+/** Defines values for PetFood. */
+public final class PetFood extends ExpandableStringEnum<PetFood> {
+    /** Static value meat for PetFood. */
+    public static final PetFood MEAT = fromString("meat");
+
+    /** Static value fish for PetFood. */
+    public static final PetFood FISH = fromString("fish");
+
+    /** Static value plant for PetFood. */
+    public static final PetFood PLANT = fromString("plant");
+
+    /**
+     * Creates or finds a PetFood from its string representation.
+     *
+     * @param name a name to look for.
+     * @return the corresponding PetFood.
+     */
+    @JsonCreator
+    public static PetFood fromString(String name) {
+        return fromString(name, PetFood.class);
+    }
+
+    /** @return known PetFood values. */
+    public static Collection<PetFood> values() {
+        return values(PetFood.class);
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/bodyformdataurlencoded/models/PetType.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyformdataurlencoded/models/PetType.java
@@ -1,0 +1,46 @@
+package fixtures.bodyformdataurlencoded.models;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/** Defines values for PetType. */
+public enum PetType {
+    /** Enum value dog. */
+    DOG("dog"),
+
+    /** Enum value cat. */
+    CAT("cat"),
+
+    /** Enum value fish. */
+    FISH("fish");
+
+    /** The actual serialized value for a PetType instance. */
+    private final String value;
+
+    PetType(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Parses a serialized value to a PetType instance.
+     *
+     * @param value the serialized value to parse.
+     * @return the parsed PetType object, or null if unable to parse.
+     */
+    @JsonCreator
+    public static PetType fromString(String value) {
+        PetType[] items = PetType.values();
+        for (PetType item : items) {
+            if (item.toString().equalsIgnoreCase(value)) {
+                return item;
+            }
+        }
+        return null;
+    }
+
+    @JsonValue
+    @Override
+    public String toString() {
+        return this.value;
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/bodyformdataurlencoded/models/package-info.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyformdataurlencoded/models/package-info.java
@@ -1,0 +1,2 @@
+/** Package containing the data models for BodyFormsDataURLEncoded. Test Infrastructure for AutoRest Swagger BAT. */
+package fixtures.bodyformdataurlencoded.models;

--- a/vanilla-tests/src/main/java/fixtures/bodyformdataurlencoded/package-info.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyformdataurlencoded/package-info.java
@@ -1,0 +1,2 @@
+/** Package containing the classes for BodyFormsDataURLEncoded. Test Infrastructure for AutoRest Swagger BAT. */
+package fixtures.bodyformdataurlencoded;

--- a/vanilla-tests/src/test/java/fixtures/bodyformdataurlencoded/FormDataUrlEncodedTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodyformdataurlencoded/FormDataUrlEncodedTests.java
@@ -13,7 +13,7 @@ import static org.junit.Assert.assertEquals;
 public class FormDataUrlEncodedTests {
 
     @Test
-    public void test() {
+    public void testFormDataUpdate() {
         BodyFormsDataURLEncoded bodyFormsDataURLEncoded = new BodyFormsDataURLEncodedBuilder()
                 .buildClient();
         Response<Void> response = bodyFormsDataURLEncoded.getFormdataurlencodeds()

--- a/vanilla-tests/src/test/java/fixtures/bodyformdataurlencoded/FormDataUrlEncodedTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodyformdataurlencoded/FormDataUrlEncodedTests.java
@@ -1,0 +1,24 @@
+package fixtures.bodyformdataurlencoded;
+
+import com.azure.core.http.rest.Response;
+import fixtures.bodyformdataurlencoded.models.PetFood;
+import fixtures.bodyformdataurlencoded.models.PetType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for {@link BodyFormsDataURLEncoded} client.
+ */
+public class FormDataUrlEncodedTests {
+
+    @Test
+    public void test() {
+        BodyFormsDataURLEncoded bodyFormsDataURLEncoded = new BodyFormsDataURLEncodedBuilder()
+                .buildClient();
+        Response<Void> response = bodyFormsDataURLEncoded.getFormdataurlencodeds()
+                .updatePetWithFormWithResponseAsync(1, PetType.DOG, PetFood.MEAT, 42, "Fido", null).block();
+
+        assertEquals(200, response.getStatusCode());
+    }
+}


### PR DESCRIPTION
This PR adds support for proxy method params that use `x-www-form-urlencoded` content type to be annotated with `@FormParam`. 

Fixes #1004 