### PR TITLE
v4 fluent, sample generation for additional properties

### DIFF
--- a/eng/pipelines/ci.yaml
+++ b/eng/pipelines/ci.yaml
@@ -92,10 +92,6 @@ jobs:
           testRunTitle: 'azure-tests'
           searchFolder: '$(System.DefaultWorkingDirectory)/azure-tests/'
 
-#      - script: |
-#          cp coverage/* node_modules/@microsoft.azure/autorest.testserver/legacy/coverage/
-#        displayName: 'Copy coverage report'
-
       - script: |
           npm --prefix node_modules/@microsoft.azure/autorest.testserver run coverage -- $(Build.Repository.Name) $(Build.SourceBranch) $(github-token) $(storage-coverage-user) $(storage-coverage-pass)
         displayName: 'Publish coverage report to storage account'

--- a/eng/pipelines/ci.yaml
+++ b/eng/pipelines/ci.yaml
@@ -97,5 +97,5 @@ jobs:
 #        displayName: 'Copy coverage report'
 
       - script: |
-          npm --prefix node_modules/@microsoft.azure/autorest.testserver run coverage-push -- $(Build.Repository.Name) $(Build.SourceBranch) $(github-token) $(storage-coverage-user) $(storage-coverage-pass)
+          npm --prefix node_modules/@microsoft.azure/autorest.testserver run coverage -- $(Build.Repository.Name) $(Build.SourceBranch) $(github-token) $(storage-coverage-user) $(storage-coverage-pass)
         displayName: 'Publish coverage report to storage account'

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   "homepage": "https://github.com/Azure/autorest.java/blob/v4/readme.md",
   "devDependencies": {
     "autorest": "^3.0.0",
-    "@microsoft.azure/autorest.testserver": "^3.0.21"
+    "@microsoft.azure/autorest.testserver": "^3.0.33"
   }
 }


### PR DESCRIPTION
Sample code (this actually caused by wrong swagger, it should have a `ScheduleTrigger` subclass with `type: ScheduleTrigger`)

```java
    public static void triggersUpdate(com.azure.mgmtlitetest.rp.DataFactoryManager manager) throws IOException {
        TriggerResource resource =
            manager
                .triggers()
                .getWithResponse("exampleResourceGroup", "exampleFactoryName", "exampleTrigger", null, Context.NONE)
                .getValue();
        resource
            .update()
            .withProperties(
                new Trigger()
                    .withDescription("Example description")
                    .withAdditionalProperties(
                        mapOf(
                            "typeProperties",
                            SerializerFactory
                                .createDefaultManagementSerializerAdapter()
                                .deserialize(
                                    "{\"recurrence\":{\"endTime\":\"2018-06-16T00:55:14.905167Z\",\"frequency\":\"Minute\",\"interval\":4,\"startTime\":\"2018-06-16T00:39:14.905167Z\",\"timeZone\":\"UTC\"}}",
                                    Object.class,
                                    SerializerEncoding.JSON),
                            "pipelines",
                            SerializerFactory
                                .createDefaultManagementSerializerAdapter()
                                .deserialize(
                                    "[{\"parameters\":{\"OutputBlobNameList\":[\"exampleoutput.csv\"]},\"pipelineReference\":{\"type\":\"PipelineReference\",\"referenceName\":\"examplePipeline\"}}]",
                                    Object.class,
                                    SerializerEncoding.JSON),
                            "type",
                            "ScheduleTrigger")))
            .apply();
    }
```