### PR TITLE
v4 fluent, add @JsonInclude for map

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientModelProperty.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientModelProperty.java
@@ -237,6 +237,11 @@ public class ClientModelProperty {
             addJsonFlattenAnnotationImport(imports);
         }
 
+        if (!isAdditionalProperties && getClientType() instanceof MapType) {
+            // required for "@JsonInclude(value = JsonInclude.Include.NON_NULL, content = JsonInclude.Include.ALWAYS)"
+            imports.add("com.fasterxml.jackson.annotation.JsonInclude");
+        }
+
         if (getWireType() != null) {
             getWireType().addImportsTo(imports, false);
         }

--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -193,6 +193,9 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                         classBlock.privateMemberVariable(String.format("%1$s %2$s", property.getWireType(), property.getName()));
                     }
                 } else {
+                    if (!property.isAdditionalProperties() && property.getClientType() instanceof MapType && settings.isFluent()) {
+                        classBlock.annotation("JsonInclude(value = JsonInclude.Include.NON_NULL, content = JsonInclude.Include.ALWAYS)");
+                    }
                     classBlock.privateMemberVariable(String.format("%1$s %2$s", property.getWireType(), property.getName()));
                 }
             }


### PR DESCRIPTION
Add `@JsonInclude(value = JsonInclude.Include.NON_NULL, content = JsonInclude.Include.ALWAYS)` to map, currently only for Fluent.

Some REST API requires setting `null` to a `key` to remove the `key`.