### PR TITLE
v4 fluentlite support resource update in example

### DIFF
--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/ExampleParser.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/ExampleParser.java
@@ -11,6 +11,7 @@ import com.azure.autorest.fluent.FluentGen;
 import com.azure.autorest.fluent.model.clientmodel.FluentCollectionMethod;
 import com.azure.autorest.fluent.model.clientmodel.FluentExample;
 import com.azure.autorest.fluent.model.clientmodel.FluentResourceCollection;
+import com.azure.autorest.fluent.model.clientmodel.FluentResourceModel;
 import com.azure.autorest.fluent.model.clientmodel.FluentStatic;
 import com.azure.autorest.fluent.model.clientmodel.MethodParameter;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.ClientModelNode;
@@ -59,6 +60,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -165,8 +167,7 @@ public class ExampleParser {
     private static List<FluentResourceCreateExample> parseResourceCreate(FluentResourceCollection collection, ResourceCreate resourceCreate) {
         List<FluentResourceCreateExample> ret = null;
 
-        ResourceUpdate resourceUpdate = resourceCreate.getResourceModel().getResourceUpdate();
-        final boolean methodIsCreateOrUpdate = resourceUpdate != null && resourceUpdate.getMethodReferences().iterator().next() == resourceCreate.getMethodReferences().iterator().next();
+        final boolean methodIsCreateOrUpdate = methodIsCreateOrUpdate(resourceCreate.getResourceModel());
 
         List<FluentCollectionMethod> collectionMethods = resourceCreate.getMethodReferences();
         for (FluentCollectionMethod collectionMethod : collectionMethods) {
@@ -262,8 +263,7 @@ public class ExampleParser {
     private static List<FluentResourceUpdateExample> parseResourceUpdate(FluentResourceCollection collection, ResourceUpdate resourceUpdate) {
         List<FluentResourceUpdateExample> ret = null;
 
-        ResourceCreate resourceCreate = resourceUpdate.getResourceModel().getResourceCreate();
-        final boolean methodIsCreateOrUpdate = resourceCreate != null && resourceUpdate.getMethodReferences().iterator().next() == resourceCreate.getMethodReferences().iterator().next();
+        final boolean methodIsCreateOrUpdate = methodIsCreateOrUpdate(resourceUpdate.getResourceModel());
         FluentCollectionMethod resourceGetMethod = null;
         if (resourceUpdate.getResourceModel().getResourceRefresh() != null) {
             resourceGetMethod = resourceUpdate.getResourceModel().getResourceRefresh().getMethodReferences().stream()
@@ -285,7 +285,7 @@ public class ExampleParser {
                 }
 
                 List<MethodParameter> methodParameters = getParameters(clientMethod);
-                ClientModel requestBodyClientModel = resourceCreate.getRequestBodyParameterModel();
+                ClientModel requestBodyClientModel = resourceUpdate.getRequestBodyParameterModel();
                 MethodParameter requestBodyParameter = methodParameters.stream()
                         .filter(p -> p.getProxyMethodParameter().getRequestParameterLocation() == RequestParameterLocation.Body)
                         .findFirst().orElse(null);
@@ -574,5 +574,10 @@ public class ExampleParser {
     private static boolean exampleIsUpdate(String name) {
         name = name.toLowerCase(Locale.ROOT);
         return name.contains("update") && !name.contains("create");
+    }
+
+    private static boolean methodIsCreateOrUpdate(FluentResourceModel resourceModel) {
+        return resourceModel.getResourceCreate() != null && resourceModel.getResourceUpdate() != null
+                && Objects.equals(resourceModel.getResourceCreate().getMethodReferences().iterator().next().getMethodName(), resourceModel.getResourceUpdate().getMethodReferences().iterator().next().getMethodName());
     }
 }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/ExampleParser.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/ExampleParser.java
@@ -18,6 +18,7 @@ import com.azure.autorest.fluent.model.clientmodel.examplemodel.ExampleNode;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.FluentBaseExample;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.FluentCollectionMethodExample;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.FluentResourceCreateExample;
+import com.azure.autorest.fluent.model.clientmodel.examplemodel.FluentResourceUpdateExample;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.ListNode;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.LiteralNode;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.MapNode;
@@ -30,6 +31,10 @@ import com.azure.autorest.fluent.model.clientmodel.fluentmodel.create.Definition
 import com.azure.autorest.fluent.model.clientmodel.fluentmodel.create.ResourceCreate;
 import com.azure.autorest.fluent.model.clientmodel.fluentmodel.method.FluentDefineMethod;
 import com.azure.autorest.fluent.model.clientmodel.fluentmodel.method.FluentMethod;
+import com.azure.autorest.fluent.model.clientmodel.fluentmodel.update.ResourceUpdate;
+import com.azure.autorest.fluent.model.clientmodel.fluentmodel.update.UpdateStage;
+import com.azure.autorest.fluent.model.clientmodel.fluentmodel.update.UpdateStageApply;
+import com.azure.autorest.fluent.model.clientmodel.fluentmodel.update.UpdateStageMisc;
 import com.azure.autorest.fluent.util.FluentUtils;
 import com.azure.autorest.model.clientmodel.ClassType;
 import com.azure.autorest.model.clientmodel.ClientMethod;
@@ -52,6 +57,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.regex.Pattern;
@@ -64,6 +70,7 @@ public class ExampleParser {
     public static List<FluentExample> parseResourceCollection(FluentResourceCollection resourceCollection) {
         List<FluentCollectionMethodExample> methodExamples = new ArrayList<>();
         List<FluentResourceCreateExample> resourceCreateExamples = new ArrayList<>();
+        List<FluentResourceUpdateExample> resourceUpdateExamples = new ArrayList<>();
 
         resourceCollection.getMethodsForTemplate().forEach(m -> {
             List<FluentCollectionMethodExample> examples = ExampleParser.parseMethod(resourceCollection, m);
@@ -77,6 +84,12 @@ public class ExampleParser {
                 resourceCreateExamples.addAll(examples);
             }
         });
+        resourceCollection.getResourceUpdates().forEach(ru -> {
+            List<FluentResourceUpdateExample> examples = ExampleParser.parseResourceUpdate(resourceCollection, ru);
+            if (examples != null) {
+                resourceUpdateExamples.addAll(examples);
+            }
+        });
 
         Map<String, FluentExample> examples = new HashMap<>();
         methodExamples.forEach(e -> {
@@ -86,6 +99,10 @@ public class ExampleParser {
         resourceCreateExamples.forEach(e -> {
             FluentExample example = getExample(examples, e.getResourceCollection(), e.getResourceCreate().getMethodReferences().iterator().next());
             example.getResourceCreateExamples().add(e);
+        });
+        resourceUpdateExamples.forEach(e -> {
+            FluentExample example = getExample(examples, e.getResourceCollection(), e.getResourceUpdate().getMethodReferences().iterator().next());
+            example.getResourceUpdateExamples().add(e);
         });
 
         return new ArrayList<>(examples.values());
@@ -115,31 +132,41 @@ public class ExampleParser {
             for (Map.Entry<String, ProxyMethodExample> entry : collectionMethod.getInnerClientMethod().getProxyMethod().getExamples().entrySet()) {
                 logger.info("Parse collection method example '{}'", entry.getKey());
 
-                ProxyMethodExample example = entry.getValue();
-                FluentCollectionMethodExample collectionMethodExample = new FluentCollectionMethodExample(entry.getKey(),
-                        FluentStatic.getFluentManager(), collection, collectionMethod);
-
-                for (MethodParameter methodParameter : methodParameters) {
-                    ExampleNode node = parseNodeFromParameter(example, methodParameter);
-
-                    if (node.getObjectValue() == null) {
-                        if (methodParameter.getClientMethodParameter().getIsRequired()) {
-                            logger.warn("Failed to assign sample value to required parameter '{}'", methodParameter.getClientMethodParameter().getName());
-                        }
-                    }
-
-                    FluentCollectionMethodExample.ParameterExample parameterExample = new FluentBaseExample.ParameterExample(node);
-                    collectionMethodExample.getParameters().add(parameterExample);
-                }
-
+                FluentCollectionMethodExample collectionMethodExample =
+                        parseMethodForExample(collection, collectionMethod, methodParameters, entry.getKey(), entry.getValue());
                 ret.add(collectionMethodExample);
             }
         }
         return ret;
     }
 
+    private static FluentCollectionMethodExample parseMethodForExample(FluentResourceCollection collection, FluentCollectionMethod collectionMethod,
+                                                                       List<MethodParameter> methodParameters,
+                                                                       String exampleName, ProxyMethodExample proxyMethodExample) {
+        FluentCollectionMethodExample collectionMethodExample = new FluentCollectionMethodExample(exampleName,
+                FluentStatic.getFluentManager(), collection, collectionMethod);
+
+        for (MethodParameter methodParameter : methodParameters) {
+            ExampleNode node = parseNodeFromParameter(proxyMethodExample, methodParameter);
+
+            if (node.getObjectValue() == null) {
+                if (methodParameter.getClientMethodParameter().getIsRequired()) {
+                    logger.warn("Failed to assign sample value to required parameter '{}'", methodParameter.getClientMethodParameter().getName());
+                }
+            }
+
+            FluentCollectionMethodExample.ParameterExample parameterExample = new FluentBaseExample.ParameterExample(node);
+            collectionMethodExample.getParameters().add(parameterExample);
+        }
+
+        return collectionMethodExample;
+    }
+
     private static List<FluentResourceCreateExample> parseResourceCreate(FluentResourceCollection collection, ResourceCreate resourceCreate) {
         List<FluentResourceCreateExample> ret = null;
+
+        ResourceUpdate resourceUpdate = resourceCreate.getResourceModel().getResourceUpdate();
+        final boolean methodIsCreateOrUpdate = resourceUpdate != null && resourceUpdate.getMethodReferences().iterator().next() == resourceCreate.getMethodReferences().iterator().next();
 
         List<FluentCollectionMethod> collectionMethods = resourceCreate.getMethodReferences();
         for (FluentCollectionMethod collectionMethod : collectionMethods) {
@@ -156,6 +183,11 @@ public class ExampleParser {
                         .findFirst().orElse(null);
 
                 for (Map.Entry<String, ProxyMethodExample> entry : collectionMethod.getInnerClientMethod().getProxyMethod().getExamples().entrySet()) {
+                    if (methodIsCreateOrUpdate && exampleIsUpdate(entry.getKey())) {
+                        // likely a resource update example
+                        break;
+                    }
+
                     logger.info("Parse resource create example '{}'", entry.getKey());
 
                     ProxyMethodExample example = entry.getValue();
@@ -221,6 +253,91 @@ public class ExampleParser {
                     }
 
                     ret.add(resourceCreateExample);
+                }
+            }
+        }
+        return ret;
+    }
+
+    private static List<FluentResourceUpdateExample> parseResourceUpdate(FluentResourceCollection collection, ResourceUpdate resourceUpdate) {
+        List<FluentResourceUpdateExample> ret = null;
+
+        ResourceCreate resourceCreate = resourceUpdate.getResourceModel().getResourceCreate();
+        final boolean methodIsCreateOrUpdate = resourceCreate != null && resourceUpdate.getMethodReferences().iterator().next() == resourceCreate.getMethodReferences().iterator().next();
+        FluentCollectionMethod resourceGetMethod = null;
+        if (resourceUpdate.getResourceModel().getResourceRefresh() != null) {
+            resourceGetMethod = resourceUpdate.getResourceModel().getResourceRefresh().getMethodReferences().stream()
+                    .filter(m -> m.getInnerClientMethod().getParameters().stream().anyMatch(p -> ClassType.Context.equals(p.getClientType())))
+                    .findFirst().orElse(null);
+        }
+        if (resourceGetMethod == null) {
+            // 'get' method not found
+            return null;
+        }
+        List<MethodParameter> resourceGetMethodParameters = getParameters(resourceGetMethod.getInnerClientMethod());
+
+        List<FluentCollectionMethod> collectionMethods = resourceUpdate.getMethodReferences();
+        for (FluentCollectionMethod collectionMethod : collectionMethods) {
+            ClientMethod clientMethod = collectionMethod.getInnerClientMethod();
+            if (collectionMethod.getInnerClientMethod().getProxyMethod().getExamples() != null && requiresExample(clientMethod)) {
+                if (ret == null) {
+                    ret = new ArrayList<>();
+                }
+
+                List<MethodParameter> methodParameters = getParameters(clientMethod);
+                ClientModel requestBodyClientModel = resourceCreate.getRequestBodyParameterModel();
+                MethodParameter requestBodyParameter = methodParameters.stream()
+                        .filter(p -> p.getProxyMethodParameter().getRequestParameterLocation() == RequestParameterLocation.Body)
+                        .findFirst().orElse(null);
+
+                for (Map.Entry<String, ProxyMethodExample> entry : collectionMethod.getInnerClientMethod().getProxyMethod().getExamples().entrySet()) {
+                    if (methodIsCreateOrUpdate && !exampleIsUpdate(entry.getKey())) {
+                        // likely not a resource update example
+                        break;
+                    }
+
+                    logger.info("Parse resource update example '{}'", entry.getKey());
+
+                    ProxyMethodExample example = entry.getValue();
+                    FluentCollectionMethodExample resourceGetExample =
+                            parseMethodForExample(collection, resourceGetMethod, resourceGetMethodParameters, entry.getKey(), example);
+                    FluentResourceUpdateExample resourceUpdateExample = new FluentResourceUpdateExample(entry.getKey(),
+                            FluentStatic.getFluentManager(), collection, resourceUpdate, resourceGetExample);
+
+                    for (UpdateStage stage : resourceUpdate.getUpdateStages()) {
+                        List<FluentMethod> fluentMethods = stage.getMethods();
+                        if (!fluentMethods.isEmpty()) {
+                            FluentMethod fluentMethod = fluentMethods.iterator().next();
+                            List<ExampleNode> exampleNodes = new ArrayList<>();
+
+                            if (stage instanceof UpdateStageApply) {
+                                // apply stage does not have parameter
+                            } else if (stage instanceof UpdateStageMisc) {
+                                UpdateStageMisc miscStage = (UpdateStageMisc) stage;
+                                MethodParameter methodParameter = findMethodParameter(methodParameters, miscStage.getMethodParameter());
+                                ExampleNode node = parseNodeFromParameter(example, methodParameter);
+
+                                if (!node.isNull()) {
+                                    exampleNodes.add(node);
+                                }
+                            } else {
+                                ClientModelProperty clientModelProperty = stage.getModelProperty();
+                                if (clientModelProperty != null) {
+                                    ExampleNode node = parseNodeFromModelProperty(example, requestBodyParameter, requestBodyClientModel, clientModelProperty);
+
+                                    if (!node.isNull()) {
+                                        exampleNodes.add(node);
+                                    }
+                                }
+                            }
+
+                            if (!exampleNodes.isEmpty()) {
+                                resourceUpdateExample.getParameters().add(new FluentBaseExample.ParameterExample(fluentMethod, exampleNodes));
+                            }
+                        }
+                    }
+
+                    ret.add(resourceUpdateExample);
                 }
             }
         }
@@ -452,5 +569,10 @@ public class ExampleParser {
             return clientMethod.getParameters().stream().anyMatch(p -> ClassType.Context.equals(p.getClientType()));
         }
         return false;
+    }
+
+    private static boolean exampleIsUpdate(String name) {
+        name = name.toLowerCase(Locale.ROOT);
+        return name.contains("update") && !name.contains("create");
     }
 }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/ExampleParser.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/ExampleParser.java
@@ -15,6 +15,7 @@ import com.azure.autorest.fluent.model.clientmodel.FluentStatic;
 import com.azure.autorest.fluent.model.clientmodel.MethodParameter;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.ClientModelNode;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.ExampleNode;
+import com.azure.autorest.fluent.model.clientmodel.examplemodel.FluentBaseExample;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.FluentCollectionMethodExample;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.FluentResourceCreateExample;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.ListNode;
@@ -127,7 +128,7 @@ public class ExampleParser {
                         }
                     }
 
-                    FluentCollectionMethodExample.ParameterExample parameterExample = new FluentCollectionMethodExample.ParameterExample(methodParameter, node);
+                    FluentCollectionMethodExample.ParameterExample parameterExample = new FluentBaseExample.ParameterExample(node);
                     collectionMethodExample.getParameters().add(parameterExample);
                 }
 
@@ -171,7 +172,7 @@ public class ExampleParser {
                             logger.warn("Failed to assign sample value to define method '{}'", defineMethod.getName());
                         }
                     }
-                    resourceCreateExample.getParameters().add(new FluentResourceCreateExample.ParameterExample(defineMethod, defineNode));
+                    resourceCreateExample.getParameters().add(new FluentBaseExample.ParameterExample(defineMethod, defineNode));
 
                     for (DefinitionStage stage : resourceCreate.getDefinitionStages()) {
                         List<FluentMethod> fluentMethods = stage.getMethods();
@@ -214,7 +215,7 @@ public class ExampleParser {
                             }
 
                             if (!exampleNodes.isEmpty()) {
-                                resourceCreateExample.getParameters().add(new FluentResourceCreateExample.ParameterExample(fluentMethod, exampleNodes));
+                                resourceCreateExample.getParameters().add(new FluentBaseExample.ParameterExample(fluentMethod, exampleNodes));
                             }
                         }
                     }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentExample.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentExample.java
@@ -7,6 +7,7 @@ package com.azure.autorest.fluent.model.clientmodel;
 
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.FluentCollectionMethodExample;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.FluentResourceCreateExample;
+import com.azure.autorest.fluent.model.clientmodel.examplemodel.FluentResourceUpdateExample;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,6 +19,7 @@ public class FluentExample implements Comparable<FluentExample> {
 
     private final List<FluentCollectionMethodExample> collectionMethodExamples = new ArrayList<>();
     private final List<FluentResourceCreateExample> resourceCreateExamples = new ArrayList<>();
+    private final List<FluentResourceUpdateExample> resourceUpdateExamples = new ArrayList<>();
 
     public FluentExample(String groupName, String methodName) {
         this.groupName = groupName;
@@ -30,6 +32,10 @@ public class FluentExample implements Comparable<FluentExample> {
 
     public List<FluentResourceCreateExample> getResourceCreateExamples() {
         return resourceCreateExamples;
+    }
+
+    public List<FluentResourceUpdateExample> getResourceUpdateExamples() {
+        return resourceUpdateExamples;
     }
 
     public String getGroupName() {

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/ExampleNode.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/ExampleNode.java
@@ -35,4 +35,8 @@ public class ExampleNode {
     public IType getClientType() {
         return clientType;
     }
+
+    public boolean isNull() {
+        return objectValue == null;
+    }
 }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentBaseExample.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentBaseExample.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.azure.autorest.fluent.model.clientmodel.examplemodel;
+
+import com.azure.autorest.fluent.model.clientmodel.FluentManager;
+import com.azure.autorest.fluent.model.clientmodel.FluentResourceCollection;
+import com.azure.autorest.fluent.model.clientmodel.fluentmodel.method.FluentMethod;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class FluentBaseExample {
+
+    private final String name;
+    private final FluentManager manager;
+    private final FluentResourceCollection collection;
+    private final List<ParameterExample> parameters = new ArrayList<>();
+
+    public static class ParameterExample {
+        private final FluentMethod fluentMethod;
+        private final List<ExampleNode> exampleNodes = new ArrayList<>();
+
+        public ParameterExample(FluentMethod fluentMethod, Collection<ExampleNode> exampleNodeIterator) {
+            this.fluentMethod = fluentMethod;
+            exampleNodes.addAll(exampleNodeIterator);
+        }
+
+        public ParameterExample(FluentMethod fluentMethod, ExampleNode exampleNode) {
+            this.fluentMethod = fluentMethod;
+            if (exampleNode != null) {
+                this.exampleNodes.add(exampleNode);
+            }
+        }
+
+        public ParameterExample(ExampleNode exampleNode) {
+            this.fluentMethod = null;
+            if (exampleNode != null) {
+                this.exampleNodes.add(exampleNode);
+            }
+        }
+
+        public FluentMethod getFluentMethod() {
+            return fluentMethod;
+        }
+
+        public List<ExampleNode> getExampleNodes() {
+            return exampleNodes;
+        }
+
+        public ExampleNode getExampleNode() {
+            return exampleNodes.isEmpty() ? null : exampleNodes.iterator().next();
+        }
+    }
+
+    public FluentBaseExample(String name, FluentManager manager, FluentResourceCollection collection) {
+        this.name = name;
+        this.manager = manager;
+        this.collection = collection;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public FluentManager getManager() {
+        return manager;
+    }
+
+    public FluentResourceCollection getResourceCollection() {
+        return collection;
+    }
+
+    public List<ParameterExample> getParameters() {
+        return parameters;
+    }
+}

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentCollectionMethodExample.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentCollectionMethodExample.java
@@ -8,59 +8,14 @@ package com.azure.autorest.fluent.model.clientmodel.examplemodel;
 import com.azure.autorest.fluent.model.clientmodel.FluentCollectionMethod;
 import com.azure.autorest.fluent.model.clientmodel.FluentManager;
 import com.azure.autorest.fluent.model.clientmodel.FluentResourceCollection;
-import com.azure.autorest.fluent.model.clientmodel.MethodParameter;
-import com.azure.autorest.util.CodeNamer;
 
-import java.util.ArrayList;
-import java.util.List;
+public class FluentCollectionMethodExample extends FluentBaseExample {
 
-public class FluentCollectionMethodExample {
-
-    private final String name;
-    private final FluentManager manager;
-    private final FluentResourceCollection collection;
     private final FluentCollectionMethod collectionMethod;
-    private final List<ParameterExample> parameters = new ArrayList<>();
-
-    public static class ParameterExample {
-        private final MethodParameter parameter;
-        private final ExampleNode exampleNode;
-
-        public ParameterExample(MethodParameter parameter, ExampleNode exampleNode) {
-            this.parameter = parameter;
-            this.exampleNode = exampleNode;
-        }
-
-        public MethodParameter getParameter() {
-            return parameter;
-        }
-
-        public ExampleNode getExampleNode() {
-            return exampleNode;
-        }
-    }
 
     public FluentCollectionMethodExample(String name, FluentManager manager, FluentResourceCollection collection, FluentCollectionMethod collectionMethod) {
-        this.name = name;
-        this.manager = manager;
-        this.collection = collection;
+        super(name, manager, collection);
         this.collectionMethod = collectionMethod;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public List<ParameterExample> getParameters() {
-        return parameters;
-    }
-
-    public FluentManager getManager() {
-        return manager;
-    }
-
-    public FluentResourceCollection getResourceCollection() {
-        return collection;
     }
 
     public FluentCollectionMethod getCollectionMethod() {

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentCollectionMethodExample.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentCollectionMethodExample.java
@@ -13,7 +13,8 @@ public class FluentCollectionMethodExample extends FluentBaseExample {
 
     private final FluentCollectionMethod collectionMethod;
 
-    public FluentCollectionMethodExample(String name, FluentManager manager, FluentResourceCollection collection, FluentCollectionMethod collectionMethod) {
+    public FluentCollectionMethodExample(String name, FluentManager manager, FluentResourceCollection collection,
+                                         FluentCollectionMethod collectionMethod) {
         super(name, manager, collection);
         this.collectionMethod = collectionMethod;
     }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentResourceCreateExample.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentResourceCreateExample.java
@@ -8,70 +8,17 @@ package com.azure.autorest.fluent.model.clientmodel.examplemodel;
 import com.azure.autorest.fluent.model.clientmodel.FluentManager;
 import com.azure.autorest.fluent.model.clientmodel.FluentResourceCollection;
 import com.azure.autorest.fluent.model.clientmodel.fluentmodel.create.ResourceCreate;
-import com.azure.autorest.fluent.model.clientmodel.fluentmodel.method.FluentMethod;
-import com.azure.autorest.util.CodeNamer;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+public class FluentResourceCreateExample extends FluentBaseExample {
 
-public class FluentResourceCreateExample {
-
-    private final String name;
-    private final FluentManager manager;
-    private final FluentResourceCollection collection;
     private final ResourceCreate resourceCreate;
-    private final List<ParameterExample> parameters = new ArrayList<>();
 
     public FluentResourceCreateExample(String name, FluentManager manager, FluentResourceCollection collection, ResourceCreate resourceCreate) {
-        this.name = name;
-        this.manager = manager;
-        this.collection = collection;
+        super(name, manager, collection);
         this.resourceCreate = resourceCreate;
-    }
-
-    public static class ParameterExample {
-        private final FluentMethod fluentMethod;
-        private final List<ExampleNode> exampleNodes = new ArrayList<>();
-
-        public ParameterExample(FluentMethod fluentMethod, Collection<ExampleNode> exampleNodeIterator) {
-            this.fluentMethod = fluentMethod;
-            exampleNodes.addAll(exampleNodeIterator);
-        }
-
-        public ParameterExample(FluentMethod fluentMethod, ExampleNode exampleNode) {
-            this.fluentMethod = fluentMethod;
-            if (exampleNode != null) {
-                this.exampleNodes.add(exampleNode);
-            }
-        }
-
-        public FluentMethod getFluentMethod() {
-            return fluentMethod;
-        }
-
-        public List<ExampleNode> getExampleNodes() {
-            return exampleNodes;
-        }
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public FluentManager getManager() {
-        return manager;
-    }
-
-    public FluentResourceCollection getResourceCollection() {
-        return collection;
     }
 
     public ResourceCreate getResourceCreate() {
         return resourceCreate;
-    }
-
-    public List<ParameterExample> getParameters() {
-        return parameters;
     }
 }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentResourceCreateExample.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentResourceCreateExample.java
@@ -13,7 +13,8 @@ public class FluentResourceCreateExample extends FluentBaseExample {
 
     private final ResourceCreate resourceCreate;
 
-    public FluentResourceCreateExample(String name, FluentManager manager, FluentResourceCollection collection, ResourceCreate resourceCreate) {
+    public FluentResourceCreateExample(String name, FluentManager manager, FluentResourceCollection collection,
+                                       ResourceCreate resourceCreate) {
         super(name, manager, collection);
         this.resourceCreate = resourceCreate;
     }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentResourceUpdateExample.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentResourceUpdateExample.java
@@ -12,13 +12,21 @@ import com.azure.autorest.fluent.model.clientmodel.fluentmodel.update.ResourceUp
 public class FluentResourceUpdateExample extends FluentBaseExample {
 
     private final ResourceUpdate resourceUpdate;
+    private final FluentCollectionMethodExample resourceGetExample;
 
-    public FluentResourceUpdateExample(String name, FluentManager manager, FluentResourceCollection collection, ResourceUpdate resourceUpdate) {
+    public FluentResourceUpdateExample(String name, FluentManager manager, FluentResourceCollection collection,
+                                       ResourceUpdate resourceUpdate,
+                                       FluentCollectionMethodExample resourceGetExample) {
         super(name, manager, collection);
         this.resourceUpdate = resourceUpdate;
+        this.resourceGetExample = resourceGetExample;
     }
 
     public ResourceUpdate getResourceUpdate() {
         return resourceUpdate;
+    }
+
+    public FluentCollectionMethodExample getResourceGetExample() {
+        return resourceGetExample;
     }
 }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentResourceUpdateExample.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentResourceUpdateExample.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.azure.autorest.fluent.model.clientmodel.examplemodel;
+
+import com.azure.autorest.fluent.model.clientmodel.FluentManager;
+import com.azure.autorest.fluent.model.clientmodel.FluentResourceCollection;
+import com.azure.autorest.fluent.model.clientmodel.fluentmodel.update.ResourceUpdate;
+
+public class FluentResourceUpdateExample extends FluentBaseExample {
+
+    private final ResourceUpdate resourceUpdate;
+
+    public FluentResourceUpdateExample(String name, FluentManager manager, FluentResourceCollection collection, ResourceUpdate resourceUpdate) {
+        super(name, manager, collection);
+        this.resourceUpdate = resourceUpdate;
+    }
+
+    public ResourceUpdate getResourceUpdate() {
+        return resourceUpdate;
+    }
+}

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/update/UpdateStage.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/update/UpdateStage.java
@@ -23,4 +23,8 @@ public class UpdateStage extends FluentInterfaceStage {
                 ? String.format("The stage of the %1$s update.", modelName)
                 : String.format("The stage of the %1$s update allowing to specify %2$s.", modelName, property.getName());
     }
+
+    public ClientModelProperty getModelProperty() {
+        return this.property;
+    }
 }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/update/UpdateStageMisc.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/update/UpdateStageMisc.java
@@ -17,4 +17,8 @@ public class UpdateStageMisc extends UpdateStage {
     public String getDescription(String modelName) {
         return String.format("The stage of the %1$s update allowing to specify %2$s.", modelName, parameter.getName());
     }
+
+    public ClientMethodParameter getMethodParameter() {
+        return parameter;
+    }
 }

--- a/fluentgen/src/test/java/com/azure/autorest/fluent/template/FluentExampleTests.java
+++ b/fluentgen/src/test/java/com/azure/autorest/fluent/template/FluentExampleTests.java
@@ -17,7 +17,6 @@ import com.azure.autorest.model.clientmodel.Client;
 import com.azure.autorest.model.javamodel.JavaFile;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -33,7 +32,6 @@ public class FluentExampleTests {
     }
 
     @Test
-    @Disabled
     public void testLocks() {
         CodeModel codeModel = TestUtils.loadCodeModel(fluentgenAccessor, "code-model-fluentnamer-locks.yaml");
         Client client = FluentStatic.getClient();
@@ -41,12 +39,11 @@ public class FluentExampleTests {
         FluentClient fluentClient = fluentgenAccessor.handleFluentLite(codeModel, client, javaPackage);
 
         List<FluentExample> examples = fluentClient.getExamples();
-        Assertions.assertTrue(!examples.isEmpty());
+        Assertions.assertFalse(examples.isEmpty());
         // TODO verification
     }
 
     @Test
-    @Disabled
     public void testStorage() {
         CodeModel codeModel = TestUtils.loadCodeModel(fluentgenAccessor, "code-model-fluentnamer-storage.yaml");
         Client client = FluentStatic.getClient();
@@ -54,13 +51,34 @@ public class FluentExampleTests {
         FluentClient fluentClient = fluentgenAccessor.handleFluentLite(codeModel, client, javaPackage);
 
         List<FluentExample> examples = fluentClient.getExamples();
-        Assertions.assertTrue(!examples.isEmpty());
+        Assertions.assertFalse(examples.isEmpty());
 
-        // TODO verification
-        for (FluentExample example : examples) {
+        {
+            FluentExample example = examples.stream()
+                    .filter(e -> e.getClassName().equals("StorageAccountsCreateSamples"))
+                    .findFirst().get();
             JavaFile javaFile = new JavaFile("dummy");
             FluentExampleTemplate.getInstance().write(example, javaFile);
             String content = javaFile.getContents().toString();
+            // Map
+            Assertions.assertTrue(content.contains(".withTags(mapOf(\"key1\", \"value1\", \"key2\", \"value2\"))"));
+            // identity
+            Assertions.assertTrue(content.contains(".withIdentity(new Identity().withType(IdentityType.USER_ASSIGNED).withUserAssignedIdentities(mapOf(\"/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{managed-identity-name}\", new UserAssignedIdentity())))"));
+            // create
+            Assertions.assertTrue(content.contains(".create()"));
+        }
+
+        {
+            FluentExample example = examples.stream()
+                    .filter(e -> e.getClassName().equals("BlobContainersCreateOrUpdateImmutabilityPolicySamples"))
+                    .findFirst().get();
+            JavaFile javaFile = new JavaFile("dummy");
+            FluentExampleTemplate.getInstance().write(example, javaFile);
+            String content = javaFile.getContents().toString();
+            // optional property/parameter not provided in example
+            Assertions.assertFalse(content.contains(".withIfMatch"));
+            // create
+            Assertions.assertTrue(content.contains(".create()"));
         }
     }
 
@@ -72,7 +90,7 @@ public class FluentExampleTests {
         FluentClient fluentClient = fluentgenAccessor.handleFluentLite(codeModel, client, javaPackage);
 
         List<FluentExample> examples = fluentClient.getExamples();
-        Assertions.assertTrue(!examples.isEmpty());
+        Assertions.assertFalse(examples.isEmpty());
 
         {
             FluentExample example = examples.stream()

--- a/fluentgen/src/test/java/com/azure/autorest/fluent/template/FluentExampleTests.java
+++ b/fluentgen/src/test/java/com/azure/autorest/fluent/template/FluentExampleTests.java
@@ -80,6 +80,21 @@ public class FluentExampleTests {
             // create
             Assertions.assertTrue(content.contains(".create()"));
         }
+
+        {
+            FluentExample example = examples.stream()
+                    .filter(e -> e.getClassName().equals("StorageAccountsUpdateSamples"))
+                    .findFirst().get();
+            JavaFile javaFile = new JavaFile("dummy");
+            FluentExampleTemplate.getInstance().write(example, javaFile);
+            String content = javaFile.getContents().toString();
+            // get
+            Assertions.assertTrue(content.contains("storageManager.storageAccounts().getByResourceGroup"));
+            // update
+            Assertions.assertTrue(content.contains("resource.update()"));
+            // apply
+            Assertions.assertTrue(content.contains(".apply()"));
+        }
     }
 
     @Test


### PR DESCRIPTION
sample
```
    public static void storageAccountEnableAD(com.azure.mgmtlitetest.storage.StorageManager storageManager) {
        StorageAccount resource =
            storageManager
                .storageAccounts()
                .getByResourceGroupWithResponse("res9407", "sto8596", null, Context.NONE)
                .getValue();
        resource
            .update()
            .withAzureFilesIdentityBasedAuthentication(
                new AzureFilesIdentityBasedAuthentication()
                    .withDirectoryServiceOptions(DirectoryServiceOptions.AD)
                    .withActiveDirectoryProperties(
                        new ActiveDirectoryProperties()
                            .withDomainName("adtest.com")
                            .withNetBiosDomainName("adtest.com")
                            .withForestName("adtest.com")
                            .withDomainGuid("aebfc118-9fa9-4732-a21f-d98e41a77ae1")
                            .withDomainSid("S-1-5-21-2400535526-2334094090-2402026252")
                            .withAzureStorageSid("S-1-5-21-2400535526-2334094090-2402026252-0012")))
            .apply();
    }
```