### PR TITLE
v4 fluent, generate samples during fluent CI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,14 @@
 # default
-*                           @jianghaolu @srnagar
+*                           @jianghaolu @srnagar @qwordy
 
 # fluentgen
-/fluentnamer                @ChenTanyi @weidongxu-microsoft @yungezz @haolingdong-msft
-/fluentgen                  @ChenTanyi @weidongxu-microsoft @yungezz @haolingdong-msft
-/fluent-tests               @ChenTanyi @weidongxu-microsoft @yungezz @haolingdong-msft
-/azure-tests                @ChenTanyi @weidongxu-microsoft @yungezz @haolingdong-msft
+/fluentnamer                @weidongxu-microsoft @yungezz @haolingdong-msft
+/fluentgen                  @weidongxu-microsoft @yungezz @haolingdong-msft
+/fluent-tests               @weidongxu-microsoft @yungezz @haolingdong-msft
+/azure-tests                @weidongxu-microsoft @yungezz @haolingdong-msft
 
 # androidgen
 /androidgen                 @JianpingChen @anuchandy
+
+# protocol
+/protocol*                  @qwordy @jianghaolu

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,10 +2,10 @@
 *                           @jianghaolu @srnagar @qwordy
 
 # fluentgen
-/fluentnamer                @weidongxu-microsoft @yungezz @haolingdong-msft
-/fluentgen                  @weidongxu-microsoft @yungezz @haolingdong-msft
-/fluent-tests               @weidongxu-microsoft @yungezz @haolingdong-msft
-/azure-tests                @weidongxu-microsoft @yungezz @haolingdong-msft
+/fluentnamer                @weidongxu-microsoft @haolingdong-msft
+/fluentgen                  @weidongxu-microsoft @haolingdong-msft
+/fluent-tests               @weidongxu-microsoft @haolingdong-msft
+/azure-tests                @weidongxu-microsoft @haolingdong-msft
 
 # androidgen
 /androidgen                 @JianpingChen @anuchandy

--- a/fluent-tests/checkstyle-suppressions.xml
+++ b/fluent-tests/checkstyle-suppressions.xml
@@ -6,7 +6,14 @@
 <suppressions>
   <!-- Add Javadoc suppression for any test files (ie. ones that live under src/test/java). -->
   <suppress checks="[a-zA-Z0-9]*" files="src[/\\]test[/\\]java[/\\].*.java"/>
-
   <suppress checks="Javadoc" files=".*[/\\]implementation[/\\].*\.java"/>
   <suppress checks="Header" files=".*package-info.java"/>
+
+  <!-- ignore missing javadoc in samples -->
+  <suppress checks="MissingJavadocMethod" files=".*[/\\]samples[/\\].*\.java"/>
+  <suppress checks="MissingJavadocType" files=".*[/\\]samples[/\\].*\.java"/>
+  <suppress checks="MissingJavadocPackage" files=".*[/\\]samples[/\\].*\.java"/>
+
+  <!-- Don't check for JavaDocPackage in samples or tests-->
+  <suppress checks="JavadocPackage" files=".*[/\\](samples|test)[/\\].*\.java"/>
 </suppressions>

--- a/fluent-tests/pom.xml
+++ b/fluent-tests/pom.xml
@@ -38,6 +38,27 @@
               </execution>
             </executions>
           </plugin>
+
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <version>3.0.0</version>
+            <executions>
+              <execution>
+                <id>compile-samples-source</id>
+                <phase>generate-test-sources</phase>
+                <goals>
+                  <goal>add-test-source</goal>
+                </goals>
+                <configuration>
+                  <sources>
+                    <source>src/samples/java</source>
+                  </sources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>

--- a/fluent-tests/prepare-tests.bat
+++ b/fluent-tests/prepare-tests.bat
@@ -9,6 +9,7 @@ java -version
 REM re-generate code
 RMDIR /S /Q "src\main\java\com\azure\mgmttest"
 RMDIR /S /Q "src\main\java\com\azure\mgmtlitetest"
+RMDIR /S /Q "src\samples"
 
 SET AUTOREST_CORE_VERSION=3.4.5
 SET MODELERFOUR_ARGUMENTS=--pipeline.modelerfour.additional-checks=false --pipeline.modelerfour.lenient-model-deduplication=true

--- a/fluent-tests/prepare-tests.bat
+++ b/fluent-tests/prepare-tests.bat
@@ -15,7 +15,7 @@ SET AUTOREST_CORE_VERSION=3.4.5
 SET MODELERFOUR_ARGUMENTS=--pipeline.modelerfour.additional-checks=false --pipeline.modelerfour.lenient-model-deduplication=true
 SET COMMON_ARGUMENTS=--java --use=../ --java.output-folder=./ %MODELERFOUR_ARGUMENTS% --azure-arm --java.license-header=MICROSOFT_MIT_SMALL
 SET FLUENT_ARGUMENTS=%COMMON_ARGUMENTS% --fluent --pipeline.modelerfour.flatten-payloads=true
