### PR TITLE
v4 fluent, support x-ms-long-running-operation-options

### DIFF
--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/CodeModelCustomConstructor.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/CodeModelCustomConstructor.java
@@ -272,6 +272,32 @@ public class CodeModelCustomConstructor extends Constructor {
                                         keyNode.getEndMark(),
                                         keyNode.getScalarStyle()),
                                         extension.getValueNode()));
+                            } else if ("x-ms-long-running-operation-options".equals(keyNode.getValue())) {
+                                actualValues.add(new NodeTuple(new ScalarNode(
+                                        keyNode.getTag(),
+                                        "xmsLongRunningOperationOptions",
+                                        keyNode.getStartMark(),
+                                        keyNode.getEndMark(),
+                                        keyNode.getScalarStyle()),
+                                        extension.getValueNode()));
+                            }
+                        }
+                        value.setValue(actualValues);
+                        break;
+                    }
+                    case "xmsLongRunningOperationOptions": {
+                        MappingNode value = (MappingNode) tuple.getValueNode();
+                        List<NodeTuple> actualValues = new ArrayList<>();
+                        for (NodeTuple extension : value.getValue()) {
+                            ScalarNode keyNode = (ScalarNode) extension.getKeyNode();
+                            if ("final-state-via".equals(keyNode.getValue())) {
+                                actualValues.add(new NodeTuple(new ScalarNode(
+                                        keyNode.getTag(),
+                                        "finalStateVia",
+                                        keyNode.getStartMark(),
+                                        keyNode.getEndMark(),
+                                        keyNode.getScalarStyle()),
+                                        extension.getValueNode()));
                             }
                         }
                         value.setValue(actualValues);

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/extensionmodel/XmsExtensions.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/extensionmodel/XmsExtensions.java
@@ -16,6 +16,8 @@ public class XmsExtensions {
 
     private boolean xmsLongRunningOperation;
 
+    private XmsLongRunningOperationOptions xmsLongRunningOperationOptions;
+
     private boolean xmsFlattened;
 
     private boolean xmsAzureResource;
@@ -112,5 +114,13 @@ public class XmsExtensions {
 
     public void setXmsInternalAutorestAnonymousSchema(XmsInternalAutorestAnonymousSchema xmsInternalAutorestAnonymousSchema) {
         this.xmsInternalAutorestAnonymousSchema = xmsInternalAutorestAnonymousSchema;
+    }
+
+    public XmsLongRunningOperationOptions getXmsLongRunningOperationOptions() {
+        return xmsLongRunningOperationOptions;
+    }
+
+    public void setXmsLongRunningOperationOptions(XmsLongRunningOperationOptions xmsLongRunningOperationOptions) {
+        this.xmsLongRunningOperationOptions = xmsLongRunningOperationOptions;
     }
 }

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/extensionmodel/XmsLongRunningOperationOptions.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/extensionmodel/XmsLongRunningOperationOptions.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.azure.autorest.extension.base.model.extensionmodel;
+
+public class XmsLongRunningOperationOptions {
+
+    // azure-async-operation
+    // location
+    // original-uri
+    private String finalStateVia;
+
+    public String getFinalStateVia() {
+        return finalStateVia;
+    }
+
+    public void setFinalStateVia(String finalStateVia) {
+        this.finalStateVia = finalStateVia;
+    }
+}


### PR DESCRIPTION
currently only support the m4 output.

real task would be in azure-core-management, and then codegen.

hdinsight need to use this option, else its `azure-async-operation` header is not a valid URL.

```
xmsLongRunningOperationOptions: {finalStateVia: location}
```