### PR TITLE
fluent, fix sportbugs issue

### DIFF
--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/method/CollectionMethodOperationByIdTemplate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/fluentmodel/method/CollectionMethodOperationByIdTemplate.java
@@ -50,7 +50,7 @@ public class CollectionMethodOperationByIdTemplate implements ImmutableMethod {
         final ResourceLocalVariables localVariables = resourceLocalVariables.getDeduplicatedLocalVariables(new HashSet<>(Collections.singleton(ModelNaming.METHOD_PARAMETER_NAME_ID)));
         final boolean removeResponseInReturnType = !includeContextParameter;
         final IType returnType = getReturnType(collectionMethod.getFluentReturnType(), removeResponseInReturnType);
-        final boolean responseInReturnTypeRemoved = returnType != collectionMethod.getFluentReturnType();
+        final boolean responseInReturnTypeRemoved = returnType != collectionMethod.getFluentReturnType() && returnType != PrimitiveType.Void;
 
         final List<ClientMethodParameter> parameters = new ArrayList<>();
         // id parameter


### PR DESCRIPTION
Avoid code like
```
public void foo() {
    ...
    fooWithResponse(...).getValue();
}
```

The last `.getValue()` is required when the method returns an object (to convert `Resposne<Bar>` to `Bar`). But when return type is void, spotbugs will report this unnecessary call.