-SET FLUENTLITE_ARGUMENTS=%COMMON_ARGUMENTS% --fluent=lite --payload-flattening-threshold=0 --pipeline.modelerfour.flatten-models=false --generate-samples
+SET FLUENTLITE_ARGUMENTS=%COMMON_ARGUMENTS% --fluent=lite --payload-flattening-threshold=0 --pipeline.modelerfour.flatten-models=false --client-flattened-annotation-target=NONE --generate-samples
 
 REM fluent premium
 CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENT_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/resources/resource-manager/Microsoft.Resources/stable/2019-08-01/resources.json --namespace=com.azure.mgmttest.resources

--- a/fluent-tests/prepare-tests.bat
+++ b/fluent-tests/prepare-tests.bat
@@ -14,7 +14,7 @@ SET AUTOREST_CORE_VERSION=3.4.5
 SET MODELERFOUR_ARGUMENTS=--pipeline.modelerfour.additional-checks=false --pipeline.modelerfour.lenient-model-deduplication=true
 SET COMMON_ARGUMENTS=--java --use=../ --java.output-folder=./ %MODELERFOUR_ARGUMENTS% --azure-arm --java.license-header=MICROSOFT_MIT_SMALL
 SET FLUENT_ARGUMENTS=%COMMON_ARGUMENTS% --fluent --pipeline.modelerfour.flatten-payloads=true
-SET FLUENTLITE_ARGUMENTS=%COMMON_ARGUMENTS% --fluent=lite
+SET FLUENTLITE_ARGUMENTS=%COMMON_ARGUMENTS% --fluent=lite --payload-flattening-threshold=0 --pipeline.modelerfour.flatten-models=false --generate-samples
 
 REM fluent premium
 CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENT_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/resources/resource-manager/Microsoft.Resources/stable/2019-08-01/resources.json --namespace=com.azure.mgmttest.resources
@@ -42,7 +42,7 @@ CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENT_ARGUMENTS% --payload-fla
 CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENT_ARGUMENTS% --payload-flattening-threshold=0 --pipeline.modelerfour.flatten-models=false --client-flattened-annotation-target=NONE --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/azurestack/resource-manager/Microsoft.AzureStack/preview/2020-06-01-preview/Product.json --namespace=com.azure.mgmttest.azurestack
 
 REM fluent lite
-CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENTLITE_ARGUMENTS% --pom-file=pom_generated_resources.xml https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/resources/resource-manager/readme.md --tag=package-resources-2020-10 --java.namespace=com.azure.mgmtlitetest.resources
+CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENTLITE_ARGUMENTS% --pom-file=pom_generated_resources.xml https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/resources/resource-manager/readme.md --tag=package-resources-2021-01 --java.namespace=com.azure.mgmtlitetest.resources
 
 CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENTLITE_ARGUMENTS% --regenerate-pom=false https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/storage/resource-manager/readme.md --tag=package-2021-01 --java.namespace=com.azure.mgmtlitetest.storage
 
@@ -50,10 +50,10 @@ CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENTLITE_ARGUMENTS% --regener
 
 CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENTLITE_ARGUMENTS% --regenerate-pom=false https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/mediaservices/resource-manager/readme.md --tag=package-2021-05 --java.namespace=com.azure.mgmtlitetest.mediaservices
 
+CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENTLITE_ARGUMENTS% --regenerate-pom=false https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/resources/resource-manager/readme.md --tag=package-policy-2020-09 --java.namespace=com.azure.mgmtlitetest.policy
+
 REM CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENTLITE_ARGUMENTS% --regenerate-pom=false https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/network/resource-manager/readme.md --tag=package-2020-06 --java.namespace=com.azure.mgmtlitetest.network
 REM CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENTLITE_ARGUMENTS% --regenerate-pom=false https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/compute/resource-manager/readme.md --tag=package-2020-06-30 --java.namespace=com.azure.mgmtlitetest.compute
-
-REM CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENTLITE_ARGUMENTS% --regenerate-pom=false https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/resources/resource-manager/readme.md --tag=package-policy-2020-09 --java.namespace=com.azure.mgmtlitetest.policy --generate-samples
 
 REM delete module-info as fluent-test is on java8
 DEL "src\main\java\module-info.java"

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentExample.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentExample.java
@@ -78,9 +78,9 @@ public class FluentExample implements Comparable<FluentExample> {
     public String getPackageName() {
         JavaSettings settings = JavaSettings.getInstance();
         if (isAggregatedExamples()) {
-            return settings.getPackage();
+            return settings.getPackage("generated");
         } else {
-            return settings.getPackage("examples");
+            return settings.getPackage("generated", "examples");
         }
     }
 


### PR DESCRIPTION
Also add `generated` segment in namespace, to distinguish them with manual samples.

Updated code owners, after reorg.