### PR TITLE
example, handle possible escaped query value in example

### DIFF
--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/ExampleParser.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/ExampleParser.java
@@ -462,7 +462,10 @@ public class ExampleParser {
                 node = new LiteralNode(methodParameter.getClientMethodParameter().getClientType(), null);
             }
         } else {
-            node = parseNodeFromMethodParameter(methodParameter, parameterValue.getObjectValue());
+            Object exampleValue = methodParameter.getClientMethodParameter().getLocation() == RequestParameterLocation.Query
+                    ? parameterValue.getUnescapedQueryValue()
+                    : parameterValue.getObjectValue();
+            node = parseNodeFromMethodParameter(methodParameter, exampleValue);
         }
         return node;
     }

--- a/fluentgen/src/test/java/com/azure/autorest/fluent/model/clientmodel/ProxyMethodExampleTests.java
+++ b/fluentgen/src/test/java/com/azure/autorest/fluent/model/clientmodel/ProxyMethodExampleTests.java
@@ -36,4 +36,34 @@ public class ProxyMethodExampleTests {
                 .build();
         Assertions.assertEquals(example.getOriginalFile(), example.getRelativeOriginalFileName());
     }
+
+    @Test
+    public void testUnescapeQueryValue() {
+        String queryNotEscaped1 = "timestamp ge datetime'2017-06-01T00:00:00' and timestamp le datetime'2017-06-04T00:00:00'";
+        String queryNotEscaped2 = "properties/extensionHandler/any(eh: eh/version gt '2.70') and contains(name,'sql') and contains(properties/nodeConfiguration/name,'$$Not$$Configured$$')";
+
+        String queryNotEscaped3 = "properties/eventDate ge 2020-05-20 AND properties/eventDate le 2020-05-30";
+        String queryEscaped3 = "properties/eventDate+ge+2020-05-20+AND+properties/eventDate+le+2020-05-30";
+
+        String queryNotEscaped4 = "(properties/archived eq false)";
+        String queryEscaped4 = "(properties%2farchived+eq+false)";
+
+        String queryNotEscaped5 = "status eq 'Active' and severity eq 'Critical'";
+        String queryEscaped5 = "status%20eq%20'Active'%20and%20severity%20eq%20'Critical'";
+
+        ProxyMethodExample.ParameterValue parameterValue = new ProxyMethodExample.ParameterValue(queryNotEscaped1);
+        Assertions.assertEquals(queryNotEscaped1, parameterValue.getUnescapedQueryValue().toString());
+
+        parameterValue = new ProxyMethodExample.ParameterValue(queryNotEscaped2);
+        Assertions.assertEquals(queryNotEscaped2, parameterValue.getUnescapedQueryValue().toString());
+
+        parameterValue = new ProxyMethodExample.ParameterValue(queryEscaped3);
+        Assertions.assertEquals(queryNotEscaped3, parameterValue.getUnescapedQueryValue().toString());
+
+        parameterValue = new ProxyMethodExample.ParameterValue(queryEscaped4);
+        Assertions.assertEquals(queryNotEscaped4, parameterValue.getUnescapedQueryValue().toString());
+
+        parameterValue = new ProxyMethodExample.ParameterValue(queryEscaped5);
+        Assertions.assertEquals(queryNotEscaped5, parameterValue.getUnescapedQueryValue().toString());
+    }
 }

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethodExample.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethodExample.java
@@ -13,10 +13,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import org.slf4j.Logger;
 
