### PR TITLE
v4 fluentlite, add defaultValueExpressionConverter to UUID

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
@@ -35,7 +35,7 @@ public class ClassType implements IType {
     public static final ClassType DateTimeRfc1123 = new ClassType.Builder().knownClass(com.azure.core.util.DateTimeRfc1123.class).defaultValueExpressionConverter((String defaultValueExpression) -> java.lang.String.format("new DateTimeRfc1123(\"%1$s\")", defaultValueExpression)).build();
     public static final ClassType AndroidDateTimeRfc1123 = new ClassType.Builder().packageName("com.azure.android.core.util").name("DateTimeRfc1123").build();
     public static final ClassType BigDecimal = new ClassType.Builder().knownClass(java.math.BigDecimal.class).defaultValueExpressionConverter((String defaultValueExpression) -> java.lang.String.format("new BigDecimal(\"%1$s\")", defaultValueExpression)).build();
-    public static final ClassType UUID = new ClassType.Builder().knownClass(java.util.UUID.class).build();
+    public static final ClassType UUID = new ClassType.Builder().knownClass(java.util.UUID.class).defaultValueExpressionConverter((String defaultValueExpression) -> java.lang.String.format("UUID.fromString(\"%1$s\")", defaultValueExpression)).build();
     public static final ClassType Object = new ClassType.Builder().knownClass(java.lang.Object.class).build();
     public static final ClassType TokenCredential = new ClassType.Builder().knownClass(com.azure.core.credential.TokenCredential.class).build();
     public static final ClassType HttpResponseException = new ClassType.Builder().knownClass(com.azure.core.exception.HttpResponseException.class).build();


### PR DESCRIPTION
sample code

```
    public static void serverAdministratorCreate(com.azure.resourcemanager.mysql.MySqlManager mySqlManager) {
        mySqlManager
            .serverAdministrators()
            .createOrUpdate(
                "testrg",
                "mysqltestsvc4",
                new ServerAdministratorResourceInner()
                    .withAdministratorType(AdministratorType.ACTIVE_DIRECTORY)
                    .withLogin("bob@contoso.com")
                    .withSid(UUID.fromString("c6b82b90-a647-49cb-8a62-0d2d3cb7ac7c"))
                    .withTenantId(UUID.fromString("c6b82b90-a647-49cb-8a62-0d2d3cb7ac7c")),
                Context.NONE);
    }
```