### PR TITLE
v4 fix subclass fluent

### DIFF
--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Cookiecuttershark.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/Cookiecuttershark.java
@@ -4,12 +4,12 @@
 
 package fixtures.bodycomplex.implementation.models;
 
-import com.azure.core.annotation.Immutable;
+import com.azure.core.annotation.Fluent;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
 /** The Cookiecuttershark model. */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "fishtype")
 @JsonTypeName("cookiecuttershark")
-@Immutable
+@Fluent
 public final class Cookiecuttershark extends Shark {}

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientModel.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientModel.java
@@ -172,11 +172,9 @@ public class ClientModel {
      * @param settings The settings for this Java generator session.
      */
     public void addImportsTo(Set<String> imports, JavaSettings settings) {
-        if (properties.stream().anyMatch(p -> !p.getIsReadOnly())) {
-            addFluentAnnotationImport(imports);
-        } else {
-            addImmutableAnnotationImport(imports);
-        }
+        // whether annotated as Immutable or Fluent is also determined by its superclass
+        addFluentAnnotationImport(imports);
+        addImmutableAnnotationImport(imports);
 
         if (settings.getClientFlattenAnnotationTarget() == JavaSettings.ClientFlattenAnnotationTarget.TYPE && needsFlatten) {
             addJsonFlattenAnnotationImport(imports);

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Cookiecuttershark.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Cookiecuttershark.java
@@ -1,5 +1,6 @@
 package fixtures.bodycomplex.models;
 
+import com.azure.core.annotation.Fluent;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Cookiecuttershark.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Cookiecuttershark.java
@@ -1,6 +1,5 @@
 package fixtures.bodycomplex.models;
 
-import com.azure.core.annotation.Immutable;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -11,7 +10,7 @@ import java.util.List;
 /** The Cookiecuttershark model. */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "fishtype")
 @JsonTypeName("cookiecuttershark")
-@Immutable
+@Fluent
 public final class Cookiecuttershark extends Shark {
     /**
      * Creates an instance of Cookiecuttershark class.


### PR DESCRIPTION
Fix https://github.com/Azure/autorest.java/issues/1052

Process `propertyReferences` on parents, and collection the `readOnly` for `Fluent`/`Immutable`. But only add setter methods when flag is on.