### PR TITLE
v4 fluent, should place Resource as 1st in super classes

### DIFF
--- a/fluentnamer/src/main/java/com/azure/autorest/fluent/transformer/ResourceTypeNormalization.java
+++ b/fluentnamer/src/main/java/com/azure/autorest/fluent/transformer/ResourceTypeNormalization.java
@@ -243,8 +243,8 @@ class ResourceTypeNormalization {
         if (compositeType.getParents().getAll() == null) {
             compositeType.getParents().setAll(new ArrayList<>());
         }
-        compositeType.getParents().getImmediate().add(parentType);
-        compositeType.getParents().getAll().add(parentType);
+        compositeType.getParents().getImmediate().add(0, parentType);
+        compositeType.getParents().getAll().add(0, parentType);
     }
 
     private static void replaceDummyParentType(ObjectSchema compositeType, ObjectSchema parentType) {


### PR DESCRIPTION
If there is more than one super classes, class other than the 1st will be flattened (class erased, properties put to this class). We do not want `Resource` super class get flattened.