### PR TITLE
Fix for multiple query parameters with same name.

### DIFF
--- a/androidgen/src/main/java/com/azure/autorest/android/model/clientmodel/AndroidProxyMethodParameter.java
+++ b/androidgen/src/main/java/com/azure/autorest/android/model/clientmodel/AndroidProxyMethodParameter.java
@@ -43,7 +43,8 @@ public class AndroidProxyMethodParameter extends ProxyMethodParameter {
                                           String headerCollectionPrefix,
                                           String parameterReference,
                                           String defaultValue,
-                                          CollectionFormat collectionFormat) {
+                                          CollectionFormat collectionFormat,
+                                          boolean explode) {
         super(description,
                 wireType,
                 clientType,
@@ -58,7 +59,8 @@ public class AndroidProxyMethodParameter extends ProxyMethodParameter {
                 headerCollectionPrefix,
                 parameterReference,
                 defaultValue,
-                collectionFormat);
+                collectionFormat,
+                explode);
     }
 
     @Override
@@ -92,7 +94,8 @@ public class AndroidProxyMethodParameter extends ProxyMethodParameter {
                     headerCollectionPrefix,
                     parameterReference,
                     defaultValue,
-                    collectionFormat);
+                    collectionFormat,
+                    explode);
         }
     }
 }

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Protocol.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Protocol.java
@@ -15,6 +15,7 @@ public class Protocol {
     private String method;
     private KnownMediaType knownMediaType;
     private SerializationStyle style;
+    private boolean explode;
     private List<String> mediaTypes;
     private List<Server> servers;
     private List<String> statusCodes;
@@ -98,5 +99,13 @@ public class Protocol {
 
     public void setStyle(SerializationStyle style) {
         this.style = style;
+    }
+    
+    public boolean getExplode() {
+        return explode;
+    }
+
+    public void setExplode(boolean explode) {
+        this.explode = explode;
     }
 }

--- a/javagen/src/main/java/com/azure/autorest/mapper/CustomProxyParameterMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/CustomProxyParameterMapper.java
@@ -81,8 +81,11 @@ public class CustomProxyParameterMapper implements IMapper<Parameter, ProxyMetho
             if (parameterRequestLocation != RequestParameterLocation.Body /*&& parameterRequestLocation != RequestParameterLocation.FormData*/) {
                 wireType = ClassType.String;
             }
-        } else if (wireType instanceof ListType && parameter.getProtocol().getHttp().getIn() != RequestParameterLocation.Body /*&& parameter.getProtocol().getHttp().getIn() != RequestParameterLocation.FormData*/) {
+        } else if (wireType instanceof ListType && parameter.getProtocol().getHttp().getIn() != RequestParameterLocation.Body /*&& parameter.getProtocol().getHttp().getIn() != RequestParameterLocation.FormData*/ && !parameter.getProtocol().getHttp().getExplode()) {
             wireType = ClassType.String;
+        }
+        if (parameter.getProtocol().getHttp().getExplode()) {
+            builder.alreadyEncoded(true);
         }
         builder.wireType(wireType);
 
@@ -146,6 +149,7 @@ public class CustomProxyParameterMapper implements IMapper<Parameter, ProxyMetho
             collectionFormat = CollectionFormat.CSV;
         }
         builder.collectionFormat(collectionFormat);
+        builder.explode(parameter.getProtocol().getHttp().getExplode());
 
         return builder.build();
     }

