### PR TITLE
provide defaultValueExpression for IType

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ArrayType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ArrayType.java
@@ -49,6 +49,11 @@ public class ArrayType implements IType {
         return defaultValueExpressionConverter.apply(sourceExpression);
     }
 
+    @Override
+    public String defaultValueExpression() {
+        return defaultValueExpression(null);
+    }
+
     public final IType getClientType() {
         // The only supported array type is byte[]
         return this;

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
@@ -178,6 +178,11 @@ public class ClassType implements IType {
         return result;
     }
 
+    @Override
+    public String defaultValueExpression() {
+        return "null";
+    }
+
     public final IType getClientType() {
         IType clientType = this;
         if (this == ClassType.DateTimeRfc1123) {

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/EnumType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/EnumType.java
@@ -99,6 +99,11 @@ public class EnumType implements IType {
         }
     }
 
+    @Override
+    public String defaultValueExpression() {
+        return "null";
+    }
+
     public final IType getClientType() {
         return this;
     }

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/GenericType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/GenericType.java
@@ -159,6 +159,11 @@ public class GenericType implements IType {
         return sourceExpression;
     }
 
+    @Override
+    public String defaultValueExpression() {
+        return "null";
+    }
+
     public final IType getClientType() {
         IType clientType = this;
 

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/IType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/IType.java
@@ -57,5 +57,17 @@ public interface IType {
      */
     String defaultValueExpression(String sourceExpression);
 
+    /**
+     * The default value expression, when this type does not have data.
+     *
+     * This is the expression of the type provided as client.
+     * By default, the expression is "null" for class types.
+     * For primitive types, this would be the Java default value, usually "0".
+     * For some collection types, this could be the empty collection.
+     *
+     * @return the default value expression, when this type does not have data.
+     */
+    String defaultValueExpression();
+
     String validate(String expression);
 }

--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -258,7 +258,7 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                             methodBlock.methodReturn(expression);
                         }
                     } else {
-                        methodBlock.ifBlock(String.format("%s == null", expression), (ifBlock) -> ifBlock.methodReturn("null"));
+                        methodBlock.ifBlock(String.format("%s == null", expression), (ifBlock) -> ifBlock.methodReturn(propertyClientType.defaultValueExpression()));
 
                         String propertyConversion = propertyType.convertToClientType(expression);
 
@@ -347,11 +347,9 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                     generateGetterJavadoc(classBlock, model, property);
 
                     classBlock.publicMethod(String.format("%1$s %2$s()", propertyClientType, propertyReference.getGetterName()), methodBlock -> {
-                        // use ternary operator to avoid directly
+                        // use ternary operator to avoid directly return null
                         String ifClause = String.format("this.%1$s() == null", targetProperty.getGetterName());
-                        String nullClause = (propertyClientTypeFinal instanceof PrimitiveType)
-                                ? ((PrimitiveType) propertyClientTypeFinal).defaultValueExpression()
-                                : "null";
+                        String nullClause = propertyClientTypeFinal.defaultValueExpression();
                         String valueClause = String.format("this.%1$s().%2$s()", targetProperty.getGetterName(), property.getGetterName());
 
                         methodBlock.methodReturn(String.format("%1$s ? %2$s : %3$s", ifClause, nullClause, valueClause));


### PR DESCRIPTION
Case, some "null" as return value will be rejected by spotbugs.

```
    public byte[] data() {
        if (this.data == null) {
            return null;
        }
        return this.data.decodedBytes();
    }
```
will have
```
Error:  Low: Should com.azure.resourcemanager.keyvault.generated.models.KeyReleasePolicy.data() return a zero length array rather than null? [com.azure.resourcemanager.keyvault.generated.models.KeyReleasePolicy] At KeyReleasePolicy.java:[line 58] PZLA_PREFER_ZERO_LENGTH_ARRAYS
```

This fix would generate
```
    public byte[] data() {
        if (this.data == null) {
            return new byte[0];
        }
        return this.data.decodedBytes();
    }
```
instead.