### PR TITLE
v4, fix javadoc bug in return value, improve schema clean-up in fluent

### DIFF
--- a/fluentnamer/src/main/java/com/azure/autorest/fluent/transformer/FluentTransformer.java
+++ b/fluentnamer/src/main/java/com/azure/autorest/fluent/transformer/FluentTransformer.java
@@ -47,7 +47,7 @@ public class FluentTransformer {
     }
 
     public CodeModel postTransform(CodeModel codeModel) {
-        codeModel = new SchemaRenamer(fluentJavaSettings.getRenameModel()).process(codeModel);
+        codeModel = new SchemaRenamer(fluentJavaSettings.getJavaNamesForRenameModel()).process(codeModel);
         codeModel = new OperationNameNormalization().process(codeModel);
         codeModel = new ResourceTypeNormalization().process(codeModel);
         codeModel = new ErrorTypeNormalization().process(codeModel);
@@ -55,7 +55,7 @@ public class FluentTransformer {
         if (fluentJavaSettings.isResourcePropertyAsSubResource()) {
             codeModel = new ResourcePropertyNormalization().process(codeModel);
         }
-        codeModel = new SchemaCleanup().process(codeModel);
+        codeModel = new SchemaCleanup(fluentJavaSettings.getJavaNamesForPreserveModel()).process(codeModel);
         return codeModel;
     }
 

--- a/fluentnamer/src/main/java/com/azure/autorest/fluent/transformer/SchemaCleanup.java
+++ b/fluentnamer/src/main/java/com/azure/autorest/fluent/transformer/SchemaCleanup.java
@@ -58,12 +58,12 @@ public class SchemaCleanup {
                         || schema.getChildren().getImmediate().isEmpty())   // no children
                 .filter(schema -> schema.getParents() == null || schema.getParents().getImmediate() == null
                         || schema.getParents().getImmediate().stream().allMatch(s -> {
-                    if (s instanceof ObjectSchema) {
-                        return !FluentType.nonResourceType((ObjectSchema) s);
-                    } else {
-                        return false;
-                    }
-                }))
+                            if (s instanceof ObjectSchema) {
+                                return !FluentType.nonResourceType((ObjectSchema) s);
+                            } else {
+                                return false;
+                            }
+                        }))
                 .collect(Collectors.toSet());
 
         Set<Schema> choicesSchemasNotInUse = new HashSet<>(codeModel.getSchemas().getSealedChoices());

--- a/fluentnamer/src/main/java/com/azure/autorest/fluent/transformer/SchemaCleanup.java
+++ b/fluentnamer/src/main/java/com/azure/autorest/fluent/transformer/SchemaCleanup.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -33,19 +34,36 @@ public class SchemaCleanup {
 
     private static final Logger logger = new PluginLogger(FluentNamer.getPluginInstance(), SchemaCleanup.class);
 
+    private final Set<String> javaNamesForPreserveModel;
+
+    public SchemaCleanup(Set<String> javaNamesForPreserveModel) {
+        this.javaNamesForPreserveModel = javaNamesForPreserveModel;
+    }
+
     public CodeModel process(CodeModel codeModel) {
+        final int MAX_TRY_COUNT = 5;    // try a few time for recursive removal (e.g., 1st pass model removed, 2nd pass model used as its properties removed)
+
+        boolean codeModelModified = true;
+        for (int i = 0; i < MAX_TRY_COUNT && codeModelModified; ++i) {
+            codeModelModified = tryCleanup(codeModel, javaNamesForPreserveModel);
+        }
+
+        return codeModel;
+    }
+
+    private static boolean tryCleanup(CodeModel codeModel, Set<String> javaNamesForPreserveModel) {
         Set<ObjectSchema> schemasNotInUse = codeModel.getSchemas().getObjects().stream()
 //                .filter(SchemaCleanup::hasFlattenedExtension)
                 .filter(schema -> schema.getChildren() == null || schema.getChildren().getImmediate() == null
                         || schema.getChildren().getImmediate().isEmpty())   // no children
                 .filter(schema -> schema.getParents() == null || schema.getParents().getImmediate() == null
                         || schema.getParents().getImmediate().stream().allMatch(s -> {
-                            if (s instanceof ObjectSchema) {
-                                return !FluentType.nonResourceType((ObjectSchema) s);
-                            } else {
-                                return false;
-                            }
-                        }))
+                    if (s instanceof ObjectSchema) {
+                        return !FluentType.nonResourceType((ObjectSchema) s);
+                    } else {
+                        return false;
+                    }
+                }))
                 .collect(Collectors.toSet());
 
         Set<Schema> choicesSchemasNotInUse = new HashSet<>(codeModel.getSchemas().getSealedChoices());
@@ -106,31 +124,36 @@ public class SchemaCleanup {
             choicesSchemasNotInUse.removeAll(schemasInUse);
         }
 
+        AtomicBoolean codeModelModified = new AtomicBoolean(false);
+
         codeModel.getSchemas().getObjects().removeIf(s -> {
-            boolean unused = schemasNotInUse.contains(s);
+            boolean unused = schemasNotInUse.contains(s) && !javaNamesForPreserveModel.contains(Utils.getJavaName(s));
             if (unused) {
                 logger.info("Remove unused object schema '{}'", Utils.getJavaName(s));
+                codeModelModified.set(true);
             }
             return unused;
         });
 
         codeModel.getSchemas().getSealedChoices().removeIf(s -> {
-            boolean unused = choicesSchemasNotInUse.contains(s);
+            boolean unused = choicesSchemasNotInUse.contains(s) && !javaNamesForPreserveModel.contains(Utils.getJavaName(s));
             if (unused) {
                 logger.info("Remove unused sealed choice schema '{}'", Utils.getJavaName(s));
+                codeModelModified.set(true);
             }
             return unused;
         });
 
         codeModel.getSchemas().getChoices().removeIf(s -> {
-            boolean unused = choicesSchemasNotInUse.contains(s);
+            boolean unused = choicesSchemasNotInUse.contains(s) && !javaNamesForPreserveModel.contains(Utils.getJavaName(s));
             if (unused) {
                 logger.info("Remove unused choice schema '{}'", Utils.getJavaName(s));
+                codeModelModified.set(true);
             }
             return unused;
         });
 
