### PR TITLE
v4, support x-internal-autorest-anonymous-schema extension

### DIFF
--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/CodeModelCustomConstructor.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/CodeModelCustomConstructor.java
@@ -256,11 +256,18 @@ public class CodeModelCustomConstructor extends Constructor {
                                         keyNode.getEndMark(),
                                         keyNode.getScalarStyle()),
                                         extension.getValueNode()));
-                            }
-                            else if ("x-ms-header-collection-prefix".equals(keyNode.getValue())) {
+                            } else if ("x-ms-header-collection-prefix".equals(keyNode.getValue())) {
                                 actualValues.add(new NodeTuple(new ScalarNode(
                                         keyNode.getTag(),
                                         "xmsHeaderCollectionPrefix",
+                                        keyNode.getStartMark(),
+                                        keyNode.getEndMark(),
+                                        keyNode.getScalarStyle()),
+                                        extension.getValueNode()));
+                            } else if ("x-internal-autorest-anonymous-schema".equals(keyNode.getValue())) {
+                                actualValues.add(new NodeTuple(new ScalarNode(
+                                        keyNode.getTag(),
+                                        "xmsInternalAutorestAnonymousSchema",
                                         keyNode.getStartMark(),
                                         keyNode.getEndMark(),
                                         keyNode.getScalarStyle()),

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/extensionmodel/XmsExtensions.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/extensionmodel/XmsExtensions.java
@@ -24,6 +24,8 @@ public class XmsExtensions {
 
     private String xmsHeaderCollectionPrefix;
 
+    private XmsInternalAutorestAnonymousSchema xmsInternalAutorestAnonymousSchema;
+
     public XmsEnum getXmsEnum() {
         return xmsEnum;
     }
@@ -102,5 +104,13 @@ public class XmsExtensions {
 
     public void setXmsHeaderCollectionPrefix(String xmsHeaderCollectionPrefix) {
         this.xmsHeaderCollectionPrefix = xmsHeaderCollectionPrefix;
+    }
+
+    public XmsInternalAutorestAnonymousSchema getXmsInternalAutorestAnonymousSchema() {
+        return xmsInternalAutorestAnonymousSchema;
+    }
+
+    public void setXmsInternalAutorestAnonymousSchema(XmsInternalAutorestAnonymousSchema xmsInternalAutorestAnonymousSchema) {
+        this.xmsInternalAutorestAnonymousSchema = xmsInternalAutorestAnonymousSchema;
     }
 }

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/extensionmodel/XmsInternalAutorestAnonymousSchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/extensionmodel/XmsInternalAutorestAnonymousSchema.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.azure.autorest.extension.base.model.extensionmodel;
+
+public class XmsInternalAutorestAnonymousSchema {
+
+    private boolean anonymous = true;
+
+    public boolean isAnonymous() {
+        return anonymous;
+    }
+
+    public void setAnonymous(boolean anonymous) {
+        this.anonymous = anonymous;
+    }
+}


### PR DESCRIPTION
This can offer more info on naming of the model.

Source yaml like this:
```
      extensions:
        x-internal-autorest-anonymous-schema:
          anonymous: true
```