### PR TITLE
v4, add operationId to ProxyMethod

### DIFF
--- a/androidgen/src/main/java/com/azure/autorest/android/model/clientmodel/AndroidProxyMethod.java
+++ b/androidgen/src/main/java/com/azure/autorest/android/model/clientmodel/AndroidProxyMethod.java
@@ -4,6 +4,7 @@ import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.model.clientmodel.ClassType;
 import com.azure.autorest.model.clientmodel.IType;
 import com.azure.autorest.model.clientmodel.ProxyMethod;
+import com.azure.autorest.model.clientmodel.ProxyMethodExample;
 import com.azure.autorest.model.clientmodel.ProxyMethodParameter;
 import com.azure.core.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -34,7 +35,8 @@ public class AndroidProxyMethod extends ProxyMethod {
                                  ClassType unexpectedResponseExceptionType,
                                  Map<ClassType, List<HttpResponseStatus>> unexpectedResponseExceptionTypes,
                                  String name, List<ProxyMethodParameter> parameters, String description,
-                                 IType returnValueWireType, boolean isResumable, Set<String> responseContentTypes) {
+                                 IType returnValueWireType, boolean isResumable, Set<String> responseContentTypes,
+                                 String operationId, Map<String, ProxyMethodExample> examples) {
         super(requestContentType,
                 returnType,
                 httpMethod,
@@ -48,7 +50,8 @@ public class AndroidProxyMethod extends ProxyMethod {
                 returnValueWireType,
                 isResumable,
                 responseContentTypes,
-                null);
+                operationId,
+                examples);
     }
 
     @Override
@@ -145,7 +148,9 @@ public class AndroidProxyMethod extends ProxyMethod {
                     description,
                     returnValueWireType,
                     isResumable,
-                    responseContentTypes);
+                    responseContentTypes,
+                    operationId,
+                    examples);
         }
     }
 }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/ExampleParser.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/ExampleParser.java
@@ -161,6 +161,7 @@ public class ExampleParser {
         if (example == null) {
             example = new FluentExample(CodeNamer.toPascalCase(groupName), CodeNamer.toPascalCase(methodName),
                     this.aggregateExamples ? null : exampleName,
+                    clientMethod.getProxyMethod().getOperationId(),
                     getApiVersion(clientMethod));
             examples.put(name, example);
         }
@@ -532,8 +533,9 @@ public class ExampleParser {
         }
     }
 
