### PR TITLE
v4, fix case that the flattened parameter has only readonly properties

### DIFF
--- a/fluent-tests/prepare-tests.bat
+++ b/fluent-tests/prepare-tests.bat
@@ -13,7 +13,7 @@ RMDIR /S /Q "src\main\java\com\azure\mgmtlitetest"
 SET AUTOREST_CORE_VERSION=3.4.5
 SET MODELERFOUR_ARGUMENTS=--pipeline.modelerfour.additional-checks=false --pipeline.modelerfour.lenient-model-deduplication=true
 SET COMMON_ARGUMENTS=--java --use=../ --java.output-folder=./ %MODELERFOUR_ARGUMENTS% --azure-arm --java.license-header=MICROSOFT_MIT_SMALL
-SET FLUENT_ARGUMENTS=%COMMON_ARGUMENTS% --fluent
+SET FLUENT_ARGUMENTS=%COMMON_ARGUMENTS% --fluent --pipeline.modelerfour.flatten-payloads=true
 SET FLUENTLITE_ARGUMENTS=%COMMON_ARGUMENTS% --fluent=lite
 
 REM fluent premium
@@ -30,7 +30,7 @@ REM multiple inheritance
 CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENT_ARGUMENTS% --payload-flattening-threshold=1 --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2019-12-12/cosmos-db.json --namespace=com.azure.mgmttest.cosmos
 
 REM flatten payload
-CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENT_ARGUMENTS% --payload-flattening-threshold=1 --pipeline.modelerfour.flatten-payloads=true --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/compute/resource-manager/Microsoft.Compute/stable/2021-03-01/cloudService.json --namespace=com.azure.mgmttest.compute
+CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENT_ARGUMENTS% --payload-flattening-threshold=1 --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/compute/resource-manager/Microsoft.Compute/stable/2021-03-01/cloudService.json --namespace=com.azure.mgmttest.compute
 
 REM error response that not conform to ARM
 CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENT_ARGUMENTS% --payload-flattening-threshold=1 --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/graphrbac/data-plane/Microsoft.GraphRbac/stable/1.6/graphrbac.json --namespace=com.azure.mgmttest.authorization

--- a/fluent-tests/prepare-tests.bat
+++ b/fluent-tests/prepare-tests.bat
@@ -27,6 +27,8 @@ CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENT_ARGUMENTS% --payload-fla
 
 CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENT_ARGUMENTS% --payload-flattening-threshold=1 --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2019-12-12/cosmos-db.json --namespace=com.azure.mgmttest.cosmos
 
+CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENT_ARGUMENTS% --payload-flattening-threshold=1 --pipeline.modelerfour.flatten-payloads=true --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/compute/resource-manager/Microsoft.Compute/stable/2021-03-01/cloudService.json --namespace=com.azure.mgmttest.compute
+
 CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENT_ARGUMENTS% --payload-flattening-threshold=1 --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/graphrbac/data-plane/Microsoft.GraphRbac/stable/1.6/graphrbac.json --namespace=com.azure.mgmttest.authorization
 
 REM fluent lite

--- a/fluent-tests/prepare-tests.bat
+++ b/fluent-tests/prepare-tests.bat
@@ -23,12 +23,16 @@ CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENT_ARGUMENTS% --payload-fla
 
 CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENT_ARGUMENTS% --payload-flattening-threshold=1 ./swagger/readme.network.md --namespace=com.azure.mgmttest.network
 
+REM error response that is subclass of ManagementException
 CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENT_ARGUMENTS% --payload-flattening-threshold=1 ./swagger/readme.appservice.md --namespace=com.azure.mgmttest.appservice
 
+REM multiple inheritance
 CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENT_ARGUMENTS% --payload-flattening-threshold=1 --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2019-12-12/cosmos-db.json --namespace=com.azure.mgmttest.cosmos
 
+REM flatten payload
 CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENT_ARGUMENTS% --payload-flattening-threshold=1 --pipeline.modelerfour.flatten-payloads=true --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/compute/resource-manager/Microsoft.Compute/stable/2021-03-01/cloudService.json --namespace=com.azure.mgmttest.compute
 
+REM error response that not conform to ARM
 CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENT_ARGUMENTS% --payload-flattening-threshold=1 --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/graphrbac/data-plane/Microsoft.GraphRbac/stable/1.6/graphrbac.json --namespace=com.azure.mgmttest.authorization
 
 REM fluent lite

--- a/fluent-tests/src/test/java/com/azure/mgmttest/CompilationTests.java
+++ b/fluent-tests/src/test/java/com/azure/mgmttest/CompilationTests.java
@@ -6,6 +6,7 @@ package com.azure.mgmttest;
 import com.azure.core.management.Resource;
 import com.azure.core.management.exception.ManagementError;
 import com.azure.core.management.exception.ManagementException;
+import com.azure.mgmttest.compute.fluent.CloudServicesUpdateDomainsClient;
 import com.azure.resourcemanager.resources.fluentcore.collection.InnerSupportsGet;
 import com.azure.resourcemanager.resources.fluentcore.collection.InnerSupportsListing;
 import com.azure.mgmttest.appservice.models.DefaultErrorResponseErrorException;
