### PR TITLE
v4 fluentlite, enhance Object example when the Object is primitive type

### DIFF
--- a/fluent-tests/prepare-tests.bat
+++ b/fluent-tests/prepare-tests.bat
@@ -43,5 +43,7 @@ CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENTLITE_ARGUMENTS% --regener
 REM CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENTLITE_ARGUMENTS% --regenerate-pom=false https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/network/resource-manager/readme.md --tag=package-2020-06 --java.namespace=com.azure.mgmtlitetest.network
 REM CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENTLITE_ARGUMENTS% --regenerate-pom=false https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/compute/resource-manager/readme.md --tag=package-2020-06-30 --java.namespace=com.azure.mgmtlitetest.compute
 
+REM CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENTLITE_ARGUMENTS% --regenerate-pom=false https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/resources/resource-manager/readme.md --tag=package-policy-2020-09 --java.namespace=com.azure.mgmtlitetest.policy --generate-samples
+
 REM delete module-info as fluent-test is on java8
 DEL "src\main\java\module-info.java"

--- a/fluentgen/src/test/java/com/azure/autorest/fluent/template/FluentExampleTests.java
+++ b/fluentgen/src/test/java/com/azure/autorest/fluent/template/FluentExampleTests.java
@@ -93,7 +93,8 @@ public class FluentExampleTests {
             FluentExampleTemplate.getInstance().write(example, javaFile);
             String content = javaFile.getContents().toString();
             // allowedValues is array of Object
-            Assertions.assertTrue(content.contains(".withAllowedValues(Arrays.asList(SerializerFactory.createDefaultManagementSerializerAdapter().deserialize(\"0\", Object.class, SerializerEncoding.JSON), SerializerFactory.createDefaultManagementSerializerAdapter().deserialize(\"30\", Object.class, SerializerEncoding.JSON), SerializerFactory.createDefaultManagementSerializerAdapter().deserialize(\"90\", Object.class, SerializerEncoding.JSON), SerializerFactory.createDefaultManagementSerializerAdapter().deserialize(\"180\", Object.class, SerializerEncoding.JSON), SerializerFactory.createDefaultManagementSerializerAdapter().deserialize(\"365\", Object.class, SerializerEncoding.JSON))).withDefaultValue(SerializerFactory.createDefaultManagementSerializerAdapter().deserialize(\"365\", Object.class, SerializerEncoding.JSON))"));
+            Assertions.assertTrue(content.contains(".withAllowedValues(Arrays.asList(0, 30, 90, 180, 365))"));
+            Assertions.assertTrue(content.contains(".withDefaultValue(365)"));
         }
     }
 }


### PR DESCRIPTION
```
    public static void createOrUpdateAPolicyDefinitionWithAdvancedParameters(
        com.azure.mgmtlitetest.rp.PolicyManager policyManager) throws IOException {
        policyManager
            .policyDefinitions()
            .define("EventHubDiagnosticLogs")
            .withMode("Indexed")
            .withDisplayName("Event Hubs should have diagnostic logging enabled")
            .withDescription(
                "Audit enabling of logs and retain them up to a year. This enables recreation of activity trails for"
                    + " investigation purposes when a security incident occurs or your network is compromised")
            .withPolicyRule(
                SerializerFactory
                    .createDefaultManagementSerializerAdapter()
                    .deserialize(
                        "{\"if\":{\"equals\":\"Microsoft.EventHub/namespaces\",\"field\":\"type\"},\"then\":{\"effect\":\"AuditIfNotExists\",\"details\":{\"type\":\"Microsoft.Insights/diagnosticSettings\",\"existenceCondition\":{\"allOf\":[{\"equals\":\"true\",\"field\":\"Microsoft.Insights/diagnosticSettings/logs[*].retentionPolicy.enabled\"},{\"equals\":\"[parameters('requiredRetentionDays')]\",\"field\":\"Microsoft.Insights/diagnosticSettings/logs[*].retentionPolicy.days\"}]}}}}",
                        Object.class,
                        SerializerEncoding.JSON))
            .withMetadata(
                SerializerFactory
                    .createDefaultManagementSerializerAdapter()
                    .deserialize("{\"category\":\"Event Hub\"}", Object.class, SerializerEncoding.JSON))
            .withParameters(
                mapOf(
                    "requiredRetentionDays",
                    new ParameterDefinitionsValue()
                        .withType(ParameterType.INTEGER)
                        .withAllowedValues(Arrays.asList(0, 30, 90, 180, 365))
                        .withDefaultValue(365)
                        .withMetadata(
                            new ParameterDefinitionsValueMetadata()
                                .withDisplayName("Required retention (days)")
                                .withDescription("The required diagnostic logs retention in days"))))
            .create();
    }
```