### PR TITLE
v4 fluent sample method for premium

### DIFF
--- a/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
@@ -174,7 +174,7 @@ public class FluentGen extends NewPlugin {
         Client client = Mappers.getClientMapper().map(codeModel);
 
         // samples for Fluent Premium
-        if (fluentJavaSettings.isGenerateSamples() && !settings.isFluentLite()) {
+        if (fluentJavaSettings.isGenerateSamples() && settings.isFluentPremium()) {
             FluentStatic.setClient(client);
             FluentStatic.setFluentJavaSettings(fluentJavaSettings);
             fluentPremiumExamples = client.getServiceClient().getMethodGroupClients().stream()

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
@@ -11,6 +11,7 @@ import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.extension.base.plugin.NewPlugin;
 import com.azure.autorest.extension.base.plugin.PluginLogger;
 import com.azure.autorest.fluent.checker.JavaFormatter;
+import com.azure.autorest.fluent.mapper.ExampleParser;
 import com.azure.autorest.fluent.mapper.FluentMapper;
 import com.azure.autorest.fluent.mapper.FluentMapperFactory;
 import com.azure.autorest.fluent.mapper.PomMapper;
@@ -66,6 +67,8 @@ public class FluentGen extends NewPlugin {
 
     private FluentJavaSettings fluentJavaSettings;
     private FluentMapper fluentMapper;
+
+    private List<FluentExample> fluentPremiumExamples;
 
     public FluentGen(Connection connection, String plugin, String sessionId) {
         super(connection, plugin, sessionId);
@@ -161,12 +164,25 @@ public class FluentGen extends NewPlugin {
     }
 
     Client handleMap(CodeModel codeModel) {
+        JavaSettings settings = JavaSettings.getInstance();
+
         FluentMapper fluentMapper = this.getFluentMapper();
 
         logger.info("Map code model to client model");
         fluentMapper.preModelMap(codeModel);
 
         Client client = Mappers.getClientMapper().map(codeModel);
+
+        // samples for Fluent Premium
+        if (fluentJavaSettings.isGenerateSamples() && !settings.isFluentLite()) {
+            FluentStatic.setClient(client);
+            FluentStatic.setFluentJavaSettings(fluentJavaSettings);
+            fluentPremiumExamples = client.getServiceClient().getMethodGroupClients().stream()
+                    .flatMap(rc -> ExampleParser.parserMethodGroup(rc).stream())
+                    .sorted()
+                    .collect(Collectors.toList());
+        }
+
         return client;
     }
 
@@ -246,6 +262,13 @@ public class FluentGen extends NewPlugin {
         // Package-info
         for (PackageInfo packageInfo : client.getPackageInfos()) {
             javaPackage.addPackageInfo(packageInfo.getPackage(), "package-info", packageInfo);
+        }
+
+        // Samples
+        if (fluentPremiumExamples != null) {
+            for (FluentExample example : fluentPremiumExamples) {
+                javaPackage.addSample(example);
+            }
         }
 
         return javaPackage;

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/ExampleParser.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/ExampleParser.java
@@ -17,7 +17,6 @@ import com.azure.autorest.fluent.model.clientmodel.MethodParameter;
 import com.azure.autorest.fluent.model.clientmodel.ModelProperty;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.ClientModelNode;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.ExampleNode;
-import com.azure.autorest.fluent.model.clientmodel.examplemodel.FluentBaseExample;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.FluentCollectionMethodExample;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.FluentResourceCreateExample;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.FluentResourceUpdateExample;
@@ -25,6 +24,7 @@ import com.azure.autorest.fluent.model.clientmodel.examplemodel.ListNode;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.LiteralNode;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.MapNode;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.ObjectNode;
+import com.azure.autorest.fluent.model.clientmodel.examplemodel.ParameterExample;
 import com.azure.autorest.fluent.model.clientmodel.fluentmodel.create.DefinitionStage;
 import com.azure.autorest.fluent.model.clientmodel.fluentmodel.create.DefinitionStageBlank;
 import com.azure.autorest.fluent.model.clientmodel.fluentmodel.create.DefinitionStageCreate;
@@ -158,7 +158,7 @@ public class ExampleParser {
                 }
             }
 
-            FluentCollectionMethodExample.ParameterExample parameterExample = new FluentBaseExample.ParameterExample(node);
+            ParameterExample parameterExample = new ParameterExample(node);
             collectionMethodExample.getParameters().add(parameterExample);
         }
 
@@ -206,7 +206,7 @@ public class ExampleParser {
                             logger.warn("Failed to assign sample value to define method '{}'", defineMethod.getName());
                         }
                     }
-                    resourceCreateExample.getParameters().add(new FluentBaseExample.ParameterExample(defineMethod, defineNode));
+                    resourceCreateExample.getParameters().add(new ParameterExample(defineMethod, defineNode));
 
                     for (DefinitionStage stage : resourceCreate.getDefinitionStages()) {
                         List<FluentMethod> fluentMethods = stage.getMethods();
@@ -249,7 +249,7 @@ public class ExampleParser {
                             }
 
                             if (!exampleNodes.isEmpty()) {
-                                resourceCreateExample.getParameters().add(new FluentBaseExample.ParameterExample(fluentMethod, exampleNodes));
+                                resourceCreateExample.getParameters().add(new ParameterExample(fluentMethod, exampleNodes));
                             }
                         }
                     }
@@ -333,7 +333,7 @@ public class ExampleParser {
                             }
 
                             if (!exampleNodes.isEmpty()) {
-                                resourceUpdateExample.getParameters().add(new FluentBaseExample.ParameterExample(fluentMethod, exampleNodes));
+                                resourceUpdateExample.getParameters().add(new ParameterExample(fluentMethod, exampleNodes));
                             }
                         }
                     }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/ExampleParser.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/ExampleParser.java