--- a/javagen/src/main/java/com/azure/autorest/mapper/CustomProxyParameterMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/CustomProxyParameterMapper.java
@@ -82,11 +82,11 @@ public class CustomProxyParameterMapper implements IMapper<Parameter, ProxyMetho
                 wireType = ClassType.String;
             }
         } else if (wireType instanceof ListType && parameter.getProtocol().getHttp().getIn() != RequestParameterLocation.Body /*&& parameter.getProtocol().getHttp().getIn() != RequestParameterLocation.FormData*/) {
-        	if (parameter.getProtocol().getHttp().getExplode()) {
+            if (parameter.getProtocol().getHttp().getExplode()) {
                 wireType = new ListType(ClassType.String);
-        	} else {
+            } else {
                 wireType = ClassType.String;
-        	}
+            }
         }
         if (parameter.getProtocol().getHttp().getExplode()) {
             builder.alreadyEncoded(true);

--- a/javagen/src/main/java/com/azure/autorest/mapper/CustomProxyParameterMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/CustomProxyParameterMapper.java
@@ -81,8 +81,12 @@ public class CustomProxyParameterMapper implements IMapper<Parameter, ProxyMetho
             if (parameterRequestLocation != RequestParameterLocation.Body /*&& parameterRequestLocation != RequestParameterLocation.FormData*/) {
                 wireType = ClassType.String;
             }
-        } else if (wireType instanceof ListType && parameter.getProtocol().getHttp().getIn() != RequestParameterLocation.Body /*&& parameter.getProtocol().getHttp().getIn() != RequestParameterLocation.FormData*/ && !parameter.getProtocol().getHttp().getExplode()) {
-            wireType = ClassType.String;
+        } else if (wireType instanceof ListType && parameter.getProtocol().getHttp().getIn() != RequestParameterLocation.Body /*&& parameter.getProtocol().getHttp().getIn() != RequestParameterLocation.FormData*/) {
+        	if (parameter.getProtocol().getHttp().getExplode()) {
+                wireType = new ListType(ClassType.String);
+        	} else {
+                wireType = ClassType.String;
+        	}
         }
         if (parameter.getProtocol().getHttp().getExplode()) {
             builder.alreadyEncoded(true);

--- a/javagen/src/main/java/com/azure/autorest/mapper/ProxyParameterMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ProxyParameterMapper.java
@@ -71,11 +71,11 @@ public class ProxyParameterMapper implements IMapper<Parameter, ProxyMethodParam
                 wireType = ClassType.String;
             }
         } else if (wireType instanceof ListType && parameter.getProtocol().getHttp().getIn() != RequestParameterLocation.Body /*&& parameter.getProtocol().getHttp().getIn() != RequestParameterLocation.FormData*/) {
-        	if (parameter.getProtocol().getHttp().getExplode()) {
+            if (parameter.getProtocol().getHttp().getExplode()) {
                 wireType = new ListType(ClassType.String);
-        	} else {
+            } else {
                 wireType = ClassType.String;
-        	}
+            }
         }
         builder.wireType(wireType);
 

--- a/javagen/src/main/java/com/azure/autorest/mapper/ProxyParameterMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ProxyParameterMapper.java
@@ -70,8 +70,12 @@ public class ProxyParameterMapper implements IMapper<Parameter, ProxyMethodParam
             if (parameterRequestLocation != RequestParameterLocation.Body /*&& parameterRequestLocation != RequestParameterLocation.FormData*/) {
                 wireType = ClassType.String;
             }
-        } else if (wireType instanceof ListType && parameter.getProtocol().getHttp().getIn() != RequestParameterLocation.Body /*&& parameter.getProtocol().getHttp().getIn() != RequestParameterLocation.FormData*/ && !parameter.getProtocol().getHttp().getExplode()) {
-            wireType = ClassType.String;
+        } else if (wireType instanceof ListType && parameter.getProtocol().getHttp().getIn() != RequestParameterLocation.Body /*&& parameter.getProtocol().getHttp().getIn() != RequestParameterLocation.FormData*/) {
+        	if (parameter.getProtocol().getHttp().getExplode()) {
+                wireType = new ListType(ClassType.String);
+        	} else {
+                wireType = ClassType.String;
+        	}
         }
         builder.wireType(wireType);
 