@@ -23,6 +24,7 @@ import com.azure.mgmttest.resources.fluent.models.ResourceGroupInner;
 import com.azure.mgmttest.storage.fluent.models.StorageAccountInner;
 import com.azure.mgmttest.storage.fluent.StorageAccountsClient;
 
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
 
@@ -83,6 +85,11 @@ public class CompilationTests {
         SqlDatabaseGetPropertiesResource sqlDatabaseGetPropertiesResource = new SqlDatabaseGetPropertiesResource();
         sqlDatabaseGetPropertiesResource.rid();
         sqlDatabaseGetPropertiesResource.colls();
+    }
+
+    public void testFlattenedParameter() {
+        CloudServicesUpdateDomainsClient cloudServicesUpdateDomainsClient = mock(CloudServicesUpdateDomainsClient.class);
+        cloudServicesUpdateDomainsClient.walkUpdateDomainWithResponseAsync(anyString(), anyString(), anyInt());
     }
 
 //    public void testIntEnum() {

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -34,10 +34,12 @@ import com.azure.core.util.CoreUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>> {
@@ -125,6 +127,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
             Map<String, String> validateExpressions = new HashMap<>();
             List<MethodTransformationDetail> methodTransformationDetails = new ArrayList<>();
 
+            Set<Parameter> originalParameters = new HashSet<>();
             for (Parameter parameter : request.getParameters().stream().filter(p -> !p.isFlattened()).collect(Collectors.toList())) {
                 ClientMethodParameter clientMethodParameter = Mappers.getClientParameterMapper().map(parameter);
 
@@ -170,6 +173,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                         && !(parameter.getSchema() instanceof ConstantSchema)) {
                     ClientMethodParameter outParameter;
                     if (parameter.getOriginalParameter() != null) {
+                        originalParameters.add(parameter.getOriginalParameter());
                         outParameter = Mappers.getClientParameterMapper().map(parameter.getOriginalParameter());
                     } else {
                         outParameter = clientMethodParameter;
@@ -197,6 +201,15 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                     }
                     detail.getParameterMappings().add(mapping);
                 }
+            }
+            // handle the case that the flattened parameter is non-required, and all its property is read-only
+            // in this case, it is not original parameter from any other parameters
+            for (Parameter parameter : request.getParameters().stream()
+                    .filter(p -> p.isFlattened() && p.getProtocol() != null && p.getProtocol().getHttp() != null)   // flattened proxy parameter
+                    .filter(p -> !originalParameters.contains(p))                                                   // but not original parameter from any other parameters
+                    .collect(Collectors.toList())) {
+                ClientMethodParameter outParameter = Mappers.getClientParameterMapper().map(parameter);
+                methodTransformationDetails.add(new MethodTransformationDetail(outParameter, new ArrayList<>()));
             }
 
             final boolean generateClientMethodWithOnlyRequiredParameters = settings.getRequiredParameterClientMethods() && hasNonRequiredParameters(parameters);

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -202,7 +202,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                     detail.getParameterMappings().add(mapping);
                 }
             }
-            // handle the case that the flattened parameter is non-required, and all its property is read-only
+            // handle the case that the flattened parameter is model with all its properties read-only
             // in this case, it is not original parameter from any other parameters
             for (Parameter parameter : request.getParameters().stream()
                     .filter(p -> p.isFlattened() && p.getProtocol() != null && p.getProtocol().getHttp() != null)   // flattened proxy parameter

--- a/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
@@ -126,9 +126,16 @@ public class ClientMethodTemplate implements IJavaTemplate<ClientMethod, JavaTyp
         for (MethodTransformationDetail transformation : clientMethod.getMethodTransformationDetails()) {
             if (transformation.getParameterMappings().isEmpty()) {
                 // the case that this flattened parameter is not original parameter from any other parameters
-                function.line("%s %s = null;",
-                        transformation.getOutParameter().getClientType(),
-                        transformation.getOutParameter().getName());
+                ClientMethodParameter outParameter = transformation.getOutParameter();
+                if (outParameter.getIsRequired() && outParameter.getClientType() instanceof ClassType) {
+                    function.line("%1$s %2$s = new %1$s();",
+                            outParameter.getClientType(),
+                            outParameter.getName());
+                } else {
+                    function.line("%1$s %2$s = null;",
+                            outParameter.getClientType(),
+                            outParameter.getName());
+                }
                 break;
             }
 


### PR DESCRIPTION
Case https://github.com/Azure/azure-rest-api-specs/blob/master/specification/compute/resource-manager/Microsoft.Compute/stable/2021-03-01/cloudService.json#L2434-L2449

The flattened parameter does not have writable property.

```
        UpdateDomainInner parameters = null;
        return FluxUtil
            .withContext(
                context ->
                    service
                        .walkUpdateDomain(
                            this.client.getEndpoint(),
                            resourceGroupName,
                            cloudServiceName,
                            updateDomain,
                            this.client.getSubscriptionId(),
                            apiVersion,
                            parameters,
                            accept,
                            context))
            .contextWrite(context -> context.putAll(FluxUtil.toReactorContext(this.client.getContext()).readOnly()));
```

Without this fix, the `UpdateDomainInner parameters = null;` will not be generated.