### PR TITLE
Fixed a Bug Where Adding a Constructor or Method with a Parameterized Parameter Failed

### DIFF
--- a/customization-base/src/main/java/com/azure/autorest/customization/ClassCustomization.java
+++ b/customization-base/src/main/java/com/azure/autorest/customization/ClassCustomization.java
@@ -35,7 +35,7 @@ public final class ClassCustomization extends CodeCustomization {
      * spaces and an opening '{'.
      */
     private static final Pattern METHOD_SIGNATURE_PATTERN =
-        Pattern.compile("^\\s*([^/*][\\w\\s]+\\([\\w\\s\\.]*\\))\\s*\\{?$", Pattern.MULTILINE);
+        Pattern.compile("^\\s*([^/*][\\w\\s]+\\([\\w\\s<>\\.]*\\))\\s*\\{?$", Pattern.MULTILINE);
 
     /*
      * This pattern attempts to find the first line of a constructor string that doesn't have a first non-space
@@ -43,7 +43,7 @@ public final class ClassCustomization extends CodeCustomization {
      * characters before and inside '( )' ignoring any trailing spaces and an opening '{'.
      */
     private static final Pattern CONSTRUCTOR_SIGNATURE_PATTERN =
-        Pattern.compile("^\\s*([^/*][\\w\\s]+\\([\\w\\s\\.]*\\))\\s*\\{?$", Pattern.MULTILINE);
+        Pattern.compile("^\\s*([^/*][\\w\\s]+\\([\\w\\s<>\\.]*\\))\\s*\\{?$", Pattern.MULTILINE);
 
     private final String packageName;
     private final String className;

--- a/customization-base/src/main/java/com/azure/autorest/customization/ClassCustomization.java
+++ b/customization-base/src/main/java/com/azure/autorest/customization/ClassCustomization.java
@@ -35,7 +35,7 @@ public final class ClassCustomization extends CodeCustomization {
      * spaces and an opening '{'.
      */
     private static final Pattern METHOD_SIGNATURE_PATTERN =
-        Pattern.compile("^\\s*([^/*][\\w\\s]+\\([\\w\\s<>\\.]*\\))\\s*\\{?$", Pattern.MULTILINE);
+        Pattern.compile("^\\s*([^/*][\\w\\s]+\\([\\w\\s<>,\\.]*\\))\\s*\\{?$", Pattern.MULTILINE);
 
     /*
      * This pattern attempts to find the first line of a constructor string that doesn't have a first non-space
@@ -43,7 +43,7 @@ public final class ClassCustomization extends CodeCustomization {
      * characters before and inside '( )' ignoring any trailing spaces and an opening '{'.
      */
     private static final Pattern CONSTRUCTOR_SIGNATURE_PATTERN =
-        Pattern.compile("^\\s*([^/*][\\w\\s]+\\([\\w\\s<>\\.]*\\))\\s*\\{?$", Pattern.MULTILINE);
+        Pattern.compile("^\\s*([^/*][\\w\\s]+\\([\\w\\s<>,\\.]*\\))\\s*\\{?$", Pattern.MULTILINE);
 
     private final String packageName;
     private final String className;


### PR DESCRIPTION
This PR makes the following changes:

- Fixed bugs with constructor and method signature extraction when generic parameters or multiple parameters exist.
- Fixed a bug when a replacing a constructor's or method's parameters and there existed a an annotation (ex. `@JsonProperty()`) on a parameter.
- Further centralization of parsing and symbol walking and additional hardening of the logic.