### PR TITLE
v4, enable Javagen plugin logging when runs FluentGen

### DIFF
--- a/androidgen/src/main/java/com/azure/autorest/android/Androidgen.java
+++ b/androidgen/src/main/java/com/azure/autorest/android/Androidgen.java
@@ -1,11 +1,11 @@
 package com.azure.autorest.android;
 
+import com.azure.autorest.Javagen;
 import com.azure.autorest.android.mapper.AndroidMapperFactory;
 import com.azure.autorest.android.template.AndroidTemplateFactory;
 import com.azure.autorest.extension.base.jsonrpc.Connection;
 import com.azure.autorest.extension.base.model.codemodel.CodeModel;
 import com.azure.autorest.extension.base.plugin.JavaSettings;
-import com.azure.autorest.extension.base.plugin.NewPlugin;
 import com.azure.autorest.extension.base.plugin.PluginLogger;
 import com.azure.autorest.mapper.Mappers;
 import com.azure.autorest.model.clientmodel.AsyncSyncClient;
@@ -36,13 +36,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class Androidgen extends NewPlugin {
+public class Androidgen extends Javagen {
     private final Logger LOGGER = new PluginLogger(this, Androidgen.class);
     private static Androidgen instance;
 
     public Androidgen(Connection connection, String plugin, String sessionId) {
         super(connection, plugin, sessionId);
         instance = this;
+        Javagen.instance = this;
     }
 
     public static Androidgen getPluginInstance() {

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
@@ -9,7 +9,6 @@ import com.azure.autorest.Javagen;
 import com.azure.autorest.extension.base.jsonrpc.Connection;
 import com.azure.autorest.extension.base.model.codemodel.CodeModel;
 import com.azure.autorest.extension.base.plugin.JavaSettings;
-import com.azure.autorest.extension.base.plugin.NewPlugin;
 import com.azure.autorest.extension.base.plugin.PluginLogger;
 import com.azure.autorest.fluent.checker.JavaFormatter;
 import com.azure.autorest.fluent.mapper.ExampleParser;

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
@@ -5,6 +5,7 @@
 
 package com.azure.autorest.fluent;
 
+import com.azure.autorest.Javagen;
 import com.azure.autorest.extension.base.jsonrpc.Connection;
 import com.azure.autorest.extension.base.model.codemodel.CodeModel;
 import com.azure.autorest.extension.base.plugin.JavaSettings;
@@ -60,7 +61,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class FluentGen extends NewPlugin {
+public class FluentGen extends Javagen {
 
     private final Logger logger = new PluginLogger(this, FluentGen.class);
     static FluentGen instance;
@@ -73,6 +74,7 @@ public class FluentGen extends NewPlugin {
     public FluentGen(Connection connection, String plugin, String sessionId) {
         super(connection, plugin, sessionId);
         instance = this;
+        Javagen.instance = this;
     }
 
     public static FluentGen getPluginInstance() {

--- a/javagen/src/main/java/com/azure/autorest/Javagen.java
+++ b/javagen/src/main/java/com/azure/autorest/Javagen.java
@@ -35,7 +35,7 @@ import java.util.stream.Collectors;
 
 public class Javagen extends NewPlugin {
     private final Logger logger = new PluginLogger(this, Javagen.class);
-    static Javagen instance;
+    protected static Javagen instance;
 
     public Javagen(Connection connection, String plugin, String sessionId) {
         super(connection, plugin, sessionId);

--- a/javagen/src/main/java/com/azure/autorest/Javagen.java
+++ b/javagen/src/main/java/com/azure/autorest/Javagen.java
@@ -46,10 +46,6 @@ public class Javagen extends NewPlugin {
         return instance;
     }
 
-    public Logger getLogger() {
-        return this.logger;
-    }
-
     @Override
     public boolean processInternal() {
         JavaSettings settings = JavaSettings.getInstance();

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethodExample.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethodExample.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
 
 public class ProxyMethodExample {
 
-//    private final Logger LOGGER = new PluginLogger(Javagen.getPluginInstance(), ProxyMethodExample.class);
+    private final Logger LOGGER = new PluginLogger(Javagen.getPluginInstance(), ProxyMethodExample.class);
 
     // https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/x-ms-examples.md
 
@@ -114,7 +114,7 @@ public class ProxyMethodExample {
                                 break;
                             }
                         }
-                        if (resourceManagerOrDataPlaneSegmentIndex > 3) {
+                        if (resourceManagerOrDataPlaneSegmentIndex > 2) {
                             originalFileName = Arrays.stream(segments)
                                     .skip(resourceManagerOrDataPlaneSegmentIndex - 2)
                                     .collect(Collectors.joining("/"));
@@ -124,11 +124,12 @@ public class ProxyMethodExample {
 
                     default:
                     {
-//                        LOGGER.error("Unknown protocol in x-ms-original-file: '{}'", originalFileName);
+                        LOGGER.error("Unknown protocol in x-ms-original-file: '{}'", originalFileName);
+                        break;
                     }
                 }
             } catch (MalformedURLException | URISyntaxException | IllegalArgumentException e) {
-//                LOGGER.error("Failed to parse x-ms-original-file: '{}'", originalFileName);
+                LOGGER.error("Failed to parse x-ms-original-file: '{}'", originalFileName);
             }
             relativeOriginalFileName = originalFileName;
         }

--- a/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
@@ -6,6 +6,7 @@ package com.azure.autorest.template;
 import com.azure.autorest.Javagen;
 import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.extension.base.plugin.JavaSettings.CredentialType;
+import com.azure.autorest.extension.base.plugin.PluginLogger;
 import com.azure.autorest.model.clientmodel.AsyncSyncClient;
 import com.azure.autorest.model.clientmodel.ClassType;
 import com.azure.autorest.model.clientmodel.ListType;
@@ -16,6 +17,7 @@ import com.azure.autorest.model.javamodel.JavaFile;
 import com.azure.autorest.model.javamodel.JavaVisibility;
 import com.azure.autorest.util.ClientModelUtil;
 import com.azure.autorest.util.CodeNamer;
+import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -28,6 +30,9 @@ import java.util.stream.Stream;
  * Writes a ServiceClient to a JavaFile.
  */
 public class ServiceClientBuilderTemplate implements IJavaTemplate<ServiceClient, JavaFile> {
+
+    private final Logger LOGGER = new PluginLogger(Javagen.getPluginInstance(), ServiceClientBuilderTemplate.class);
+
     private static ServiceClientBuilderTemplate _instance = new ServiceClientBuilderTemplate();
 
     private final String JACKSON_SERIALIZER = "JacksonAdapter.createDefaultSerializerAdapter()";
@@ -333,7 +338,7 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ServiceClient
             if (settings.getCredentialTypes().contains(CredentialType.AZURE_KEY_CREDENTIAL)) {
                 if (JavaSettings.getInstance().getKeyCredentialHeaderName() == null
                     || JavaSettings.getInstance().getKeyCredentialHeaderName().isEmpty()) {
-                    Javagen.getPluginInstance().getLogger().error("key-credential-header-name is required for " +
+                    LOGGER.error("key-credential-header-name is required for " +
                             "azurekeycredential credential type");
                     throw new IllegalStateException("key-credential-header-name is required for " +
                             "azurekeycredential credential type");


### PR DESCRIPTION
This might not a best approach.

It requires `FluentGen` and `Androidgen` to fill in `Javagen.instance`, so that `Javagen.getPluginInstance()` works (not being a null), when calling `new PluginLogger(Javagen.getPluginInstance(), ...)`.