--- a/javagen/src/main/java/com/azure/autorest/mapper/ProxyParameterMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ProxyParameterMapper.java
@@ -70,7 +70,7 @@ public class ProxyParameterMapper implements IMapper<Parameter, ProxyMethodParam
             if (parameterRequestLocation != RequestParameterLocation.Body /*&& parameterRequestLocation != RequestParameterLocation.FormData*/) {
                 wireType = ClassType.String;
             }
-        } else if (wireType instanceof ListType && parameter.getProtocol().getHttp().getIn() != RequestParameterLocation.Body /*&& parameter.getProtocol().getHttp().getIn() != RequestParameterLocation.FormData*/) {
+        } else if (wireType instanceof ListType && parameter.getProtocol().getHttp().getIn() != RequestParameterLocation.Body /*&& parameter.getProtocol().getHttp().getIn() != RequestParameterLocation.FormData*/ && !parameter.getProtocol().getHttp().getExplode()) {
             wireType = ClassType.String;
         }
         builder.wireType(wireType);
@@ -136,6 +136,7 @@ public class ProxyParameterMapper implements IMapper<Parameter, ProxyMethodParam
             collectionFormat = CollectionFormat.CSV;
         }
         builder.collectionFormat(collectionFormat);
+        builder.explode(parameter.getProtocol().getHttp().getExplode());
 
         return builder.build();
     }

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethodParameter.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethodParameter.java
@@ -225,7 +225,7 @@ public class ProxyMethodParameter {
                 imports.add("com.azure.core.util.serializer.CollectionFormat");
                 imports.add("com.azure.core.util.serializer.JacksonAdapter");
             } else if (getClientType() instanceof ListType && getExplode()) {
-                imports.add("java.util.stream");
+                imports.add("java.util.stream.Collectors");
             }
         }
 //        if (getRequestParameterLocation() == RequestParameterLocation.FormData) {

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethodParameter.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethodParameter.java
@@ -221,9 +221,11 @@ public class ProxyMethodParameter {
         if (getRequestParameterLocation() != RequestParameterLocation.Body) {
             if (getClientType() == ArrayType.ByteArray) {
                 imports.add("com.azure.core.util.Base64Util");
-            } else if (getClientType() instanceof ListType) {
+            } else if (getClientType() instanceof ListType && !getExplode()) {
                 imports.add("com.azure.core.util.serializer.CollectionFormat");
                 imports.add("com.azure.core.util.serializer.JacksonAdapter");
+            } else if (getClientType() instanceof ListType && getExplode()) {
+                imports.add("java.util.stream");
             }
         }
 //        if (getRequestParameterLocation() == RequestParameterLocation.FormData) {

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethodParameter.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethodParameter.java
@@ -74,6 +74,10 @@ public class ProxyMethodParameter {
      * The collection format if the parameter is a list type.
      */
     private CollectionFormat collectionFormat;
+    /**
+     * The explode if the parameter is a list type.
+     */
+    private boolean explode;	
 
     /**
      * Create a new RestAPIParameter based on the provided properties.
@@ -92,9 +96,9 @@ public class ProxyMethodParameter {
      * @param parameterReference The reference to this parameter from a caller.
      * @param defaultValue The default value of the parameter.
      * @param collectionFormat The collection format if the parameter is a list type.
+     * @param explode Whether arrays and objects should generate separate parameters for each array item or object property.
      */
-    protected ProxyMethodParameter(String description, IType wireType, IType clientType, String name, com.azure.autorest.extension.base.model.codemodel.RequestParameterLocation requestParameterLocation, String requestParameterName, boolean alreadyEncoded, boolean isConstant, boolean isRequired, boolean isNullable, boolean fromClient, String headerCollectionPrefix, String parameterReference, String defaultValue, CollectionFormat collectionFormat) {
-        this.description = description;
+    private ProxyMethodParameter(String description, IType wireType, IType clientType, String name, com.azure.autorest.extension.base.model.codemodel.RequestParameterLocation requestParameterLocation, String requestParameterName, boolean alreadyEncoded, boolean isConstant, boolean isRequired, boolean isNullable, boolean fromClient, String headerCollectionPrefix, String parameterReference, String defaultValue, CollectionFormat collectionFormat, boolean explode) {        this.description = description;
         this.wireType = wireType;
         this.clientType = clientType;
         this.name = name;
@@ -108,6 +112,7 @@ public class ProxyMethodParameter {
         this.headerCollectionPrefix = headerCollectionPrefix;
         this.parameterReference = parameterReference;
         this.collectionFormat = collectionFormat;
+        this.explode = explode;
         this.defaultValue = defaultValue;
     }
 
@@ -175,6 +180,9 @@ public class ProxyMethodParameter {
         return collectionFormat;
     }
 
+    public final boolean getExplode() {
+        return explode;
+    }
 
     public final String convertFromClientType(String source, String target, boolean alwaysNull) {
         return convertFromClientType(source, target, alwaysNull, false);
@@ -241,6 +249,7 @@ public class ProxyMethodParameter {
         protected String parameterReference;
         protected String defaultValue;
         protected CollectionFormat collectionFormat;
+        private boolean explode;
 
         /**
          * Sets the description of this parameter.
@@ -391,6 +400,16 @@ public class ProxyMethodParameter {
             this.collectionFormat = collectionFormat;
             return this;
         }
+        
+        /**
+         * Sets the explode if the parameter is a list type.
+         * @param explode the explode if the parameter is a list type
+         * @return the Builder itself
+         */
+        public Builder explode(boolean explode) {
+            this.explode = explode;
+            return this;
+        }
 
         public ProxyMethodParameter build() {
             return new ProxyMethodParameter(description,
@@ -407,7 +426,8 @@ public class ProxyMethodParameter {
                     headerCollectionPrefix,
                     parameterReference,
                     defaultValue,
-                    collectionFormat);
+                    collectionFormat,
+                    explode);
         }
     }
 }

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethodParameter.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethodParameter.java
@@ -252,7 +252,7 @@ public class ProxyMethodParameter {
         protected String parameterReference;
         protected String defaultValue;
         protected CollectionFormat collectionFormat;
-        private boolean explode;
+        protected boolean explode;
 
         /**
          * Sets the description of this parameter.

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethodParameter.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethodParameter.java
@@ -98,7 +98,7 @@ public class ProxyMethodParameter {
      * @param collectionFormat The collection format if the parameter is a list type.
      * @param explode Whether arrays and objects should generate separate parameters for each array item or object property.
      */
-    private ProxyMethodParameter(String description, IType wireType, IType clientType, String name, com.azure.autorest.extension.base.model.codemodel.RequestParameterLocation requestParameterLocation, String requestParameterName, boolean alreadyEncoded, boolean isConstant, boolean isRequired, boolean isNullable, boolean fromClient, String headerCollectionPrefix, String parameterReference, String defaultValue, CollectionFormat collectionFormat, boolean explode) {
+    protected ProxyMethodParameter(String description, IType wireType, IType clientType, String name, com.azure.autorest.extension.base.model.codemodel.RequestParameterLocation requestParameterLocation, String requestParameterName, boolean alreadyEncoded, boolean isConstant, boolean isRequired, boolean isNullable, boolean fromClient, String headerCollectionPrefix, String parameterReference, String defaultValue, CollectionFormat collectionFormat, boolean explode) {
         this.description = description;
         this.wireType = wireType;
         this.clientType = clientType;

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethodParameter.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethodParameter.java
@@ -98,7 +98,8 @@ public class ProxyMethodParameter {
      * @param collectionFormat The collection format if the parameter is a list type.
      * @param explode Whether arrays and objects should generate separate parameters for each array item or object property.
      */
-    private ProxyMethodParameter(String description, IType wireType, IType clientType, String name, com.azure.autorest.extension.base.model.codemodel.RequestParameterLocation requestParameterLocation, String requestParameterName, boolean alreadyEncoded, boolean isConstant, boolean isRequired, boolean isNullable, boolean fromClient, String headerCollectionPrefix, String parameterReference, String defaultValue, CollectionFormat collectionFormat, boolean explode) {        this.description = description;
+    private ProxyMethodParameter(String description, IType wireType, IType clientType, String name, com.azure.autorest.extension.base.model.codemodel.RequestParameterLocation requestParameterLocation, String requestParameterName, boolean alreadyEncoded, boolean isConstant, boolean isRequired, boolean isNullable, boolean fromClient, String headerCollectionPrefix, String parameterReference, String defaultValue, CollectionFormat collectionFormat, boolean explode) {
+        this.description = description;
         this.wireType = wireType;
         this.clientType = clientType;
         this.name = name;

--- a/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
@@ -224,11 +224,11 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
                     parameter.getRequestParameterLocation() != RequestParameterLocation.Body &&
                     //parameter.getRequestParameterLocation() != RequestParameterLocation.FormData &&
                     (parameterClientType instanceof ArrayType || parameterClientType instanceof ListType)) {
-            	if (parameter.getExplode() == false) {
+                if (parameter.getExplode() == false) {
                     parameterWireType = ClassType.String;
-            	} else {
-            		parameterWireType = new ListType(ClassType.String);
-            	}
+                } else {
+                    parameterWireType = new ListType(ClassType.String);
+                }
             }
 
             if (parameterWireType != parameterClientType) {
@@ -277,9 +277,9 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
                                         parameter.getCollectionFormat().toString().toUpperCase());
                             }
                         } else {
-                        	expression = String.format("%s.stream().map(Object::toString)"+ 
-                        			".collect(Collectors.toList())",
-                        			parameterName);
+                            expression = String.format("%s.stream().map(Object::toString)"+ 
+                                    ".collect(Collectors.toList())",
+                                    parameterName);
                         }
                         function.line("%s %s = %s;", parameterWireTypeName, parameterWireName, expression);
                         addedConversion = true;

--- a/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
@@ -223,8 +223,11 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
             if (parameterWireType != ClassType.Base64Url &&
                     parameter.getRequestParameterLocation() != RequestParameterLocation.Body &&
                     //parameter.getRequestParameterLocation() != RequestParameterLocation.FormData &&
-                    (parameterClientType instanceof ArrayType || parameterClientType instanceof ListType)) {
+                    (parameterClientType instanceof ArrayType || parameterClientType instanceof ListType) &&
+                    (parameter.getExplode() == false)) {
                 parameterWireType = ClassType.String;
+            } else if (parameter.getExplode()){
+                parameterWireType = parameterClientType;
             }
 
             if (parameterWireType != parameterClientType) {
@@ -273,7 +276,13 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
                                         parameter.getCollectionFormat().toString().toUpperCase());
                             }
                         }
-                        function.line("%s %s = %s;", parameterWireTypeName, parameterWireName, expression);
+                        // don't convert if explode is true
+                        if (parameter.getExplode()) {
+                            function.line("%s %s = %s;", parameterWireTypeName, parameterWireName, parameterName);
+                        }
+                    	else {
+                            function.line("%s %s = %s;", parameterWireTypeName, parameterWireName, expression);
+                    	}
                         addedConversion = true;
                     }
                 }

--- a/javagen/src/main/java/com/azure/autorest/template/ProxyTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ProxyTemplate.java
@@ -101,7 +101,8 @@ public class ProxyTemplate implements IJavaTemplate<Proxy, JavaClass> {
                                     parameterDeclarationBuilder.append(String.format("value = \"%1$s\", encoded = true, multipleQueryParams = true", parameter.getRequestParameterName()));
                                 } else if (parameter.getRequestParameterLocation() == RequestParameterLocation.Query && parameter.getExplode()) {
                                     parameterDeclarationBuilder.append(String.format("value = \"%1$s\", multipleQueryParams = true", parameter.getRequestParameterName()));
-                                } else if ((parameter.getRequestParameterLocation() == RequestParameterLocation.Path || parameter.getRequestParameterLocation() == RequestParameterLocation.Query)
+                                } else if ((parameter.getRequestParameterLocation() == RequestParameterLocation.Path ||
+                                            parameter.getRequestParameterLocation() == RequestParameterLocation.Query)
                                         && parameter.getAlreadyEncoded()) {
                                     parameterDeclarationBuilder.append(String.format("value = \"%1$s\", encoded = true", parameter.getRequestParameterName()));
                                 } else if (parameter.getRequestParameterLocation() == RequestParameterLocation.Header && parameter.getHeaderCollectionPrefix() != null

--- a/javagen/src/main/java/com/azure/autorest/template/ProxyTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ProxyTemplate.java
@@ -97,9 +97,15 @@ public class ProxyTemplate implements IJavaTemplate<Proxy, JavaClass> {
                             case Query:
                             case Header:
                                 parameterDeclarationBuilder.append(String.format("@%1$sParam(", CodeNamer.toPascalCase(parameter.getRequestParameterLocation().toString())));
-                                if ((parameter.getRequestParameterLocation() == RequestParameterLocation.Path || parameter.getRequestParameterLocation() == RequestParameterLocation.Query) && parameter.getAlreadyEncoded()) {
+                                if (parameter.getRequestParameterLocation() == RequestParameterLocation.Query && parameter.getAlreadyEncoded() && parameter.getExplode()) {
+                                    parameterDeclarationBuilder.append(String.format("value = \"%1$s\", encoded = true, multipleQueryParams = true", parameter.getRequestParameterName()));
+                                } else if (parameter.getRequestParameterLocation() == RequestParameterLocation.Query && parameter.getExplode()) {
+                                    parameterDeclarationBuilder.append(String.format("value = \"%1$s\", multipleQueryParams = true", parameter.getRequestParameterName()));
+                                } else if ((parameter.getRequestParameterLocation() == RequestParameterLocation.Path || parameter.getRequestParameterLocation() == RequestParameterLocation.Query)
+                                        && parameter.getAlreadyEncoded()) {
                                     parameterDeclarationBuilder.append(String.format("value = \"%1$s\", encoded = true", parameter.getRequestParameterName()));
-                                } else if (parameter.getRequestParameterLocation() == RequestParameterLocation.Header && parameter.getHeaderCollectionPrefix() != null && !parameter.getHeaderCollectionPrefix().isEmpty()) {
+                                } else if (parameter.getRequestParameterLocation() == RequestParameterLocation.Header && parameter.getHeaderCollectionPrefix() != null
+                                        && !parameter.getHeaderCollectionPrefix().isEmpty()) {
                                     parameterDeclarationBuilder.append(String.format("\"%1$s\"", parameter.getHeaderCollectionPrefix()));
                                 } else {
                                     parameterDeclarationBuilder.append(String.format("\"%1$s\"", parameter.getRequestParameterName()));

--- a/vanilla-tests/src/main/java/fixtures/url/multi/Queries.java
+++ b/vanilla-tests/src/main/java/fixtures/url/multi/Queries.java
@@ -14,10 +14,9 @@ import com.azure.core.http.rest.Response;
 import com.azure.core.http.rest.RestProxy;
 import com.azure.core.util.Context;
 import com.azure.core.util.FluxUtil;
-import com.azure.core.util.serializer.CollectionFormat;
-import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.url.multi.models.ErrorException;
 import java.util.List;
+import java.util.stream.Collectors;
 import reactor.core.publisher.Mono;
 
 /** An instance of this class provides access to all the operations defined in Queries. */
@@ -51,7 +50,7 @@ public final class Queries {
         Mono<Response<Void>> arrayStringMultiNull(
                 @HostParam("$host") String host,
                 @QueryParam("arrayQuery") String arrayQuery,
-                @HeaderParam("Accept") String accept,
+                @QueryParam(value = "arrayQuery", multipleQueryParams = true) List<String> arrayQuery,
                 Context context);
 
         @Get("/queries/array/multi/string/empty")
@@ -59,7 +58,7 @@ public final class Queries {
         @UnexpectedResponseExceptionType(ErrorException.class)
         Mono<Response<Void>> arrayStringMultiEmpty(
                 @HostParam("$host") String host,
-                @QueryParam("arrayQuery") String arrayQuery,
+                @QueryParam(value = "arrayQuery", multipleQueryParams = true) List<String> arrayQuery,
                 @HeaderParam("Accept") String accept,
                 Context context);
 
@@ -68,7 +67,7 @@ public final class Queries {
         @UnexpectedResponseExceptionType(ErrorException.class)
         Mono<Response<Void>> arrayStringMultiValid(
                 @HostParam("$host") String host,
-                @QueryParam("arrayQuery") String arrayQuery,
+                @QueryParam(value = "arrayQuery", multipleQueryParams = true) List<String> arrayQuery,
                 @HeaderParam("Accept") String accept,
                 Context context);
     }
@@ -89,8 +88,7 @@ public final class Queries {
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
         }
         final String accept = "application/json";
-        String arrayQueryConverted =
-                JacksonAdapter.createDefaultSerializerAdapter().serializeList(arrayQuery, CollectionFormat.CSV);
+        List<String> arrayQueryConverted = arrayQuery.stream().map(Object::toString).collect(Collectors.toList());
         return FluxUtil.withContext(
                 context -> service.arrayStringMultiNull(this.client.getHost(), arrayQueryConverted, accept, context));
     }
@@ -163,8 +161,7 @@ public final class Queries {
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
         }
         final String accept = "application/json";
-        String arrayQueryConverted =
-                JacksonAdapter.createDefaultSerializerAdapter().serializeList(arrayQuery, CollectionFormat.CSV);
+        List<String> arrayQueryConverted = arrayQuery.stream().map(Object::toString).collect(Collectors.toList());
         return FluxUtil.withContext(
                 context -> service.arrayStringMultiEmpty(this.client.getHost(), arrayQueryConverted, accept, context));
     }
@@ -239,8 +236,7 @@ public final class Queries {
                     new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
         }
         final String accept = "application/json";
-        String arrayQueryConverted =
-                JacksonAdapter.createDefaultSerializerAdapter().serializeList(arrayQuery, CollectionFormat.CSV);
+        List<String> arrayQueryConverted = arrayQuery.stream().map(Object::toString).collect(Collectors.toList());
         return FluxUtil.withContext(
                 context -> service.arrayStringMultiValid(this.client.getHost(), arrayQueryConverted, accept, context));
     }

--- a/vanilla-tests/src/main/java/fixtures/url/multi/Queries.java
+++ b/vanilla-tests/src/main/java/fixtures/url/multi/Queries.java
@@ -49,8 +49,8 @@ public final class Queries {
         @UnexpectedResponseExceptionType(ErrorException.class)
         Mono<Response<Void>> arrayStringMultiNull(
                 @HostParam("$host") String host,
-                @QueryParam("arrayQuery") String arrayQuery,
                 @QueryParam(value = "arrayQuery", multipleQueryParams = true) List<String> arrayQuery,
+                @HeaderParam("Accept") String accept,
                 Context context);
 
         @Get("/queries/array/multi/string/empty")


### PR DESCRIPTION
Add support for `collectionFormat multi` that is implemented with `explode` parameter. After identifying that we need `collectionFormat multi`, we store it in the builder and add flag `multipleQueryParams = true`. The multiple parameters part is implemented in [azure-sdk-for-java/pull/21203](https://github.com/Azure/azure-sdk-for-java/pull/21203).

This will fix the following:
* [Support URL with multiple query param with same same](https://github.com/Azure/azure-sdk-for-java/issues/13124)

