### PR TITLE
Use Constant Patterns and Fix Links to Repo

### DIFF
--- a/customization-base/src/main/java/com/azure/autorest/customization/PropertyCustomization.java
+++ b/customization-base/src/main/java/com/azure/autorest/customization/PropertyCustomization.java
@@ -13,6 +13,7 @@ import com.azure.autorest.customization.implementation.ls.models.WorkspaceEditCo
 
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 
@@ -20,6 +21,8 @@ import java.util.stream.Collectors;
  * The Javadoc customization for an AutoRest generated classes and methods.
  */
 public final class PropertyCustomization extends CodeCustomization {
+    private static final Pattern METHOD_PARAMS_CAPTURE = Pattern.compile("\\(.*\\)");
+
     private final String packageName;
     private final String className;
     private final String propertyName;
@@ -51,7 +54,8 @@ public final class PropertyCustomization extends CodeCustomization {
                 Utils.applyWorkspaceEdit(edit, editor, languageClient);
             } else if (symbol.getKind() == SymbolKind.METHOD) {
                 String methodName = symbol.getName().replace(propertyPascalName, newPascalName)
-                    .replace(propertyName, newName).replaceFirst("\\(.*\\)", "");
+                    .replace(propertyName, newName);
+                methodName = METHOD_PARAMS_CAPTURE.matcher(methodName).replaceFirst("");
                 WorkspaceEdit edit = languageClient.renameSymbol(fileUri, symbol.getLocation().getRange().getStart(), methodName);
                 Utils.applyWorkspaceEdit(edit, editor, languageClient);
             }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/checker/JavaFormatter.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/checker/JavaFormatter.java
@@ -17,8 +17,9 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 public class JavaFormatter {
-
     private static final Logger logger = new PluginLogger(FluentGen.getPluginInstance(), JavaFormatter.class);
+
+    private static final Pattern NEW_LINE = Pattern.compile("\r?\n");
 
     private static final boolean ENABLED;
     static {
@@ -82,7 +83,7 @@ public class JavaFormatter {
         final String quote = "\"";
 
         List<String> formattedLines = new ArrayList<>();
-        String[] lines = content.split("\r?\n", -1);
+        String[] lines = NEW_LINE.split(content, -1);
         for (String line : lines) {
             if (line.length() > lengthLimit) {
                 int firstQuote = line.indexOf(quote);

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/projectmodel/Changelog.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/projectmodel/Changelog.java
@@ -28,8 +28,10 @@ import java.util.stream.Collectors;
 import static java.time.temporal.ChronoField.*;
 
 public class Changelog {
-
     private static final Logger logger = new PluginLogger(FluentGen.getPluginInstance(), Changelog.class);
+
+    private static final Pattern UNRELEASED_VERSION_PATTERN =
+        Pattern.compile("^## ([0-9][-.a-z|0-9]+) \\(Unreleased\\)");
 
     private final List<String> lines;
 
@@ -56,7 +58,6 @@ public class Changelog {
         String previousUnreleasedVersion = null;
         List<String> previousChangelog = new ArrayList<>();
 
-        Pattern unreleasedVersionPattern = Pattern.compile("^## ([0-9][-.a-z|0-9]+) \\(Unreleased\\)");
         Pattern currentVersionPattern = Pattern.compile("^## " + Pattern.quote(project.getVersion())+ " \\(.*\\)");
 
         boolean beforeUnreleasedSection = true;
@@ -67,7 +68,7 @@ public class Changelog {
                     beforeUnreleasedSection = false;
 
                     if (line.trim().endsWith("(Unreleased)")) {
-                        Matcher m = unreleasedVersionPattern.matcher(line.trim());
+                        Matcher m = UNRELEASED_VERSION_PATTERN.matcher(line.trim());
                         if (m.find()) {
                             previousUnreleasedVersion = m.group(1);
                             logger.info("Found last unreleased version '{}'", previousUnreleasedVersion);

--- a/javagen/src/main/java/com/azure/autorest/model/javamodel/JavaFileContents.java
+++ b/javagen/src/main/java/com/azure/autorest/model/javamodel/JavaFileContents.java
@@ -15,10 +15,12 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Consumer;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class JavaFileContents {
     private static final String singleIndent = "    ";
+    private static final Pattern QUOTED_NEW_LINE = Pattern.compile(Pattern.quote("\n"));
 
     private StringBuilder contents;
     private StringBuilder linePrefix;
@@ -64,7 +66,7 @@ public class JavaFileContents {
     }
 
     public final String[] getLines() {
-        return toString().split(java.util.regex.Pattern.quote("\n"), -1);
+        return QUOTED_NEW_LINE.split(toString(), -1);
     }
 
     public final void addToPrefix(String toAdd) {
@@ -105,7 +107,7 @@ public class JavaFileContents {
     }
 
     private List<String> wordWrap(String line, boolean addPrefix) {
-        ArrayList<String> lines = new ArrayList<String>();
+        ArrayList<String> lines = new ArrayList<>();
 
         if (wordWrapWidth == null) {
             lines.add(line);

--- a/javagen/src/main/java/com/azure/autorest/model/javamodel/JavaImportComparer.java
+++ b/javagen/src/main/java/com/azure/autorest/model/javamodel/JavaImportComparer.java
@@ -5,7 +5,7 @@ import java.util.Locale;
 
 public class JavaImportComparer implements Comparator<String> {
     private static String[] getImportParts(String import_Keyword) {
-        return import_Keyword.split("[.]", -1);
+        return import_Keyword.split("\\.", -1);
     }
 
     private static boolean isLastPart(int importIndex, String[] importParts) {

--- a/javagen/src/main/java/com/azure/autorest/template/PackageInfoTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/PackageInfoTemplate.java
@@ -9,32 +9,33 @@ import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.model.clientmodel.PackageInfo;
 import com.azure.autorest.model.javamodel.JavaFile;
 
+import java.util.regex.Pattern;
+
 /**
  * Writes a PackageInfo to a JavaFile.
  */
 public class PackageInfoTemplate implements IJavaTemplate<PackageInfo, JavaFile> {
-    private static PackageInfoTemplate _instance = new PackageInfoTemplate();
+    private static final PackageInfoTemplate INSTANCE = new PackageInfoTemplate();
+
+    private static final Pattern NEW_LINE = Pattern.compile(Pattern.quote("\r\n"));
 
     private PackageInfoTemplate() {
     }
 
     public static PackageInfoTemplate getInstance() {
-        return _instance;
+        return INSTANCE;
     }
 
     public final void write(PackageInfo packageInfo, JavaFile javaFile) {
         JavaSettings settings = JavaSettings.getInstance();
         if (settings.getFileHeaderText() != null && !settings.getFileHeaderText().isEmpty()) {
             javaFile.lineComment(settings.getMaximumJavadocCommentWidth(), (comment) ->
-            {
-                comment.line(settings.getFileHeaderText());
-            });
+                comment.line(settings.getFileHeaderText()));
             javaFile.line();
         }
 
-        javaFile.javadocComment(settings.getMaximumJavadocCommentWidth(), (comment) ->
-        {
-            for (String desc : packageInfo.getDescription().split(java.util.regex.Pattern.quote(String.valueOf(new char[]{'\r', '\n'})), -1)) {
+        javaFile.javadocComment(settings.getMaximumJavadocCommentWidth(), (comment) -> {
+            for (String desc : NEW_LINE.split(packageInfo.getDescription(), -1)) {
                 comment.description(desc);
             }
         });

--- a/javagen/src/main/java/com/azure/autorest/util/CodeNamer.java
+++ b/javagen/src/main/java/com/azure/autorest/util/CodeNamer.java
@@ -83,6 +83,7 @@ public class CodeNamer {
     private static final Pattern ESCAPE_COMMENT = Pattern.compile(Pattern.quote("*/"));
     private static final Pattern MERGE_UNDERSCORES = Pattern.compile("_{2,}");
     private static final Pattern CHARACTERS_TO_REPLACE_WITH_UNDERSCORE = Pattern.compile("[\\\\/.+ -]+");
+    private static final Pattern NEW_LINE = Pattern.compile("\r?\n");
 
     public static void setFactory(NamerFactory templateFactory) {
         factory = templateFactory;
@@ -274,7 +275,7 @@ public class CodeNamer {
     public static List<String> wordWrap(String text, int width) {
         Objects.requireNonNull(text);
         List<String> ret = new ArrayList<>();
-        String[] lines = text.split("\r?\n", -1);
+        String[] lines = NEW_LINE.split(text, -1);
         for (String line : lines) {
             String processedLine = line.trim();
 

--- a/postprocessor/package.json
+++ b/postprocessor/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jianghaolu/autorest.java.v3"
+    "url": "https://github.com/Azure/autorest.java"
   },
   "readme": "./readme.md",
   "keywords": [

--- a/preprocessor/package.json
+++ b/preprocessor/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jianghaolu/autorest.java.v3"
+    "url": "https://github.com/Azure/autorest.java"
   },
   "readme": "./readme.md",
   "keywords": [


### PR DESCRIPTION
This PR updates multiple locations to use constant `Pattern`s instead of compiling the pattern on every call. Additionally, this fixes a few git links to the non-standard repo.