-        return codeModel;
+        return codeModelModified.get();
     }
 
     private static Schema schemaOrElementInCollection(Schema schema) {

--- a/fluentnamer/src/main/java/com/azure/autorest/fluent/util/FluentJavaSettings.java
+++ b/fluentnamer/src/main/java/com/azure/autorest/fluent/util/FluentJavaSettings.java
@@ -42,6 +42,8 @@ public class FluentJavaSettings {
 
     private final Set<String> javaNamesForRemoveModel = new HashSet<>();
 
+    private final Set<String> javaNamesForPreserveModel = new HashSet<>();
+
 //    /**
 //     * Whether to generate property method with track1 naming (e.g. foo, withFoo), instead of track2 naming (e.g. getFoo, setFoo).
 //     */
@@ -107,12 +109,16 @@ public class FluentJavaSettings {
         return namingOverride;
     }
 
-    public Map<String, String> getRenameModel() {
+    public Map<String, String> getJavaNamesForRenameModel() {
         return renameModel;
     }
 
     public Set<String> getJavaNamesForRemoveModel() {
         return javaNamesForRemoveModel;
+    }
+
+    public Set<String> getJavaNamesForPreserveModel() {
+        return javaNamesForPreserveModel;
     }
 
     public String getPomFilename() {
@@ -191,6 +197,16 @@ public class FluentJavaSettings {
         loadStringSetting("remove-model", s -> {
             if (!CoreUtils.isNullOrEmpty(s)) {
                 javaNamesForRemoveModel.addAll(
+                        Arrays.stream(s.split(Pattern.quote(",")))
+                                .map(String::trim)
+                                .filter(s1 -> !s1.isEmpty())
+                                .collect(Collectors.toSet()));
+            }
+        });
+
+        loadStringSetting("preserve-model", s -> {
+            if (!CoreUtils.isNullOrEmpty(s)) {
+                javaNamesForPreserveModel.addAll(
                         Arrays.stream(s.split(Pattern.quote(",")))
                                 .map(String::trim)
                                 .filter(s1 -> !s1.isEmpty())

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -703,7 +703,9 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
 
             if (description == null && operation.getResponses() != null && !operation.getResponses().isEmpty()) {
                 Schema responseSchema = operation.getResponses().get(0).getSchema();
-                if (responseSchema != null && responseSchema.getLanguage() != null && responseSchema.getLanguage().getDefault() != null) {
+                if (responseSchema != null && !CoreUtils.isNullOrEmpty(responseSchema.getSummary())) {
+                    description = formatReturnTypeDescription(responseSchema.getSummary());
+                } else if (responseSchema != null && responseSchema.getLanguage() != null && responseSchema.getLanguage().getDefault() != null) {
                     String responseSchemaDescription = responseSchema.getLanguage().getDefault().getDescription();
                     if (!CoreUtils.isNullOrEmpty(responseSchemaDescription)) {
                         description = formatReturnTypeDescription(responseSchemaDescription);
@@ -735,7 +737,11 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
 
     private static String formatReturnTypeDescription(String description) {
         description = description.trim();
-        int endIndex = description.indexOf(".");
+        int endIndex = description.indexOf(". ");   // Get 1st sentence.
+        if (endIndex == -1 && description.length() > 0 && description.charAt(description.length() - 1) == '.') {
+            // Remove last period.
+            endIndex = description.length() - 1;
+        }
         if (endIndex != -1) {
             description = description.substring(0, endIndex);
         }

--- a/javagen/src/main/java/com/azure/autorest/mapper/ModelMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ModelMapper.java
@@ -157,11 +157,12 @@ public class ModelMapper implements IMapper<ObjectSchema, ClientModel> {
                 }
             }
 
-            if (compositeType.getLanguage().getDefault() == null
-                    || CoreUtils.isNullOrEmpty(compositeType.getLanguage().getDefault().getDescription())) {
+            String summary = compositeType.getSummary();
+            String description = compositeType.getLanguage().getJava() == null ? null : compositeType.getLanguage().getJava().getDescription();
+            if (CoreUtils.isNullOrEmpty(summary) && CoreUtils.isNullOrEmpty(description)) {
                 builder.description(String.format("The %s model.", compositeType.getLanguage().getJava().getName()));
             } else {
-                builder.description(compositeType.getLanguage().getDefault().getDescription());
+                builder.description(SchemaUtil.mergeDescription(summary, description));
             }
 
             String modelSerializedName = compositeType.getDiscriminatorValue();

--- a/javagen/src/main/java/com/azure/autorest/mapper/ModelPropertyMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ModelPropertyMapper.java
@@ -38,32 +38,15 @@ public class ModelPropertyMapper implements IMapper<Property, ClientModelPropert
                 .isReadOnly(property.isReadOnly());
 
 
-        StringBuilder descriptionSb = new StringBuilder();
-        String summaryInProperty = "";
-        String descriptionInProperty = "";
-        if(property.getSchema() != null && !CoreUtils.isNullOrEmpty(property.getSchema().getSummary())) {
-            summaryInProperty = property.getSchema().getSummary();
-        }
-        if (property.getLanguage().getJava() != null && !CoreUtils.isNullOrEmpty(property.getLanguage().getJava().getDescription())) {
-            descriptionInProperty = property.getLanguage().getJava().getDescription();
-        }
-
-        if (descriptionInProperty.isEmpty() && summaryInProperty.isEmpty()) {
-            descriptionSb.append(String.format("The %s property.", property.getSerializedName()));
-        } else if(summaryInProperty.isEmpty()) {
-            descriptionSb.append(descriptionInProperty);
-        } else if(descriptionInProperty.isEmpty()) {
-            descriptionSb.append(summaryInProperty);
+        String description;
+        String summaryInProperty = property.getSchema() == null ? null : property.getSchema().getSummary();
+        String descriptionInProperty = property.getLanguage().getJava() == null ? null : property.getLanguage().getJava().getDescription();
+        if (CoreUtils.isNullOrEmpty(summaryInProperty) && CoreUtils.isNullOrEmpty(descriptionInProperty)) {
+            description = String.format("The %s property.", property.getSerializedName());
         } else {
-            if(summaryInProperty.equals(descriptionInProperty)) {
-                descriptionSb.append(descriptionInProperty);
-            } else {
-                descriptionSb.append(summaryInProperty).append(" ").append(descriptionInProperty);
-            }
+            description = SchemaUtil.mergeDescription(summaryInProperty, descriptionInProperty);
         }
-
-        builder.description(descriptionSb.toString());
-
+        builder.description(description);
 
         boolean flattened = false;
         if (settings.getModelerSettings().isFlattenModel()) {   // enabled by modelerfour

--- a/javagen/src/main/java/com/azure/autorest/util/SchemaUtil.java
+++ b/javagen/src/main/java/com/azure/autorest/util/SchemaUtil.java
@@ -10,7 +10,9 @@ import com.azure.autorest.mapper.Mappers;
 import com.azure.autorest.model.clientmodel.IType;
 import com.azure.autorest.model.clientmodel.PrimitiveType;
 import com.azure.core.http.HttpMethod;
+import com.azure.core.util.CoreUtils;
 
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
@@ -113,5 +115,20 @@ public class SchemaUtil {
                 .filter(r -> r.getProtocol() != null && r.getProtocol().getHttp() != null && r.getProtocol().getHttp().getHeaders() != null)
                 .flatMap(r -> r.getProtocol().getHttp().getHeaders().stream().map(Header::getSchema))
                 .anyMatch(Objects::nonNull);
+    }
+
+    public static String mergeDescription(String summary, String description) {
+        if (Objects.equals(summary, description)) {
+            summary = null;
+        }
+
+        List<String> parts = new ArrayList<>();
+        if (!CoreUtils.isNullOrEmpty(summary)) {
+            parts.add(summary);
+        }
+        if (!CoreUtils.isNullOrEmpty(description)) {
+            parts.add(description);
+        }
+        return String.join(" ", parts);
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -91,6 +91,7 @@ Following settings only works when `fluent` option is specified.
 | `--remove-inner` | CSV. Exclude from inner classes. |
 | `--rename-model` | CSV. Rename classes. Each item is of pattern `from:to`. |
 | `--remove-model` | CSV. Remove classes. |
+| `--preserve-model` | CSV. Preserve classes from clean-up. |
 | `--name-for-ungrouped-operations` | String. Name for ungrouped operation group. Default to `ResourceProviders` for Lite. |
 
 `fluent` option will change the default value for some vanilla options.
@@ -857,6 +858,9 @@ help-content:
       - key: remove-model
         type: string
         description: CSV. Remove classes.
+      - key: preserve-model
+        type: string
+        description: CSV. Preserve classes from clean-up.
       - key: name-for-ungrouped-operations
         type: string
         description: String. Name for ungrouped operation group. Default to `ResourceProviders` for Lite.

--- a/vanilla-tests/src/main/java/fixtures/bodyarray/Arrays.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyarray/Arrays.java
@@ -1321,7 +1321,7 @@ public final class Arrays {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float array value [0, -0.
+     * @return float array value [0, -0.01, 1.2e20].
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<List<Float>>> getFloatValidWithResponseAsync() {
@@ -1338,7 +1338,7 @@ public final class Arrays {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float array value [0, -0.
+     * @return float array value [0, -0.01, 1.2e20].
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<List<Float>> getFloatValidAsync() {
@@ -1358,7 +1358,7 @@ public final class Arrays {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float array value [0, -0.
+     * @return float array value [0, -0.01, 1.2e20].
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Float> getFloatValid() {
@@ -1420,7 +1420,7 @@ public final class Arrays {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float array value [0.
+     * @return float array value [0.0, null, -1.2e20].
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<List<Float>>> getFloatInvalidNullWithResponseAsync() {
@@ -1437,7 +1437,7 @@ public final class Arrays {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float array value [0.
+     * @return float array value [0.0, null, -1.2e20].
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<List<Float>> getFloatInvalidNullAsync() {
@@ -1457,7 +1457,7 @@ public final class Arrays {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float array value [0.
+     * @return float array value [0.0, null, -1.2e20].
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Float> getFloatInvalidNull() {
@@ -1469,7 +1469,7 @@ public final class Arrays {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return boolean array value [1.
+     * @return boolean array value [1.0, 'number', 0.0].
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<List<Float>>> getFloatInvalidStringWithResponseAsync() {
@@ -1486,7 +1486,7 @@ public final class Arrays {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return boolean array value [1.
+     * @return boolean array value [1.0, 'number', 0.0].
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<List<Float>> getFloatInvalidStringAsync() {
@@ -1506,7 +1506,7 @@ public final class Arrays {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return boolean array value [1.
+     * @return boolean array value [1.0, 'number', 0.0].
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Float> getFloatInvalidString() {
@@ -1518,7 +1518,7 @@ public final class Arrays {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float array value [0, -0.
+     * @return float array value [0, -0.01, 1.2e20].
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<List<Double>>> getDoubleValidWithResponseAsync() {
@@ -1535,7 +1535,7 @@ public final class Arrays {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float array value [0, -0.
+     * @return float array value [0, -0.01, 1.2e20].
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<List<Double>> getDoubleValidAsync() {
@@ -1555,7 +1555,7 @@ public final class Arrays {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float array value [0, -0.
+     * @return float array value [0, -0.01, 1.2e20].
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Double> getDoubleValid() {
@@ -1617,7 +1617,7 @@ public final class Arrays {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float array value [0.
+     * @return float array value [0.0, null, -1.2e20].
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<List<Double>>> getDoubleInvalidNullWithResponseAsync() {
@@ -1634,7 +1634,7 @@ public final class Arrays {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float array value [0.
+     * @return float array value [0.0, null, -1.2e20].
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<List<Double>> getDoubleInvalidNullAsync() {
@@ -1654,7 +1654,7 @@ public final class Arrays {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float array value [0.
+     * @return float array value [0.0, null, -1.2e20].
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Double> getDoubleInvalidNull() {
@@ -1666,7 +1666,7 @@ public final class Arrays {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return boolean array value [1.
+     * @return boolean array value [1.0, 'number', 0.0].
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<List<Double>>> getDoubleInvalidStringWithResponseAsync() {
@@ -1683,7 +1683,7 @@ public final class Arrays {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return boolean array value [1.
+     * @return boolean array value [1.0, 'number', 0.0].
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<List<Double>> getDoubleInvalidStringAsync() {
@@ -1703,7 +1703,7 @@ public final class Arrays {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return boolean array value [1.
+     * @return boolean array value [1.0, 'number', 0.0].
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Double> getDoubleInvalidString() {
@@ -2777,7 +2777,7 @@ public final class Arrays {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return duration array value ['P123DT22H14M12.
+     * @return duration array value ['P123DT22H14M12.011S', 'P5DT1H0M0S'].
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<List<Duration>>> getDurationValidWithResponseAsync() {
@@ -2794,7 +2794,7 @@ public final class Arrays {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return duration array value ['P123DT22H14M12.
+     * @return duration array value ['P123DT22H14M12.011S', 'P5DT1H0M0S'].
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<List<Duration>> getDurationValidAsync() {
@@ -2814,7 +2814,7 @@ public final class Arrays {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return duration array value ['P123DT22H14M12.
+     * @return duration array value ['P123DT22H14M12.011S', 'P5DT1H0M0S'].
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public List<Duration> getDurationValid() {

--- a/vanilla-tests/src/main/java/fixtures/bodydatetime/DatetimeOperations.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydatetime/DatetimeOperations.java
@@ -517,7 +517,7 @@ public final class DatetimeOperations {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return max datetime value 9999-12-31t23:59:59.
+     * @return max datetime value 9999-12-31t23:59:59.999z.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<OffsetDateTime>> getUtcLowercaseMaxDateTimeWithResponseAsync() {
@@ -535,7 +535,7 @@ public final class DatetimeOperations {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return max datetime value 9999-12-31t23:59:59.
+     * @return max datetime value 9999-12-31t23:59:59.999z.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<OffsetDateTime> getUtcLowercaseMaxDateTimeAsync() {
@@ -555,7 +555,7 @@ public final class DatetimeOperations {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return max datetime value 9999-12-31t23:59:59.
+     * @return max datetime value 9999-12-31t23:59:59.999z.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getUtcLowercaseMaxDateTime() {
@@ -567,7 +567,7 @@ public final class DatetimeOperations {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return max datetime value 9999-12-31T23:59:59.
+     * @return max datetime value 9999-12-31T23:59:59.999Z.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<OffsetDateTime>> getUtcUppercaseMaxDateTimeWithResponseAsync() {
@@ -585,7 +585,7 @@ public final class DatetimeOperations {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return max datetime value 9999-12-31T23:59:59.
+     * @return max datetime value 9999-12-31T23:59:59.999Z.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<OffsetDateTime> getUtcUppercaseMaxDateTimeAsync() {
@@ -605,7 +605,7 @@ public final class DatetimeOperations {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return max datetime value 9999-12-31T23:59:59.
+     * @return max datetime value 9999-12-31T23:59:59.999Z.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getUtcUppercaseMaxDateTime() {
@@ -720,7 +720,7 @@ public final class DatetimeOperations {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return max datetime value with positive num offset 9999-12-31t23:59:59.
+     * @return max datetime value with positive num offset 9999-12-31t23:59:59.999+14:00.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<OffsetDateTime>> getLocalPositiveOffsetLowercaseMaxDateTimeWithResponseAsync() {
@@ -738,7 +738,7 @@ public final class DatetimeOperations {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return max datetime value with positive num offset 9999-12-31t23:59:59.
+     * @return max datetime value with positive num offset 9999-12-31t23:59:59.999+14:00.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<OffsetDateTime> getLocalPositiveOffsetLowercaseMaxDateTimeAsync() {
@@ -758,7 +758,7 @@ public final class DatetimeOperations {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return max datetime value with positive num offset 9999-12-31t23:59:59.
+     * @return max datetime value with positive num offset 9999-12-31t23:59:59.999+14:00.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getLocalPositiveOffsetLowercaseMaxDateTime() {
@@ -770,7 +770,7 @@ public final class DatetimeOperations {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return max datetime value with positive num offset 9999-12-31T23:59:59.
+     * @return max datetime value with positive num offset 9999-12-31T23:59:59.999+14:00.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<OffsetDateTime>> getLocalPositiveOffsetUppercaseMaxDateTimeWithResponseAsync() {
@@ -788,7 +788,7 @@ public final class DatetimeOperations {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return max datetime value with positive num offset 9999-12-31T23:59:59.
+     * @return max datetime value with positive num offset 9999-12-31T23:59:59.999+14:00.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<OffsetDateTime> getLocalPositiveOffsetUppercaseMaxDateTimeAsync() {
@@ -808,7 +808,7 @@ public final class DatetimeOperations {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return max datetime value with positive num offset 9999-12-31T23:59:59.
+     * @return max datetime value with positive num offset 9999-12-31T23:59:59.999+14:00.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getLocalPositiveOffsetUppercaseMaxDateTime() {
@@ -873,7 +873,7 @@ public final class DatetimeOperations {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return max datetime value with positive num offset 9999-12-31T23:59:59.
+     * @return max datetime value with positive num offset 9999-12-31T23:59:59.999-14:00.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<OffsetDateTime>> getLocalNegativeOffsetUppercaseMaxDateTimeWithResponseAsync() {
@@ -891,7 +891,7 @@ public final class DatetimeOperations {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return max datetime value with positive num offset 9999-12-31T23:59:59.
+     * @return max datetime value with positive num offset 9999-12-31T23:59:59.999-14:00.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<OffsetDateTime> getLocalNegativeOffsetUppercaseMaxDateTimeAsync() {
@@ -911,7 +911,7 @@ public final class DatetimeOperations {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return max datetime value with positive num offset 9999-12-31T23:59:59.
+     * @return max datetime value with positive num offset 9999-12-31T23:59:59.999-14:00.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getLocalNegativeOffsetUppercaseMaxDateTime() {
@@ -923,7 +923,7 @@ public final class DatetimeOperations {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return max datetime value with positive num offset 9999-12-31t23:59:59.
+     * @return max datetime value with positive num offset 9999-12-31t23:59:59.999-14:00.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<OffsetDateTime>> getLocalNegativeOffsetLowercaseMaxDateTimeWithResponseAsync() {
@@ -941,7 +941,7 @@ public final class DatetimeOperations {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return max datetime value with positive num offset 9999-12-31t23:59:59.
+     * @return max datetime value with positive num offset 9999-12-31t23:59:59.999-14:00.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<OffsetDateTime> getLocalNegativeOffsetLowercaseMaxDateTimeAsync() {
@@ -961,7 +961,7 @@ public final class DatetimeOperations {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return max datetime value with positive num offset 9999-12-31t23:59:59.
+     * @return max datetime value with positive num offset 9999-12-31t23:59:59.999-14:00.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public OffsetDateTime getLocalNegativeOffsetLowercaseMaxDateTime() {

--- a/vanilla-tests/src/main/java/fixtures/bodydictionary/AutoRestSwaggerBATDictionaryServiceAsyncClient.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydictionary/AutoRestSwaggerBATDictionaryServiceAsyncClient.java
@@ -505,7 +505,7 @@ public final class AutoRestSwaggerBATDictionaryServiceAsyncClient {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float dictionary value {"0": 0, "1": -0.
+     * @return float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Map<String, Float>>> getFloatValidWithResponse() {
@@ -517,7 +517,7 @@ public final class AutoRestSwaggerBATDictionaryServiceAsyncClient {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float dictionary value {"0": 0, "1": -0.
+     * @return float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Float>> getFloatValid() {
@@ -557,7 +557,7 @@ public final class AutoRestSwaggerBATDictionaryServiceAsyncClient {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float dictionary value {"0": 0.
+     * @return float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Map<String, Float>>> getFloatInvalidNullWithResponse() {
@@ -569,7 +569,7 @@ public final class AutoRestSwaggerBATDictionaryServiceAsyncClient {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float dictionary value {"0": 0.
+     * @return float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Float>> getFloatInvalidNull() {
@@ -581,7 +581,7 @@ public final class AutoRestSwaggerBATDictionaryServiceAsyncClient {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return boolean dictionary value {"0": 1.
+     * @return boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Map<String, Float>>> getFloatInvalidStringWithResponse() {
@@ -593,7 +593,7 @@ public final class AutoRestSwaggerBATDictionaryServiceAsyncClient {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return boolean dictionary value {"0": 1.
+     * @return boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Float>> getFloatInvalidString() {
@@ -605,7 +605,7 @@ public final class AutoRestSwaggerBATDictionaryServiceAsyncClient {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float dictionary value {"0": 0, "1": -0.
+     * @return float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Map<String, Double>>> getDoubleValidWithResponse() {
@@ -617,7 +617,7 @@ public final class AutoRestSwaggerBATDictionaryServiceAsyncClient {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float dictionary value {"0": 0, "1": -0.
+     * @return float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Double>> getDoubleValid() {
@@ -657,7 +657,7 @@ public final class AutoRestSwaggerBATDictionaryServiceAsyncClient {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float dictionary value {"0": 0.
+     * @return float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Map<String, Double>>> getDoubleInvalidNullWithResponse() {
@@ -669,7 +669,7 @@ public final class AutoRestSwaggerBATDictionaryServiceAsyncClient {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float dictionary value {"0": 0.
+     * @return float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Double>> getDoubleInvalidNull() {
@@ -681,7 +681,7 @@ public final class AutoRestSwaggerBATDictionaryServiceAsyncClient {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return boolean dictionary value {"0": 1.
+     * @return boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Map<String, Double>>> getDoubleInvalidStringWithResponse() {
@@ -693,7 +693,7 @@ public final class AutoRestSwaggerBATDictionaryServiceAsyncClient {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return boolean dictionary value {"0": 1.
+     * @return boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Double>> getDoubleInvalidString() {
@@ -1073,7 +1073,7 @@ public final class AutoRestSwaggerBATDictionaryServiceAsyncClient {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return duration dictionary value {"0": "P123DT22H14M12.
+     * @return duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Map<String, Duration>>> getDurationValidWithResponse() {
@@ -1085,7 +1085,7 @@ public final class AutoRestSwaggerBATDictionaryServiceAsyncClient {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return duration dictionary value {"0": "P123DT22H14M12.
+     * @return duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Duration>> getDurationValid() {

--- a/vanilla-tests/src/main/java/fixtures/bodydictionary/AutoRestSwaggerBATDictionaryServiceClient.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydictionary/AutoRestSwaggerBATDictionaryServiceClient.java
@@ -263,7 +263,7 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float dictionary value {"0": 0, "1": -0.
+     * @return float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Float> getFloatValid() {
@@ -288,7 +288,7 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float dictionary value {"0": 0.
+     * @return float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Float> getFloatInvalidNull() {
@@ -300,7 +300,7 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return boolean dictionary value {"0": 1.
+     * @return boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Float> getFloatInvalidString() {
@@ -312,7 +312,7 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float dictionary value {"0": 0, "1": -0.
+     * @return float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Double> getDoubleValid() {
@@ -337,7 +337,7 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float dictionary value {"0": 0.
+     * @return float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Double> getDoubleInvalidNull() {
@@ -349,7 +349,7 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return boolean dictionary value {"0": 1.
+     * @return boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Double> getDoubleInvalidString() {
@@ -541,7 +541,7 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return duration dictionary value {"0": "P123DT22H14M12.
+     * @return duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Duration> getDurationValid() {

--- a/vanilla-tests/src/main/java/fixtures/bodydictionary/implementation/DictionariesImpl.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydictionary/implementation/DictionariesImpl.java
@@ -1432,7 +1432,7 @@ public final class DictionariesImpl {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float dictionary value {"0": 0, "1": -0.
+     * @return float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Map<String, Float>>> getFloatValidWithResponseAsync() {
@@ -1449,7 +1449,7 @@ public final class DictionariesImpl {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float dictionary value {"0": 0, "1": -0.
+     * @return float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Float>> getFloatValidAsync() {
@@ -1469,7 +1469,7 @@ public final class DictionariesImpl {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float dictionary value {"0": 0, "1": -0.
+     * @return float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Float> getFloatValid() {
@@ -1531,7 +1531,7 @@ public final class DictionariesImpl {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float dictionary value {"0": 0.
+     * @return float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Map<String, Float>>> getFloatInvalidNullWithResponseAsync() {
@@ -1548,7 +1548,7 @@ public final class DictionariesImpl {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float dictionary value {"0": 0.
+     * @return float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Float>> getFloatInvalidNullAsync() {
@@ -1568,7 +1568,7 @@ public final class DictionariesImpl {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float dictionary value {"0": 0.
+     * @return float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Float> getFloatInvalidNull() {
@@ -1580,7 +1580,7 @@ public final class DictionariesImpl {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return boolean dictionary value {"0": 1.
+     * @return boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Map<String, Float>>> getFloatInvalidStringWithResponseAsync() {
@@ -1597,7 +1597,7 @@ public final class DictionariesImpl {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return boolean dictionary value {"0": 1.
+     * @return boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Float>> getFloatInvalidStringAsync() {
@@ -1617,7 +1617,7 @@ public final class DictionariesImpl {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return boolean dictionary value {"0": 1.
+     * @return boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Float> getFloatInvalidString() {
@@ -1629,7 +1629,7 @@ public final class DictionariesImpl {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float dictionary value {"0": 0, "1": -0.
+     * @return float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Map<String, Double>>> getDoubleValidWithResponseAsync() {
@@ -1646,7 +1646,7 @@ public final class DictionariesImpl {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float dictionary value {"0": 0, "1": -0.
+     * @return float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Double>> getDoubleValidAsync() {
@@ -1666,7 +1666,7 @@ public final class DictionariesImpl {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float dictionary value {"0": 0, "1": -0.
+     * @return float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Double> getDoubleValid() {
@@ -1728,7 +1728,7 @@ public final class DictionariesImpl {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float dictionary value {"0": 0.
+     * @return float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Map<String, Double>>> getDoubleInvalidNullWithResponseAsync() {
@@ -1745,7 +1745,7 @@ public final class DictionariesImpl {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float dictionary value {"0": 0.
+     * @return float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Double>> getDoubleInvalidNullAsync() {
@@ -1765,7 +1765,7 @@ public final class DictionariesImpl {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return float dictionary value {"0": 0.
+     * @return float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Double> getDoubleInvalidNull() {
@@ -1777,7 +1777,7 @@ public final class DictionariesImpl {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return boolean dictionary value {"0": 1.
+     * @return boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Map<String, Double>>> getDoubleInvalidStringWithResponseAsync() {
@@ -1794,7 +1794,7 @@ public final class DictionariesImpl {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return boolean dictionary value {"0": 1.
+     * @return boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Double>> getDoubleInvalidStringAsync() {
@@ -1814,7 +1814,7 @@ public final class DictionariesImpl {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return boolean dictionary value {"0": 1.
+     * @return boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Double> getDoubleInvalidString() {
@@ -2544,7 +2544,7 @@ public final class DictionariesImpl {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return duration dictionary value {"0": "P123DT22H14M12.
+     * @return duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Map<String, Duration>>> getDurationValidWithResponseAsync() {
@@ -2561,7 +2561,7 @@ public final class DictionariesImpl {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return duration dictionary value {"0": "P123DT22H14M12.
+     * @return duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Map<String, Duration>> getDurationValidAsync() {
@@ -2581,7 +2581,7 @@ public final class DictionariesImpl {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return duration dictionary value {"0": "P123DT22H14M12.
+     * @return duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Map<String, Duration> getDurationValid() {

--- a/vanilla-tests/src/main/java/fixtures/bodynumber/Numbers.java
+++ b/vanilla-tests/src/main/java/fixtures/bodynumber/Numbers.java
@@ -481,7 +481,7 @@ public final class Numbers {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return big float value 3.
+     * @return big float value 3.402823e+20.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Float>> getBigFloatWithResponseAsync() {
@@ -498,7 +498,7 @@ public final class Numbers {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return big float value 3.
+     * @return big float value 3.402823e+20.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Float> getBigFloatAsync() {
@@ -518,7 +518,7 @@ public final class Numbers {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return big float value 3.
+     * @return big float value 3.402823e+20.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public float getBigFloat() {
@@ -582,7 +582,7 @@ public final class Numbers {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return big double value 2.
+     * @return big double value 2.5976931e+101.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Double>> getBigDoubleWithResponseAsync() {
@@ -599,7 +599,7 @@ public final class Numbers {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return big double value 2.
+     * @return big double value 2.5976931e+101.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Double> getBigDoubleAsync() {
@@ -619,7 +619,7 @@ public final class Numbers {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return big double value 2.
+     * @return big double value 2.5976931e+101.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public double getBigDouble() {
@@ -678,7 +678,7 @@ public final class Numbers {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return big double value 99999999.
+     * @return big double value 99999999.99.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Double>> getBigDoublePositiveDecimalWithResponseAsync() {
@@ -696,7 +696,7 @@ public final class Numbers {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return big double value 99999999.
+     * @return big double value 99999999.99.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Double> getBigDoublePositiveDecimalAsync() {
@@ -716,7 +716,7 @@ public final class Numbers {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return big double value 99999999.
+     * @return big double value 99999999.99.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public double getBigDoublePositiveDecimal() {
@@ -775,7 +775,7 @@ public final class Numbers {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return big double value -99999999.
+     * @return big double value -99999999.99.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Double>> getBigDoubleNegativeDecimalWithResponseAsync() {
@@ -793,7 +793,7 @@ public final class Numbers {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return big double value -99999999.
+     * @return big double value -99999999.99.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Double> getBigDoubleNegativeDecimalAsync() {
@@ -813,7 +813,7 @@ public final class Numbers {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return big double value -99999999.
+     * @return big double value -99999999.99.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public double getBigDoubleNegativeDecimal() {
@@ -880,7 +880,7 @@ public final class Numbers {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return big decimal value 2.
+     * @return big decimal value 2.5976931e+101.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<BigDecimal>> getBigDecimalWithResponseAsync() {
@@ -897,7 +897,7 @@ public final class Numbers {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return big decimal value 2.
+     * @return big decimal value 2.5976931e+101.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<BigDecimal> getBigDecimalAsync() {
@@ -917,7 +917,7 @@ public final class Numbers {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return big decimal value 2.
+     * @return big decimal value 2.5976931e+101.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public BigDecimal getBigDecimal() {
@@ -971,7 +971,7 @@ public final class Numbers {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return big decimal value 99999999.
+     * @return big decimal value 99999999.99.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<BigDecimal>> getBigDecimalPositiveDecimalWithResponseAsync() {
@@ -989,7 +989,7 @@ public final class Numbers {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return big decimal value 99999999.
+     * @return big decimal value 99999999.99.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<BigDecimal> getBigDecimalPositiveDecimalAsync() {
@@ -1009,7 +1009,7 @@ public final class Numbers {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return big decimal value 99999999.
+     * @return big decimal value 99999999.99.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public BigDecimal getBigDecimalPositiveDecimal() {
@@ -1063,7 +1063,7 @@ public final class Numbers {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return big decimal value -99999999.
+     * @return big decimal value -99999999.99.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<BigDecimal>> getBigDecimalNegativeDecimalWithResponseAsync() {
@@ -1081,7 +1081,7 @@ public final class Numbers {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return big decimal value -99999999.
+     * @return big decimal value -99999999.99.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<BigDecimal> getBigDecimalNegativeDecimalAsync() {
@@ -1101,7 +1101,7 @@ public final class Numbers {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return big decimal value -99999999.
+     * @return big decimal value -99999999.99.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public BigDecimal getBigDecimalNegativeDecimal() {
@@ -1160,7 +1160,7 @@ public final class Numbers {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return big double value 3.
+     * @return big double value 3.402823e-20.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Double>> getSmallFloatWithResponseAsync() {
@@ -1177,7 +1177,7 @@ public final class Numbers {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return big double value 3.
+     * @return big double value 3.402823e-20.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Double> getSmallFloatAsync() {
@@ -1197,7 +1197,7 @@ public final class Numbers {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return big double value 3.
+     * @return big double value 3.402823e-20.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public double getSmallFloat() {
@@ -1261,7 +1261,7 @@ public final class Numbers {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return big double value 2.
+     * @return big double value 2.5976931e-101.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Double>> getSmallDoubleWithResponseAsync() {
@@ -1278,7 +1278,7 @@ public final class Numbers {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return big double value 2.
+     * @return big double value 2.5976931e-101.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Double> getSmallDoubleAsync() {
@@ -1298,7 +1298,7 @@ public final class Numbers {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return big double value 2.
+     * @return big double value 2.5976931e-101.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public double getSmallDouble() {
@@ -1365,7 +1365,7 @@ public final class Numbers {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return small decimal value 2.
+     * @return small decimal value 2.5976931e-101.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<BigDecimal>> getSmallDecimalWithResponseAsync() {
@@ -1382,7 +1382,7 @@ public final class Numbers {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return small decimal value 2.
+     * @return small decimal value 2.5976931e-101.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<BigDecimal> getSmallDecimalAsync() {
@@ -1402,7 +1402,7 @@ public final class Numbers {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return small decimal value 2.
+     * @return small decimal value 2.5976931e-101.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public BigDecimal getSmallDecimal() {

--- a/vanilla-tests/src/main/java/fixtures/header/Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/header/Headers.java
@@ -1262,7 +1262,7 @@ public final class Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return a response with header value "value": 0.
+     * @return a response with header value "value": 0.07 or -3.0.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HeadersResponseFloatResponse> responseFloatWithResponseAsync(String scenario) {
@@ -1285,7 +1285,7 @@ public final class Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return a response with header value "value": 0.
+     * @return a response with header value "value": 0.07 or -3.0.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HeadersResponseFloatResponse> responseFloatWithResponseAsync(String scenario, Context context) {
@@ -1307,7 +1307,7 @@ public final class Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return a response with header value "value": 0.
+     * @return a response with header value "value": 0.07 or -3.0.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> responseFloatAsync(String scenario) {
@@ -1322,7 +1322,7 @@ public final class Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return a response with header value "value": 0.
+     * @return a response with header value "value": 0.07 or -3.0.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> responseFloatAsync(String scenario, Context context) {
@@ -1351,7 +1351,7 @@ public final class Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return a response with header value "value": 0.
+     * @return a response with header value "value": 0.07 or -3.0.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public HeadersResponseFloatResponse responseFloatWithResponse(String scenario, Context context) {
@@ -1480,7 +1480,7 @@ public final class Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return a response with header value "value": 7e120 or -3.
+     * @return a response with header value "value": 7e120 or -3.0.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HeadersResponseDoubleResponse> responseDoubleWithResponseAsync(String scenario) {
@@ -1504,7 +1504,7 @@ public final class Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return a response with header value "value": 7e120 or -3.
+     * @return a response with header value "value": 7e120 or -3.0.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HeadersResponseDoubleResponse> responseDoubleWithResponseAsync(String scenario, Context context) {
@@ -1526,7 +1526,7 @@ public final class Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return a response with header value "value": 7e120 or -3.
+     * @return a response with header value "value": 7e120 or -3.0.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> responseDoubleAsync(String scenario) {
@@ -1541,7 +1541,7 @@ public final class Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return a response with header value "value": 7e120 or -3.
+     * @return a response with header value "value": 7e120 or -3.0.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> responseDoubleAsync(String scenario, Context context) {
@@ -1570,7 +1570,7 @@ public final class Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return a response with header value "value": 7e120 or -3.
+     * @return a response with header value "value": 7e120 or -3.0.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public HeadersResponseDoubleResponse responseDoubleWithResponse(String scenario, Context context) {
@@ -2875,7 +2875,7 @@ public final class Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return a response with header values "P123DT22H14M12.
+     * @return a response with header values "P123DT22H14M12.011S".
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HeadersResponseDurationResponse> responseDurationWithResponseAsync(String scenario) {
@@ -2899,7 +2899,7 @@ public final class Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return a response with header values "P123DT22H14M12.
+     * @return a response with header values "P123DT22H14M12.011S".
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<HeadersResponseDurationResponse> responseDurationWithResponseAsync(String scenario, Context context) {
@@ -2921,7 +2921,7 @@ public final class Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return a response with header values "P123DT22H14M12.
+     * @return a response with header values "P123DT22H14M12.011S".
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> responseDurationAsync(String scenario) {
@@ -2937,7 +2937,7 @@ public final class Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return a response with header values "P123DT22H14M12.
+     * @return a response with header values "P123DT22H14M12.011S".
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> responseDurationAsync(String scenario, Context context) {
@@ -2966,7 +2966,7 @@ public final class Headers {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return a response with header values "P123DT22H14M12.
+     * @return a response with header values "P123DT22H14M12.011S".
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public HeadersResponseDurationResponse responseDurationWithResponse(String scenario, Context context) {

--- a/vanilla-tests/src/main/java/fixtures/url/Paths.java
+++ b/vanilla-tests/src/main/java/fixtures/url/Paths.java
@@ -551,7 +551,7 @@ public final class Paths {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return '1.
+     * @return '1.034E+20' numeric value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> floatScientificPositiveWithResponseAsync() {
@@ -570,7 +570,7 @@ public final class Paths {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return '1.
+     * @return '1.034E+20' numeric value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> floatScientificPositiveAsync() {
@@ -593,7 +593,7 @@ public final class Paths {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return '-1.
+     * @return '-1.034E-20' numeric value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> floatScientificNegativeWithResponseAsync() {
@@ -612,7 +612,7 @@ public final class Paths {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return '-1.
+     * @return '-1.034E-20' numeric value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> floatScientificNegativeAsync() {
@@ -635,7 +635,7 @@ public final class Paths {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return '9999999.
+     * @return '9999999.999' numeric value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> doubleDecimalPositiveWithResponseAsync() {
@@ -654,7 +654,7 @@ public final class Paths {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return '9999999.
+     * @return '9999999.999' numeric value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> doubleDecimalPositiveAsync() {
@@ -677,7 +677,7 @@ public final class Paths {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return '-9999999.
+     * @return '-9999999.999' numeric value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> doubleDecimalNegativeWithResponseAsync() {
@@ -696,7 +696,7 @@ public final class Paths {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return '-9999999.
+     * @return '-9999999.999' numeric value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> doubleDecimalNegativeAsync() {

--- a/vanilla-tests/src/main/java/fixtures/url/Queries.java
+++ b/vanilla-tests/src/main/java/fixtures/url/Queries.java
@@ -836,7 +836,7 @@ public final class Queries {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return '1.
+     * @return '1.034E+20' numeric value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> floatScientificPositiveWithResponseAsync() {
@@ -855,7 +855,7 @@ public final class Queries {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return '1.
+     * @return '1.034E+20' numeric value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> floatScientificPositiveAsync() {
@@ -878,7 +878,7 @@ public final class Queries {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return '-1.
+     * @return '-1.034E-20' numeric value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> floatScientificNegativeWithResponseAsync() {
@@ -897,7 +897,7 @@ public final class Queries {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return '-1.
+     * @return '-1.034E-20' numeric value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> floatScientificNegativeAsync() {
@@ -991,7 +991,7 @@ public final class Queries {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return '9999999.
+     * @return '9999999.999' numeric value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> doubleDecimalPositiveWithResponseAsync() {
@@ -1010,7 +1010,7 @@ public final class Queries {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return '9999999.
+     * @return '9999999.999' numeric value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> doubleDecimalPositiveAsync() {
@@ -1033,7 +1033,7 @@ public final class Queries {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return '-9999999.
+     * @return '-9999999.999' numeric value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<Void>> doubleDecimalNegativeWithResponseAsync() {
@@ -1052,7 +1052,7 @@ public final class Queries {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return '-9999999.
+     * @return '-9999999.999' numeric value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> doubleDecimalNegativeAsync() {


### PR DESCRIPTION
Update javadoc on class to include `summary`.

E.g. (summary + description)
```
/**
 * Planned maintenance configuration, used to configure when updates can be deployed to a Managed Cluster. See [planned
 * maintenance](https://docs.microsoft.com/azure/aks/planned-maintenance) for more information about planned
 * maintenance.
 */
```