### PR TITLE
v4 fluentlite, update sample.md to inline all java codes

### DIFF
--- a/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
@@ -321,18 +321,19 @@ public class FluentGen extends NewPlugin {
                 javaPackage.addPom(fluentJavaSettings.getPomFilename(), pom);
             }
 
+            // Samples
+            List<JavaFile> sampleJavaFiles = new ArrayList<>();
+            for (FluentExample example : fluentClient.getExamples()) {
+                sampleJavaFiles.add(javaPackage.addSample(example));
+            }
+
             // Readme and Changelog
             if (isSdkIntegration) {
                 javaPackage.addReadmeMarkdown(project);
                 javaPackage.addChangelogMarkdown(project.getChangelog());
                 if (fluentJavaSettings.isGenerateSamples() && project.getSdkRepositoryUri().isPresent()) {
-                    javaPackage.addSampleMarkdown(project, fluentClient.getExamples());
+                    javaPackage.addSampleMarkdown(fluentClient.getExamples(), sampleJavaFiles);
                 }
-            }
-
-            // Samples
-            for (FluentExample example : fluentClient.getExamples()) {
-                javaPackage.addSample(example);
             }
         }
 

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentBaseExample.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentBaseExample.java
@@ -47,7 +47,7 @@ public abstract class FluentBaseExample implements FluentExample {
 
     @Override
     public String getEntryDescription() {
-        return manager.getDescription();
+        return String.format("Entry point to %1$s.", manager.getType().getName());
     }
 
     public FluentResourceCollection getResourceCollection() {

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/javamodel/FluentJavaPackage.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/javamodel/FluentJavaPackage.java
@@ -55,8 +55,8 @@ public class FluentJavaPackage extends JavaPackage {
         textFiles.add(textFile);
     }
 
-    public final void addSampleMarkdown(Project project, List<FluentExample> examples) {
-        TextFile textFile = new TextFile("SAMPLE.md", new SampleTemplate().write(project, examples));
+    public final void addSampleMarkdown(List<FluentExample> examples, List<JavaFile> sampleJavaFiles) {
+        TextFile textFile = new TextFile("SAMPLE.md", new SampleTemplate().write(examples, sampleJavaFiles));
         this.checkDuplicateFile(textFile.getFilePath());
         textFiles.add(textFile);
     }
@@ -106,11 +106,12 @@ public class FluentJavaPackage extends JavaPackage {
         addJavaFile(javaFile);
     }
 
-    public final void addSample(FluentExample example) {
+    public final JavaFile addSample(FluentExample example) {
         JavaSettings settings = JavaSettings.getInstance();
         JavaFile javaFile = getJavaFileFactory().createSampleFile(
                 settings.getPackage(), example.getClassName());
         FluentExampleTemplate.getInstance().write(example, javaFile);
         addJavaFile(javaFile);
+        return javaFile;
     }
 }


### PR DESCRIPTION
inline the sample code in sample.md, instead of let sample.md to link to java files (which having problem link to correct tag in released doc)