+import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -27,7 +30,7 @@ public class ProxyMethodExample {
 
     private final Logger LOGGER = new PluginLogger(Javagen.getPluginInstance(), ProxyMethodExample.class);
 
-    // https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/x-ms-examples.md
+    // https://azure.github.io/autorest/extensions/#x-ms-examples
 
     public static class ParameterValue {
         private final Object objectValue;
@@ -45,6 +48,25 @@ public class ProxyMethodExample {
          */
         public Object getObjectValue() {
             return objectValue;
+        }
+
+        /**
+         * Gets the un-escaped query value.
+         *
+         * This is done by heuristic, and not guaranteed to be correct.
+         *
+         * @return the un-escaped query value
+         */
+        public Object getUnescapedQueryValue() {
+            Object unescapedValue = objectValue;
+            if (objectValue instanceof String) {
+                try {
+                    unescapedValue = URLDecoder.decode((String) objectValue, StandardCharsets.UTF_8.name());
+                } catch (UnsupportedEncodingException e) {
+                    // NOOP
+                }
+            }
+            return unescapedValue;
         }
 
         @Override

--- a/javagen/src/main/java/com/azure/autorest/template/ProtocolSampleTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ProtocolSampleTemplate.java
@@ -3,6 +3,7 @@
 
 package com.azure.autorest.template;
 
+import com.azure.autorest.extension.base.model.codemodel.RequestParameterLocation;
 import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.model.clientmodel.AsyncSyncClient;
 import com.azure.autorest.model.clientmodel.ClassType;
@@ -77,8 +78,10 @@ public class ProtocolSampleTemplate implements IJavaTemplate<ProtocolExample, Ja
                 ClientMethodParameter p = method.getParameters().get(i);
                 if (p.getName().equalsIgnoreCase(parameterName)) {
                     if (p.getClientType() != ClassType.BinaryData) {
-                        // simple type
-                        params.set(i, p.getClientType().defaultValueExpression(parameterValue.getObjectValue().toString()));
+                        String exampleValue = p.getLocation() == RequestParameterLocation.Query
+                                ? parameterValue.getUnescapedQueryValue().toString()
+                                : parameterValue.getObjectValue().toString();
+                        params.set(i, p.getClientType().defaultValueExpression(exampleValue));
                     } else {
                         // BinaryData
                         String binaryDataValue = ClassType.String.defaultValueExpression(parameterValue.getJsonString());
@@ -93,27 +96,25 @@ public class ProtocolSampleTemplate implements IJavaTemplate<ProtocolExample, Ja
             }
             if (!matchRequiredParameter) {
                 method.getProxyMethod().getAllParameters().stream().filter(p -> !p.getFromClient()).filter(p -> p.getName().equalsIgnoreCase(parameterName)).findFirst().ifPresent(p -> {
-                    String clientValue = p.getClientType()
-                            .defaultValueExpression(parameterValue.getObjectValue().toString());
-
                     switch (p.getRequestParameterLocation()) {
                         case Query:
                             requestOptionsStmts.add(
                                     String.format("requestOptions.addQueryParam(\"%s\", %s);",
-                                            parameterName, clientValue));
+                                            parameterName,
+                                            p.getClientType().defaultValueExpression(parameterValue.getUnescapedQueryValue().toString())));
                             break;
 
                         case Header:
                             requestOptionsStmts.add(
                                     String.format("requestOptions.addHeader(\"%s\", %s);",
-                                            parameterName, clientValue));
+                                            parameterName,
+                                            p.getClientType().defaultValueExpression(parameterValue.getObjectValue().toString())));
                             break;
 
                         case Body:
-                            String binaryDataValue = ClassType.String.defaultValueExpression(parameterValue.getJsonString());
                             requestOptionsStmts.add(
                                     String.format("requestOptions.setBody(BinaryData.fromString(%s));",
-                                            binaryDataValue));
+                                            ClassType.String.defaultValueExpression(parameterValue.getJsonString())));
                             break;
 
                         // Path cannot be optional


### PR DESCRIPTION
fix https://github.com/Azure/autorest.java/issues/1216

some RP use example with escaped query string
https://github.com/Azure/azure-rest-api-specs/blob/master/specification/consumption/resource-manager/Microsoft.Consumption/stable/2021-10-01/examples/ReservationTransactionsListByEnrollmentNumber.json#L4