@@ -177,7 +177,7 @@ public class ExampleParser {
 
             List<MethodParameter> methodParameters = getParameters(clientMethod);
             for (Map.Entry<String, ProxyMethodExample> entry : clientMethod.getProxyMethod().getExamples().entrySet()) {
-                logger.info("Parse collection method example '{}'", entry.getKey());
+                logger.info("Parse client method example '{}'", entry.getKey());
 
                 FluentClientMethodExample collectionMethodExample =
                         parseMethodForExample(methodGroup, clientMethod, methodParameters, entry.getKey(), entry.getValue());

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/ExampleParser.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/ExampleParser.java
@@ -17,6 +17,7 @@ import com.azure.autorest.fluent.model.clientmodel.MethodParameter;
 import com.azure.autorest.fluent.model.clientmodel.ModelProperty;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.ClientModelNode;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.ExampleNode;
+import com.azure.autorest.fluent.model.clientmodel.examplemodel.FluentClientMethodExample;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.FluentCollectionMethodExample;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.FluentResourceCreateExample;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.FluentResourceUpdateExample;
@@ -46,6 +47,7 @@ import com.azure.autorest.model.clientmodel.ClientModel;
 import com.azure.autorest.model.clientmodel.IType;
 import com.azure.autorest.model.clientmodel.ListType;
 import com.azure.autorest.model.clientmodel.MapType;
+import com.azure.autorest.model.clientmodel.MethodGroupClient;
 import com.azure.autorest.model.clientmodel.ProxyMethodExample;
 import com.azure.autorest.model.clientmodel.ProxyMethodParameter;
 import com.azure.autorest.util.CodeNamer;
@@ -69,6 +71,25 @@ import java.util.stream.Collectors;
 public class ExampleParser {
 
     private static final Logger logger = new PluginLogger(FluentGen.getPluginInstance(), ExampleParser.class);
+
+    public static List<FluentExample> parserMethodGroup(MethodGroupClient methodGroup) {
+        List<FluentClientMethodExample> methodExamples = new ArrayList<>();
+
+        methodGroup.getClientMethods().forEach(m -> {
+            List<FluentClientMethodExample> examples = ExampleParser.parseMethod(methodGroup, m);
+            if (examples != null) {
+                methodExamples.addAll(examples);
+            }
+        });
+
+        Map<String, FluentExample> examples = new HashMap<>();
+        methodExamples.forEach(e -> {
+            FluentExample example = getExample(examples, e.getMethodGroup(), e.getClientMethod());
+            example.getClientMethodExamples().add(e);
+        });
+
+        return new ArrayList<>(examples.values());
+    }
 
     public static List<FluentExample> parseResourceCollection(FluentResourceCollection resourceCollection) {
         List<FluentCollectionMethodExample> methodExamples = new ArrayList<>();
@@ -113,8 +134,13 @@ public class ExampleParser {
 
     private static FluentExample getExample(Map<String, FluentExample> examples,
                                             FluentResourceCollection resourceCollection, FluentCollectionMethod collectionMethod) {
-        String groupName = resourceCollection.getInnerGroupClient().getClassBaseName();
-        String methodName = collectionMethod.getInnerProxyMethod().getName();
+        return getExample(examples, resourceCollection.getInnerGroupClient(), collectionMethod.getInnerClientMethod());
+    }
+
+    private static FluentExample getExample(Map<String, FluentExample> examples,
+                                            MethodGroupClient methodGroup, ClientMethod clientMethod) {
+        String groupName = methodGroup.getClassBaseName();
+        String methodName = clientMethod.getProxyMethod().getName();
         String name = CodeNamer.toPascalCase(groupName) + CodeNamer.toPascalCase(methodName);
         FluentExample example = examples.get(name);
         if (example == null) {
@@ -143,11 +169,50 @@ public class ExampleParser {
         return ret;
     }
 
+    private static List<FluentClientMethodExample> parseMethod(MethodGroupClient methodGroup, ClientMethod clientMethod) {
+        List<FluentClientMethodExample> ret = null;
+
+        if (clientMethod.getProxyMethod().getExamples() != null && requiresExample(clientMethod)) {
+            ret = new ArrayList<>();
+
+            List<MethodParameter> methodParameters = getParameters(clientMethod);
+            for (Map.Entry<String, ProxyMethodExample> entry : clientMethod.getProxyMethod().getExamples().entrySet()) {
+                logger.info("Parse collection method example '{}'", entry.getKey());
+
+                FluentClientMethodExample collectionMethodExample =
+                        parseMethodForExample(methodGroup, clientMethod, methodParameters, entry.getKey(), entry.getValue());
+                ret.add(collectionMethodExample);
+            }
+        }
+        return ret;
+    }
+
     private static FluentCollectionMethodExample parseMethodForExample(FluentResourceCollection collection, FluentCollectionMethod collectionMethod,
                                                                        List<MethodParameter> methodParameters,
                                                                        String exampleName, ProxyMethodExample proxyMethodExample) {
         FluentCollectionMethodExample collectionMethodExample = new FluentCollectionMethodExample(exampleName,
                 FluentStatic.getFluentManager(), collection, collectionMethod);
+
+        for (MethodParameter methodParameter : methodParameters) {
+            ExampleNode node = parseNodeFromParameter(proxyMethodExample, methodParameter);
+
+            if (node.getObjectValue() == null) {
+                if (methodParameter.getClientMethodParameter().getIsRequired()) {
+                    logger.warn("Failed to assign sample value to required parameter '{}'", methodParameter.getClientMethodParameter().getName());
+                }
+            }
+
+            ParameterExample parameterExample = new ParameterExample(node);
+            collectionMethodExample.getParameters().add(parameterExample);
+        }
+
+        return collectionMethodExample;
+    }
+
+    private static FluentClientMethodExample parseMethodForExample(MethodGroupClient methodGroup, ClientMethod clientMethod,
+                                                                       List<MethodParameter> methodParameters,
+                                                                       String exampleName, ProxyMethodExample proxyMethodExample) {
+        FluentClientMethodExample collectionMethodExample = new FluentClientMethodExample(exampleName,methodGroup, clientMethod);
 
         for (MethodParameter methodParameter : methodParameters) {
             ExampleNode node = parseNodeFromParameter(proxyMethodExample, methodParameter);

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentExample.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentExample.java
@@ -5,6 +5,7 @@
 
 package com.azure.autorest.fluent.model.clientmodel;
 
+import com.azure.autorest.fluent.model.clientmodel.examplemodel.FluentClientMethodExample;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.FluentCollectionMethodExample;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.FluentResourceCreateExample;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.FluentResourceUpdateExample;
@@ -21,6 +22,8 @@ public class FluentExample implements Comparable<FluentExample> {
     private final List<FluentResourceCreateExample> resourceCreateExamples = new ArrayList<>();
     private final List<FluentResourceUpdateExample> resourceUpdateExamples = new ArrayList<>();
 
+    private final List<FluentClientMethodExample> clientMethodExamples = new ArrayList<>();
+
     public FluentExample(String groupName, String methodName) {
         this.groupName = groupName;
         this.methodName = methodName;
@@ -36,6 +39,10 @@ public class FluentExample implements Comparable<FluentExample> {
 
     public List<FluentResourceUpdateExample> getResourceUpdateExamples() {
         return resourceUpdateExamples;
+    }
+
+    public List<FluentClientMethodExample> getClientMethodExamples() {
+        return clientMethodExamples;
     }
 
     public String getGroupName() {

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentBaseExample.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentBaseExample.java
@@ -7,54 +7,17 @@ package com.azure.autorest.fluent.model.clientmodel.examplemodel;
 
 import com.azure.autorest.fluent.model.clientmodel.FluentManager;
 import com.azure.autorest.fluent.model.clientmodel.FluentResourceCollection;
-import com.azure.autorest.fluent.model.clientmodel.fluentmodel.method.FluentMethod;
+import com.azure.autorest.model.clientmodel.ClassType;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
-public class FluentBaseExample {
+public abstract class FluentBaseExample implements FluentExample {
 
     private final String name;
     private final FluentManager manager;
     private final FluentResourceCollection collection;
     private final List<ParameterExample> parameters = new ArrayList<>();
-
-    public static class ParameterExample {
-        private final FluentMethod fluentMethod;
-        private final List<ExampleNode> exampleNodes = new ArrayList<>();
-
-        public ParameterExample(FluentMethod fluentMethod, Collection<ExampleNode> exampleNodeIterator) {
-            this.fluentMethod = fluentMethod;
-            exampleNodes.addAll(exampleNodeIterator);
-        }
-
-        public ParameterExample(FluentMethod fluentMethod, ExampleNode exampleNode) {
-            this.fluentMethod = fluentMethod;
-            if (exampleNode != null) {
-                this.exampleNodes.add(exampleNode);
-            }
-        }
-
-        public ParameterExample(ExampleNode exampleNode) {
-            this.fluentMethod = null;
-            if (exampleNode != null) {
-                this.exampleNodes.add(exampleNode);
-            }
-        }
-
-        public FluentMethod getFluentMethod() {
-            return fluentMethod;
-        }
-
-        public List<ExampleNode> getExampleNodes() {
-            return exampleNodes;
-        }
-
-        public ExampleNode getExampleNode() {
-            return exampleNodes.isEmpty() ? null : exampleNodes.iterator().next();
-        }
-    }
 
     public FluentBaseExample(String name, FluentManager manager, FluentResourceCollection collection) {
         this.name = name;
@@ -62,6 +25,7 @@ public class FluentBaseExample {
         this.collection = collection;
     }
 
+    @Override
     public String getName() {
         return name;
     }
@@ -70,10 +34,27 @@ public class FluentBaseExample {
         return manager;
     }
 
+
+    @Override
+    public ClassType getEntryType() {
+        return manager.getType();
+    }
+
+    @Override
+    public String getEntryName() {
+        return "manager";
+    }
+
+    @Override
+    public String getEntryDescription() {
+        return manager.getDescription();
+    }
+
     public FluentResourceCollection getResourceCollection() {
         return collection;
     }
 
+    @Override
     public List<ParameterExample> getParameters() {
         return parameters;
     }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentClientMethodExample.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentClientMethodExample.java
@@ -7,7 +7,9 @@ package com.azure.autorest.fluent.model.clientmodel.examplemodel;
 
 import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.fluent.model.FluentType;
+import com.azure.autorest.fluent.model.clientmodel.FluentStatic;
 import com.azure.autorest.fluent.model.clientmodel.ModelNaming;
+import com.azure.autorest.fluent.util.FluentJavaSettings;
 import com.azure.autorest.model.clientmodel.ClassType;
 import com.azure.autorest.model.clientmodel.ClientMethod;
 import com.azure.autorest.model.clientmodel.MethodGroupClient;
@@ -32,9 +34,17 @@ public class FluentClientMethodExample implements FluentMethodExample {
         this.clientMethod = clientMethod;
     }
 
+    public MethodGroupClient getMethodGroup() {
+        return methodGroup;
+    }
+
+    public ClientMethod getClientMethod() {
+        return clientMethod;
+    }
+
     @Override
     public String getName() {
-        return null;
+        return name;
     }
 
     @Override
@@ -67,8 +77,23 @@ public class FluentClientMethodExample implements FluentMethodExample {
             throw new IllegalStateException("Package '" + namespace + "' is not supported by Fluent Premium");
         }
 
-        String managerReference = MANAGER_REFERENCE.get(lastIdentifier) + "()";
-        String serviceClientReference = ModelNaming.METHOD_SERVICE_CLIENT + "()";   // TODO resources contains multiple service client reference
+        String managerReference = MANAGER_REFERENCE.get(lastIdentifier) + "." + ModelNaming.METHOD_MANAGER + "()";
+        String serviceClientReference = ModelNaming.METHOD_SERVICE_CLIENT + "()";
+        if ("authorization".equals(lastIdentifier)) {
+            serviceClientReference = "roleServiceClient()";
+        } else if ("resources".equals(lastIdentifier)) {
+            String tag = FluentStatic.getFluentJavaSettings().getAutorestSettings().getTag();
+            if (tag.contains("feature")) {
+                serviceClientReference = "featureClient()";
+            } else if (tag.contains("policy")) {
+                serviceClientReference = "policyClient()";
+            } else if (tag.contains("subscriptions")) {
+                serviceClientReference = "subscriptionClient()";
+            } else if (tag.contains("locks")) {
+                serviceClientReference = "managementLockClient()";
+            }
+        }
+
         String methodGroupReference =  "get" + CodeNamer.toPascalCase(methodGroup.getVariableName()) + "()";
         return managerReference + "." + serviceClientReference + "." + methodGroupReference;
     }
@@ -80,6 +105,32 @@ public class FluentClientMethodExample implements FluentMethodExample {
 
     private final static Map<String, String> MANAGER_REFERENCE = new HashMap<>();
     static {
-        MANAGER_REFERENCE.put("containerservice", "kubernetesClusters");
+        MANAGER_REFERENCE.put("appplatform", "springServices()");
+        MANAGER_REFERENCE.put("appservice", "webApps()");
+        MANAGER_REFERENCE.put("authorization", "accessManagement().roleAssignments()");
+        MANAGER_REFERENCE.put("cdn", "cdnProfiles()");
+        MANAGER_REFERENCE.put("compute", "virtualMachines()");
+        MANAGER_REFERENCE.put("containerregistry", "containerRegistries()");
+        MANAGER_REFERENCE.put("containerinstance", "containerGroups()");
+        MANAGER_REFERENCE.put("cosmos", "cosmosDBAccounts()");
+        MANAGER_REFERENCE.put("dns", "dnsZones()");
+        MANAGER_REFERENCE.put("eventhubs", "eventHubs()");
+        MANAGER_REFERENCE.put("keyvault", "vaults()");
+        MANAGER_REFERENCE.put("monitor", "diagnosticSettings()");
+        MANAGER_REFERENCE.put("msi", "identities()");
+        MANAGER_REFERENCE.put("network", "networks()");
+        MANAGER_REFERENCE.put("privatedns", "privateDnsZones()");
+        MANAGER_REFERENCE.put("redis", "redisCaches()");
+        MANAGER_REFERENCE.put("resources", "genericResources()");
+        MANAGER_REFERENCE.put("search", "searchServices()");
+        MANAGER_REFERENCE.put("servicebus", "serviceBusNamespaces()");
+        MANAGER_REFERENCE.put("sql", "sqlServers()");
+        MANAGER_REFERENCE.put("storage", "storageAccounts()");
+        MANAGER_REFERENCE.put("trafficmanager", "trafficManagerProfiles()");
+    }
+
+    private final static Map<String, String> SERVICE_CLIENT_REFERENCE = new HashMap<>();
+    static {
+        SERVICE_CLIENT_REFERENCE.put("authorization", "roleServiceClient()");
     }
 }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentClientMethodExample.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentClientMethodExample.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.azure.autorest.fluent.model.clientmodel.examplemodel;
+
+import com.azure.autorest.extension.base.plugin.JavaSettings;
+import com.azure.autorest.fluent.model.FluentType;
+import com.azure.autorest.fluent.model.clientmodel.ModelNaming;
+import com.azure.autorest.model.clientmodel.ClassType;
+import com.azure.autorest.model.clientmodel.ClientMethod;
+import com.azure.autorest.model.clientmodel.MethodGroupClient;
+import com.azure.autorest.util.CodeNamer;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+public class FluentClientMethodExample implements FluentMethodExample {
+
+    private final String name;
+    private final MethodGroupClient methodGroup;
+    private final ClientMethod clientMethod;
+    private final List<ParameterExample> parameters = new ArrayList<>();
+
+    public FluentClientMethodExample(String name, MethodGroupClient methodGroup, ClientMethod clientMethod) {
+        this.name = name;
+        this.methodGroup = methodGroup;
+        this.clientMethod = clientMethod;
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+
+    @Override
+    public ClassType getEntryType() {
+        return FluentType.AzureResourceManager;
+    }
+
+    @Override
+    public String getEntryName() {
+        return "azure";
+    }
+
+    @Override
+    public String getEntryDescription() {
+        return "The entry point for accessing resource management APIs in Azure.";
+    }
+
+    @Override
+    public List<ParameterExample> getParameters() {
+        return parameters;
+    }
+
+    @Override
+    public String getMethodReference() {
+        String namespace = JavaSettings.getInstance().getPackage();
+        String[] identifiers = namespace.split(Pattern.quote("."));
+        String lastIdentifier = identifiers[identifiers.length - 1];
+
+        if (!MANAGER_REFERENCE.containsKey(lastIdentifier)) {
+            throw new IllegalStateException("Package '" + namespace + "' is not supported by Fluent Premium");
+        }
+
+        String managerReference = MANAGER_REFERENCE.get(lastIdentifier) + "()";
+        String serviceClientReference = ModelNaming.METHOD_SERVICE_CLIENT + "()";   // TODO resources contains multiple service client reference
+        String methodGroupReference =  "get" + CodeNamer.toPascalCase(methodGroup.getVariableName()) + "()";
+        return managerReference + "." + serviceClientReference + "." + methodGroupReference;
+    }
+
+    @Override
+    public String getMethodName() {
+        return clientMethod.getName();
+    }
+
+    private final static Map<String, String> MANAGER_REFERENCE = new HashMap<>();
+    static {
+        MANAGER_REFERENCE.put("containerservice", "kubernetesClusters");
+    }
+}

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentClientMethodExample.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentClientMethodExample.java
@@ -9,7 +9,6 @@ import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.fluent.model.FluentType;
 import com.azure.autorest.fluent.model.clientmodel.FluentStatic;
 import com.azure.autorest.fluent.model.clientmodel.ModelNaming;
-import com.azure.autorest.fluent.util.FluentJavaSettings;
 import com.azure.autorest.model.clientmodel.ClassType;
 import com.azure.autorest.model.clientmodel.ClientMethod;
 import com.azure.autorest.model.clientmodel.MethodGroupClient;
@@ -21,6 +20,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+/**
+ * Model of example for service client method (usually for Fluent Premium).
+ */
 public class FluentClientMethodExample implements FluentMethodExample {
 
     private final String name;
@@ -127,10 +129,5 @@ public class FluentClientMethodExample implements FluentMethodExample {
         MANAGER_REFERENCE.put("sql", "sqlServers()");
         MANAGER_REFERENCE.put("storage", "storageAccounts()");
         MANAGER_REFERENCE.put("trafficmanager", "trafficManagerProfiles()");
-    }
-
-    private final static Map<String, String> SERVICE_CLIENT_REFERENCE = new HashMap<>();
-    static {
-        SERVICE_CLIENT_REFERENCE.put("authorization", "roleServiceClient()");
     }
 }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentCollectionMethodExample.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentCollectionMethodExample.java
@@ -8,11 +8,12 @@ package com.azure.autorest.fluent.model.clientmodel.examplemodel;
 import com.azure.autorest.fluent.model.clientmodel.FluentCollectionMethod;
 import com.azure.autorest.fluent.model.clientmodel.FluentManager;
 import com.azure.autorest.fluent.model.clientmodel.FluentResourceCollection;
+import com.azure.autorest.util.CodeNamer;
 
 /**
  * Model of example for FluentCollectionMethod.
  */
-public class FluentCollectionMethodExample extends FluentBaseExample {
+public class FluentCollectionMethodExample extends FluentBaseExample implements FluentMethodExample {
 
     private final FluentCollectionMethod collectionMethod;
 
@@ -24,5 +25,15 @@ public class FluentCollectionMethodExample extends FluentBaseExample {
 
     public FluentCollectionMethod getCollectionMethod() {
         return collectionMethod;
+    }
+
+    @Override
+    public String getMethodReference() {
+        return CodeNamer.toCamelCase(this.getResourceCollection().getInterfaceType().getName()) + "()";
+    }
+
+    @Override
+    public String getMethodName() {
+        return collectionMethod.getMethodName();
     }
 }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentExample.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentExample.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.azure.autorest.fluent.model.clientmodel.examplemodel;
+
+import com.azure.autorest.model.clientmodel.ClassType;
+
+import java.util.List;
+
+public interface FluentExample {
+
+    String getName();
+
+    ClassType getEntryType();
+
+    String getEntryName();
+
+    String getEntryDescription();
+
+    List<ParameterExample> getParameters();
+}

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentExample.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentExample.java
@@ -9,15 +9,33 @@ import com.azure.autorest.model.clientmodel.ClassType;
 
 import java.util.List;
 
+/**
+ * Basic info for Fluent samples.
+ */
 public interface FluentExample {
 
+    /**
+     * @return the name of the sample.
+     */
     String getName();
 
+    /**
+     * @return the type of the entry (usually a {@link com.azure.autorest.fluent.model.clientmodel.FluentManager}).
+     */
     ClassType getEntryType();
 
+    /**
+     * @return the name of the entry.
+     */
     String getEntryName();
 
+    /**
+     * @return the description of the entry.
+     */
     String getEntryDescription();
 
+    /**
+     * @return the list of parameters used in the sample.
+     */
     List<ParameterExample> getParameters();
 }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentMethodExample.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentMethodExample.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.azure.autorest.fluent.model.clientmodel.examplemodel;
+
+public interface FluentMethodExample extends FluentExample {
+
+    /**
+     * Gets the reference from entry class to the method.
+     *
+     * E.g. "deployments()" for collection method from Fluent Lite,
+     * or "serviceClient().getDeployments()" for service client method from Fluent Premium.
+     *
+     * This method is used together with {@link FluentExample#getEntryType()}.
+     *
+     * @return the reference from entry class to the method.
+     */
+    String getMethodReference();
+
+    String getMethodName();
+}

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentMethodExample.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentMethodExample.java
@@ -5,6 +5,9 @@
 
 package com.azure.autorest.fluent.model.clientmodel.examplemodel;
 
+/**
+ * Basic info for Fluent samples with method call.
+ */
 public interface FluentMethodExample extends FluentExample {
 
     /**
@@ -19,5 +22,8 @@ public interface FluentMethodExample extends FluentExample {
      */
     String getMethodReference();
 
+    /**
+     * @return the method name (of the resource collection method, or the client method).
+     */
     String getMethodName();
 }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/ParameterExample.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/ParameterExample.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.azure.autorest.fluent.model.clientmodel.examplemodel;
+
+import com.azure.autorest.fluent.model.clientmodel.fluentmodel.method.FluentMethod;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class ParameterExample {
+    private final FluentMethod fluentMethod;
+    private final List<ExampleNode> exampleNodes = new ArrayList<>();
+
+    public ParameterExample(FluentMethod fluentMethod, Collection<ExampleNode> exampleNodeIterator) {
+        this.fluentMethod = fluentMethod;
+        exampleNodes.addAll(exampleNodeIterator);
+    }
+
+    public ParameterExample(FluentMethod fluentMethod, ExampleNode exampleNode) {
+        this.fluentMethod = fluentMethod;
+        if (exampleNode != null) {
+            this.exampleNodes.add(exampleNode);
+        }
+    }
+
+    public ParameterExample(ExampleNode exampleNode) {
+        this.fluentMethod = null;
+        if (exampleNode != null) {
+            this.exampleNodes.add(exampleNode);
+        }
+    }
+
+    public FluentMethod getFluentMethod() {
+        return fluentMethod;
+    }
+
+    public List<ExampleNode> getExampleNodes() {
+        return exampleNodes;
+    }
+
+    public ExampleNode getExampleNode() {
+        return exampleNodes.isEmpty() ? null : exampleNodes.iterator().next();
+    }
+}

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/create/ResourceCreate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/create/ResourceCreate.java
@@ -318,7 +318,7 @@ public class ResourceCreate extends ResourceOperation {
         if (resourceNamePathParameter.isPresent()) {
             return resourceNamePathParameter.get().getIsConstant() || resourceNamePathParameter.get().getFromClient();
         } else {
-            throw new IllegalStateException(String.format("resource name parameter not found in proxy method %1$s, name segment %2$s",
+            throw new IllegalStateException(String.format("Resource name parameter not found in proxy method %1$s, name segment %2$s",
                     proxyMethod.getName(), parameterName));
         }
     }
@@ -334,7 +334,7 @@ public class ResourceCreate extends ResourceOperation {
             return pathParameter.get();
         } else {
             FluentCollectionMethod method = this.getMethodReferencesOfFullParameters().iterator().next();
-            throw new IllegalStateException(String.format("resource name parameter not found in client method %1$s, name segment %2$s",
+            throw new IllegalStateException(String.format("Resource name parameter not found in client method %1$s, name segment %2$s",
                     method.getInnerClientMethod().getName(), parameterName));
         }
     }
@@ -395,7 +395,7 @@ public class ResourceCreate extends ResourceOperation {
             }
         }
         if (resourceNameOfImmediateParent == null) {
-            throw new IllegalStateException(String.format("resource name of immediate parent not found for url %1$s, model %2$s, candidate parameter names %3$s",
+            throw new IllegalStateException(String.format("Resource name of immediate parent not found for url %1$s, model %2$s, candidate parameter names %3$s",
                     urlPathSegments.getPath(), resourceModel.getName(), serializedParameterNames));
         }
         // if parent is resourceGroup, just set it as such
@@ -420,7 +420,7 @@ public class ResourceCreate extends ResourceOperation {
                     parameters, this.getResourceLocalVariables(),
                     resourceCollection, methodOpt.get());
         } else {
-            throw new IllegalStateException("create method not found on model " + resourceModel.getName());
+            throw new IllegalStateException("Create method not found on model " + resourceModel.getName());
         }
     }
 

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/get/ResourceRefresh.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/get/ResourceRefresh.java
@@ -73,7 +73,7 @@ public class ResourceRefresh extends ResourceOperation {
                     resourceCollection, methodOpt.get(),
                     resourceModel.getResourceCreate().getResourceLocalVariables());
         } else {
-            throw new IllegalStateException("refresh method not found on model " + resourceModel.getName());
+            throw new IllegalStateException("Refresh method not found on model " + resourceModel.getName());
         }
     }
 

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/update/ResourceUpdate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/update/ResourceUpdate.java
@@ -225,7 +225,7 @@ public class ResourceUpdate extends ResourceOperation {
                     resourceCollection, methodOpt.get(),
                     resourceModel.getResourceCreate().getResourceLocalVariables());
         } else {
-            throw new IllegalStateException("update method not found on model " + resourceModel.getName());
+            throw new IllegalStateException("Update method not found on model " + resourceModel.getName());
         }
     }
 

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentExampleTemplate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentExampleTemplate.java
@@ -67,6 +67,10 @@ public class FluentExampleTemplate {
                 example.getCollectionMethodExamples().stream()
                         .map(this::generateExampleMethod)
                         .collect(Collectors.toList()));
+        exampleMethods.addAll(
+                example.getClientMethodExamples().stream()
+                        .map(this::generateExampleMethod)
+                        .collect(Collectors.toList()));
 
         Set<String> imports = exampleMethods.stream().flatMap(em -> em.getImports().stream()).collect(Collectors.toSet());
         javaFile.declareImport(imports);
@@ -109,25 +113,25 @@ public class FluentExampleTemplate {
         });
     }
 
-    private ExampleMethod generateExampleMethod(FluentMethodExample collectionMethodExample) {
-        String methodName = CodeNamer.toCamelCase(CodeNamer.removeInvalidCharacters(collectionMethodExample.getName()));
-        String managerName = collectionMethodExample.getEntryName();
+    private ExampleMethod generateExampleMethod(FluentMethodExample methodExample) {
+        String methodName = CodeNamer.toCamelCase(CodeNamer.removeInvalidCharacters(methodExample.getName()));
+        String managerName = methodExample.getEntryName();
 
         ExampleNodeVisitor visitor = new ExampleNodeVisitor();
-        String parameterInvocations = collectionMethodExample.getParameters().stream()
+        String parameterInvocations = methodExample.getParameters().stream()
                 .map(p -> visitor.accept(p.getExampleNode()))
                 .collect(Collectors.joining(", "));
 
         String snippet = String.format("%1$s.%2$s.%3$s(%4$s);",
                 managerName,
-                collectionMethodExample.getMethodReference(),
-                collectionMethodExample.getMethodName(),
+                methodExample.getMethodReference(),
+                methodExample.getMethodName(),
                 parameterInvocations);
 
         ExampleMethod exampleMethod = new ExampleMethod()
-                .setExample(collectionMethodExample)
+                .setExample(methodExample)
                 .setImports(visitor.imports)
-                .setMethodSignature(String.format("void %1$s(%2$s %3$s)", methodName, FluentStatic.getFluentManager().getType().getFullName(), managerName))
+                .setMethodSignature(String.format("void %1$s(%2$s %3$s)", methodName, methodExample.getEntryType().getFullName(), managerName))
                 .setMethodContent(snippet)
                 .setHelperFeatures(visitor.helperFeatures);
         return exampleMethod;

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentExampleTemplate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentExampleTemplate.java
@@ -7,19 +7,20 @@ package com.azure.autorest.fluent.template;
 
 import com.azure.autorest.extension.base.plugin.PluginLogger;
 import com.azure.autorest.fluent.FluentGen;
-import com.azure.autorest.fluent.model.clientmodel.FluentExample;
 import com.azure.autorest.fluent.model.clientmodel.FluentStatic;
 import com.azure.autorest.fluent.model.clientmodel.ModelProperty;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.ClientModelNode;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.ExampleNode;
-import com.azure.autorest.fluent.model.clientmodel.examplemodel.FluentBaseExample;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.FluentCollectionMethodExample;
+import com.azure.autorest.fluent.model.clientmodel.examplemodel.FluentExample;
+import com.azure.autorest.fluent.model.clientmodel.examplemodel.FluentMethodExample;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.FluentResourceCreateExample;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.FluentResourceUpdateExample;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.ListNode;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.LiteralNode;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.MapNode;
 import com.azure.autorest.fluent.model.clientmodel.examplemodel.ObjectNode;
+import com.azure.autorest.fluent.model.clientmodel.examplemodel.ParameterExample;
 import com.azure.autorest.model.clientmodel.ClassType;
 import com.azure.autorest.model.clientmodel.ClientModel;
 import com.azure.autorest.model.clientmodel.PrimitiveType;
@@ -50,7 +51,7 @@ public class FluentExampleTemplate {
         return INSTANCE;
     }
 
-    public final void write(FluentExample example, JavaFile javaFile) {
+    public final void write(com.azure.autorest.fluent.model.clientmodel.FluentExample example, JavaFile javaFile) {
         String className = example.getClassName();
 
         List<ExampleMethod> exampleMethods = new ArrayList<>();
@@ -79,8 +80,8 @@ public class FluentExampleTemplate {
             for (ExampleMethod exampleMethod : exampleMethods) {
                 classBlock.javadocComment(commentBlock -> {
                     commentBlock.description(String.format("Sample code: %1$s", exampleMethod.getExample().getName()));
-                    commentBlock.param(CodeNamer.toCamelCase(exampleMethod.getExample().getManager().getType().getName()),
-                            exampleMethod.getExample().getManager().getDescription());
+                    commentBlock.param(exampleMethod.getExample().getEntryName(),
+                            exampleMethod.getExample().getEntryDescription());
                 });
                 String methodSignature = exampleMethod.getMethodSignature();
                 if (exampleMethod.getHelperFeatures().contains(HelperFeature.ThrowsIOException)) {
@@ -108,19 +109,19 @@ public class FluentExampleTemplate {
         });
     }
 
-    private ExampleMethod generateExampleMethod(FluentCollectionMethodExample collectionMethodExample) {
+    private ExampleMethod generateExampleMethod(FluentMethodExample collectionMethodExample) {
         String methodName = CodeNamer.toCamelCase(CodeNamer.removeInvalidCharacters(collectionMethodExample.getName()));
-        String managerName = CodeNamer.toCamelCase(collectionMethodExample.getManager().getType().getName());
+        String managerName = collectionMethodExample.getEntryName();
 
         ExampleNodeVisitor visitor = new ExampleNodeVisitor();
         String parameterInvocations = collectionMethodExample.getParameters().stream()
                 .map(p -> visitor.accept(p.getExampleNode()))
                 .collect(Collectors.joining(", "));
 
-        String snippet = String.format("%1$s.%2$s().%3$s(%4$s);",
+        String snippet = String.format("%1$s.%2$s.%3$s(%4$s);",
                 managerName,
-                CodeNamer.toCamelCase(collectionMethodExample.getResourceCollection().getInterfaceType().getName()),
-                collectionMethodExample.getCollectionMethod().getMethodName(),
+                collectionMethodExample.getMethodReference(),
+                collectionMethodExample.getMethodName(),
                 parameterInvocations);
 
         ExampleMethod exampleMethod = new ExampleMethod()
@@ -134,12 +135,12 @@ public class FluentExampleTemplate {
 
     private ExampleMethod generateExampleMethod(FluentResourceCreateExample resourceCreateExample) {
         String methodName = CodeNamer.toCamelCase(CodeNamer.removeInvalidCharacters(resourceCreateExample.getName()));
-        String managerName = CodeNamer.toCamelCase(resourceCreateExample.getManager().getType().getName());
+        String managerName = resourceCreateExample.getEntryName();
 
         ExampleNodeVisitor visitor = new ExampleNodeVisitor();
         StringBuilder sb = new StringBuilder(managerName)
                 .append(".").append(CodeNamer.toCamelCase(resourceCreateExample.getResourceCollection().getInterfaceType().getName())).append("()");
-        for (FluentResourceCreateExample.ParameterExample parameter : resourceCreateExample.getParameters()) {
+        for (ParameterExample parameter : resourceCreateExample.getParameters()) {
             String parameterInvocations = parameter.getExampleNodes().stream()
                     .map(visitor::accept)
                     .collect(Collectors.joining(", "));
@@ -165,7 +166,7 @@ public class FluentExampleTemplate {
 
     private ExampleMethod generateExampleMethod(FluentResourceUpdateExample resourceUpdateExample) {
         String methodName = CodeNamer.toCamelCase(CodeNamer.removeInvalidCharacters(resourceUpdateExample.getName()));
-        String managerName = CodeNamer.toCamelCase(resourceUpdateExample.getManager().getType().getName());
+        String managerName = resourceUpdateExample.getEntryName();
 
         ExampleNodeVisitor visitor = new ExampleNodeVisitor();
 
@@ -184,7 +185,7 @@ public class FluentExampleTemplate {
 
         StringBuilder sb = new StringBuilder(resourceGetSnippet);
         sb.append("resource").append(".update()");
-        for (FluentResourceCreateExample.ParameterExample parameter : resourceUpdateExample.getParameters()) {
+        for (ParameterExample parameter : resourceUpdateExample.getParameters()) {
             parameterInvocations = parameter.getExampleNodes().stream()
                     .map(visitor::accept)
                     .collect(Collectors.joining(", "));
@@ -312,17 +313,17 @@ public class FluentExampleTemplate {
     }
 
     private static class ExampleMethod {
-        private FluentBaseExample example;
+        private FluentExample example;
         private Set<String> imports;
         private String methodSignature;
         private String methodContent;
         private Set<HelperFeature> helperFeatures;
 
-        public FluentBaseExample getExample() {
+        public FluentExample getExample() {
             return example;
         }
 
-        public ExampleMethod setExample(FluentBaseExample example) {
+        public ExampleMethod setExample(FluentExample example) {
             this.example = example;
             return this;
         }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/util/FluentUtils.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/util/FluentUtils.java
@@ -307,7 +307,7 @@ public class FluentUtils {
             // local variables
             LocalVariable localVariable = localVariables.getLocalVariableByMethodParameter(parameter);
             if (localVariable == null) {
-                throw new IllegalStateException(String.format("local variable not found for method %1$s, model %2$s, parameter %3$s, available local variables %4$s",
+                throw new IllegalStateException(String.format("Local variable not found for method %1$s, model %2$s, parameter %3$s, available local variables %4$s",
                         collectionMethod.getMethodName(),
                         resourceModel.getName(),
                         parameter.getName(),

--- a/fluentgen/src/test/java/com/azure/autorest/fluent/template/FluentExampleTests.java
+++ b/fluentgen/src/test/java/com/azure/autorest/fluent/template/FluentExampleTests.java
@@ -89,7 +89,7 @@ public class FluentExampleTests {
             FluentExampleTemplate.getInstance().write(example, javaFile);
             String content = javaFile.getContents().toString();
             // get
-            Assertions.assertTrue(content.contains("storageManager.storageAccounts().getByResourceGroup"));
+            Assertions.assertTrue(content.contains("manager.storageAccounts().getByResourceGroup"));
             // update
             Assertions.assertTrue(content.contains("resource.update()"));
             // apply

--- a/fluentnamer/src/main/java/com/azure/autorest/fluent/model/FluentType.java
+++ b/fluentnamer/src/main/java/com/azure/autorest/fluent/model/FluentType.java
@@ -27,7 +27,7 @@ public class FluentType {
 
     public static final ClassType SystemData = new ClassType.Builder().knownClass(com.azure.core.management.SystemData.class).build();
 
-    //public static final ClassType AzureResourceManager = new ClassType.Builder().packageName("com.azure.resourcemanager").name("AzureResourceManager").build();
+    public static final ClassType AzureResourceManager = new ClassType.Builder().packageName("com.azure.resourcemanager").name("AzureResourceManager").build();
 
     private FluentType() {
     }

--- a/fluentnamer/src/main/java/com/azure/autorest/fluent/model/FluentType.java
+++ b/fluentnamer/src/main/java/com/azure/autorest/fluent/model/FluentType.java
@@ -27,6 +27,8 @@ public class FluentType {
 
     public static final ClassType SystemData = new ClassType.Builder().knownClass(com.azure.core.management.SystemData.class).build();
 
+    //public static final ClassType AzureResourceManager = new ClassType.Builder().packageName("com.azure.resourcemanager").name("AzureResourceManager").build();
+
     private FluentType() {
     }
 


### PR DESCRIPTION
It would require `flatten-payload=false`

sample code

```
// Copyright (c) Microsoft Corporation. All rights reserved.
// Licensed under the MIT License.
// Code generated by Microsoft (R) AutoRest Code Generator.

package com.azure.resourcemanager.resources;

import com.azure.core.management.serializer.SerializerFactory;
import com.azure.core.util.Context;
import com.azure.core.util.serializer.SerializerEncoding;
import com.azure.resourcemanager.resources.fluent.models.PolicyAssignmentInner;
import com.azure.resourcemanager.resources.models.EnforcementMode;
import com.azure.resourcemanager.resources.models.Identity;
import com.azure.resourcemanager.resources.models.NonComplianceMessage;
import com.azure.resourcemanager.resources.models.ParameterValuesValue;
import com.azure.resourcemanager.resources.models.ResourceIdentityType;

import java.io.IOException;
import java.util.Arrays;
import java.util.HashMap;
import java.util.Map;

/** Samples for PolicyAssignments Create. */
public final class PolicyAssignmentsCreateSamples {
    /**
     * Sample code: Create or update a policy assignment.
     *
     * @param azure The entry point for accessing resource management APIs in Azure.
     */
    public static void createOrUpdateAPolicyAssignment(com.azure.resourcemanager.AzureResourceManager azure)
        throws IOException {
        azure
            .genericResources()
            .manager()
            .policyClient()
            .getPolicyAssignments()
            .createWithResponse(
                "subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
                "EnforceNaming",
                new PolicyAssignmentInner()
                    .withDisplayName("Enforce resource naming rules")
                    .withPolicyDefinitionId(
                        "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming")
                    .withParameters(
                        mapOf(
                            "prefix",
                            new ParameterValuesValue()
                                .withValue(
                                    SerializerFactory
                                        .createDefaultManagementSerializerAdapter()
                                        .deserialize("\"DeptA\"", Object.class, SerializerEncoding.JSON)),
                            "suffix",
                            new ParameterValuesValue()
                                .withValue(
                                    SerializerFactory
                                        .createDefaultManagementSerializerAdapter()
                                        .deserialize("\"-LC\"", Object.class, SerializerEncoding.JSON))))
                    .withDescription("Force resource names to begin with given DeptA and end with -LC")
                    .withMetadata(
                        SerializerFactory
                            .createDefaultManagementSerializerAdapter()
                            .deserialize("{\"assignedBy\":\"Special Someone\"}", Object.class, SerializerEncoding.JSON))
                    .withNonComplianceMessages(
                        Arrays
                            .asList(
                                new NonComplianceMessage()
                                    .withMessage("Resource names must start with 'DeptA' and end with '-LC'."))),
                Context.NONE);
    }

    /**
     * Sample code: Create or update a policy assignment with multiple non-compliance messages.
     *
     * @param azure The entry point for accessing resource management APIs in Azure.
     */
    public static void createOrUpdateAPolicyAssignmentWithMultipleNonComplianceMessages(
        com.azure.resourcemanager.AzureResourceManager azure) {
        azure
            .genericResources()
            .manager()
            .policyClient()
            .getPolicyAssignments()
            .createWithResponse(
                "subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
                "securityInitAssignment",
                new PolicyAssignmentInner()
                    .withDisplayName("Enforce security policies")
                    .withPolicyDefinitionId(
                        "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policySetDefinitions/securityInitiative")
                    .withNonComplianceMessages(
                        Arrays
                            .asList(
                                new NonComplianceMessage()
                                    .withMessage(
                                        "Resources must comply with all internal security policies. See <internal site"
                                            + " URL> for more info."),
                                new NonComplianceMessage()
                                    .withMessage("Resource names must start with 'DeptA' and end with '-LC'.")
                                    .withPolicyDefinitionReferenceId("10420126870854049575"),
                                new NonComplianceMessage()
                                    .withMessage("Storage accounts must have firewall rules configured.")
                                    .withPolicyDefinitionReferenceId("8572513655450389710"))),
                Context.NONE);
    }

    /**
     * Sample code: Create or update a policy assignment without enforcing policy effect during resource creation or
     * update.
     *
     * @param azure The entry point for accessing resource management APIs in Azure.
     */
    public static void createOrUpdateAPolicyAssignmentWithoutEnforcingPolicyEffectDuringResourceCreationOrUpdate(
        com.azure.resourcemanager.AzureResourceManager azure) throws IOException {
        azure
            .genericResources()
            .manager()
            .policyClient()
            .getPolicyAssignments()
            .createWithResponse(
                "subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
                "EnforceNaming",
                new PolicyAssignmentInner()
                    .withDisplayName("Enforce resource naming rules")
                    .withPolicyDefinitionId(
                        "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming")
                    .withParameters(
                        mapOf(
                            "prefix",
                            new ParameterValuesValue()
                                .withValue(
                                    SerializerFactory
                                        .createDefaultManagementSerializerAdapter()
                                        .deserialize("\"DeptA\"", Object.class, SerializerEncoding.JSON)),
                            "suffix",
                            new ParameterValuesValue()
                                .withValue(
                                    SerializerFactory
                                        .createDefaultManagementSerializerAdapter()
                                        .deserialize("\"-LC\"", Object.class, SerializerEncoding.JSON))))
                    .withDescription("Force resource names to begin with given DeptA and end with -LC")
                    .withMetadata(
                        SerializerFactory
                            .createDefaultManagementSerializerAdapter()
                            .deserialize("{\"assignedBy\":\"Special Someone\"}", Object.class, SerializerEncoding.JSON))
                    .withEnforcementMode(EnforcementMode.DO_NOT_ENFORCE),
                Context.NONE);
    }

    /**
     * Sample code: Create or update a policy assignment with a managed identity.
     *
     * @param azure The entry point for accessing resource management APIs in Azure.
     */
    public static void createOrUpdateAPolicyAssignmentWithAManagedIdentity(
        com.azure.resourcemanager.AzureResourceManager azure) throws IOException {
        azure
            .genericResources()
            .manager()
            .policyClient()
            .getPolicyAssignments()
            .createWithResponse(
                "subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
                "EnforceNaming",
                new PolicyAssignmentInner()
                    .withLocation("eastus")
                    .withIdentity(new Identity().withType(ResourceIdentityType.SYSTEM_ASSIGNED))
                    .withDisplayName("Enforce resource naming rules")
                    .withPolicyDefinitionId(
                        "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming")
                    .withParameters(
                        mapOf(
                            "prefix",
                            new ParameterValuesValue()
                                .withValue(
                                    SerializerFactory
                                        .createDefaultManagementSerializerAdapter()
                                        .deserialize("\"DeptA\"", Object.class, SerializerEncoding.JSON)),
                            "suffix",
                            new ParameterValuesValue()
                                .withValue(
                                    SerializerFactory
                                        .createDefaultManagementSerializerAdapter()
                                        .deserialize("\"-LC\"", Object.class, SerializerEncoding.JSON))))
                    .withDescription("Force resource names to begin with given DeptA and end with -LC")
                    .withMetadata(
                        SerializerFactory
                            .createDefaultManagementSerializerAdapter()
                            .deserialize("{\"assignedBy\":\"Foo Bar\"}", Object.class, SerializerEncoding.JSON))
                    .withEnforcementMode(EnforcementMode.DEFAULT),
                Context.NONE);
    }

    @SuppressWarnings("unchecked")
    private static <T> Map<String, T> mapOf(Object... inputs) {
        Map<String, T> map = new HashMap<>();
        for (int i = 0; i < inputs.length; i += 2) {
            String key = (String) inputs[i];
            T value = (T) inputs[i + 1];
            map.put(key, value);
        }
        return map;
    }
}
```