+    @SuppressWarnings("unchecked")
     private static ExampleNode parseNode(IType type, Object objectValue) {
-        ExampleNode node = null;
+        ExampleNode node;
         if (type instanceof ListType && objectValue instanceof List) {
             IType elementType = ((ListType) type).getElementType();
             ListNode listNode = new ListNode(elementType, objectValue);

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentExample.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentExample.java
@@ -18,6 +18,7 @@ public class FluentExample implements Comparable<FluentExample> {
 
     private final String groupName;
     private final String methodName;
+    private final String operationId;
     private final String apiVersion;
     private final String exampleName;
 
@@ -27,16 +28,17 @@ public class FluentExample implements Comparable<FluentExample> {
 
     private final List<FluentClientMethodExample> clientMethodExamples = new ArrayList<>();
 
-    public FluentExample(String groupName, String methodName, String apiVersion) {
-        this.groupName = groupName;
-        this.methodName = methodName;
-        this.apiVersion = apiVersion;
-        this.exampleName = null;
-    }
+//    public FluentExample(String groupName, String methodName, String operationId, String apiVersion) {
+//        this.groupName = groupName;
+//        this.methodName = methodName;
+//        this.apiVersion = apiVersion;
+//        this.exampleName = null;
+//    }
 
-    public FluentExample(String groupName, String methodName, String exampleName, String apiVersion) {
+    public FluentExample(String groupName, String methodName, String exampleName, String operationId, String apiVersion) {
         this.groupName = groupName;
         this.methodName = methodName;
+        this.operationId = operationId;
         this.apiVersion = apiVersion;
         this.exampleName = exampleName;
     }
@@ -63,6 +65,10 @@ public class FluentExample implements Comparable<FluentExample> {
 
     public String getMethodName() {
         return methodName;
+    }
+
+    public String getOperationId() {
+        return operationId;
     }
 
     public String getApiVersion() {

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentExampleTemplate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentExampleTemplate.java
@@ -116,18 +116,9 @@ public class FluentExampleTemplate {
     }
 
     private String getExampleTag(com.azure.autorest.fluent.model.clientmodel.FluentExample example, FluentExample exampleInfo) {
-        StringBuilder sb = new StringBuilder();
-
-        if ("ResourceProvider".equals(example.getGroupName())) {
-            // no operation group
-            sb.append("operationId: ").append(example.getMethodName()).append(System.lineSeparator());
-        } else {
-            sb.append("operationId: ").append(example.getGroupName()).append("_").append(example.getMethodName()).append(System.lineSeparator());
-        }
-        sb.append("api-version: ").append(example.getApiVersion()).append(System.lineSeparator());
-        sb.append("x-ms-examples: ").append(exampleInfo.getName());
-
-        return sb.toString();
+        return "operationId: " + example.getOperationId() + System.lineSeparator() +
+                "api-version: " + example.getApiVersion() + System.lineSeparator() +
+                "x-ms-examples: " + exampleInfo.getName();
     }
 
     private ExampleMethod generateExampleMethod(FluentMethodExample methodExample) {

--- a/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodExampleMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodExampleMapper.java
@@ -11,7 +11,7 @@ import java.util.Map;
 
 public class ProxyMethodExampleMapper implements IMapper<Object, ProxyMethodExample> {
 
-    private static ProxyMethodExampleMapper INSTANCE = new ProxyMethodExampleMapper();
+    private static final ProxyMethodExampleMapper INSTANCE = new ProxyMethodExampleMapper();
 
     protected ProxyMethodExampleMapper() {
     }
@@ -20,17 +20,20 @@ public class ProxyMethodExampleMapper implements IMapper<Object, ProxyMethodExam
         return INSTANCE;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public ProxyMethodExample map(Object xmsExample) {
         ProxyMethodExample.Builder builder = new ProxyMethodExample.Builder();
 
         if (xmsExample instanceof Map) {
             Object parameters = ((Map<String, Object>) xmsExample).get("parameters");
-            if (parameters != null && parameters instanceof Map) {
+            if (parameters instanceof Map) {
                 for (Map.Entry<String, Object> entry : ((Map<String, Object>) parameters).entrySet()) {
                     builder.parameter(entry.getKey(), entry.getValue());
                 }
             }
+            String xmsOriginalFile = (String) ((Map<String, Object>) xmsExample).get("x-ms-original-file");
+            builder.xmsOriginalFile(xmsOriginalFile);
         }
         return builder.build();
     }

--- a/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
@@ -15,6 +15,7 @@ import com.azure.autorest.model.clientmodel.ProxyMethodExample;
 import com.azure.autorest.model.clientmodel.ProxyMethodParameter;
 import com.azure.autorest.util.SchemaUtil;
 import com.azure.core.http.HttpMethod;
+import com.azure.core.util.CoreUtils;
 import io.netty.handler.codec.http.HttpResponseStatus;
 
 import java.util.ArrayList;
@@ -53,6 +54,21 @@ public class ProxyMethodMapper implements IMapper<Operation, Map<Request, ProxyM
                 .description(operation.getDescription())
                 .name(operation.getLanguage().getJava().getName())
                 .isResumable(false);
+
+        if (operation.getLanguage() != null && operation.getLanguage().getDefault() != null) {  // "default" could be null for generated method like "listNext"
+            String operationId;
+            if (operation.getOperationGroup() != null
+                    && operation.getOperationGroup().getLanguage() != null
+                    && operation.getOperationGroup().getLanguage().getDefault() != null
+                    && !CoreUtils.isNullOrEmpty(operation.getOperationGroup().getLanguage().getDefault().getName())
+                    // hack for Fluent, as Lite use "ResourceProvider" if operation group is unnamed
+                    && !(settings.isFluent() && "ResourceProvider".equals(operation.getOperationGroup().getLanguage().getDefault().getName()))) {
+                operationId = operation.getOperationGroup().getLanguage().getDefault().getName() + "_" + operation.getLanguage().getDefault().getName();
+            } else {
+                operationId = operation.getLanguage().getDefault().getName();
+            }
+            builder.operationId(operationId);
+        }
 
         List<HttpResponseStatus> expectedStatusCodes = operation.getResponses().stream()
                 .flatMap(r -> r.getProtocol().getHttp().getStatusCodes().stream())

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethod.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethod.java
@@ -73,6 +73,8 @@ public class ProxyMethod {
 
     private Map<String, ProxyMethodExample> examples;
 
+    private String operationId;
+
     /**
      * Create a new RestAPIMethod with the provided properties.
      * @param requestContentType The Content-Type of the request.
@@ -87,6 +89,7 @@ public class ProxyMethod {
      * @param description The description of this method.
      * @param isResumable Whether or not this method is resumable.
      * @param responseContentTypes The metia-types in response.
+     * @param operationId the operation ID.
      * @param examples the examples for the method.
      */
     protected ProxyMethod(String requestContentType, IType returnType, HttpMethod httpMethod, String urlPath,
@@ -95,7 +98,7 @@ public class ProxyMethod {
                           Map<ClassType, List<HttpResponseStatus>> unexpectedResponseExceptionTypes,
                           String name, List<ProxyMethodParameter> parameters, String description,
                           IType returnValueWireType, boolean isResumable, Set<String> responseContentTypes,
-                          Map<String, ProxyMethodExample> examples) {
+                          String operationId, Map<String, ProxyMethodExample> examples) {
         this.requestContentType = requestContentType;
         this.returnType = returnType;
         this.httpMethod = httpMethod;
@@ -109,6 +112,7 @@ public class ProxyMethod {
         this.returnValueWireType = returnValueWireType;
         this.isResumable = isResumable;
         this.responseContentTypes = responseContentTypes;
+        this.operationId = operationId;
         this.examples = examples;
     }
 
@@ -178,6 +182,10 @@ public class ProxyMethod {
 
     public final Set<String> getResponseContentTypes() {
         return responseContentTypes;
+    }
+
+    public String getOperationId() {
+        return operationId;
     }
 
     public Map<String, ProxyMethodExample> getExamples() {
@@ -293,6 +301,7 @@ public class ProxyMethod {
         protected boolean isResumable;
         protected Set<String> responseContentTypes;
         protected Map<String, ProxyMethodExample> examples;
+        protected String operationId;
 
         /*
          * Sets the Content-Type of the request.
@@ -435,6 +444,16 @@ public class ProxyMethod {
         }
 
         /**
+         * Sets the operation ID for reference.
+         * @param operationId the operation ID
+         * @return the Builder itself
+         */
+        public Builder operationId(String operationId) {
+            this.operationId = operationId;
+            return this;
+        }
+
+        /**
          * @return an immutable ProxyMethod instance with the configurations on this builder.
          */
         public ProxyMethod build() {
@@ -451,6 +470,7 @@ public class ProxyMethod {
                     returnValueWireType,
                     isResumable,
                     responseContentTypes,
+                    operationId,
                     examples);
         }
     }

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethodExample.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethodExample.java
@@ -44,14 +44,26 @@ public class ProxyMethodExample {
     }
 
     private final Map<String, ParameterValue> parameters = new HashMap<>();
+    private final String xmsOriginalFile;
+    private final String operationId;
 
     public Map<String, ParameterValue> getParameters() {
         return parameters;
     }
 
+    public String getXmsOriginalFile() {
+        return xmsOriginalFile;
+    }
+
+    public String getOperationId() {
+        return operationId;
+    }
+
     // response is ignored for now
 
-    public ProxyMethodExample() {
+    private ProxyMethodExample(String xmsOriginalFile, String operationId) {
+        this.xmsOriginalFile = xmsOriginalFile;
+        this.operationId = operationId;
     }
 
     @Override
@@ -63,6 +75,8 @@ public class ProxyMethodExample {
 
     public static final class Builder {
         private final Map<String, ParameterValue> parameters = new HashMap<>();
+        private String xmsOriginalFile;
+        private String operationId;
 
         public Builder() {
         }
@@ -74,8 +88,18 @@ public class ProxyMethodExample {
             return this;
         }
 
+        public Builder xmsOriginalFile(String xmsOriginalFile) {
+            this.xmsOriginalFile = xmsOriginalFile;
+            return this;
+        }
+
+        public Builder operationId(String operationId) {
+            this.operationId = operationId;
+            return this;
+        }
+
         public ProxyMethodExample build() {
-            ProxyMethodExample proxyMethodExample = new ProxyMethodExample();
+            ProxyMethodExample proxyMethodExample = new ProxyMethodExample(xmsOriginalFile, operationId);
             proxyMethodExample.parameters.putAll(this.parameters);
             return proxyMethodExample;
         }

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethodExample.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethodExample.java
@@ -45,7 +45,6 @@ public class ProxyMethodExample {
 
     private final Map<String, ParameterValue> parameters = new HashMap<>();
     private final String xmsOriginalFile;
-    private final String operationId;
 
     public Map<String, ParameterValue> getParameters() {
         return parameters;
@@ -55,15 +54,10 @@ public class ProxyMethodExample {
         return xmsOriginalFile;
     }
 
-    public String getOperationId() {
-        return operationId;
-    }
-
     // response is ignored for now
 
-    private ProxyMethodExample(String xmsOriginalFile, String operationId) {
+    private ProxyMethodExample(String xmsOriginalFile) {
         this.xmsOriginalFile = xmsOriginalFile;
-        this.operationId = operationId;
     }
 
     @Override
@@ -76,7 +70,6 @@ public class ProxyMethodExample {
     public static final class Builder {
         private final Map<String, ParameterValue> parameters = new HashMap<>();
         private String xmsOriginalFile;
-        private String operationId;
 
         public Builder() {
         }
@@ -93,13 +86,8 @@ public class ProxyMethodExample {
             return this;
         }
 
-        public Builder operationId(String operationId) {
-            this.operationId = operationId;
-            return this;
-        }
-
         public ProxyMethodExample build() {
-            ProxyMethodExample proxyMethodExample = new ProxyMethodExample(xmsOriginalFile, operationId);
+            ProxyMethodExample proxyMethodExample = new ProxyMethodExample(xmsOriginalFile);
             proxyMethodExample.parameters.putAll(this.parameters);
             return proxyMethodExample;
         }


### PR DESCRIPTION
1. print it in example for possible reference to swagger
2. in future, test scenario will have an additional input with operationId (but without details on operation like in m4), for constructing a e2e test
3. also add support for `x-ms-original-file` which will be added to m4 in future, to let codegen know the original file of the example