### PR TITLE
LLC, remove Context from sync method

### DIFF
--- a/eng/pipelines/fluent_integration.yaml
+++ b/eng/pipelines/fluent_integration.yaml
@@ -12,7 +12,7 @@ jobs:
 - job: 'Build'
   timeoutInMinutes: 60
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-latest'
 
   steps:
   - task: NodeTool@0

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -739,6 +739,14 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
      */
     protected JavaVisibility methodVisibility(ClientMethodType methodType, boolean hasContextParameter) {
         if (JavaSettings.getInstance().isLowLevelClient()) {
+            /*
+            Rule for LLC
+
+            1. Only generate "WithResponse" method for simple API (hence exclude SimpleAsync and SimpleSync).
+            2. For sync method, Context is included in "RequestOptions", hence do not generate method with Context parameter.
+            3. For async method, Context is not included in the first place (this rule is valid for all clients).
+             */
+
             return (methodType == ClientMethodType.SimpleAsync || methodType == ClientMethodType.SimpleSync
                     || (methodType == ClientMethodType.PagingSync && hasContextParameter)
                     || (methodType == ClientMethodType.LongRunningBeginSync && hasContextParameter)

--- a/protocol-resilience-test/llcinitial/src/main/java/fixtures/llcresi/LLCClient.java
+++ b/protocol-resilience-test/llcinitial/src/main/java/fixtures/llcresi/LLCClient.java
@@ -11,7 +11,6 @@ import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import fixtures.llcresi.implementation.ParamsImpl;
 
 /** Initializes a new instance of the synchronous LLCClient type. */
@@ -46,14 +45,13 @@ public final class LLCClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return true Boolean value on path.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getRequiredWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getRequiredWithResponse(requestOptions, context);
+    public Response<BinaryData> getRequiredWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getRequiredWithResponse(requestOptions);
     }
 
     /**
@@ -75,14 +73,12 @@ public final class LLCClient {
      *
      * @param parameter I am a body parameter. My only valid JSON entry is { url: "http://example.org/myimage.jpeg" }.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return any object.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> postParametersWithResponse(
-            BinaryData parameter, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.postParametersWithResponse(parameter, requestOptions, context);
+    public Response<BinaryData> postParametersWithResponse(BinaryData parameter, RequestOptions requestOptions) {
+        return this.serviceClient.postParametersWithResponse(parameter, requestOptions);
     }
 }

--- a/protocol-resilience-test/llcinitial/src/main/java/fixtures/llcresi/implementation/ParamsImpl.java
+++ b/protocol-resilience-test/llcinitial/src/main/java/fixtures/llcresi/implementation/ParamsImpl.java
@@ -131,14 +131,13 @@ public final class ParamsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return true Boolean value on path.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getRequiredWithResponse(RequestOptions requestOptions, Context context) {
-        return getRequiredWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getRequiredWithResponse(RequestOptions requestOptions) {
+        return getRequiredWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -220,14 +219,12 @@ public final class ParamsImpl {
      *
      * @param parameter I am a body parameter. My only valid JSON entry is { url: "http://example.org/myimage.jpeg" }.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return any object.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> postParametersWithResponse(
-            BinaryData parameter, RequestOptions requestOptions, Context context) {
-        return postParametersWithResponseAsync(parameter, requestOptions, context).block();
+    public Response<BinaryData> postParametersWithResponse(BinaryData parameter, RequestOptions requestOptions) {
+        return postParametersWithResponseAsync(parameter, requestOptions).block();
     }
 }

--- a/protocol-resilience-test/llcupdate1/src/main/java/fixtures/llcresi/LLCClient.java
+++ b/protocol-resilience-test/llcupdate1/src/main/java/fixtures/llcresi/LLCClient.java
@@ -11,7 +11,6 @@ import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import fixtures.llcresi.implementation.ParamsImpl;
 
 /** Initializes a new instance of the synchronous LLCClient type. */
@@ -47,14 +46,13 @@ public final class LLCClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return true Boolean value on path.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getRequiredWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getRequiredWithResponse(requestOptions, context);
+    public Response<BinaryData> getRequiredWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getRequiredWithResponse(requestOptions);
     }
 
     /**
@@ -83,29 +81,26 @@ public final class LLCClient {
      * @param parameter I am a body parameter with a new content type. My only valid JSON entry is { url:
      *     "http://example.org/myimage.jpeg" }.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return any object.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> postParametersWithResponse(
-            BinaryData parameter, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.postParametersWithResponse(parameter, requestOptions, context);
+    public Response<BinaryData> postParametersWithResponse(BinaryData parameter, RequestOptions requestOptions) {
+        return this.serviceClient.postParametersWithResponse(parameter, requestOptions);
     }
 
     /**
      * Delete something.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> deleteParametersWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.deleteParametersWithResponse(requestOptions, context);
+    public Response<Void> deleteParametersWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.deleteParametersWithResponse(requestOptions);
     }
 
     /**
@@ -118,13 +113,12 @@ public final class LLCClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return any object.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getNewOperationWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getNewOperationWithResponse(requestOptions, context);
+    public Response<BinaryData> getNewOperationWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getNewOperationWithResponse(requestOptions);
     }
 }

--- a/protocol-resilience-test/llcupdate1/src/main/java/fixtures/llcresi/implementation/ParamsImpl.java
+++ b/protocol-resilience-test/llcupdate1/src/main/java/fixtures/llcresi/implementation/ParamsImpl.java
@@ -143,14 +143,13 @@ public final class ParamsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return true Boolean value on path.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getRequiredWithResponse(RequestOptions requestOptions, Context context) {
-        return getRequiredWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getRequiredWithResponse(RequestOptions requestOptions) {
+        return getRequiredWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -253,15 +252,13 @@ public final class ParamsImpl {
      * @param parameter I am a body parameter with a new content type. My only valid JSON entry is { url:
      *     "http://example.org/myimage.jpeg" }.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return any object.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> postParametersWithResponse(
-            BinaryData parameter, RequestOptions requestOptions, Context context) {
-        return postParametersWithResponseAsync(parameter, requestOptions, context).block();
+    public Response<BinaryData> postParametersWithResponse(BinaryData parameter, RequestOptions requestOptions) {
+        return postParametersWithResponseAsync(parameter, requestOptions).block();
     }
 
     /**
@@ -296,14 +293,13 @@ public final class ParamsImpl {
      * Delete something.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> deleteParametersWithResponse(RequestOptions requestOptions, Context context) {
-        return deleteParametersWithResponseAsync(requestOptions, context).block();
+    public Response<Void> deleteParametersWithResponse(RequestOptions requestOptions) {
+        return deleteParametersWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -355,13 +351,12 @@ public final class ParamsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return any object.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getNewOperationWithResponse(RequestOptions requestOptions, Context context) {
-        return getNewOperationWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getNewOperationWithResponse(RequestOptions requestOptions) {
+        return getNewOperationWithResponseAsync(requestOptions).block();
     }
 }

--- a/protocol-tests/src/main/java/fixtures/bodycomplex/ArrayClient.java
+++ b/protocol-tests/src/main/java/fixtures/bodycomplex/ArrayClient.java
@@ -11,7 +11,6 @@ import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import fixtures.bodycomplex.implementation.ArraysImpl;
 
 /** Initializes a new instance of the synchronous AutoRestComplexTestService type. */
@@ -42,14 +41,13 @@ public final class ArrayClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with array property.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getValidWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getValidWithResponse(requestOptions, context);
+    public Response<BinaryData> getValidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getValidWithResponse(requestOptions);
     }
 
     /**
@@ -68,14 +66,13 @@ public final class ArrayClient {
      * @param complexBody Please put an array with 4 items: "1, 2, 3, 4", "", null, "&amp;amp;S#$(*Y", "The quick brown
      *     fox jumps over the lazy dog".
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putValidWithResponse(BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.putValidWithResponse(complexBody, requestOptions, context);
+    public Response<Void> putValidWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return this.serviceClient.putValidWithResponse(complexBody, requestOptions);
     }
 
     /**
@@ -92,14 +89,13 @@ public final class ArrayClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with array property which is empty.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getEmptyWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getEmptyWithResponse(requestOptions, context);
+    public Response<BinaryData> getEmptyWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getEmptyWithResponse(requestOptions);
     }
 
     /**
@@ -117,14 +113,13 @@ public final class ArrayClient {
      *
      * @param complexBody Please put an empty array.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putEmptyWithResponse(BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.putEmptyWithResponse(complexBody, requestOptions, context);
+    public Response<Void> putEmptyWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return this.serviceClient.putEmptyWithResponse(complexBody, requestOptions);
     }
 
     /**
@@ -141,13 +136,12 @@ public final class ArrayClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with array property while server doesn't provide a response payload.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getNotProvidedWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getNotProvidedWithResponse(requestOptions, context);
+    public Response<BinaryData> getNotProvidedWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getNotProvidedWithResponse(requestOptions);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/bodycomplex/BasicClient.java
+++ b/protocol-tests/src/main/java/fixtures/bodycomplex/BasicClient.java
@@ -11,7 +11,6 @@ import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import fixtures.bodycomplex.implementation.BasicsImpl;
 
 /** Initializes a new instance of the synchronous AutoRestComplexTestService type. */
@@ -42,14 +41,13 @@ public final class BasicClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex type {id: 2, name: 'abc', color: 'YELLOW'}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getValidWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getValidWithResponse(requestOptions, context);
+    public Response<BinaryData> getValidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getValidWithResponse(requestOptions);
     }
 
     /**
@@ -75,14 +73,13 @@ public final class BasicClient {
      *
      * @param complexBody Please put {id: 2, name: 'abc', color: 'Magenta'}.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putValidWithResponse(BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.putValidWithResponse(complexBody, requestOptions, context);
+    public Response<Void> putValidWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return this.serviceClient.putValidWithResponse(complexBody, requestOptions);
     }
 
     /**
@@ -99,14 +96,13 @@ public final class BasicClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a basic complex type that is invalid for the local strong type.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getInvalidWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getInvalidWithResponse(requestOptions, context);
+    public Response<BinaryData> getInvalidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getInvalidWithResponse(requestOptions);
     }
 
     /**
@@ -123,14 +119,13 @@ public final class BasicClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a basic complex type that is empty.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getEmptyWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getEmptyWithResponse(requestOptions, context);
+    public Response<BinaryData> getEmptyWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getEmptyWithResponse(requestOptions);
     }
 
     /**
@@ -147,14 +142,13 @@ public final class BasicClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a basic complex type whose properties are null.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getNullWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getNullWithResponse(requestOptions, context);
+    public Response<BinaryData> getNullWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getNullWithResponse(requestOptions);
     }
 
     /**
@@ -171,13 +165,12 @@ public final class BasicClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a basic complex type while the server doesn't provide a response payload.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getNotProvidedWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getNotProvidedWithResponse(requestOptions, context);
+    public Response<BinaryData> getNotProvidedWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getNotProvidedWithResponse(requestOptions);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/bodycomplex/DictionaryClient.java
+++ b/protocol-tests/src/main/java/fixtures/bodycomplex/DictionaryClient.java
@@ -11,7 +11,6 @@ import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import fixtures.bodycomplex.implementation.DictionariesImpl;
 
 /** Initializes a new instance of the synchronous AutoRestComplexTestService type. */
@@ -42,14 +41,13 @@ public final class DictionaryClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with dictionary property.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getValidWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getValidWithResponse(requestOptions, context);
+    public Response<BinaryData> getValidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getValidWithResponse(requestOptions);
     }
 
     /**
@@ -68,14 +66,13 @@ public final class DictionaryClient {
      * @param complexBody Please put a dictionary with 5 key-value pairs: "txt":"notepad", "bmp":"mspaint",
      *     "xls":"excel", "exe":"", "":null.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putValidWithResponse(BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.putValidWithResponse(complexBody, requestOptions, context);
+    public Response<Void> putValidWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return this.serviceClient.putValidWithResponse(complexBody, requestOptions);
     }
 
     /**
@@ -92,14 +89,13 @@ public final class DictionaryClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with dictionary property which is empty.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getEmptyWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getEmptyWithResponse(requestOptions, context);
+    public Response<BinaryData> getEmptyWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getEmptyWithResponse(requestOptions);
     }
 
     /**
@@ -117,14 +113,13 @@ public final class DictionaryClient {
      *
      * @param complexBody Please put an empty dictionary.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putEmptyWithResponse(BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.putEmptyWithResponse(complexBody, requestOptions, context);
+    public Response<Void> putEmptyWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return this.serviceClient.putEmptyWithResponse(complexBody, requestOptions);
     }
 
     /**
@@ -141,14 +136,13 @@ public final class DictionaryClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with dictionary property which is null.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getNullWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getNullWithResponse(requestOptions, context);
+    public Response<BinaryData> getNullWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getNullWithResponse(requestOptions);
     }
 
     /**
@@ -165,13 +159,12 @@ public final class DictionaryClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with dictionary property while server doesn't provide a response payload.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getNotProvidedWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getNotProvidedWithResponse(requestOptions, context);
+    public Response<BinaryData> getNotProvidedWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getNotProvidedWithResponse(requestOptions);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/bodycomplex/FlattencomplexClient.java
+++ b/protocol-tests/src/main/java/fixtures/bodycomplex/FlattencomplexClient.java
@@ -11,7 +11,6 @@ import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import fixtures.bodycomplex.implementation.FlattencomplexesImpl;
 
 /** Initializes a new instance of the synchronous AutoRestComplexTestService type. */
@@ -41,13 +40,12 @@ public final class FlattencomplexClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getValidWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getValidWithResponse(requestOptions, context);
+    public Response<BinaryData> getValidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getValidWithResponse(requestOptions);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/bodycomplex/InheritanceClient.java
+++ b/protocol-tests/src/main/java/fixtures/bodycomplex/InheritanceClient.java
@@ -11,7 +11,6 @@ import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import fixtures.bodycomplex.implementation.InheritancesImpl;
 
 /** Initializes a new instance of the synchronous AutoRestComplexTestService type. */
@@ -50,14 +49,13 @@ public final class InheritanceClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types that extend others.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getValidWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getValidWithResponse(requestOptions, context);
+    public Response<BinaryData> getValidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getValidWithResponse(requestOptions);
     }
 
     /**
@@ -85,13 +83,12 @@ public final class InheritanceClient {
      *     dogs, the 1st one named "Potato" with id=1 and food="tomato", and the 2nd one named "Tomato" with id=-1 and
      *     food="french fries".
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putValidWithResponse(BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.putValidWithResponse(complexBody, requestOptions, context);
+    public Response<Void> putValidWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return this.serviceClient.putValidWithResponse(complexBody, requestOptions);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/bodycomplex/PolymorphicrecursiveClient.java
+++ b/protocol-tests/src/main/java/fixtures/bodycomplex/PolymorphicrecursiveClient.java
@@ -11,7 +11,6 @@ import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import fixtures.bodycomplex.implementation.PolymorphicrecursivesImpl;
 
 /** Initializes a new instance of the synchronous AutoRestComplexTestService type. */
@@ -44,14 +43,13 @@ public final class PolymorphicrecursiveClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types that are polymorphic and have recursive references.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getValidWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getValidWithResponse(requestOptions, context);
+    public Response<BinaryData> getValidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getValidWithResponse(requestOptions);
     }
 
     /**
@@ -77,13 +75,12 @@ public final class PolymorphicrecursiveClient {
      *     "fishtype": "sawshark", "species": "dangerous", "length": 10, "age": 105 } ] }, { "fishtype": "sawshark",
      *     "species": "dangerous", "length": 10, "age": 105 } ] }.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putValidWithResponse(BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.putValidWithResponse(complexBody, requestOptions, context);
+    public Response<Void> putValidWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return this.serviceClient.putValidWithResponse(complexBody, requestOptions);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/bodycomplex/PolymorphismClient.java
+++ b/protocol-tests/src/main/java/fixtures/bodycomplex/PolymorphismClient.java
@@ -11,7 +11,6 @@ import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import fixtures.bodycomplex.implementation.PolymorphismsImpl;
 
 /** Initializes a new instance of the synchronous AutoRestComplexTestService type. */
@@ -44,14 +43,13 @@ public final class PolymorphismClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types that are polymorphic.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getValidWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getValidWithResponse(requestOptions, context);
+    public Response<BinaryData> getValidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getValidWithResponse(requestOptions);
     }
 
     /**
@@ -76,14 +74,13 @@ public final class PolymorphismClient {
      *     254]).toString('base64'), 'species':'dangerous', }, { 'fishtype': 'goblin', 'age': 1, 'birthday':
      *     '2015-08-08T00:00:00Z', 'length': 30.0, 'species': 'scary', 'jawsize': 5 } ] };.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putValidWithResponse(BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.putValidWithResponse(complexBody, requestOptions, context);
+    public Response<Void> putValidWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return this.serviceClient.putValidWithResponse(complexBody, requestOptions);
     }
 
     /**
@@ -98,14 +95,13 @@ public final class PolymorphismClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types that are polymorphic, JSON key contains a dot.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getDotSyntaxWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getDotSyntaxWithResponse(requestOptions, context);
+    public Response<BinaryData> getDotSyntaxWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getDotSyntaxWithResponse(requestOptions);
     }
 
     /**
@@ -134,16 +130,14 @@ public final class PolymorphismClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex object composing a polymorphic scalar property and array property with polymorphic element type,
      *     with discriminator specified.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getComposedWithDiscriminatorWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getComposedWithDiscriminatorWithResponse(requestOptions, context);
+    public Response<BinaryData> getComposedWithDiscriminatorWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getComposedWithDiscriminatorWithResponse(requestOptions);
     }
 
     /**
@@ -172,16 +166,14 @@ public final class PolymorphismClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex object composing a polymorphic scalar property and array property with polymorphic element type,
      *     without discriminator specified on wire.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getComposedWithoutDiscriminatorWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getComposedWithoutDiscriminatorWithResponse(requestOptions, context);
+    public Response<BinaryData> getComposedWithoutDiscriminatorWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getComposedWithoutDiscriminatorWithResponse(requestOptions);
     }
 
     /**
@@ -208,15 +200,14 @@ public final class PolymorphismClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types that are polymorphic, but not at the root of the hierarchy; also have additional
      *     properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getComplicatedWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getComplicatedWithResponse(requestOptions, context);
+    public Response<BinaryData> getComplicatedWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getComplicatedWithResponse(requestOptions);
     }
 
     /**
@@ -244,15 +235,13 @@ public final class PolymorphismClient {
      *
      * @param complexBody The complexBody parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putComplicatedWithResponse(
-            BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.putComplicatedWithResponse(complexBody, requestOptions, context);
+    public Response<Void> putComplicatedWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return this.serviceClient.putComplicatedWithResponse(complexBody, requestOptions);
     }
 
     /**
@@ -300,15 +289,14 @@ public final class PolymorphismClient {
      *
      * @param complexBody The complexBody parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<BinaryData> putMissingDiscriminatorWithResponse(
-            BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.putMissingDiscriminatorWithResponse(complexBody, requestOptions, context);
+            BinaryData complexBody, RequestOptions requestOptions) {
+        return this.serviceClient.putMissingDiscriminatorWithResponse(complexBody, requestOptions);
     }
 
     /**
@@ -333,14 +321,12 @@ public final class PolymorphismClient {
      *     "shark", "species": "predator", "birthday": "2012-01-05T01:00:00Z", "length": 20, "age": 6 }, { "fishtype":
      *     "sawshark", "species": "dangerous", "picture": base64(FF FF FF FF FE), "length": 10, "age": 105 } ] }.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putValidMissingRequiredWithResponse(
-            BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.putValidMissingRequiredWithResponse(complexBody, requestOptions, context);
+    public Response<Void> putValidMissingRequiredWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return this.serviceClient.putValidMissingRequiredWithResponse(complexBody, requestOptions);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/bodycomplex/PrimitiveClient.java
+++ b/protocol-tests/src/main/java/fixtures/bodycomplex/PrimitiveClient.java
@@ -11,7 +11,6 @@ import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import fixtures.bodycomplex.implementation.PrimitivesImpl;
 
 /** Initializes a new instance of the synchronous AutoRestComplexTestService type. */
@@ -41,14 +40,13 @@ public final class PrimitiveClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with integer properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getIntWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getIntWithResponse(requestOptions, context);
+    public Response<BinaryData> getIntWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getIntWithResponse(requestOptions);
     }
 
     /**
@@ -65,14 +63,13 @@ public final class PrimitiveClient {
      *
      * @param complexBody Please put -1 and 2.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putIntWithResponse(BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.putIntWithResponse(complexBody, requestOptions, context);
+    public Response<Void> putIntWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return this.serviceClient.putIntWithResponse(complexBody, requestOptions);
     }
 
     /**
@@ -88,14 +85,13 @@ public final class PrimitiveClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with long properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getLongWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getLongWithResponse(requestOptions, context);
+    public Response<BinaryData> getLongWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getLongWithResponse(requestOptions);
     }
 
     /**
@@ -112,14 +108,13 @@ public final class PrimitiveClient {
      *
      * @param complexBody Please put 1099511627775 and -999511627788.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putLongWithResponse(BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.putLongWithResponse(complexBody, requestOptions, context);
+    public Response<Void> putLongWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return this.serviceClient.putLongWithResponse(complexBody, requestOptions);
     }
 
     /**
@@ -135,14 +130,13 @@ public final class PrimitiveClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with float properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getFloatWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getFloatWithResponse(requestOptions, context);
+    public Response<BinaryData> getFloatWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getFloatWithResponse(requestOptions);
     }
 
     /**
@@ -159,14 +153,13 @@ public final class PrimitiveClient {
      *
      * @param complexBody Please put 1.05 and -0.003.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putFloatWithResponse(BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.putFloatWithResponse(complexBody, requestOptions, context);
+    public Response<Void> putFloatWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return this.serviceClient.putFloatWithResponse(complexBody, requestOptions);
     }
 
     /**
@@ -182,14 +175,13 @@ public final class PrimitiveClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with double properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getDoubleWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getDoubleWithResponse(requestOptions, context);
+    public Response<BinaryData> getDoubleWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getDoubleWithResponse(requestOptions);
     }
 
     /**
@@ -206,15 +198,13 @@ public final class PrimitiveClient {
      *
      * @param complexBody Please put 3e-100 and -0.000000000000000000000000000000000000000000000000000000005.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putDoubleWithResponse(
-            BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.putDoubleWithResponse(complexBody, requestOptions, context);
+    public Response<Void> putDoubleWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return this.serviceClient.putDoubleWithResponse(complexBody, requestOptions);
     }
 
     /**
@@ -230,14 +220,13 @@ public final class PrimitiveClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with bool properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getBoolWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getBoolWithResponse(requestOptions, context);
+    public Response<BinaryData> getBoolWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getBoolWithResponse(requestOptions);
     }
 
     /**
@@ -254,14 +243,13 @@ public final class PrimitiveClient {
      *
      * @param complexBody Please put true and false.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putBoolWithResponse(BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.putBoolWithResponse(complexBody, requestOptions, context);
+    public Response<Void> putBoolWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return this.serviceClient.putBoolWithResponse(complexBody, requestOptions);
     }
 
     /**
@@ -278,14 +266,13 @@ public final class PrimitiveClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with string properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getStringWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getStringWithResponse(requestOptions, context);
+    public Response<BinaryData> getStringWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getStringWithResponse(requestOptions);
     }
 
     /**
@@ -303,15 +290,13 @@ public final class PrimitiveClient {
      *
      * @param complexBody Please put 'goodrequest', '', and null.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putStringWithResponse(
-            BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.putStringWithResponse(complexBody, requestOptions, context);
+    public Response<Void> putStringWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return this.serviceClient.putStringWithResponse(complexBody, requestOptions);
     }
 
     /**
@@ -327,14 +312,13 @@ public final class PrimitiveClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with date properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getDateWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getDateWithResponse(requestOptions, context);
+    public Response<BinaryData> getDateWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getDateWithResponse(requestOptions);
     }
 
     /**
@@ -351,14 +335,13 @@ public final class PrimitiveClient {
      *
      * @param complexBody Please put '0001-01-01' and '2016-02-29'.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putDateWithResponse(BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.putDateWithResponse(complexBody, requestOptions, context);
+    public Response<Void> putDateWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return this.serviceClient.putDateWithResponse(complexBody, requestOptions);
     }
 
     /**
@@ -374,14 +357,13 @@ public final class PrimitiveClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with datetime properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getDateTimeWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getDateTimeWithResponse(requestOptions, context);
+    public Response<BinaryData> getDateTimeWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getDateTimeWithResponse(requestOptions);
     }
 
     /**
@@ -398,15 +380,13 @@ public final class PrimitiveClient {
      *
      * @param complexBody Please put '0001-01-01T12:00:00-04:00' and '2015-05-18T11:38:00-08:00'.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putDateTimeWithResponse(
-            BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.putDateTimeWithResponse(complexBody, requestOptions, context);
+    public Response<Void> putDateTimeWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return this.serviceClient.putDateTimeWithResponse(complexBody, requestOptions);
     }
 
     /**
@@ -422,14 +402,13 @@ public final class PrimitiveClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with datetimeRfc1123 properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getDateTimeRfc1123WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getDateTimeRfc1123WithResponse(requestOptions, context);
+    public Response<BinaryData> getDateTimeRfc1123WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getDateTimeRfc1123WithResponse(requestOptions);
     }
 
     /**
@@ -446,15 +425,13 @@ public final class PrimitiveClient {
      *
      * @param complexBody Please put 'Mon, 01 Jan 0001 12:00:00 GMT' and 'Mon, 18 May 2015 11:38:00 GMT'.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putDateTimeRfc1123WithResponse(
-            BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.putDateTimeRfc1123WithResponse(complexBody, requestOptions, context);
+    public Response<Void> putDateTimeRfc1123WithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return this.serviceClient.putDateTimeRfc1123WithResponse(complexBody, requestOptions);
     }
 
     /**
@@ -469,14 +446,13 @@ public final class PrimitiveClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with duration properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getDurationWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getDurationWithResponse(requestOptions, context);
+    public Response<BinaryData> getDurationWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getDurationWithResponse(requestOptions);
     }
 
     /**
@@ -492,15 +468,13 @@ public final class PrimitiveClient {
      *
      * @param complexBody Please put 'P123DT22H14M12.011S'.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putDurationWithResponse(
-            BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.putDurationWithResponse(complexBody, requestOptions, context);
+    public Response<Void> putDurationWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return this.serviceClient.putDurationWithResponse(complexBody, requestOptions);
     }
 
     /**
@@ -515,14 +489,13 @@ public final class PrimitiveClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with byte properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getByteWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getByteWithResponse(requestOptions, context);
+    public Response<BinaryData> getByteWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getByteWithResponse(requestOptions);
     }
 
     /**
@@ -538,13 +511,12 @@ public final class PrimitiveClient {
      *
      * @param complexBody Please put non-ascii byte string hex(FF FE FD FC 00 FA F9 F8 F7 F6).
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putByteWithResponse(BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.putByteWithResponse(complexBody, requestOptions, context);
+    public Response<Void> putByteWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return this.serviceClient.putByteWithResponse(complexBody, requestOptions);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/bodycomplex/ReadonlypropertyClient.java
+++ b/protocol-tests/src/main/java/fixtures/bodycomplex/ReadonlypropertyClient.java
@@ -11,7 +11,6 @@ import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import fixtures.bodycomplex.implementation.ReadonlypropertiesImpl;
 
 /** Initializes a new instance of the synchronous AutoRestComplexTestService type. */
@@ -41,14 +40,13 @@ public final class ReadonlypropertyClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types that have readonly properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getValidWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getValidWithResponse(requestOptions, context);
+    public Response<BinaryData> getValidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getValidWithResponse(requestOptions);
     }
 
     /**
@@ -65,13 +63,12 @@ public final class ReadonlypropertyClient {
      *
      * @param complexBody The complexBody parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putValidWithResponse(BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.putValidWithResponse(complexBody, requestOptions, context);
+    public Response<Void> putValidWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return this.serviceClient.putValidWithResponse(complexBody, requestOptions);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/bodycomplex/implementation/ArraysImpl.java
+++ b/protocol-tests/src/main/java/fixtures/bodycomplex/implementation/ArraysImpl.java
@@ -134,14 +134,13 @@ public final class ArraysImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with array property.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getValidWithResponse(RequestOptions requestOptions, Context context) {
-        return getValidWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getValidWithResponse(RequestOptions requestOptions) {
+        return getValidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -213,14 +212,13 @@ public final class ArraysImpl {
      * @param complexBody Please put an array with 4 items: "1, 2, 3, 4", "", null, "&amp;amp;S#$(*Y", "The quick brown
      *     fox jumps over the lazy dog".
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putValidWithResponse(BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return putValidWithResponseAsync(complexBody, requestOptions, context).block();
+    public Response<Void> putValidWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return putValidWithResponseAsync(complexBody, requestOptions).block();
     }
 
     /**
@@ -284,14 +282,13 @@ public final class ArraysImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with array property which is empty.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getEmptyWithResponse(RequestOptions requestOptions, Context context) {
-        return getEmptyWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getEmptyWithResponse(RequestOptions requestOptions) {
+        return getEmptyWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -360,14 +357,13 @@ public final class ArraysImpl {
      *
      * @param complexBody Please put an empty array.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putEmptyWithResponse(BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return putEmptyWithResponseAsync(complexBody, requestOptions, context).block();
+    public Response<Void> putEmptyWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return putEmptyWithResponseAsync(complexBody, requestOptions).block();
     }
 
     /**
@@ -431,13 +427,12 @@ public final class ArraysImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with array property while server doesn't provide a response payload.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getNotProvidedWithResponse(RequestOptions requestOptions, Context context) {
-        return getNotProvidedWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getNotProvidedWithResponse(RequestOptions requestOptions) {
+        return getNotProvidedWithResponseAsync(requestOptions).block();
     }
 }

--- a/protocol-tests/src/main/java/fixtures/bodycomplex/implementation/BasicsImpl.java
+++ b/protocol-tests/src/main/java/fixtures/bodycomplex/implementation/BasicsImpl.java
@@ -137,14 +137,13 @@ public final class BasicsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex type {id: 2, name: 'abc', color: 'YELLOW'}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getValidWithResponse(RequestOptions requestOptions, Context context) {
-        return getValidWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getValidWithResponse(RequestOptions requestOptions) {
+        return getValidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -248,14 +247,13 @@ public final class BasicsImpl {
      *
      * @param complexBody Please put {id: 2, name: 'abc', color: 'Magenta'}.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putValidWithResponse(BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return putValidWithResponseAsync(complexBody, requestOptions, context).block();
+    public Response<Void> putValidWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return putValidWithResponseAsync(complexBody, requestOptions).block();
     }
 
     /**
@@ -319,14 +317,13 @@ public final class BasicsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a basic complex type that is invalid for the local strong type.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getInvalidWithResponse(RequestOptions requestOptions, Context context) {
-        return getInvalidWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getInvalidWithResponse(RequestOptions requestOptions) {
+        return getInvalidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -390,14 +387,13 @@ public final class BasicsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a basic complex type that is empty.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getEmptyWithResponse(RequestOptions requestOptions, Context context) {
-        return getEmptyWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getEmptyWithResponse(RequestOptions requestOptions) {
+        return getEmptyWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -461,14 +457,13 @@ public final class BasicsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a basic complex type whose properties are null.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getNullWithResponse(RequestOptions requestOptions, Context context) {
-        return getNullWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getNullWithResponse(RequestOptions requestOptions) {
+        return getNullWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -532,13 +527,12 @@ public final class BasicsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a basic complex type while the server doesn't provide a response payload.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getNotProvidedWithResponse(RequestOptions requestOptions, Context context) {
-        return getNotProvidedWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getNotProvidedWithResponse(RequestOptions requestOptions) {
+        return getNotProvidedWithResponseAsync(requestOptions).block();
     }
 }

--- a/protocol-tests/src/main/java/fixtures/bodycomplex/implementation/DictionariesImpl.java
+++ b/protocol-tests/src/main/java/fixtures/bodycomplex/implementation/DictionariesImpl.java
@@ -139,14 +139,13 @@ public final class DictionariesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with dictionary property.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getValidWithResponse(RequestOptions requestOptions, Context context) {
-        return getValidWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getValidWithResponse(RequestOptions requestOptions) {
+        return getValidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -218,14 +217,13 @@ public final class DictionariesImpl {
      * @param complexBody Please put a dictionary with 5 key-value pairs: "txt":"notepad", "bmp":"mspaint",
      *     "xls":"excel", "exe":"", "":null.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putValidWithResponse(BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return putValidWithResponseAsync(complexBody, requestOptions, context).block();
+    public Response<Void> putValidWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return putValidWithResponseAsync(complexBody, requestOptions).block();
     }
 
     /**
@@ -289,14 +287,13 @@ public final class DictionariesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with dictionary property which is empty.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getEmptyWithResponse(RequestOptions requestOptions, Context context) {
-        return getEmptyWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getEmptyWithResponse(RequestOptions requestOptions) {
+        return getEmptyWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -365,14 +362,13 @@ public final class DictionariesImpl {
      *
      * @param complexBody Please put an empty dictionary.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putEmptyWithResponse(BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return putEmptyWithResponseAsync(complexBody, requestOptions, context).block();
+    public Response<Void> putEmptyWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return putEmptyWithResponseAsync(complexBody, requestOptions).block();
     }
 
     /**
@@ -436,14 +432,13 @@ public final class DictionariesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with dictionary property which is null.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getNullWithResponse(RequestOptions requestOptions, Context context) {
-        return getNullWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getNullWithResponse(RequestOptions requestOptions) {
+        return getNullWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -507,13 +502,12 @@ public final class DictionariesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with dictionary property while server doesn't provide a response payload.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getNotProvidedWithResponse(RequestOptions requestOptions, Context context) {
-        return getNotProvidedWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getNotProvidedWithResponse(RequestOptions requestOptions) {
+        return getNotProvidedWithResponseAsync(requestOptions).block();
     }
 }

--- a/protocol-tests/src/main/java/fixtures/bodycomplex/implementation/FlattencomplexesImpl.java
+++ b/protocol-tests/src/main/java/fixtures/bodycomplex/implementation/FlattencomplexesImpl.java
@@ -109,13 +109,12 @@ public final class FlattencomplexesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getValidWithResponse(RequestOptions requestOptions, Context context) {
-        return getValidWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getValidWithResponse(RequestOptions requestOptions) {
+        return getValidWithResponseAsync(requestOptions).block();
     }
 }

--- a/protocol-tests/src/main/java/fixtures/bodycomplex/implementation/InheritancesImpl.java
+++ b/protocol-tests/src/main/java/fixtures/bodycomplex/implementation/InheritancesImpl.java
@@ -144,14 +144,13 @@ public final class InheritancesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types that extend others.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getValidWithResponse(RequestOptions requestOptions, Context context) {
-        return getValidWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getValidWithResponse(RequestOptions requestOptions) {
+        return getValidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -250,13 +249,12 @@ public final class InheritancesImpl {
      *     dogs, the 1st one named "Potato" with id=1 and food="tomato", and the 2nd one named "Tomato" with id=-1 and
      *     food="french fries".
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putValidWithResponse(BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return putValidWithResponseAsync(complexBody, requestOptions, context).block();
+    public Response<Void> putValidWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return putValidWithResponseAsync(complexBody, requestOptions).block();
     }
 }

--- a/protocol-tests/src/main/java/fixtures/bodycomplex/implementation/PolymorphicrecursivesImpl.java
+++ b/protocol-tests/src/main/java/fixtures/bodycomplex/implementation/PolymorphicrecursivesImpl.java
@@ -127,14 +127,13 @@ public final class PolymorphicrecursivesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types that are polymorphic and have recursive references.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getValidWithResponse(RequestOptions requestOptions, Context context) {
-        return getValidWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getValidWithResponse(RequestOptions requestOptions) {
+        return getValidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -227,13 +226,12 @@ public final class PolymorphicrecursivesImpl {
      *     "fishtype": "sawshark", "species": "dangerous", "length": 10, "age": 105 } ] }, { "fishtype": "sawshark",
      *     "species": "dangerous", "length": 10, "age": 105 } ] }.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putValidWithResponse(BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return putValidWithResponseAsync(complexBody, requestOptions, context).block();
+    public Response<Void> putValidWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return putValidWithResponseAsync(complexBody, requestOptions).block();
     }
 }

--- a/protocol-tests/src/main/java/fixtures/bodycomplex/implementation/PolymorphismsImpl.java
+++ b/protocol-tests/src/main/java/fixtures/bodycomplex/implementation/PolymorphismsImpl.java
@@ -163,14 +163,13 @@ public final class PolymorphismsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types that are polymorphic.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getValidWithResponse(RequestOptions requestOptions, Context context) {
-        return getValidWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getValidWithResponse(RequestOptions requestOptions) {
+        return getValidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -260,14 +259,13 @@ public final class PolymorphismsImpl {
      *     254]).toString('base64'), 'species':'dangerous', }, { 'fishtype': 'goblin', 'age': 1, 'birthday':
      *     '2015-08-08T00:00:00Z', 'length': 30.0, 'species': 'scary', 'jawsize': 5 } ] };.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putValidWithResponse(BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return putValidWithResponseAsync(complexBody, requestOptions, context).block();
+    public Response<Void> putValidWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return putValidWithResponseAsync(complexBody, requestOptions).block();
     }
 
     /**
@@ -325,14 +323,13 @@ public final class PolymorphismsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types that are polymorphic, JSON key contains a dot.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getDotSyntaxWithResponse(RequestOptions requestOptions, Context context) {
-        return getDotSyntaxWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getDotSyntaxWithResponse(RequestOptions requestOptions) {
+        return getDotSyntaxWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -436,16 +433,14 @@ public final class PolymorphismsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex object composing a polymorphic scalar property and array property with polymorphic element type,
      *     with discriminator specified.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getComposedWithDiscriminatorWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return getComposedWithDiscriminatorWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getComposedWithDiscriminatorWithResponse(RequestOptions requestOptions) {
+        return getComposedWithDiscriminatorWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -549,16 +544,14 @@ public final class PolymorphismsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex object composing a polymorphic scalar property and array property with polymorphic element type,
      *     without discriminator specified on wire.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getComposedWithoutDiscriminatorWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return getComposedWithoutDiscriminatorWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getComposedWithoutDiscriminatorWithResponse(RequestOptions requestOptions) {
+        return getComposedWithoutDiscriminatorWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -654,15 +647,14 @@ public final class PolymorphismsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types that are polymorphic, but not at the root of the hierarchy; also have additional
      *     properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getComplicatedWithResponse(RequestOptions requestOptions, Context context) {
-        return getComplicatedWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getComplicatedWithResponse(RequestOptions requestOptions) {
+        return getComplicatedWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -761,15 +753,13 @@ public final class PolymorphismsImpl {
      *
      * @param complexBody The complexBody parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putComplicatedWithResponse(
-            BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return putComplicatedWithResponseAsync(complexBody, requestOptions, context).block();
+    public Response<Void> putComplicatedWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return putComplicatedWithResponseAsync(complexBody, requestOptions).block();
     }
 
     /**
@@ -930,15 +920,14 @@ public final class PolymorphismsImpl {
      *
      * @param complexBody The complexBody parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<BinaryData> putMissingDiscriminatorWithResponse(
-            BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return putMissingDiscriminatorWithResponseAsync(complexBody, requestOptions, context).block();
+            BinaryData complexBody, RequestOptions requestOptions) {
+        return putMissingDiscriminatorWithResponseAsync(complexBody, requestOptions).block();
     }
 
     /**
@@ -1030,14 +1019,12 @@ public final class PolymorphismsImpl {
      *     "shark", "species": "predator", "birthday": "2012-01-05T01:00:00Z", "length": 20, "age": 6 }, { "fishtype":
      *     "sawshark", "species": "dangerous", "picture": base64(FF FF FF FF FE), "length": 10, "age": 105 } ] }.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putValidMissingRequiredWithResponse(
-            BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return putValidMissingRequiredWithResponseAsync(complexBody, requestOptions, context).block();
+    public Response<Void> putValidMissingRequiredWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return putValidMissingRequiredWithResponseAsync(complexBody, requestOptions).block();
     }
 }

--- a/protocol-tests/src/main/java/fixtures/bodycomplex/implementation/PrimitivesImpl.java
+++ b/protocol-tests/src/main/java/fixtures/bodycomplex/implementation/PrimitivesImpl.java
@@ -227,14 +227,13 @@ public final class PrimitivesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with integer properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getIntWithResponse(RequestOptions requestOptions, Context context) {
-        return getIntWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getIntWithResponse(RequestOptions requestOptions) {
+        return getIntWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -300,14 +299,13 @@ public final class PrimitivesImpl {
      *
      * @param complexBody Please put -1 and 2.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putIntWithResponse(BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return putIntWithResponseAsync(complexBody, requestOptions, context).block();
+    public Response<Void> putIntWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return putIntWithResponseAsync(complexBody, requestOptions).block();
     }
 
     /**
@@ -368,14 +366,13 @@ public final class PrimitivesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with long properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getLongWithResponse(RequestOptions requestOptions, Context context) {
-        return getLongWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getLongWithResponse(RequestOptions requestOptions) {
+        return getLongWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -441,14 +438,13 @@ public final class PrimitivesImpl {
      *
      * @param complexBody Please put 1099511627775 and -999511627788.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putLongWithResponse(BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return putLongWithResponseAsync(complexBody, requestOptions, context).block();
+    public Response<Void> putLongWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return putLongWithResponseAsync(complexBody, requestOptions).block();
     }
 
     /**
@@ -509,14 +505,13 @@ public final class PrimitivesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with float properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getFloatWithResponse(RequestOptions requestOptions, Context context) {
-        return getFloatWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getFloatWithResponse(RequestOptions requestOptions) {
+        return getFloatWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -582,14 +577,13 @@ public final class PrimitivesImpl {
      *
      * @param complexBody Please put 1.05 and -0.003.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putFloatWithResponse(BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return putFloatWithResponseAsync(complexBody, requestOptions, context).block();
+    public Response<Void> putFloatWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return putFloatWithResponseAsync(complexBody, requestOptions).block();
     }
 
     /**
@@ -650,14 +644,13 @@ public final class PrimitivesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with double properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getDoubleWithResponse(RequestOptions requestOptions, Context context) {
-        return getDoubleWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getDoubleWithResponse(RequestOptions requestOptions) {
+        return getDoubleWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -723,15 +716,13 @@ public final class PrimitivesImpl {
      *
      * @param complexBody Please put 3e-100 and -0.000000000000000000000000000000000000000000000000000000005.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putDoubleWithResponse(
-            BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return putDoubleWithResponseAsync(complexBody, requestOptions, context).block();
+    public Response<Void> putDoubleWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return putDoubleWithResponseAsync(complexBody, requestOptions).block();
     }
 
     /**
@@ -792,14 +783,13 @@ public final class PrimitivesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with bool properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getBoolWithResponse(RequestOptions requestOptions, Context context) {
-        return getBoolWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getBoolWithResponse(RequestOptions requestOptions) {
+        return getBoolWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -865,14 +855,13 @@ public final class PrimitivesImpl {
      *
      * @param complexBody Please put true and false.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putBoolWithResponse(BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return putBoolWithResponseAsync(complexBody, requestOptions, context).block();
+    public Response<Void> putBoolWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return putBoolWithResponseAsync(complexBody, requestOptions).block();
     }
 
     /**
@@ -936,14 +925,13 @@ public final class PrimitivesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with string properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getStringWithResponse(RequestOptions requestOptions, Context context) {
-        return getStringWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getStringWithResponse(RequestOptions requestOptions) {
+        return getStringWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1012,15 +1000,13 @@ public final class PrimitivesImpl {
      *
      * @param complexBody Please put 'goodrequest', '', and null.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putStringWithResponse(
-            BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return putStringWithResponseAsync(complexBody, requestOptions, context).block();
+    public Response<Void> putStringWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return putStringWithResponseAsync(complexBody, requestOptions).block();
     }
 
     /**
@@ -1081,14 +1067,13 @@ public final class PrimitivesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with date properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getDateWithResponse(RequestOptions requestOptions, Context context) {
-        return getDateWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getDateWithResponse(RequestOptions requestOptions) {
+        return getDateWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1154,14 +1139,13 @@ public final class PrimitivesImpl {
      *
      * @param complexBody Please put '0001-01-01' and '2016-02-29'.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putDateWithResponse(BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return putDateWithResponseAsync(complexBody, requestOptions, context).block();
+    public Response<Void> putDateWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return putDateWithResponseAsync(complexBody, requestOptions).block();
     }
 
     /**
@@ -1222,14 +1206,13 @@ public final class PrimitivesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with datetime properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getDateTimeWithResponse(RequestOptions requestOptions, Context context) {
-        return getDateTimeWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getDateTimeWithResponse(RequestOptions requestOptions) {
+        return getDateTimeWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1295,15 +1278,13 @@ public final class PrimitivesImpl {
      *
      * @param complexBody Please put '0001-01-01T12:00:00-04:00' and '2015-05-18T11:38:00-08:00'.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putDateTimeWithResponse(
-            BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return putDateTimeWithResponseAsync(complexBody, requestOptions, context).block();
+    public Response<Void> putDateTimeWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return putDateTimeWithResponseAsync(complexBody, requestOptions).block();
     }
 
     /**
@@ -1366,14 +1347,13 @@ public final class PrimitivesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with datetimeRfc1123 properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getDateTimeRfc1123WithResponse(RequestOptions requestOptions, Context context) {
-        return getDateTimeRfc1123WithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getDateTimeRfc1123WithResponse(RequestOptions requestOptions) {
+        return getDateTimeRfc1123WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1440,15 +1420,13 @@ public final class PrimitivesImpl {
      *
      * @param complexBody Please put 'Mon, 01 Jan 0001 12:00:00 GMT' and 'Mon, 18 May 2015 11:38:00 GMT'.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putDateTimeRfc1123WithResponse(
-            BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return putDateTimeRfc1123WithResponseAsync(complexBody, requestOptions, context).block();
+    public Response<Void> putDateTimeRfc1123WithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return putDateTimeRfc1123WithResponseAsync(complexBody, requestOptions).block();
     }
 
     /**
@@ -1506,14 +1484,13 @@ public final class PrimitivesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with duration properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getDurationWithResponse(RequestOptions requestOptions, Context context) {
-        return getDurationWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getDurationWithResponse(RequestOptions requestOptions) {
+        return getDurationWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1576,15 +1553,13 @@ public final class PrimitivesImpl {
      *
      * @param complexBody Please put 'P123DT22H14M12.011S'.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putDurationWithResponse(
-            BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return putDurationWithResponseAsync(complexBody, requestOptions, context).block();
+    public Response<Void> putDurationWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return putDurationWithResponseAsync(complexBody, requestOptions).block();
     }
 
     /**
@@ -1642,14 +1617,13 @@ public final class PrimitivesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types with byte properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getByteWithResponse(RequestOptions requestOptions, Context context) {
-        return getByteWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getByteWithResponse(RequestOptions requestOptions) {
+        return getByteWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1712,13 +1686,12 @@ public final class PrimitivesImpl {
      *
      * @param complexBody Please put non-ascii byte string hex(FF FE FD FC 00 FA F9 F8 F7 F6).
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putByteWithResponse(BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return putByteWithResponseAsync(complexBody, requestOptions, context).block();
+    public Response<Void> putByteWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return putByteWithResponseAsync(complexBody, requestOptions).block();
     }
 }

--- a/protocol-tests/src/main/java/fixtures/bodycomplex/implementation/ReadonlypropertiesImpl.java
+++ b/protocol-tests/src/main/java/fixtures/bodycomplex/implementation/ReadonlypropertiesImpl.java
@@ -118,14 +118,13 @@ public final class ReadonlypropertiesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return complex types that have readonly properties.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getValidWithResponse(RequestOptions requestOptions, Context context) {
-        return getValidWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getValidWithResponse(RequestOptions requestOptions) {
+        return getValidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -191,13 +190,12 @@ public final class ReadonlypropertiesImpl {
      *
      * @param complexBody The complexBody parameter.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putValidWithResponse(BinaryData complexBody, RequestOptions requestOptions, Context context) {
-        return putValidWithResponseAsync(complexBody, requestOptions, context).block();
+    public Response<Void> putValidWithResponse(BinaryData complexBody, RequestOptions requestOptions) {
+        return putValidWithResponseAsync(complexBody, requestOptions).block();
     }
 }

--- a/protocol-tests/src/main/java/fixtures/bodystring/EnumClient.java
+++ b/protocol-tests/src/main/java/fixtures/bodystring/EnumClient.java
@@ -11,7 +11,6 @@ import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import fixtures.bodystring.implementation.EnumsImpl;
 
 /** Initializes a new instance of the synchronous AutoRestSwaggerBATService type. */
@@ -38,14 +37,13 @@ public final class EnumClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<String> getNotExpandableWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getNotExpandableWithResponse(requestOptions, context);
+    public Response<String> getNotExpandableWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getNotExpandableWithResponse(requestOptions);
     }
 
     /**
@@ -59,15 +57,13 @@ public final class EnumClient {
      *
      * @param stringBody string body.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putNotExpandableWithResponse(
-            BinaryData stringBody, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.putNotExpandableWithResponse(stringBody, requestOptions, context);
+    public Response<Void> putNotExpandableWithResponse(BinaryData stringBody, RequestOptions requestOptions) {
+        return this.serviceClient.putNotExpandableWithResponse(stringBody, requestOptions);
     }
 
     /**
@@ -80,14 +76,13 @@ public final class EnumClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<String> getReferencedWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getReferencedWithResponse(requestOptions, context);
+    public Response<String> getReferencedWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getReferencedWithResponse(requestOptions);
     }
 
     /**
@@ -101,15 +96,13 @@ public final class EnumClient {
      *
      * @param enumStringBody enum string body.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putReferencedWithResponse(
-            BinaryData enumStringBody, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.putReferencedWithResponse(enumStringBody, requestOptions, context);
+    public Response<Void> putReferencedWithResponse(BinaryData enumStringBody, RequestOptions requestOptions) {
+        return this.serviceClient.putReferencedWithResponse(enumStringBody, requestOptions);
     }
 
     /**
@@ -125,14 +118,13 @@ public final class EnumClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return value 'green-color' from the constant.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getReferencedConstantWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getReferencedConstantWithResponse(requestOptions, context);
+    public Response<BinaryData> getReferencedConstantWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getReferencedConstantWithResponse(requestOptions);
     }
 
     /**
@@ -149,14 +141,12 @@ public final class EnumClient {
      *
      * @param enumStringBody enum string body.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putReferencedConstantWithResponse(
-            BinaryData enumStringBody, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.putReferencedConstantWithResponse(enumStringBody, requestOptions, context);
+    public Response<Void> putReferencedConstantWithResponse(BinaryData enumStringBody, RequestOptions requestOptions) {
+        return this.serviceClient.putReferencedConstantWithResponse(enumStringBody, requestOptions);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/bodystring/StringOperationClient.java
+++ b/protocol-tests/src/main/java/fixtures/bodystring/StringOperationClient.java
@@ -11,7 +11,6 @@ import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import fixtures.bodystring.implementation.StringOperationsImpl;
 
 /** Initializes a new instance of the synchronous AutoRestSwaggerBATService type. */
@@ -38,14 +37,13 @@ public final class StringOperationClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return null string value value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getNullWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getNullWithResponse(requestOptions, context);
+    public Response<BinaryData> getNullWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getNullWithResponse(requestOptions);
     }
 
     /**
@@ -58,14 +56,13 @@ public final class StringOperationClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putNullWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.putNullWithResponse(requestOptions, context);
+    public Response<Void> putNullWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.putNullWithResponse(requestOptions);
     }
 
     /**
@@ -78,14 +75,13 @@ public final class StringOperationClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return empty string value value ''.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getEmptyWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getEmptyWithResponse(requestOptions, context);
+    public Response<BinaryData> getEmptyWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getEmptyWithResponse(requestOptions);
     }
 
     /**
@@ -98,14 +94,13 @@ public final class StringOperationClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putEmptyWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.putEmptyWithResponse(requestOptions, context);
+    public Response<Void> putEmptyWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.putEmptyWithResponse(requestOptions);
     }
 
     /**
@@ -118,14 +113,13 @@ public final class StringOperationClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getMbcsWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getMbcsWithResponse(requestOptions, context);
+    public Response<BinaryData> getMbcsWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getMbcsWithResponse(requestOptions);
     }
 
     /**
@@ -138,14 +132,13 @@ public final class StringOperationClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putMbcsWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.putMbcsWithResponse(requestOptions, context);
+    public Response<Void> putMbcsWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.putMbcsWithResponse(requestOptions);
     }
 
     /**
@@ -159,15 +152,14 @@ public final class StringOperationClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time
      *     for all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getWhitespaceWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getWhitespaceWithResponse(requestOptions, context);
+    public Response<BinaryData> getWhitespaceWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getWhitespaceWithResponse(requestOptions);
     }
 
     /**
@@ -181,14 +173,13 @@ public final class StringOperationClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putWhitespaceWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.putWhitespaceWithResponse(requestOptions, context);
+    public Response<Void> putWhitespaceWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.putWhitespaceWithResponse(requestOptions);
     }
 
     /**
@@ -201,14 +192,13 @@ public final class StringOperationClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return string value when no string value is sent in response payload.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getNotProvidedWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getNotProvidedWithResponse(requestOptions, context);
+    public Response<BinaryData> getNotProvidedWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getNotProvidedWithResponse(requestOptions);
     }
 
     /**
@@ -221,14 +211,13 @@ public final class StringOperationClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return value that is base64 encoded.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<byte[]> getBase64EncodedWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getBase64EncodedWithResponse(requestOptions, context);
+    public Response<byte[]> getBase64EncodedWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getBase64EncodedWithResponse(requestOptions);
     }
 
     /**
@@ -241,14 +230,13 @@ public final class StringOperationClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return value that is base64url encoded.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getBase64UrlEncodedWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getBase64UrlEncodedWithResponse(requestOptions, context);
+    public Response<BinaryData> getBase64UrlEncodedWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getBase64UrlEncodedWithResponse(requestOptions);
     }
 
     /**
@@ -262,15 +250,13 @@ public final class StringOperationClient {
      *
      * @param stringBody string body.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putBase64UrlEncodedWithResponse(
-            BinaryData stringBody, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.putBase64UrlEncodedWithResponse(stringBody, requestOptions, context);
+    public Response<Void> putBase64UrlEncodedWithResponse(BinaryData stringBody, RequestOptions requestOptions) {
+        return this.serviceClient.putBase64UrlEncodedWithResponse(stringBody, requestOptions);
     }
 
     /**
@@ -283,13 +269,12 @@ public final class StringOperationClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return null value that is expected to be base64url encoded.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getNullBase64UrlEncodedWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getNullBase64UrlEncodedWithResponse(requestOptions, context);
+    public Response<BinaryData> getNullBase64UrlEncodedWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getNullBase64UrlEncodedWithResponse(requestOptions);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/bodystring/implementation/EnumsImpl.java
+++ b/protocol-tests/src/main/java/fixtures/bodystring/implementation/EnumsImpl.java
@@ -130,14 +130,13 @@ public final class EnumsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<String> getNotExpandableWithResponse(RequestOptions requestOptions, Context context) {
-        return getNotExpandableWithResponseAsync(requestOptions, context).block();
+    public Response<String> getNotExpandableWithResponse(RequestOptions requestOptions) {
+        return getNotExpandableWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -195,15 +194,13 @@ public final class EnumsImpl {
      *
      * @param stringBody string body.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putNotExpandableWithResponse(
-            BinaryData stringBody, RequestOptions requestOptions, Context context) {
-        return putNotExpandableWithResponseAsync(stringBody, requestOptions, context).block();
+    public Response<Void> putNotExpandableWithResponse(BinaryData stringBody, RequestOptions requestOptions) {
+        return putNotExpandableWithResponseAsync(stringBody, requestOptions).block();
     }
 
     /**
@@ -255,14 +252,13 @@ public final class EnumsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<String> getReferencedWithResponse(RequestOptions requestOptions, Context context) {
-        return getReferencedWithResponseAsync(requestOptions, context).block();
+    public Response<String> getReferencedWithResponse(RequestOptions requestOptions) {
+        return getReferencedWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -320,15 +316,13 @@ public final class EnumsImpl {
      *
      * @param enumStringBody enum string body.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putReferencedWithResponse(
-            BinaryData enumStringBody, RequestOptions requestOptions, Context context) {
-        return putReferencedWithResponseAsync(enumStringBody, requestOptions, context).block();
+    public Response<Void> putReferencedWithResponse(BinaryData enumStringBody, RequestOptions requestOptions) {
+        return putReferencedWithResponseAsync(enumStringBody, requestOptions).block();
     }
 
     /**
@@ -391,14 +385,13 @@ public final class EnumsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return value 'green-color' from the constant.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getReferencedConstantWithResponse(RequestOptions requestOptions, Context context) {
-        return getReferencedConstantWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getReferencedConstantWithResponse(RequestOptions requestOptions) {
+        return getReferencedConstantWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -466,14 +459,12 @@ public final class EnumsImpl {
      *
      * @param enumStringBody enum string body.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putReferencedConstantWithResponse(
-            BinaryData enumStringBody, RequestOptions requestOptions, Context context) {
-        return putReferencedConstantWithResponseAsync(enumStringBody, requestOptions, context).block();
+    public Response<Void> putReferencedConstantWithResponse(BinaryData enumStringBody, RequestOptions requestOptions) {
+        return putReferencedConstantWithResponseAsync(enumStringBody, requestOptions).block();
     }
 }

--- a/protocol-tests/src/main/java/fixtures/bodystring/implementation/StringOperationsImpl.java
+++ b/protocol-tests/src/main/java/fixtures/bodystring/implementation/StringOperationsImpl.java
@@ -161,14 +161,13 @@ public final class StringOperationsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return null string value value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getNullWithResponse(RequestOptions requestOptions, Context context) {
-        return getNullWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getNullWithResponse(RequestOptions requestOptions) {
+        return getNullWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -220,14 +219,13 @@ public final class StringOperationsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putNullWithResponse(RequestOptions requestOptions, Context context) {
-        return putNullWithResponseAsync(requestOptions, context).block();
+    public Response<Void> putNullWithResponse(RequestOptions requestOptions) {
+        return putNullWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -279,14 +277,13 @@ public final class StringOperationsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return empty string value value ''.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getEmptyWithResponse(RequestOptions requestOptions, Context context) {
-        return getEmptyWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getEmptyWithResponse(RequestOptions requestOptions) {
+        return getEmptyWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -341,14 +338,13 @@ public final class StringOperationsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putEmptyWithResponse(RequestOptions requestOptions, Context context) {
-        return putEmptyWithResponseAsync(requestOptions, context).block();
+    public Response<Void> putEmptyWithResponse(RequestOptions requestOptions) {
+        return putEmptyWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -400,14 +396,13 @@ public final class StringOperationsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getMbcsWithResponse(RequestOptions requestOptions, Context context) {
-        return getMbcsWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getMbcsWithResponse(RequestOptions requestOptions) {
+        return getMbcsWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -464,14 +459,13 @@ public final class StringOperationsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putMbcsWithResponse(RequestOptions requestOptions, Context context) {
-        return putMbcsWithResponseAsync(requestOptions, context).block();
+    public Response<Void> putMbcsWithResponse(RequestOptions requestOptions) {
+        return putMbcsWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -528,15 +522,14 @@ public final class StringOperationsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return string value with leading and trailing whitespace '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time
      *     for all good men to come to the aid of their country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getWhitespaceWithResponse(RequestOptions requestOptions, Context context) {
-        return getWhitespaceWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getWhitespaceWithResponse(RequestOptions requestOptions) {
+        return getWhitespaceWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -596,14 +589,13 @@ public final class StringOperationsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putWhitespaceWithResponse(RequestOptions requestOptions, Context context) {
-        return putWhitespaceWithResponseAsync(requestOptions, context).block();
+    public Response<Void> putWhitespaceWithResponse(RequestOptions requestOptions) {
+        return putWhitespaceWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -655,14 +647,13 @@ public final class StringOperationsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return string value when no string value is sent in response payload.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getNotProvidedWithResponse(RequestOptions requestOptions, Context context) {
-        return getNotProvidedWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getNotProvidedWithResponse(RequestOptions requestOptions) {
+        return getNotProvidedWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -715,14 +706,13 @@ public final class StringOperationsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return value that is base64 encoded.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<byte[]> getBase64EncodedWithResponse(RequestOptions requestOptions, Context context) {
-        return getBase64EncodedWithResponseAsync(requestOptions, context).block();
+    public Response<byte[]> getBase64EncodedWithResponse(RequestOptions requestOptions) {
+        return getBase64EncodedWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -776,14 +766,13 @@ public final class StringOperationsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return value that is base64url encoded.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getBase64UrlEncodedWithResponse(RequestOptions requestOptions, Context context) {
-        return getBase64UrlEncodedWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getBase64UrlEncodedWithResponse(RequestOptions requestOptions) {
+        return getBase64UrlEncodedWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -841,15 +830,13 @@ public final class StringOperationsImpl {
      *
      * @param stringBody string body.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putBase64UrlEncodedWithResponse(
-            BinaryData stringBody, RequestOptions requestOptions, Context context) {
-        return putBase64UrlEncodedWithResponseAsync(stringBody, requestOptions, context).block();
+    public Response<Void> putBase64UrlEncodedWithResponse(BinaryData stringBody, RequestOptions requestOptions) {
+        return putBase64UrlEncodedWithResponseAsync(stringBody, requestOptions).block();
     }
 
     /**
@@ -903,13 +890,12 @@ public final class StringOperationsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return null value that is expected to be base64url encoded.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getNullBase64UrlEncodedWithResponse(RequestOptions requestOptions, Context context) {
-        return getNullBase64UrlEncodedWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getNullBase64UrlEncodedWithResponse(RequestOptions requestOptions) {
+        return getNullBase64UrlEncodedWithResponseAsync(requestOptions).block();
     }
 }

--- a/protocol-tests/src/main/java/fixtures/header/AutoRestSwaggerBATHeaderServiceClient.java
+++ b/protocol-tests/src/main/java/fixtures/header/AutoRestSwaggerBATHeaderServiceClient.java
@@ -10,7 +10,6 @@ import com.azure.core.annotation.ServiceMethod;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.util.Context;
 import fixtures.header.implementation.HeadersImpl;
 
 /** Initializes a new instance of the synchronous AutoRestSwaggerBATHeaderService type. */
@@ -39,28 +38,26 @@ public final class AutoRestSwaggerBATHeaderServiceClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> paramExistingKeyWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.paramExistingKeyWithResponse(requestOptions, context);
+    public Response<Void> paramExistingKeyWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.paramExistingKeyWithResponse(requestOptions);
     }
 
     /**
      * Get a response with header value "User-Agent": "overwrite".
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a response with header value "User-Agent": "overwrite".
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> responseExistingKeyWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.responseExistingKeyWithResponse(requestOptions, context);
+    public Response<Void> responseExistingKeyWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.responseExistingKeyWithResponse(requestOptions);
     }
 
     /**
@@ -75,28 +72,26 @@ public final class AutoRestSwaggerBATHeaderServiceClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> paramProtectedKeyWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.paramProtectedKeyWithResponse(requestOptions, context);
+    public Response<Void> paramProtectedKeyWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.paramProtectedKeyWithResponse(requestOptions);
     }
 
     /**
      * Get a response with header value "Content-Type": "text/html".
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a response with header value "Content-Type": "text/html".
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> responseProtectedKeyWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.responseProtectedKeyWithResponse(requestOptions, context);
+    public Response<Void> responseProtectedKeyWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.responseProtectedKeyWithResponse(requestOptions);
     }
 
     /**
@@ -112,14 +107,13 @@ public final class AutoRestSwaggerBATHeaderServiceClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> paramIntegerWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.paramIntegerWithResponse(requestOptions, context);
+    public Response<Void> paramIntegerWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.paramIntegerWithResponse(requestOptions);
     }
 
     /**
@@ -134,14 +128,13 @@ public final class AutoRestSwaggerBATHeaderServiceClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a response with header value "value": 1 or -2.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> responseIntegerWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.responseIntegerWithResponse(requestOptions, context);
+    public Response<Void> responseIntegerWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.responseIntegerWithResponse(requestOptions);
     }
 
     /**
@@ -158,14 +151,13 @@ public final class AutoRestSwaggerBATHeaderServiceClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> paramLongWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.paramLongWithResponse(requestOptions, context);
+    public Response<Void> paramLongWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.paramLongWithResponse(requestOptions);
     }
 
     /**
@@ -180,14 +172,13 @@ public final class AutoRestSwaggerBATHeaderServiceClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a response with header value "value": 105 or -2.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> responseLongWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.responseLongWithResponse(requestOptions, context);
+    public Response<Void> responseLongWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.responseLongWithResponse(requestOptions);
     }
 
     /**
@@ -204,14 +195,13 @@ public final class AutoRestSwaggerBATHeaderServiceClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> paramFloatWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.paramFloatWithResponse(requestOptions, context);
+    public Response<Void> paramFloatWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.paramFloatWithResponse(requestOptions);
     }
 
     /**
@@ -226,14 +216,13 @@ public final class AutoRestSwaggerBATHeaderServiceClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a response with header value "value": 0.07 or -3.0.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> responseFloatWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.responseFloatWithResponse(requestOptions, context);
+    public Response<Void> responseFloatWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.responseFloatWithResponse(requestOptions);
     }
 
     /**
@@ -250,14 +239,13 @@ public final class AutoRestSwaggerBATHeaderServiceClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> paramDoubleWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.paramDoubleWithResponse(requestOptions, context);
+    public Response<Void> paramDoubleWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.paramDoubleWithResponse(requestOptions);
     }
 
     /**
@@ -272,14 +260,13 @@ public final class AutoRestSwaggerBATHeaderServiceClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a response with header value "value": 7e120 or -3.0.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> responseDoubleWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.responseDoubleWithResponse(requestOptions, context);
+    public Response<Void> responseDoubleWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.responseDoubleWithResponse(requestOptions);
     }
 
     /**
@@ -295,14 +282,13 @@ public final class AutoRestSwaggerBATHeaderServiceClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> paramBoolWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.paramBoolWithResponse(requestOptions, context);
+    public Response<Void> paramBoolWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.paramBoolWithResponse(requestOptions);
     }
 
     /**
@@ -317,14 +303,13 @@ public final class AutoRestSwaggerBATHeaderServiceClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a response with header value "value": true or false.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> responseBoolWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.responseBoolWithResponse(requestOptions, context);
+    public Response<Void> responseBoolWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.responseBoolWithResponse(requestOptions);
     }
 
     /**
@@ -341,14 +326,13 @@ public final class AutoRestSwaggerBATHeaderServiceClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> paramStringWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.paramStringWithResponse(requestOptions, context);
+    public Response<Void> paramStringWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.paramStringWithResponse(requestOptions);
     }
 
     /**
@@ -363,14 +347,13 @@ public final class AutoRestSwaggerBATHeaderServiceClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a response with header values "The quick brown fox jumps over the lazy dog" or null or "".
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> responseStringWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.responseStringWithResponse(requestOptions, context);
+    public Response<Void> responseStringWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.responseStringWithResponse(requestOptions);
     }
 
     /**
@@ -387,14 +370,13 @@ public final class AutoRestSwaggerBATHeaderServiceClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> paramDateWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.paramDateWithResponse(requestOptions, context);
+    public Response<Void> paramDateWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.paramDateWithResponse(requestOptions);
     }
 
     /**
@@ -409,14 +391,13 @@ public final class AutoRestSwaggerBATHeaderServiceClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a response with header values "2010-01-01" or "0001-01-01".
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> responseDateWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.responseDateWithResponse(requestOptions, context);
+    public Response<Void> responseDateWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.responseDateWithResponse(requestOptions);
     }
 
     /**
@@ -433,14 +414,13 @@ public final class AutoRestSwaggerBATHeaderServiceClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> paramDatetimeWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.paramDatetimeWithResponse(requestOptions, context);
+    public Response<Void> paramDatetimeWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.paramDatetimeWithResponse(requestOptions);
     }
 
     /**
@@ -455,14 +435,13 @@ public final class AutoRestSwaggerBATHeaderServiceClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z".
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> responseDatetimeWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.responseDatetimeWithResponse(requestOptions, context);
+    public Response<Void> responseDatetimeWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.responseDatetimeWithResponse(requestOptions);
     }
 
     /**
@@ -479,14 +458,13 @@ public final class AutoRestSwaggerBATHeaderServiceClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> paramDatetimeRfc1123WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.paramDatetimeRfc1123WithResponse(requestOptions, context);
+    public Response<Void> paramDatetimeRfc1123WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.paramDatetimeRfc1123WithResponse(requestOptions);
     }
 
     /**
@@ -501,14 +479,13 @@ public final class AutoRestSwaggerBATHeaderServiceClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT".
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> responseDatetimeRfc1123WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.responseDatetimeRfc1123WithResponse(requestOptions, context);
+    public Response<Void> responseDatetimeRfc1123WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.responseDatetimeRfc1123WithResponse(requestOptions);
     }
 
     /**
@@ -524,14 +501,13 @@ public final class AutoRestSwaggerBATHeaderServiceClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> paramDurationWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.paramDurationWithResponse(requestOptions, context);
+    public Response<Void> paramDurationWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.paramDurationWithResponse(requestOptions);
     }
 
     /**
@@ -546,14 +522,13 @@ public final class AutoRestSwaggerBATHeaderServiceClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a response with header values "P123DT22H14M12.011S".
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> responseDurationWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.responseDurationWithResponse(requestOptions, context);
+    public Response<Void> responseDurationWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.responseDurationWithResponse(requestOptions);
     }
 
     /**
@@ -569,14 +544,13 @@ public final class AutoRestSwaggerBATHeaderServiceClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> paramByteWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.paramByteWithResponse(requestOptions, context);
+    public Response<Void> paramByteWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.paramByteWithResponse(requestOptions);
     }
 
     /**
@@ -591,14 +565,13 @@ public final class AutoRestSwaggerBATHeaderServiceClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a response with header values "啊齄丂狛狜隣郎隣兀﨩".
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> responseByteWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.responseByteWithResponse(requestOptions, context);
+    public Response<Void> responseByteWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.responseByteWithResponse(requestOptions);
     }
 
     /**
@@ -614,14 +587,13 @@ public final class AutoRestSwaggerBATHeaderServiceClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> paramEnumWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.paramEnumWithResponse(requestOptions, context);
+    public Response<Void> paramEnumWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.paramEnumWithResponse(requestOptions);
     }
 
     /**
@@ -636,27 +608,25 @@ public final class AutoRestSwaggerBATHeaderServiceClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a response with header values "GREY" or null.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> responseEnumWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.responseEnumWithResponse(requestOptions, context);
+    public Response<Void> responseEnumWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.responseEnumWithResponse(requestOptions);
     }
 
     /**
      * Send x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> customRequestIdWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.customRequestIdWithResponse(requestOptions, context);
+    public Response<Void> customRequestIdWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.customRequestIdWithResponse(requestOptions);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/header/implementation/HeadersImpl.java
+++ b/protocol-tests/src/main/java/fixtures/header/implementation/HeadersImpl.java
@@ -211,14 +211,13 @@ public final class HeadersImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> paramExistingKeyWithResponse(RequestOptions requestOptions, Context context) {
-        return paramExistingKeyWithResponseAsync(requestOptions, context).block();
+    public Response<Void> paramExistingKeyWithResponse(RequestOptions requestOptions) {
+        return paramExistingKeyWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -253,14 +252,13 @@ public final class HeadersImpl {
      * Get a response with header value "User-Agent": "overwrite".
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a response with header value "User-Agent": "overwrite".
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> responseExistingKeyWithResponse(RequestOptions requestOptions, Context context) {
-        return responseExistingKeyWithResponseAsync(requestOptions, context).block();
+    public Response<Void> responseExistingKeyWithResponse(RequestOptions requestOptions) {
+        return responseExistingKeyWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -319,14 +317,13 @@ public final class HeadersImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> paramProtectedKeyWithResponse(RequestOptions requestOptions, Context context) {
-        return paramProtectedKeyWithResponseAsync(requestOptions, context).block();
+    public Response<Void> paramProtectedKeyWithResponse(RequestOptions requestOptions) {
+        return paramProtectedKeyWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -361,14 +358,13 @@ public final class HeadersImpl {
      * Get a response with header value "Content-Type": "text/html".
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a response with header value "Content-Type": "text/html".
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> responseProtectedKeyWithResponse(RequestOptions requestOptions, Context context) {
-        return responseProtectedKeyWithResponseAsync(requestOptions, context).block();
+    public Response<Void> responseProtectedKeyWithResponse(RequestOptions requestOptions) {
+        return responseProtectedKeyWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -429,14 +425,13 @@ public final class HeadersImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> paramIntegerWithResponse(RequestOptions requestOptions, Context context) {
-        return paramIntegerWithResponseAsync(requestOptions, context).block();
+    public Response<Void> paramIntegerWithResponse(RequestOptions requestOptions) {
+        return paramIntegerWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -494,14 +489,13 @@ public final class HeadersImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a response with header value "value": 1 or -2.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> responseIntegerWithResponse(RequestOptions requestOptions, Context context) {
-        return responseIntegerWithResponseAsync(requestOptions, context).block();
+    public Response<Void> responseIntegerWithResponse(RequestOptions requestOptions) {
+        return responseIntegerWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -565,14 +559,13 @@ public final class HeadersImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> paramLongWithResponse(RequestOptions requestOptions, Context context) {
-        return paramLongWithResponseAsync(requestOptions, context).block();
+    public Response<Void> paramLongWithResponse(RequestOptions requestOptions) {
+        return paramLongWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -630,14 +623,13 @@ public final class HeadersImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a response with header value "value": 105 or -2.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> responseLongWithResponse(RequestOptions requestOptions, Context context) {
-        return responseLongWithResponseAsync(requestOptions, context).block();
+    public Response<Void> responseLongWithResponse(RequestOptions requestOptions) {
+        return responseLongWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -701,14 +693,13 @@ public final class HeadersImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> paramFloatWithResponse(RequestOptions requestOptions, Context context) {
-        return paramFloatWithResponseAsync(requestOptions, context).block();
+    public Response<Void> paramFloatWithResponse(RequestOptions requestOptions) {
+        return paramFloatWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -766,14 +757,13 @@ public final class HeadersImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a response with header value "value": 0.07 or -3.0.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> responseFloatWithResponse(RequestOptions requestOptions, Context context) {
-        return responseFloatWithResponseAsync(requestOptions, context).block();
+    public Response<Void> responseFloatWithResponse(RequestOptions requestOptions) {
+        return responseFloatWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -837,14 +827,13 @@ public final class HeadersImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> paramDoubleWithResponse(RequestOptions requestOptions, Context context) {
-        return paramDoubleWithResponseAsync(requestOptions, context).block();
+    public Response<Void> paramDoubleWithResponse(RequestOptions requestOptions) {
+        return paramDoubleWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -902,14 +891,13 @@ public final class HeadersImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a response with header value "value": 7e120 or -3.0.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> responseDoubleWithResponse(RequestOptions requestOptions, Context context) {
-        return responseDoubleWithResponseAsync(requestOptions, context).block();
+    public Response<Void> responseDoubleWithResponse(RequestOptions requestOptions) {
+        return responseDoubleWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -970,14 +958,13 @@ public final class HeadersImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> paramBoolWithResponse(RequestOptions requestOptions, Context context) {
-        return paramBoolWithResponseAsync(requestOptions, context).block();
+    public Response<Void> paramBoolWithResponse(RequestOptions requestOptions) {
+        return paramBoolWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1035,14 +1022,13 @@ public final class HeadersImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a response with header value "value": true or false.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> responseBoolWithResponse(RequestOptions requestOptions, Context context) {
-        return responseBoolWithResponseAsync(requestOptions, context).block();
+    public Response<Void> responseBoolWithResponse(RequestOptions requestOptions) {
+        return responseBoolWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1106,14 +1092,13 @@ public final class HeadersImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> paramStringWithResponse(RequestOptions requestOptions, Context context) {
-        return paramStringWithResponseAsync(requestOptions, context).block();
+    public Response<Void> paramStringWithResponse(RequestOptions requestOptions) {
+        return paramStringWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1171,14 +1156,13 @@ public final class HeadersImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a response with header values "The quick brown fox jumps over the lazy dog" or null or "".
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> responseStringWithResponse(RequestOptions requestOptions, Context context) {
-        return responseStringWithResponseAsync(requestOptions, context).block();
+    public Response<Void> responseStringWithResponse(RequestOptions requestOptions) {
+        return responseStringWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1242,14 +1226,13 @@ public final class HeadersImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> paramDateWithResponse(RequestOptions requestOptions, Context context) {
-        return paramDateWithResponseAsync(requestOptions, context).block();
+    public Response<Void> paramDateWithResponse(RequestOptions requestOptions) {
+        return paramDateWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1307,14 +1290,13 @@ public final class HeadersImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a response with header values "2010-01-01" or "0001-01-01".
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> responseDateWithResponse(RequestOptions requestOptions, Context context) {
-        return responseDateWithResponseAsync(requestOptions, context).block();
+    public Response<Void> responseDateWithResponse(RequestOptions requestOptions) {
+        return responseDateWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1378,14 +1360,13 @@ public final class HeadersImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> paramDatetimeWithResponse(RequestOptions requestOptions, Context context) {
-        return paramDatetimeWithResponseAsync(requestOptions, context).block();
+    public Response<Void> paramDatetimeWithResponse(RequestOptions requestOptions) {
+        return paramDatetimeWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1444,14 +1425,13 @@ public final class HeadersImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z".
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> responseDatetimeWithResponse(RequestOptions requestOptions, Context context) {
-        return responseDatetimeWithResponseAsync(requestOptions, context).block();
+    public Response<Void> responseDatetimeWithResponse(RequestOptions requestOptions) {
+        return responseDatetimeWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1516,14 +1496,13 @@ public final class HeadersImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> paramDatetimeRfc1123WithResponse(RequestOptions requestOptions, Context context) {
-        return paramDatetimeRfc1123WithResponseAsync(requestOptions, context).block();
+    public Response<Void> paramDatetimeRfc1123WithResponse(RequestOptions requestOptions) {
+        return paramDatetimeRfc1123WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1583,14 +1562,13 @@ public final class HeadersImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT".
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> responseDatetimeRfc1123WithResponse(RequestOptions requestOptions, Context context) {
-        return responseDatetimeRfc1123WithResponseAsync(requestOptions, context).block();
+    public Response<Void> responseDatetimeRfc1123WithResponse(RequestOptions requestOptions) {
+        return responseDatetimeRfc1123WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1651,14 +1629,13 @@ public final class HeadersImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> paramDurationWithResponse(RequestOptions requestOptions, Context context) {
-        return paramDurationWithResponseAsync(requestOptions, context).block();
+    public Response<Void> paramDurationWithResponse(RequestOptions requestOptions) {
+        return paramDurationWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1717,14 +1694,13 @@ public final class HeadersImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a response with header values "P123DT22H14M12.011S".
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> responseDurationWithResponse(RequestOptions requestOptions, Context context) {
-        return responseDurationWithResponseAsync(requestOptions, context).block();
+    public Response<Void> responseDurationWithResponse(RequestOptions requestOptions) {
+        return responseDurationWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1785,14 +1761,13 @@ public final class HeadersImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> paramByteWithResponse(RequestOptions requestOptions, Context context) {
-        return paramByteWithResponseAsync(requestOptions, context).block();
+    public Response<Void> paramByteWithResponse(RequestOptions requestOptions) {
+        return paramByteWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1850,14 +1825,13 @@ public final class HeadersImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a response with header values "啊齄丂狛狜隣郎隣兀﨩".
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> responseByteWithResponse(RequestOptions requestOptions, Context context) {
-        return responseByteWithResponseAsync(requestOptions, context).block();
+    public Response<Void> responseByteWithResponse(RequestOptions requestOptions) {
+        return responseByteWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1918,14 +1892,13 @@ public final class HeadersImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> paramEnumWithResponse(RequestOptions requestOptions, Context context) {
-        return paramEnumWithResponseAsync(requestOptions, context).block();
+    public Response<Void> paramEnumWithResponse(RequestOptions requestOptions) {
+        return paramEnumWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1983,14 +1956,13 @@ public final class HeadersImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a response with header values "GREY" or null.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> responseEnumWithResponse(RequestOptions requestOptions, Context context) {
-        return responseEnumWithResponseAsync(requestOptions, context).block();
+    public Response<Void> responseEnumWithResponse(RequestOptions requestOptions) {
+        return responseEnumWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -2024,13 +1996,12 @@ public final class HeadersImpl {
      * Send x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> customRequestIdWithResponse(RequestOptions requestOptions, Context context) {
-        return customRequestIdWithResponseAsync(requestOptions, context).block();
+    public Response<Void> customRequestIdWithResponse(RequestOptions requestOptions) {
+        return customRequestIdWithResponseAsync(requestOptions).block();
     }
 }

--- a/protocol-tests/src/main/java/fixtures/httpinfrastructure/HttpClientFailureClient.java
+++ b/protocol-tests/src/main/java/fixtures/httpinfrastructure/HttpClientFailureClient.java
@@ -10,7 +10,6 @@ import com.azure.core.annotation.ServiceMethod;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.util.Context;
 import fixtures.httpinfrastructure.implementation.HttpClientFailuresImpl;
 
 /** Initializes a new instance of the synchronous AutoRestHttpInfrastructureTestService type. */
@@ -31,48 +30,26 @@ public final class HttpClientFailureClient {
      * Return 400 status code - should be represented in the client as an error.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head400WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.head400WithResponse(requestOptions, context);
+    public Response<Void> head400WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.head400WithResponse(requestOptions);
     }
 
     /**
      * Return 400 status code - should be represented in the client as an error.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get400WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get400WithResponse(requestOptions, context);
-    }
-
-    /**
-     * Return 400 status code - should be represented in the client as an error.
-     *
-     * <p><strong>Request Body Schema</strong>
-     *
-     * <pre>{@code
-     * Boolean
-     * }</pre>
-     *
-     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
-     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
-     *     false.
-     * @return the response.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> put400WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.put400WithResponse(requestOptions, context);
+    public Response<Void> get400WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get400WithResponse(requestOptions);
     }
 
     /**
@@ -85,14 +62,13 @@ public final class HttpClientFailureClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> patch400WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.patch400WithResponse(requestOptions, context);
+    public Response<Void> put400WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.put400WithResponse(requestOptions);
     }
 
     /**
@@ -105,14 +81,13 @@ public final class HttpClientFailureClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> post400WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.post400WithResponse(requestOptions, context);
+    public Response<Void> patch400WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.patch400WithResponse(requestOptions);
     }
 
     /**
@@ -125,56 +100,71 @@ public final class HttpClientFailureClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> delete400WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.delete400WithResponse(requestOptions, context);
+    public Response<Void> post400WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.post400WithResponse(requestOptions);
+    }
+
+    /**
+     * Return 400 status code - should be represented in the client as an error.
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * Boolean
+     * }</pre>
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> delete400WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.delete400WithResponse(requestOptions);
     }
 
     /**
      * Return 401 status code - should be represented in the client as an error.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head401WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.head401WithResponse(requestOptions, context);
+    public Response<Void> head401WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.head401WithResponse(requestOptions);
     }
 
     /**
      * Return 402 status code - should be represented in the client as an error.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get402WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get402WithResponse(requestOptions, context);
+    public Response<Void> get402WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get402WithResponse(requestOptions);
     }
 
     /**
      * Return 403 status code - should be represented in the client as an error.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get403WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get403WithResponse(requestOptions, context);
+    public Response<Void> get403WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get403WithResponse(requestOptions);
     }
 
     /**
@@ -187,14 +177,13 @@ public final class HttpClientFailureClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> put404WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.put404WithResponse(requestOptions, context);
+    public Response<Void> put404WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.put404WithResponse(requestOptions);
     }
 
     /**
@@ -207,14 +196,13 @@ public final class HttpClientFailureClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> patch405WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.patch405WithResponse(requestOptions, context);
+    public Response<Void> patch405WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.patch405WithResponse(requestOptions);
     }
 
     /**
@@ -227,14 +215,13 @@ public final class HttpClientFailureClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> post406WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.post406WithResponse(requestOptions, context);
+    public Response<Void> post406WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.post406WithResponse(requestOptions);
     }
 
     /**
@@ -247,14 +234,13 @@ public final class HttpClientFailureClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> delete407WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.delete407WithResponse(requestOptions, context);
+    public Response<Void> delete407WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.delete407WithResponse(requestOptions);
     }
 
     /**
@@ -267,56 +253,52 @@ public final class HttpClientFailureClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> put409WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.put409WithResponse(requestOptions, context);
+    public Response<Void> put409WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.put409WithResponse(requestOptions);
     }
 
     /**
      * Return 410 status code - should be represented in the client as an error.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head410WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.head410WithResponse(requestOptions, context);
+    public Response<Void> head410WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.head410WithResponse(requestOptions);
     }
 
     /**
      * Return 411 status code - should be represented in the client as an error.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get411WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get411WithResponse(requestOptions, context);
+    public Response<Void> get411WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get411WithResponse(requestOptions);
     }
 
     /**
      * Return 412 status code - should be represented in the client as an error.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get412WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get412WithResponse(requestOptions, context);
+    public Response<Void> get412WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get412WithResponse(requestOptions);
     }
 
     /**
@@ -329,14 +311,13 @@ public final class HttpClientFailureClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> put413WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.put413WithResponse(requestOptions, context);
+    public Response<Void> put413WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.put413WithResponse(requestOptions);
     }
 
     /**
@@ -349,14 +330,13 @@ public final class HttpClientFailureClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> patch414WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.patch414WithResponse(requestOptions, context);
+    public Response<Void> patch414WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.patch414WithResponse(requestOptions);
     }
 
     /**
@@ -369,28 +349,26 @@ public final class HttpClientFailureClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> post415WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.post415WithResponse(requestOptions, context);
+    public Response<Void> post415WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.post415WithResponse(requestOptions);
     }
 
     /**
      * Return 416 status code - should be represented in the client as an error.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get416WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get416WithResponse(requestOptions, context);
+    public Response<Void> get416WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get416WithResponse(requestOptions);
     }
 
     /**
@@ -403,27 +381,25 @@ public final class HttpClientFailureClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> delete417WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.delete417WithResponse(requestOptions, context);
+    public Response<Void> delete417WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.delete417WithResponse(requestOptions);
     }
 
     /**
      * Return 429 status code - should be represented in the client as an error.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head429WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.head429WithResponse(requestOptions, context);
+    public Response<Void> head429WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.head429WithResponse(requestOptions);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/httpinfrastructure/HttpFailureClient.java
+++ b/protocol-tests/src/main/java/fixtures/httpinfrastructure/HttpFailureClient.java
@@ -10,7 +10,6 @@ import com.azure.core.annotation.ServiceMethod;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.util.Context;
 import fixtures.httpinfrastructure.implementation.HttpFailuresImpl;
 
 /** Initializes a new instance of the synchronous AutoRestHttpInfrastructureTestService type. */
@@ -37,14 +36,13 @@ public final class HttpFailureClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return empty error form server.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Boolean> getEmptyErrorWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getEmptyErrorWithResponse(requestOptions, context);
+    public Response<Boolean> getEmptyErrorWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getEmptyErrorWithResponse(requestOptions);
     }
 
     /**
@@ -57,14 +55,13 @@ public final class HttpFailureClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return empty error form server.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Boolean> getNoModelErrorWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getNoModelErrorWithResponse(requestOptions, context);
+    public Response<Boolean> getNoModelErrorWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getNoModelErrorWithResponse(requestOptions);
     }
 
     /**
@@ -77,13 +74,12 @@ public final class HttpFailureClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return empty response from server.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Boolean> getNoModelEmptyWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getNoModelEmptyWithResponse(requestOptions, context);
+    public Response<Boolean> getNoModelEmptyWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getNoModelEmptyWithResponse(requestOptions);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/httpinfrastructure/HttpRedirectsClient.java
+++ b/protocol-tests/src/main/java/fixtures/httpinfrastructure/HttpRedirectsClient.java
@@ -11,7 +11,6 @@ import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import fixtures.httpinfrastructure.implementation.HttpRedirectsImpl;
 
 /** Initializes a new instance of the synchronous AutoRestHttpInfrastructureTestService type. */
@@ -32,14 +31,13 @@ public final class HttpRedirectsClient {
      * Return 300 status code and redirect to /http/success/200.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head300WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.head300WithResponse(requestOptions, context);
+    public Response<Void> head300WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.head300WithResponse(requestOptions);
     }
 
     /**
@@ -54,42 +52,39 @@ public final class HttpRedirectsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> get300WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get300WithResponse(requestOptions, context);
+    public Response<BinaryData> get300WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get300WithResponse(requestOptions);
     }
 
     /**
      * Return 301 status code and redirect to /http/success/200.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head301WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.head301WithResponse(requestOptions, context);
+    public Response<Void> head301WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.head301WithResponse(requestOptions);
     }
 
     /**
      * Return 301 status code and redirect to /http/success/200.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get301WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get301WithResponse(requestOptions, context);
+    public Response<Void> get301WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get301WithResponse(requestOptions);
     }
 
     /**
@@ -103,42 +98,39 @@ public final class HttpRedirectsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> put301WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.put301WithResponse(requestOptions, context);
+    public Response<Void> put301WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.put301WithResponse(requestOptions);
     }
 
     /**
      * Return 302 status code and redirect to /http/success/200.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head302WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.head302WithResponse(requestOptions, context);
+    public Response<Void> head302WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.head302WithResponse(requestOptions);
     }
 
     /**
      * Return 302 status code and redirect to /http/success/200.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get302WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get302WithResponse(requestOptions, context);
+    public Response<Void> get302WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get302WithResponse(requestOptions);
     }
 
     /**
@@ -152,14 +144,13 @@ public final class HttpRedirectsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> patch302WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.patch302WithResponse(requestOptions, context);
+    public Response<Void> patch302WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.patch302WithResponse(requestOptions);
     }
 
     /**
@@ -173,42 +164,39 @@ public final class HttpRedirectsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> post303WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.post303WithResponse(requestOptions, context);
+    public Response<Void> post303WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.post303WithResponse(requestOptions);
     }
 
     /**
      * Redirect with 307, resulting in a 200 success.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head307WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.head307WithResponse(requestOptions, context);
+    public Response<Void> head307WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.head307WithResponse(requestOptions);
     }
 
     /**
      * Redirect get with 307, resulting in a 200 success.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get307WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get307WithResponse(requestOptions, context);
+    public Response<Void> get307WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get307WithResponse(requestOptions);
     }
 
     /**
@@ -221,14 +209,13 @@ public final class HttpRedirectsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> put307WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.put307WithResponse(requestOptions, context);
+    public Response<Void> put307WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.put307WithResponse(requestOptions);
     }
 
     /**
@@ -241,14 +228,13 @@ public final class HttpRedirectsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> patch307WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.patch307WithResponse(requestOptions, context);
+    public Response<Void> patch307WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.patch307WithResponse(requestOptions);
     }
 
     /**
@@ -261,14 +247,13 @@ public final class HttpRedirectsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> post307WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.post307WithResponse(requestOptions, context);
+    public Response<Void> post307WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.post307WithResponse(requestOptions);
     }
 
     /**
@@ -281,13 +266,12 @@ public final class HttpRedirectsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> delete307WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.delete307WithResponse(requestOptions, context);
+    public Response<Void> delete307WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.delete307WithResponse(requestOptions);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/httpinfrastructure/HttpRetryClient.java
+++ b/protocol-tests/src/main/java/fixtures/httpinfrastructure/HttpRetryClient.java
@@ -10,7 +10,6 @@ import com.azure.core.annotation.ServiceMethod;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.util.Context;
 import fixtures.httpinfrastructure.implementation.HttpRetriesImpl;
 
 /** Initializes a new instance of the synchronous AutoRestHttpInfrastructureTestService type. */
@@ -31,14 +30,13 @@ public final class HttpRetryClient {
      * Return 408 status code, then 200 after retry.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head408WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.head408WithResponse(requestOptions, context);
+    public Response<Void> head408WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.head408WithResponse(requestOptions);
     }
 
     /**
@@ -51,14 +49,13 @@ public final class HttpRetryClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> put500WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.put500WithResponse(requestOptions, context);
+    public Response<Void> put500WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.put500WithResponse(requestOptions);
     }
 
     /**
@@ -71,28 +68,26 @@ public final class HttpRetryClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> patch500WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.patch500WithResponse(requestOptions, context);
+    public Response<Void> patch500WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.patch500WithResponse(requestOptions);
     }
 
     /**
      * Return 502 status code, then 200 after retry.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get502WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get502WithResponse(requestOptions, context);
+    public Response<Void> get502WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get502WithResponse(requestOptions);
     }
 
     /**
@@ -105,14 +100,13 @@ public final class HttpRetryClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> post503WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.post503WithResponse(requestOptions, context);
+    public Response<Void> post503WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.post503WithResponse(requestOptions);
     }
 
     /**
@@ -125,14 +119,13 @@ public final class HttpRetryClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> delete503WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.delete503WithResponse(requestOptions, context);
+    public Response<Void> delete503WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.delete503WithResponse(requestOptions);
     }
 
     /**
@@ -145,14 +138,13 @@ public final class HttpRetryClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> put504WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.put504WithResponse(requestOptions, context);
+    public Response<Void> put504WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.put504WithResponse(requestOptions);
     }
 
     /**
@@ -165,13 +157,12 @@ public final class HttpRetryClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> patch504WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.patch504WithResponse(requestOptions, context);
+    public Response<Void> patch504WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.patch504WithResponse(requestOptions);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/httpinfrastructure/HttpServerFailureClient.java
+++ b/protocol-tests/src/main/java/fixtures/httpinfrastructure/HttpServerFailureClient.java
@@ -10,7 +10,6 @@ import com.azure.core.annotation.ServiceMethod;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.util.Context;
 import fixtures.httpinfrastructure.implementation.HttpServerFailuresImpl;
 
 /** Initializes a new instance of the synchronous AutoRestHttpInfrastructureTestService type. */
@@ -31,28 +30,26 @@ public final class HttpServerFailureClient {
      * Return 501 status code - should be represented in the client as an error.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head501WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.head501WithResponse(requestOptions, context);
+    public Response<Void> head501WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.head501WithResponse(requestOptions);
     }
 
     /**
      * Return 501 status code - should be represented in the client as an error.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get501WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get501WithResponse(requestOptions, context);
+    public Response<Void> get501WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get501WithResponse(requestOptions);
     }
 
     /**
@@ -65,14 +62,13 @@ public final class HttpServerFailureClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> post505WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.post505WithResponse(requestOptions, context);
+    public Response<Void> post505WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.post505WithResponse(requestOptions);
     }
 
     /**
@@ -85,13 +81,12 @@ public final class HttpServerFailureClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> delete505WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.delete505WithResponse(requestOptions, context);
+    public Response<Void> delete505WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.delete505WithResponse(requestOptions);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/httpinfrastructure/HttpSuccessClient.java
+++ b/protocol-tests/src/main/java/fixtures/httpinfrastructure/HttpSuccessClient.java
@@ -10,7 +10,6 @@ import com.azure.core.annotation.ServiceMethod;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.util.Context;
 import fixtures.httpinfrastructure.implementation.HttpSuccessImpl;
 
 /** Initializes a new instance of the synchronous AutoRestHttpInfrastructureTestService type. */
@@ -31,14 +30,13 @@ public final class HttpSuccessClient {
      * Return 200 status code if successful.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head200WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.head200WithResponse(requestOptions, context);
+    public Response<Void> head200WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.head200WithResponse(requestOptions);
     }
 
     /**
@@ -51,14 +49,13 @@ public final class HttpSuccessClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return 200 success.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Boolean> get200WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get200WithResponse(requestOptions, context);
+    public Response<Boolean> get200WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get200WithResponse(requestOptions);
     }
 
     /**
@@ -71,14 +68,13 @@ public final class HttpSuccessClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> put200WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.put200WithResponse(requestOptions, context);
+    public Response<Void> put200WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.put200WithResponse(requestOptions);
     }
 
     /**
@@ -91,14 +87,13 @@ public final class HttpSuccessClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> patch200WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.patch200WithResponse(requestOptions, context);
+    public Response<Void> patch200WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.patch200WithResponse(requestOptions);
     }
 
     /**
@@ -111,14 +106,13 @@ public final class HttpSuccessClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> post200WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.post200WithResponse(requestOptions, context);
+    public Response<Void> post200WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.post200WithResponse(requestOptions);
     }
 
     /**
@@ -131,14 +125,13 @@ public final class HttpSuccessClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> delete200WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.delete200WithResponse(requestOptions, context);
+    public Response<Void> delete200WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.delete200WithResponse(requestOptions);
     }
 
     /**
@@ -151,14 +144,13 @@ public final class HttpSuccessClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> put201WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.put201WithResponse(requestOptions, context);
+    public Response<Void> put201WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.put201WithResponse(requestOptions);
     }
 
     /**
@@ -171,14 +163,13 @@ public final class HttpSuccessClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> post201WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.post201WithResponse(requestOptions, context);
+    public Response<Void> post201WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.post201WithResponse(requestOptions);
     }
 
     /**
@@ -191,14 +182,13 @@ public final class HttpSuccessClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> put202WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.put202WithResponse(requestOptions, context);
+    public Response<Void> put202WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.put202WithResponse(requestOptions);
     }
 
     /**
@@ -211,14 +201,13 @@ public final class HttpSuccessClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> patch202WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.patch202WithResponse(requestOptions, context);
+    public Response<Void> patch202WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.patch202WithResponse(requestOptions);
     }
 
     /**
@@ -231,14 +220,13 @@ public final class HttpSuccessClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> post202WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.post202WithResponse(requestOptions, context);
+    public Response<Void> post202WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.post202WithResponse(requestOptions);
     }
 
     /**
@@ -251,28 +239,26 @@ public final class HttpSuccessClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> delete202WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.delete202WithResponse(requestOptions, context);
+    public Response<Void> delete202WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.delete202WithResponse(requestOptions);
     }
 
     /**
      * Return 204 status code if successful.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head204WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.head204WithResponse(requestOptions, context);
+    public Response<Void> head204WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.head204WithResponse(requestOptions);
     }
 
     /**
@@ -285,14 +271,13 @@ public final class HttpSuccessClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> put204WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.put204WithResponse(requestOptions, context);
+    public Response<Void> put204WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.put204WithResponse(requestOptions);
     }
 
     /**
@@ -305,14 +290,13 @@ public final class HttpSuccessClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> patch204WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.patch204WithResponse(requestOptions, context);
+    public Response<Void> patch204WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.patch204WithResponse(requestOptions);
     }
 
     /**
@@ -325,14 +309,13 @@ public final class HttpSuccessClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> post204WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.post204WithResponse(requestOptions, context);
+    public Response<Void> post204WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.post204WithResponse(requestOptions);
     }
 
     /**
@@ -345,14 +328,13 @@ public final class HttpSuccessClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> delete204WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.delete204WithResponse(requestOptions, context);
+    public Response<Void> delete204WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.delete204WithResponse(requestOptions);
     }
 
     /**
@@ -365,13 +347,12 @@ public final class HttpSuccessClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Boolean> head404WithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.head404WithResponse(requestOptions, context);
+    public Response<Boolean> head404WithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.head404WithResponse(requestOptions);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/httpinfrastructure/MultipleResponsesClient.java
+++ b/protocol-tests/src/main/java/fixtures/httpinfrastructure/MultipleResponsesClient.java
@@ -11,7 +11,6 @@ import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import fixtures.httpinfrastructure.implementation.MultipleResponsesImpl;
 
 /** Initializes a new instance of the synchronous AutoRestHttpInfrastructureTestService type. */
@@ -40,15 +39,13 @@ public final class MultipleResponsesClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> get200Model204NoModelDefaultError200ValidWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get200Model204NoModelDefaultError200ValidWithResponse(requestOptions, context);
+    public Response<BinaryData> get200Model204NoModelDefaultError200ValidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get200Model204NoModelDefaultError200ValidWithResponse(requestOptions);
     }
 
     /**
@@ -63,15 +60,13 @@ public final class MultipleResponsesClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> get200Model204NoModelDefaultError204ValidWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get200Model204NoModelDefaultError204ValidWithResponse(requestOptions, context);
+    public Response<BinaryData> get200Model204NoModelDefaultError204ValidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get200Model204NoModelDefaultError204ValidWithResponse(requestOptions);
     }
 
     /**
@@ -86,15 +81,13 @@ public final class MultipleResponsesClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> get200Model204NoModelDefaultError201InvalidWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get200Model204NoModelDefaultError201InvalidWithResponse(requestOptions, context);
+    public Response<BinaryData> get200Model204NoModelDefaultError201InvalidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get200Model204NoModelDefaultError201InvalidWithResponse(requestOptions);
     }
 
     /**
@@ -109,15 +102,13 @@ public final class MultipleResponsesClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> get200Model204NoModelDefaultError202NoneWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get200Model204NoModelDefaultError202NoneWithResponse(requestOptions, context);
+    public Response<BinaryData> get200Model204NoModelDefaultError202NoneWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get200Model204NoModelDefaultError202NoneWithResponse(requestOptions);
     }
 
     /**
@@ -132,15 +123,13 @@ public final class MultipleResponsesClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> get200Model204NoModelDefaultError400ValidWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get200Model204NoModelDefaultError400ValidWithResponse(requestOptions, context);
+    public Response<BinaryData> get200Model204NoModelDefaultError400ValidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get200Model204NoModelDefaultError400ValidWithResponse(requestOptions);
     }
 
     /**
@@ -155,15 +144,13 @@ public final class MultipleResponsesClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> get200Model201ModelDefaultError200ValidWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get200Model201ModelDefaultError200ValidWithResponse(requestOptions, context);
+    public Response<BinaryData> get200Model201ModelDefaultError200ValidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get200Model201ModelDefaultError200ValidWithResponse(requestOptions);
     }
 
     /**
@@ -178,15 +165,13 @@ public final class MultipleResponsesClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> get200Model201ModelDefaultError201ValidWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get200Model201ModelDefaultError201ValidWithResponse(requestOptions, context);
+    public Response<BinaryData> get200Model201ModelDefaultError201ValidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get200Model201ModelDefaultError201ValidWithResponse(requestOptions);
     }
 
     /**
@@ -201,15 +186,13 @@ public final class MultipleResponsesClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> get200Model201ModelDefaultError400ValidWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get200Model201ModelDefaultError400ValidWithResponse(requestOptions, context);
+    public Response<BinaryData> get200Model201ModelDefaultError400ValidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get200Model201ModelDefaultError400ValidWithResponse(requestOptions);
     }
 
     /**
@@ -222,16 +205,14 @@ public final class MultipleResponsesClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<BinaryData> get200ModelA201ModelC404ModelDDefaultError200ValidWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get200ModelA201ModelC404ModelDDefaultError200ValidWithResponse(
-                requestOptions, context);
+            RequestOptions requestOptions) {
+        return this.serviceClient.get200ModelA201ModelC404ModelDDefaultError200ValidWithResponse(requestOptions);
     }
 
     /**
@@ -244,16 +225,14 @@ public final class MultipleResponsesClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<BinaryData> get200ModelA201ModelC404ModelDDefaultError201ValidWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get200ModelA201ModelC404ModelDDefaultError201ValidWithResponse(
-                requestOptions, context);
+            RequestOptions requestOptions) {
+        return this.serviceClient.get200ModelA201ModelC404ModelDDefaultError201ValidWithResponse(requestOptions);
     }
 
     /**
@@ -266,16 +245,14 @@ public final class MultipleResponsesClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<BinaryData> get200ModelA201ModelC404ModelDDefaultError404ValidWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get200ModelA201ModelC404ModelDDefaultError404ValidWithResponse(
-                requestOptions, context);
+            RequestOptions requestOptions) {
+        return this.serviceClient.get200ModelA201ModelC404ModelDDefaultError404ValidWithResponse(requestOptions);
     }
 
     /**
@@ -288,121 +265,105 @@ public final class MultipleResponsesClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<BinaryData> get200ModelA201ModelC404ModelDDefaultError400ValidWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get200ModelA201ModelC404ModelDDefaultError400ValidWithResponse(
-                requestOptions, context);
+            RequestOptions requestOptions) {
+        return this.serviceClient.get200ModelA201ModelC404ModelDDefaultError400ValidWithResponse(requestOptions);
     }
 
     /**
      * Send a 202 response with no payload.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get202None204NoneDefaultError202NoneWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get202None204NoneDefaultError202NoneWithResponse(requestOptions, context);
+    public Response<Void> get202None204NoneDefaultError202NoneWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get202None204NoneDefaultError202NoneWithResponse(requestOptions);
     }
 
     /**
      * Send a 204 response with no payload.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get202None204NoneDefaultError204NoneWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get202None204NoneDefaultError204NoneWithResponse(requestOptions, context);
+    public Response<Void> get202None204NoneDefaultError204NoneWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get202None204NoneDefaultError204NoneWithResponse(requestOptions);
     }
 
     /**
      * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get202None204NoneDefaultError400ValidWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get202None204NoneDefaultError400ValidWithResponse(requestOptions, context);
+    public Response<Void> get202None204NoneDefaultError400ValidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get202None204NoneDefaultError400ValidWithResponse(requestOptions);
     }
 
     /**
      * Send a 202 response with an unexpected payload {'property': 'value'}.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get202None204NoneDefaultNone202InvalidWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get202None204NoneDefaultNone202InvalidWithResponse(requestOptions, context);
+    public Response<Void> get202None204NoneDefaultNone202InvalidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get202None204NoneDefaultNone202InvalidWithResponse(requestOptions);
     }
 
     /**
      * Send a 204 response with no payload.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get202None204NoneDefaultNone204NoneWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get202None204NoneDefaultNone204NoneWithResponse(requestOptions, context);
+    public Response<Void> get202None204NoneDefaultNone204NoneWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get202None204NoneDefaultNone204NoneWithResponse(requestOptions);
     }
 
     /**
      * Send a 400 response with no payload.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get202None204NoneDefaultNone400NoneWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get202None204NoneDefaultNone400NoneWithResponse(requestOptions, context);
+    public Response<Void> get202None204NoneDefaultNone400NoneWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get202None204NoneDefaultNone400NoneWithResponse(requestOptions);
     }
 
     /**
      * Send a 400 response with an unexpected payload {'property': 'value'}.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get202None204NoneDefaultNone400InvalidWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get202None204NoneDefaultNone400InvalidWithResponse(requestOptions, context);
+    public Response<Void> get202None204NoneDefaultNone400InvalidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get202None204NoneDefaultNone400InvalidWithResponse(requestOptions);
     }
 
     /**
@@ -417,14 +378,13 @@ public final class MultipleResponsesClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getDefaultModelA200ValidWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getDefaultModelA200ValidWithResponse(requestOptions, context);
+    public Response<BinaryData> getDefaultModelA200ValidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getDefaultModelA200ValidWithResponse(requestOptions);
     }
 
     /**
@@ -439,98 +399,91 @@ public final class MultipleResponsesClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getDefaultModelA200NoneWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getDefaultModelA200NoneWithResponse(requestOptions, context);
+    public Response<BinaryData> getDefaultModelA200NoneWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getDefaultModelA200NoneWithResponse(requestOptions);
     }
 
     /**
      * Send a 400 response with valid payload: {'statusCode': '400'}.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getDefaultModelA400ValidWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getDefaultModelA400ValidWithResponse(requestOptions, context);
+    public Response<Void> getDefaultModelA400ValidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getDefaultModelA400ValidWithResponse(requestOptions);
     }
 
     /**
      * Send a 400 response with no payload.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getDefaultModelA400NoneWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getDefaultModelA400NoneWithResponse(requestOptions, context);
+    public Response<Void> getDefaultModelA400NoneWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getDefaultModelA400NoneWithResponse(requestOptions);
     }
 
     /**
      * Send a 200 response with invalid payload: {'statusCode': '200'}.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getDefaultNone200InvalidWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getDefaultNone200InvalidWithResponse(requestOptions, context);
+    public Response<Void> getDefaultNone200InvalidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getDefaultNone200InvalidWithResponse(requestOptions);
     }
 
     /**
      * Send a 200 response with no payload.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getDefaultNone200NoneWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getDefaultNone200NoneWithResponse(requestOptions, context);
+    public Response<Void> getDefaultNone200NoneWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getDefaultNone200NoneWithResponse(requestOptions);
     }
 
     /**
      * Send a 400 response with valid payload: {'statusCode': '400'}.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getDefaultNone400InvalidWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getDefaultNone400InvalidWithResponse(requestOptions, context);
+    public Response<Void> getDefaultNone400InvalidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getDefaultNone400InvalidWithResponse(requestOptions);
     }
 
     /**
      * Send a 400 response with no payload.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getDefaultNone400NoneWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getDefaultNone400NoneWithResponse(requestOptions, context);
+    public Response<Void> getDefaultNone400NoneWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getDefaultNone400NoneWithResponse(requestOptions);
     }
 
     /**
@@ -546,14 +499,13 @@ public final class MultipleResponsesClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> get200ModelA200NoneWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get200ModelA200NoneWithResponse(requestOptions, context);
+    public Response<BinaryData> get200ModelA200NoneWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get200ModelA200NoneWithResponse(requestOptions);
     }
 
     /**
@@ -568,14 +520,13 @@ public final class MultipleResponsesClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> get200ModelA200ValidWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get200ModelA200ValidWithResponse(requestOptions, context);
+    public Response<BinaryData> get200ModelA200ValidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get200ModelA200ValidWithResponse(requestOptions);
     }
 
     /**
@@ -590,14 +541,13 @@ public final class MultipleResponsesClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> get200ModelA200InvalidWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get200ModelA200InvalidWithResponse(requestOptions, context);
+    public Response<BinaryData> get200ModelA200InvalidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get200ModelA200InvalidWithResponse(requestOptions);
     }
 
     /**
@@ -612,14 +562,13 @@ public final class MultipleResponsesClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> get200ModelA400NoneWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get200ModelA400NoneWithResponse(requestOptions, context);
+    public Response<BinaryData> get200ModelA400NoneWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get200ModelA400NoneWithResponse(requestOptions);
     }
 
     /**
@@ -634,14 +583,13 @@ public final class MultipleResponsesClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> get200ModelA400ValidWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get200ModelA400ValidWithResponse(requestOptions, context);
+    public Response<BinaryData> get200ModelA400ValidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get200ModelA400ValidWithResponse(requestOptions);
     }
 
     /**
@@ -656,14 +604,13 @@ public final class MultipleResponsesClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> get200ModelA400InvalidWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get200ModelA400InvalidWithResponse(requestOptions, context);
+    public Response<BinaryData> get200ModelA400InvalidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get200ModelA400InvalidWithResponse(requestOptions);
     }
 
     /**
@@ -678,13 +625,12 @@ public final class MultipleResponsesClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> get200ModelA202ValidWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.get200ModelA202ValidWithResponse(requestOptions, context);
+    public Response<BinaryData> get200ModelA202ValidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.get200ModelA202ValidWithResponse(requestOptions);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/httpinfrastructure/implementation/HttpClientFailuresImpl.java
+++ b/protocol-tests/src/main/java/fixtures/httpinfrastructure/implementation/HttpClientFailuresImpl.java
@@ -151,14 +151,13 @@ public final class HttpClientFailuresImpl {
      * Return 400 status code - should be represented in the client as an error.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head400WithResponse(RequestOptions requestOptions, Context context) {
-        return head400WithResponseAsync(requestOptions, context).block();
+    public Response<Void> head400WithResponse(RequestOptions requestOptions) {
+        return head400WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -192,14 +191,13 @@ public final class HttpClientFailuresImpl {
      * Return 400 status code - should be represented in the client as an error.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get400WithResponse(RequestOptions requestOptions, Context context) {
-        return get400WithResponseAsync(requestOptions, context).block();
+    public Response<Void> get400WithResponse(RequestOptions requestOptions) {
+        return get400WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -251,14 +249,13 @@ public final class HttpClientFailuresImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> put400WithResponse(RequestOptions requestOptions, Context context) {
-        return put400WithResponseAsync(requestOptions, context).block();
+    public Response<Void> put400WithResponse(RequestOptions requestOptions) {
+        return put400WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -310,14 +307,13 @@ public final class HttpClientFailuresImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> patch400WithResponse(RequestOptions requestOptions, Context context) {
-        return patch400WithResponseAsync(requestOptions, context).block();
+    public Response<Void> patch400WithResponse(RequestOptions requestOptions) {
+        return patch400WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -369,14 +365,13 @@ public final class HttpClientFailuresImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> post400WithResponse(RequestOptions requestOptions, Context context) {
-        return post400WithResponseAsync(requestOptions, context).block();
+    public Response<Void> post400WithResponse(RequestOptions requestOptions) {
+        return post400WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -428,14 +423,13 @@ public final class HttpClientFailuresImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> delete400WithResponse(RequestOptions requestOptions, Context context) {
-        return delete400WithResponseAsync(requestOptions, context).block();
+    public Response<Void> delete400WithResponse(RequestOptions requestOptions) {
+        return delete400WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -469,14 +463,13 @@ public final class HttpClientFailuresImpl {
      * Return 401 status code - should be represented in the client as an error.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head401WithResponse(RequestOptions requestOptions, Context context) {
-        return head401WithResponseAsync(requestOptions, context).block();
+    public Response<Void> head401WithResponse(RequestOptions requestOptions) {
+        return head401WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -510,14 +503,13 @@ public final class HttpClientFailuresImpl {
      * Return 402 status code - should be represented in the client as an error.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get402WithResponse(RequestOptions requestOptions, Context context) {
-        return get402WithResponseAsync(requestOptions, context).block();
+    public Response<Void> get402WithResponse(RequestOptions requestOptions) {
+        return get402WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -551,14 +543,13 @@ public final class HttpClientFailuresImpl {
      * Return 403 status code - should be represented in the client as an error.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get403WithResponse(RequestOptions requestOptions, Context context) {
-        return get403WithResponseAsync(requestOptions, context).block();
+    public Response<Void> get403WithResponse(RequestOptions requestOptions) {
+        return get403WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -610,14 +601,13 @@ public final class HttpClientFailuresImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> put404WithResponse(RequestOptions requestOptions, Context context) {
-        return put404WithResponseAsync(requestOptions, context).block();
+    public Response<Void> put404WithResponse(RequestOptions requestOptions) {
+        return put404WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -669,14 +659,13 @@ public final class HttpClientFailuresImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> patch405WithResponse(RequestOptions requestOptions, Context context) {
-        return patch405WithResponseAsync(requestOptions, context).block();
+    public Response<Void> patch405WithResponse(RequestOptions requestOptions) {
+        return patch405WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -728,14 +717,13 @@ public final class HttpClientFailuresImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> post406WithResponse(RequestOptions requestOptions, Context context) {
-        return post406WithResponseAsync(requestOptions, context).block();
+    public Response<Void> post406WithResponse(RequestOptions requestOptions) {
+        return post406WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -787,14 +775,13 @@ public final class HttpClientFailuresImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> delete407WithResponse(RequestOptions requestOptions, Context context) {
-        return delete407WithResponseAsync(requestOptions, context).block();
+    public Response<Void> delete407WithResponse(RequestOptions requestOptions) {
+        return delete407WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -846,14 +833,13 @@ public final class HttpClientFailuresImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> put409WithResponse(RequestOptions requestOptions, Context context) {
-        return put409WithResponseAsync(requestOptions, context).block();
+    public Response<Void> put409WithResponse(RequestOptions requestOptions) {
+        return put409WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -887,14 +873,13 @@ public final class HttpClientFailuresImpl {
      * Return 410 status code - should be represented in the client as an error.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head410WithResponse(RequestOptions requestOptions, Context context) {
-        return head410WithResponseAsync(requestOptions, context).block();
+    public Response<Void> head410WithResponse(RequestOptions requestOptions) {
+        return head410WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -928,14 +913,13 @@ public final class HttpClientFailuresImpl {
      * Return 411 status code - should be represented in the client as an error.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get411WithResponse(RequestOptions requestOptions, Context context) {
-        return get411WithResponseAsync(requestOptions, context).block();
+    public Response<Void> get411WithResponse(RequestOptions requestOptions) {
+        return get411WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -969,14 +953,13 @@ public final class HttpClientFailuresImpl {
      * Return 412 status code - should be represented in the client as an error.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get412WithResponse(RequestOptions requestOptions, Context context) {
-        return get412WithResponseAsync(requestOptions, context).block();
+    public Response<Void> get412WithResponse(RequestOptions requestOptions) {
+        return get412WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1028,14 +1011,13 @@ public final class HttpClientFailuresImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> put413WithResponse(RequestOptions requestOptions, Context context) {
-        return put413WithResponseAsync(requestOptions, context).block();
+    public Response<Void> put413WithResponse(RequestOptions requestOptions) {
+        return put413WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1087,14 +1069,13 @@ public final class HttpClientFailuresImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> patch414WithResponse(RequestOptions requestOptions, Context context) {
-        return patch414WithResponseAsync(requestOptions, context).block();
+    public Response<Void> patch414WithResponse(RequestOptions requestOptions) {
+        return patch414WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1146,14 +1127,13 @@ public final class HttpClientFailuresImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> post415WithResponse(RequestOptions requestOptions, Context context) {
-        return post415WithResponseAsync(requestOptions, context).block();
+    public Response<Void> post415WithResponse(RequestOptions requestOptions) {
+        return post415WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1187,14 +1167,13 @@ public final class HttpClientFailuresImpl {
      * Return 416 status code - should be represented in the client as an error.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get416WithResponse(RequestOptions requestOptions, Context context) {
-        return get416WithResponseAsync(requestOptions, context).block();
+    public Response<Void> get416WithResponse(RequestOptions requestOptions) {
+        return get416WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1246,14 +1225,13 @@ public final class HttpClientFailuresImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> delete417WithResponse(RequestOptions requestOptions, Context context) {
-        return delete417WithResponseAsync(requestOptions, context).block();
+    public Response<Void> delete417WithResponse(RequestOptions requestOptions) {
+        return delete417WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1287,13 +1265,12 @@ public final class HttpClientFailuresImpl {
      * Return 429 status code - should be represented in the client as an error.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head429WithResponse(RequestOptions requestOptions, Context context) {
-        return head429WithResponseAsync(requestOptions, context).block();
+    public Response<Void> head429WithResponse(RequestOptions requestOptions) {
+        return head429WithResponseAsync(requestOptions).block();
     }
 }

--- a/protocol-tests/src/main/java/fixtures/httpinfrastructure/implementation/HttpFailuresImpl.java
+++ b/protocol-tests/src/main/java/fixtures/httpinfrastructure/implementation/HttpFailuresImpl.java
@@ -106,14 +106,13 @@ public final class HttpFailuresImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return empty error form server.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Boolean> getEmptyErrorWithResponse(RequestOptions requestOptions, Context context) {
-        return getEmptyErrorWithResponseAsync(requestOptions, context).block();
+    public Response<Boolean> getEmptyErrorWithResponse(RequestOptions requestOptions) {
+        return getEmptyErrorWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -165,14 +164,13 @@ public final class HttpFailuresImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return empty error form server.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Boolean> getNoModelErrorWithResponse(RequestOptions requestOptions, Context context) {
-        return getNoModelErrorWithResponseAsync(requestOptions, context).block();
+    public Response<Boolean> getNoModelErrorWithResponse(RequestOptions requestOptions) {
+        return getNoModelErrorWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -224,13 +222,12 @@ public final class HttpFailuresImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return empty response from server.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Boolean> getNoModelEmptyWithResponse(RequestOptions requestOptions, Context context) {
-        return getNoModelEmptyWithResponseAsync(requestOptions, context).block();
+    public Response<Boolean> getNoModelEmptyWithResponse(RequestOptions requestOptions) {
+        return getNoModelEmptyWithResponseAsync(requestOptions).block();
     }
 }

--- a/protocol-tests/src/main/java/fixtures/httpinfrastructure/implementation/HttpRedirectsImpl.java
+++ b/protocol-tests/src/main/java/fixtures/httpinfrastructure/implementation/HttpRedirectsImpl.java
@@ -128,14 +128,13 @@ public final class HttpRedirectsImpl {
      * Return 300 status code and redirect to /http/success/200.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head300WithResponse(RequestOptions requestOptions, Context context) {
-        return head300WithResponseAsync(requestOptions, context).block();
+    public Response<Void> head300WithResponse(RequestOptions requestOptions) {
+        return head300WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -193,14 +192,13 @@ public final class HttpRedirectsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> get300WithResponse(RequestOptions requestOptions, Context context) {
-        return get300WithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> get300WithResponse(RequestOptions requestOptions) {
+        return get300WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -234,14 +232,13 @@ public final class HttpRedirectsImpl {
      * Return 301 status code and redirect to /http/success/200.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head301WithResponse(RequestOptions requestOptions, Context context) {
-        return head301WithResponseAsync(requestOptions, context).block();
+    public Response<Void> head301WithResponse(RequestOptions requestOptions) {
+        return head301WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -275,14 +272,13 @@ public final class HttpRedirectsImpl {
      * Return 301 status code and redirect to /http/success/200.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get301WithResponse(RequestOptions requestOptions, Context context) {
-        return get301WithResponseAsync(requestOptions, context).block();
+    public Response<Void> get301WithResponse(RequestOptions requestOptions) {
+        return get301WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -337,14 +333,13 @@ public final class HttpRedirectsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> put301WithResponse(RequestOptions requestOptions, Context context) {
-        return put301WithResponseAsync(requestOptions, context).block();
+    public Response<Void> put301WithResponse(RequestOptions requestOptions) {
+        return put301WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -378,14 +373,13 @@ public final class HttpRedirectsImpl {
      * Return 302 status code and redirect to /http/success/200.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head302WithResponse(RequestOptions requestOptions, Context context) {
-        return head302WithResponseAsync(requestOptions, context).block();
+    public Response<Void> head302WithResponse(RequestOptions requestOptions) {
+        return head302WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -419,14 +413,13 @@ public final class HttpRedirectsImpl {
      * Return 302 status code and redirect to /http/success/200.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get302WithResponse(RequestOptions requestOptions, Context context) {
-        return get302WithResponseAsync(requestOptions, context).block();
+    public Response<Void> get302WithResponse(RequestOptions requestOptions) {
+        return get302WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -481,14 +474,13 @@ public final class HttpRedirectsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> patch302WithResponse(RequestOptions requestOptions, Context context) {
-        return patch302WithResponseAsync(requestOptions, context).block();
+    public Response<Void> patch302WithResponse(RequestOptions requestOptions) {
+        return patch302WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -543,14 +535,13 @@ public final class HttpRedirectsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> post303WithResponse(RequestOptions requestOptions, Context context) {
-        return post303WithResponseAsync(requestOptions, context).block();
+    public Response<Void> post303WithResponse(RequestOptions requestOptions) {
+        return post303WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -584,14 +575,13 @@ public final class HttpRedirectsImpl {
      * Redirect with 307, resulting in a 200 success.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head307WithResponse(RequestOptions requestOptions, Context context) {
-        return head307WithResponseAsync(requestOptions, context).block();
+    public Response<Void> head307WithResponse(RequestOptions requestOptions) {
+        return head307WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -625,14 +615,13 @@ public final class HttpRedirectsImpl {
      * Redirect get with 307, resulting in a 200 success.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get307WithResponse(RequestOptions requestOptions, Context context) {
-        return get307WithResponseAsync(requestOptions, context).block();
+    public Response<Void> get307WithResponse(RequestOptions requestOptions) {
+        return get307WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -684,14 +673,13 @@ public final class HttpRedirectsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> put307WithResponse(RequestOptions requestOptions, Context context) {
-        return put307WithResponseAsync(requestOptions, context).block();
+    public Response<Void> put307WithResponse(RequestOptions requestOptions) {
+        return put307WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -743,14 +731,13 @@ public final class HttpRedirectsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> patch307WithResponse(RequestOptions requestOptions, Context context) {
-        return patch307WithResponseAsync(requestOptions, context).block();
+    public Response<Void> patch307WithResponse(RequestOptions requestOptions) {
+        return patch307WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -802,14 +789,13 @@ public final class HttpRedirectsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> post307WithResponse(RequestOptions requestOptions, Context context) {
-        return post307WithResponseAsync(requestOptions, context).block();
+    public Response<Void> post307WithResponse(RequestOptions requestOptions) {
+        return post307WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -861,13 +847,12 @@ public final class HttpRedirectsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> delete307WithResponse(RequestOptions requestOptions, Context context) {
-        return delete307WithResponseAsync(requestOptions, context).block();
+    public Response<Void> delete307WithResponse(RequestOptions requestOptions) {
+        return delete307WithResponseAsync(requestOptions).block();
     }
 }

--- a/protocol-tests/src/main/java/fixtures/httpinfrastructure/implementation/HttpRetriesImpl.java
+++ b/protocol-tests/src/main/java/fixtures/httpinfrastructure/implementation/HttpRetriesImpl.java
@@ -105,14 +105,13 @@ public final class HttpRetriesImpl {
      * Return 408 status code, then 200 after retry.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head408WithResponse(RequestOptions requestOptions, Context context) {
-        return head408WithResponseAsync(requestOptions, context).block();
+    public Response<Void> head408WithResponse(RequestOptions requestOptions) {
+        return head408WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -164,14 +163,13 @@ public final class HttpRetriesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> put500WithResponse(RequestOptions requestOptions, Context context) {
-        return put500WithResponseAsync(requestOptions, context).block();
+    public Response<Void> put500WithResponse(RequestOptions requestOptions) {
+        return put500WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -223,14 +221,13 @@ public final class HttpRetriesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> patch500WithResponse(RequestOptions requestOptions, Context context) {
-        return patch500WithResponseAsync(requestOptions, context).block();
+    public Response<Void> patch500WithResponse(RequestOptions requestOptions) {
+        return patch500WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -264,14 +261,13 @@ public final class HttpRetriesImpl {
      * Return 502 status code, then 200 after retry.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get502WithResponse(RequestOptions requestOptions, Context context) {
-        return get502WithResponseAsync(requestOptions, context).block();
+    public Response<Void> get502WithResponse(RequestOptions requestOptions) {
+        return get502WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -323,14 +319,13 @@ public final class HttpRetriesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> post503WithResponse(RequestOptions requestOptions, Context context) {
-        return post503WithResponseAsync(requestOptions, context).block();
+    public Response<Void> post503WithResponse(RequestOptions requestOptions) {
+        return post503WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -382,14 +377,13 @@ public final class HttpRetriesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> delete503WithResponse(RequestOptions requestOptions, Context context) {
-        return delete503WithResponseAsync(requestOptions, context).block();
+    public Response<Void> delete503WithResponse(RequestOptions requestOptions) {
+        return delete503WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -441,14 +435,13 @@ public final class HttpRetriesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> put504WithResponse(RequestOptions requestOptions, Context context) {
-        return put504WithResponseAsync(requestOptions, context).block();
+    public Response<Void> put504WithResponse(RequestOptions requestOptions) {
+        return put504WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -500,13 +493,12 @@ public final class HttpRetriesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> patch504WithResponse(RequestOptions requestOptions, Context context) {
-        return patch504WithResponseAsync(requestOptions, context).block();
+    public Response<Void> patch504WithResponse(RequestOptions requestOptions) {
+        return patch504WithResponseAsync(requestOptions).block();
     }
 }

--- a/protocol-tests/src/main/java/fixtures/httpinfrastructure/implementation/HttpServerFailuresImpl.java
+++ b/protocol-tests/src/main/java/fixtures/httpinfrastructure/implementation/HttpServerFailuresImpl.java
@@ -92,14 +92,13 @@ public final class HttpServerFailuresImpl {
      * Return 501 status code - should be represented in the client as an error.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head501WithResponse(RequestOptions requestOptions, Context context) {
-        return head501WithResponseAsync(requestOptions, context).block();
+    public Response<Void> head501WithResponse(RequestOptions requestOptions) {
+        return head501WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -133,14 +132,13 @@ public final class HttpServerFailuresImpl {
      * Return 501 status code - should be represented in the client as an error.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get501WithResponse(RequestOptions requestOptions, Context context) {
-        return get501WithResponseAsync(requestOptions, context).block();
+    public Response<Void> get501WithResponse(RequestOptions requestOptions) {
+        return get501WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -192,14 +190,13 @@ public final class HttpServerFailuresImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> post505WithResponse(RequestOptions requestOptions, Context context) {
-        return post505WithResponseAsync(requestOptions, context).block();
+    public Response<Void> post505WithResponse(RequestOptions requestOptions) {
+        return post505WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -251,13 +248,12 @@ public final class HttpServerFailuresImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> delete505WithResponse(RequestOptions requestOptions, Context context) {
-        return delete505WithResponseAsync(requestOptions, context).block();
+    public Response<Void> delete505WithResponse(RequestOptions requestOptions) {
+        return delete505WithResponseAsync(requestOptions).block();
     }
 }

--- a/protocol-tests/src/main/java/fixtures/httpinfrastructure/implementation/HttpSuccessImpl.java
+++ b/protocol-tests/src/main/java/fixtures/httpinfrastructure/implementation/HttpSuccessImpl.java
@@ -136,14 +136,13 @@ public final class HttpSuccessImpl {
      * Return 200 status code if successful.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head200WithResponse(RequestOptions requestOptions, Context context) {
-        return head200WithResponseAsync(requestOptions, context).block();
+    public Response<Void> head200WithResponse(RequestOptions requestOptions) {
+        return head200WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -195,14 +194,13 @@ public final class HttpSuccessImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return 200 success.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Boolean> get200WithResponse(RequestOptions requestOptions, Context context) {
-        return get200WithResponseAsync(requestOptions, context).block();
+    public Response<Boolean> get200WithResponse(RequestOptions requestOptions) {
+        return get200WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -254,14 +252,13 @@ public final class HttpSuccessImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> put200WithResponse(RequestOptions requestOptions, Context context) {
-        return put200WithResponseAsync(requestOptions, context).block();
+    public Response<Void> put200WithResponse(RequestOptions requestOptions) {
+        return put200WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -313,14 +310,13 @@ public final class HttpSuccessImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> patch200WithResponse(RequestOptions requestOptions, Context context) {
-        return patch200WithResponseAsync(requestOptions, context).block();
+    public Response<Void> patch200WithResponse(RequestOptions requestOptions) {
+        return patch200WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -372,14 +368,13 @@ public final class HttpSuccessImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> post200WithResponse(RequestOptions requestOptions, Context context) {
-        return post200WithResponseAsync(requestOptions, context).block();
+    public Response<Void> post200WithResponse(RequestOptions requestOptions) {
+        return post200WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -431,14 +426,13 @@ public final class HttpSuccessImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> delete200WithResponse(RequestOptions requestOptions, Context context) {
-        return delete200WithResponseAsync(requestOptions, context).block();
+    public Response<Void> delete200WithResponse(RequestOptions requestOptions) {
+        return delete200WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -490,14 +484,13 @@ public final class HttpSuccessImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> put201WithResponse(RequestOptions requestOptions, Context context) {
-        return put201WithResponseAsync(requestOptions, context).block();
+    public Response<Void> put201WithResponse(RequestOptions requestOptions) {
+        return put201WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -549,14 +542,13 @@ public final class HttpSuccessImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> post201WithResponse(RequestOptions requestOptions, Context context) {
-        return post201WithResponseAsync(requestOptions, context).block();
+    public Response<Void> post201WithResponse(RequestOptions requestOptions) {
+        return post201WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -608,14 +600,13 @@ public final class HttpSuccessImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> put202WithResponse(RequestOptions requestOptions, Context context) {
-        return put202WithResponseAsync(requestOptions, context).block();
+    public Response<Void> put202WithResponse(RequestOptions requestOptions) {
+        return put202WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -667,14 +658,13 @@ public final class HttpSuccessImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> patch202WithResponse(RequestOptions requestOptions, Context context) {
-        return patch202WithResponseAsync(requestOptions, context).block();
+    public Response<Void> patch202WithResponse(RequestOptions requestOptions) {
+        return patch202WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -726,14 +716,13 @@ public final class HttpSuccessImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> post202WithResponse(RequestOptions requestOptions, Context context) {
-        return post202WithResponseAsync(requestOptions, context).block();
+    public Response<Void> post202WithResponse(RequestOptions requestOptions) {
+        return post202WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -785,14 +774,13 @@ public final class HttpSuccessImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> delete202WithResponse(RequestOptions requestOptions, Context context) {
-        return delete202WithResponseAsync(requestOptions, context).block();
+    public Response<Void> delete202WithResponse(RequestOptions requestOptions) {
+        return delete202WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -826,14 +814,13 @@ public final class HttpSuccessImpl {
      * Return 204 status code if successful.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> head204WithResponse(RequestOptions requestOptions, Context context) {
-        return head204WithResponseAsync(requestOptions, context).block();
+    public Response<Void> head204WithResponse(RequestOptions requestOptions) {
+        return head204WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -885,14 +872,13 @@ public final class HttpSuccessImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> put204WithResponse(RequestOptions requestOptions, Context context) {
-        return put204WithResponseAsync(requestOptions, context).block();
+    public Response<Void> put204WithResponse(RequestOptions requestOptions) {
+        return put204WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -944,14 +930,13 @@ public final class HttpSuccessImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> patch204WithResponse(RequestOptions requestOptions, Context context) {
-        return patch204WithResponseAsync(requestOptions, context).block();
+    public Response<Void> patch204WithResponse(RequestOptions requestOptions) {
+        return patch204WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1003,14 +988,13 @@ public final class HttpSuccessImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> post204WithResponse(RequestOptions requestOptions, Context context) {
-        return post204WithResponseAsync(requestOptions, context).block();
+    public Response<Void> post204WithResponse(RequestOptions requestOptions) {
+        return post204WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1062,14 +1046,13 @@ public final class HttpSuccessImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> delete204WithResponse(RequestOptions requestOptions, Context context) {
-        return delete204WithResponseAsync(requestOptions, context).block();
+    public Response<Void> delete204WithResponse(RequestOptions requestOptions) {
+        return delete204WithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1121,13 +1104,12 @@ public final class HttpSuccessImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Boolean> head404WithResponse(RequestOptions requestOptions, Context context) {
-        return head404WithResponseAsync(requestOptions, context).block();
+    public Response<Boolean> head404WithResponse(RequestOptions requestOptions) {
+        return head404WithResponseAsync(requestOptions).block();
     }
 }

--- a/protocol-tests/src/main/java/fixtures/httpinfrastructure/implementation/MultipleResponsesImpl.java
+++ b/protocol-tests/src/main/java/fixtures/httpinfrastructure/implementation/MultipleResponsesImpl.java
@@ -243,15 +243,13 @@ public final class MultipleResponsesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> get200Model204NoModelDefaultError200ValidWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return get200Model204NoModelDefaultError200ValidWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> get200Model204NoModelDefaultError200ValidWithResponse(RequestOptions requestOptions) {
+        return get200Model204NoModelDefaultError200ValidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -314,15 +312,13 @@ public final class MultipleResponsesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> get200Model204NoModelDefaultError204ValidWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return get200Model204NoModelDefaultError204ValidWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> get200Model204NoModelDefaultError204ValidWithResponse(RequestOptions requestOptions) {
+        return get200Model204NoModelDefaultError204ValidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -385,15 +381,13 @@ public final class MultipleResponsesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> get200Model204NoModelDefaultError201InvalidWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return get200Model204NoModelDefaultError201InvalidWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> get200Model204NoModelDefaultError201InvalidWithResponse(RequestOptions requestOptions) {
+        return get200Model204NoModelDefaultError201InvalidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -456,15 +450,13 @@ public final class MultipleResponsesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> get200Model204NoModelDefaultError202NoneWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return get200Model204NoModelDefaultError202NoneWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> get200Model204NoModelDefaultError202NoneWithResponse(RequestOptions requestOptions) {
+        return get200Model204NoModelDefaultError202NoneWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -527,15 +519,13 @@ public final class MultipleResponsesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> get200Model204NoModelDefaultError400ValidWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return get200Model204NoModelDefaultError400ValidWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> get200Model204NoModelDefaultError400ValidWithResponse(RequestOptions requestOptions) {
+        return get200Model204NoModelDefaultError400ValidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -598,15 +588,13 @@ public final class MultipleResponsesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> get200Model201ModelDefaultError200ValidWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return get200Model201ModelDefaultError200ValidWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> get200Model201ModelDefaultError200ValidWithResponse(RequestOptions requestOptions) {
+        return get200Model201ModelDefaultError200ValidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -669,15 +657,13 @@ public final class MultipleResponsesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> get200Model201ModelDefaultError201ValidWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return get200Model201ModelDefaultError201ValidWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> get200Model201ModelDefaultError201ValidWithResponse(RequestOptions requestOptions) {
+        return get200Model201ModelDefaultError201ValidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -740,15 +726,13 @@ public final class MultipleResponsesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> get200Model201ModelDefaultError400ValidWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return get200Model201ModelDefaultError400ValidWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> get200Model201ModelDefaultError400ValidWithResponse(RequestOptions requestOptions) {
+        return get200Model201ModelDefaultError400ValidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -806,15 +790,14 @@ public final class MultipleResponsesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<BinaryData> get200ModelA201ModelC404ModelDDefaultError200ValidWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return get200ModelA201ModelC404ModelDDefaultError200ValidWithResponseAsync(requestOptions, context).block();
+            RequestOptions requestOptions) {
+        return get200ModelA201ModelC404ModelDDefaultError200ValidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -872,15 +855,14 @@ public final class MultipleResponsesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<BinaryData> get200ModelA201ModelC404ModelDDefaultError201ValidWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return get200ModelA201ModelC404ModelDDefaultError201ValidWithResponseAsync(requestOptions, context).block();
+            RequestOptions requestOptions) {
+        return get200ModelA201ModelC404ModelDDefaultError201ValidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -938,15 +920,14 @@ public final class MultipleResponsesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<BinaryData> get200ModelA201ModelC404ModelDDefaultError404ValidWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return get200ModelA201ModelC404ModelDDefaultError404ValidWithResponseAsync(requestOptions, context).block();
+            RequestOptions requestOptions) {
+        return get200ModelA201ModelC404ModelDDefaultError404ValidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1004,15 +985,14 @@ public final class MultipleResponsesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<BinaryData> get200ModelA201ModelC404ModelDDefaultError400ValidWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return get200ModelA201ModelC404ModelDDefaultError400ValidWithResponseAsync(requestOptions, context).block();
+            RequestOptions requestOptions) {
+        return get200ModelA201ModelC404ModelDDefaultError400ValidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1049,15 +1029,13 @@ public final class MultipleResponsesImpl {
      * Send a 202 response with no payload.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get202None204NoneDefaultError202NoneWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return get202None204NoneDefaultError202NoneWithResponseAsync(requestOptions, context).block();
+    public Response<Void> get202None204NoneDefaultError202NoneWithResponse(RequestOptions requestOptions) {
+        return get202None204NoneDefaultError202NoneWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1094,15 +1072,13 @@ public final class MultipleResponsesImpl {
      * Send a 204 response with no payload.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get202None204NoneDefaultError204NoneWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return get202None204NoneDefaultError204NoneWithResponseAsync(requestOptions, context).block();
+    public Response<Void> get202None204NoneDefaultError204NoneWithResponse(RequestOptions requestOptions) {
+        return get202None204NoneDefaultError204NoneWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1139,15 +1115,13 @@ public final class MultipleResponsesImpl {
      * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get202None204NoneDefaultError400ValidWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return get202None204NoneDefaultError400ValidWithResponseAsync(requestOptions, context).block();
+    public Response<Void> get202None204NoneDefaultError400ValidWithResponse(RequestOptions requestOptions) {
+        return get202None204NoneDefaultError400ValidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1184,15 +1158,13 @@ public final class MultipleResponsesImpl {
      * Send a 202 response with an unexpected payload {'property': 'value'}.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get202None204NoneDefaultNone202InvalidWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return get202None204NoneDefaultNone202InvalidWithResponseAsync(requestOptions, context).block();
+    public Response<Void> get202None204NoneDefaultNone202InvalidWithResponse(RequestOptions requestOptions) {
+        return get202None204NoneDefaultNone202InvalidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1228,15 +1200,13 @@ public final class MultipleResponsesImpl {
      * Send a 204 response with no payload.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get202None204NoneDefaultNone204NoneWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return get202None204NoneDefaultNone204NoneWithResponseAsync(requestOptions, context).block();
+    public Response<Void> get202None204NoneDefaultNone204NoneWithResponse(RequestOptions requestOptions) {
+        return get202None204NoneDefaultNone204NoneWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1272,15 +1242,13 @@ public final class MultipleResponsesImpl {
      * Send a 400 response with no payload.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get202None204NoneDefaultNone400NoneWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return get202None204NoneDefaultNone400NoneWithResponseAsync(requestOptions, context).block();
+    public Response<Void> get202None204NoneDefaultNone400NoneWithResponse(RequestOptions requestOptions) {
+        return get202None204NoneDefaultNone400NoneWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1317,15 +1285,13 @@ public final class MultipleResponsesImpl {
      * Send a 400 response with an unexpected payload {'property': 'value'}.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> get202None204NoneDefaultNone400InvalidWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return get202None204NoneDefaultNone400InvalidWithResponseAsync(requestOptions, context).block();
+    public Response<Void> get202None204NoneDefaultNone400InvalidWithResponse(RequestOptions requestOptions) {
+        return get202None204NoneDefaultNone400InvalidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1385,14 +1351,13 @@ public final class MultipleResponsesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getDefaultModelA200ValidWithResponse(RequestOptions requestOptions, Context context) {
-        return getDefaultModelA200ValidWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getDefaultModelA200ValidWithResponse(RequestOptions requestOptions) {
+        return getDefaultModelA200ValidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1452,14 +1417,13 @@ public final class MultipleResponsesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getDefaultModelA200NoneWithResponse(RequestOptions requestOptions, Context context) {
-        return getDefaultModelA200NoneWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getDefaultModelA200NoneWithResponse(RequestOptions requestOptions) {
+        return getDefaultModelA200NoneWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1495,14 +1459,13 @@ public final class MultipleResponsesImpl {
      * Send a 400 response with valid payload: {'statusCode': '400'}.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getDefaultModelA400ValidWithResponse(RequestOptions requestOptions, Context context) {
-        return getDefaultModelA400ValidWithResponseAsync(requestOptions, context).block();
+    public Response<Void> getDefaultModelA400ValidWithResponse(RequestOptions requestOptions) {
+        return getDefaultModelA400ValidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1538,14 +1501,13 @@ public final class MultipleResponsesImpl {
      * Send a 400 response with no payload.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getDefaultModelA400NoneWithResponse(RequestOptions requestOptions, Context context) {
-        return getDefaultModelA400NoneWithResponseAsync(requestOptions, context).block();
+    public Response<Void> getDefaultModelA400NoneWithResponse(RequestOptions requestOptions) {
+        return getDefaultModelA400NoneWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1581,14 +1543,13 @@ public final class MultipleResponsesImpl {
      * Send a 200 response with invalid payload: {'statusCode': '200'}.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getDefaultNone200InvalidWithResponse(RequestOptions requestOptions, Context context) {
-        return getDefaultNone200InvalidWithResponseAsync(requestOptions, context).block();
+    public Response<Void> getDefaultNone200InvalidWithResponse(RequestOptions requestOptions) {
+        return getDefaultNone200InvalidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1623,14 +1584,13 @@ public final class MultipleResponsesImpl {
      * Send a 200 response with no payload.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getDefaultNone200NoneWithResponse(RequestOptions requestOptions, Context context) {
-        return getDefaultNone200NoneWithResponseAsync(requestOptions, context).block();
+    public Response<Void> getDefaultNone200NoneWithResponse(RequestOptions requestOptions) {
+        return getDefaultNone200NoneWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1666,14 +1626,13 @@ public final class MultipleResponsesImpl {
      * Send a 400 response with valid payload: {'statusCode': '400'}.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getDefaultNone400InvalidWithResponse(RequestOptions requestOptions, Context context) {
-        return getDefaultNone400InvalidWithResponseAsync(requestOptions, context).block();
+    public Response<Void> getDefaultNone400InvalidWithResponse(RequestOptions requestOptions) {
+        return getDefaultNone400InvalidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1708,14 +1667,13 @@ public final class MultipleResponsesImpl {
      * Send a 400 response with no payload.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getDefaultNone400NoneWithResponse(RequestOptions requestOptions, Context context) {
-        return getDefaultNone400NoneWithResponseAsync(requestOptions, context).block();
+    public Response<Void> getDefaultNone400NoneWithResponse(RequestOptions requestOptions) {
+        return getDefaultNone400NoneWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1778,14 +1736,13 @@ public final class MultipleResponsesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> get200ModelA200NoneWithResponse(RequestOptions requestOptions, Context context) {
-        return get200ModelA200NoneWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> get200ModelA200NoneWithResponse(RequestOptions requestOptions) {
+        return get200ModelA200NoneWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1845,14 +1802,13 @@ public final class MultipleResponsesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> get200ModelA200ValidWithResponse(RequestOptions requestOptions, Context context) {
-        return get200ModelA200ValidWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> get200ModelA200ValidWithResponse(RequestOptions requestOptions) {
+        return get200ModelA200ValidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1912,14 +1868,13 @@ public final class MultipleResponsesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> get200ModelA200InvalidWithResponse(RequestOptions requestOptions, Context context) {
-        return get200ModelA200InvalidWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> get200ModelA200InvalidWithResponse(RequestOptions requestOptions) {
+        return get200ModelA200InvalidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1979,14 +1934,13 @@ public final class MultipleResponsesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> get200ModelA400NoneWithResponse(RequestOptions requestOptions, Context context) {
-        return get200ModelA400NoneWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> get200ModelA400NoneWithResponse(RequestOptions requestOptions) {
+        return get200ModelA400NoneWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -2046,14 +2000,13 @@ public final class MultipleResponsesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> get200ModelA400ValidWithResponse(RequestOptions requestOptions, Context context) {
-        return get200ModelA400ValidWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> get200ModelA400ValidWithResponse(RequestOptions requestOptions) {
+        return get200ModelA400ValidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -2113,14 +2066,13 @@ public final class MultipleResponsesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> get200ModelA400InvalidWithResponse(RequestOptions requestOptions, Context context) {
-        return get200ModelA400InvalidWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> get200ModelA400InvalidWithResponse(RequestOptions requestOptions) {
+        return get200ModelA400InvalidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -2180,13 +2132,12 @@ public final class MultipleResponsesImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> get200ModelA202ValidWithResponse(RequestOptions requestOptions, Context context) {
-        return get200ModelA202ValidWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> get200ModelA202ValidWithResponse(RequestOptions requestOptions) {
+        return get200ModelA202ValidWithResponseAsync(requestOptions).block();
     }
 }

--- a/protocol-tests/src/main/java/fixtures/llcinitial/LLCClient.java
+++ b/protocol-tests/src/main/java/fixtures/llcinitial/LLCClient.java
@@ -11,7 +11,6 @@ import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import fixtures.llcinitial.implementation.ParamsImpl;
 
 /** Initializes a new instance of the synchronous LLCClient type. */
@@ -48,13 +47,12 @@ public final class LLCClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return true Boolean value on path.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getRequiredWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getRequiredWithResponse(requestOptions, context);
+    public Response<BinaryData> getRequiredWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getRequiredWithResponse(requestOptions);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/llcinitial/implementation/ParamsImpl.java
+++ b/protocol-tests/src/main/java/fixtures/llcinitial/implementation/ParamsImpl.java
@@ -128,13 +128,12 @@ public final class ParamsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return true Boolean value on path.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getRequiredWithResponse(RequestOptions requestOptions, Context context) {
-        return getRequiredWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getRequiredWithResponse(RequestOptions requestOptions) {
+        return getRequiredWithResponseAsync(requestOptions).block();
     }
 }

--- a/protocol-tests/src/main/java/fixtures/llcupdate1/LLCClient.java
+++ b/protocol-tests/src/main/java/fixtures/llcupdate1/LLCClient.java
@@ -11,7 +11,6 @@ import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import fixtures.llcupdate1.implementation.ParamsImpl;
 
 /** Initializes a new instance of the synchronous LLCClient type. */
@@ -48,13 +47,12 @@ public final class LLCClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return true Boolean value on path.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getRequiredWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getRequiredWithResponse(requestOptions, context);
+    public Response<BinaryData> getRequiredWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getRequiredWithResponse(requestOptions);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/llcupdate1/implementation/ParamsImpl.java
+++ b/protocol-tests/src/main/java/fixtures/llcupdate1/implementation/ParamsImpl.java
@@ -128,13 +128,12 @@ public final class ParamsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return true Boolean value on path.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getRequiredWithResponse(RequestOptions requestOptions, Context context) {
-        return getRequiredWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> getRequiredWithResponse(RequestOptions requestOptions) {
+        return getRequiredWithResponseAsync(requestOptions).block();
     }
 }

--- a/protocol-tests/src/main/java/fixtures/lro/LRORetrysClient.java
+++ b/protocol-tests/src/main/java/fixtures/lro/LRORetrysClient.java
@@ -10,7 +10,6 @@ import com.azure.core.annotation.ServiceMethod;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.azure.core.util.polling.SyncPoller;
 import fixtures.lro.implementation.LRORetrysImpl;
 
@@ -70,15 +69,13 @@ public final class LRORetrysClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPut201CreatingSucceeded200(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPut201CreatingSucceeded200(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPut201CreatingSucceeded200(RequestOptions requestOptions) {
+        return this.serviceClient.beginPut201CreatingSucceeded200(requestOptions);
     }
 
     /**
@@ -123,15 +120,13 @@ public final class LRORetrysClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutAsyncRelativeRetrySucceeded(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPutAsyncRelativeRetrySucceeded(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPutAsyncRelativeRetrySucceeded(RequestOptions requestOptions) {
+        return this.serviceClient.beginPutAsyncRelativeRetrySucceeded(requestOptions);
     }
 
     /**
@@ -158,15 +153,14 @@ public final class LRORetrysClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
     public SyncPoller<BinaryData, BinaryData> beginDeleteProvisioning202Accepted200Succeeded(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginDeleteProvisioning202Accepted200Succeeded(requestOptions, context);
+            RequestOptions requestOptions) {
+        return this.serviceClient.beginDeleteProvisioning202Accepted200Succeeded(requestOptions);
     }
 
     /**
@@ -174,14 +168,13 @@ public final class LRORetrysClient {
      * until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginDelete202Retry200(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginDelete202Retry200(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginDelete202Retry200(RequestOptions requestOptions) {
+        return this.serviceClient.beginDelete202Retry200(requestOptions);
     }
 
     /**
@@ -189,15 +182,13 @@ public final class LRORetrysClient {
      * indicated in the Azure-AsyncOperation header for operation status.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncRelativeRetrySucceeded(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginDeleteAsyncRelativeRetrySucceeded(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncRelativeRetrySucceeded(RequestOptions requestOptions) {
+        return this.serviceClient.beginDeleteAsyncRelativeRetrySucceeded(requestOptions);
     }
 
     /**
@@ -223,14 +214,13 @@ public final class LRORetrysClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPost202Retry200(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPost202Retry200(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPost202Retry200(RequestOptions requestOptions) {
+        return this.serviceClient.beginPost202Retry200(requestOptions);
     }
 
     /**
@@ -257,14 +247,12 @@ public final class LRORetrysClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPostAsyncRelativeRetrySucceeded(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPostAsyncRelativeRetrySucceeded(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPostAsyncRelativeRetrySucceeded(RequestOptions requestOptions) {
+        return this.serviceClient.beginPostAsyncRelativeRetrySucceeded(requestOptions);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/lro/LROsClient.java
+++ b/protocol-tests/src/main/java/fixtures/lro/LROsClient.java
@@ -10,7 +10,6 @@ import com.azure.core.annotation.ServiceMethod;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.azure.core.util.polling.SyncPoller;
 import fixtures.lro.implementation.LROsImpl;
 
@@ -69,14 +68,13 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPut200Succeeded(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPut200Succeeded(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPut200Succeeded(RequestOptions requestOptions) {
+        return this.serviceClient.beginPut200Succeeded(requestOptions);
     }
 
     /**
@@ -120,15 +118,13 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPatch200SucceededIgnoreHeaders(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPatch200SucceededIgnoreHeaders(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPatch200SucceededIgnoreHeaders(RequestOptions requestOptions) {
+        return this.serviceClient.beginPatch200SucceededIgnoreHeaders(requestOptions);
     }
 
     /**
@@ -172,14 +168,13 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPut201Succeeded(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPut201Succeeded(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPut201Succeeded(RequestOptions requestOptions) {
+        return this.serviceClient.beginPut201Succeeded(requestOptions);
     }
 
     /**
@@ -207,14 +202,13 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return array of Product.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPost202List(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPost202List(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPost202List(RequestOptions requestOptions) {
+        return this.serviceClient.beginPost202List(requestOptions);
     }
 
     /**
@@ -258,15 +252,13 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPut200SucceededNoState(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPut200SucceededNoState(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPut200SucceededNoState(RequestOptions requestOptions) {
+        return this.serviceClient.beginPut200SucceededNoState(requestOptions);
     }
 
     /**
@@ -310,14 +302,13 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPut202Retry200(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPut202Retry200(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPut202Retry200(RequestOptions requestOptions) {
+        return this.serviceClient.beginPut202Retry200(requestOptions);
     }
 
     /**
@@ -362,15 +353,13 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPut201CreatingSucceeded200(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPut201CreatingSucceeded200(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPut201CreatingSucceeded200(RequestOptions requestOptions) {
+        return this.serviceClient.beginPut201CreatingSucceeded200(requestOptions);
     }
 
     /**
@@ -415,15 +404,13 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPut200UpdatingSucceeded204(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPut200UpdatingSucceeded204(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPut200UpdatingSucceeded204(RequestOptions requestOptions) {
+        return this.serviceClient.beginPut200UpdatingSucceeded204(requestOptions);
     }
 
     /**
@@ -468,15 +455,13 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPut201CreatingFailed200(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPut201CreatingFailed200(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPut201CreatingFailed200(RequestOptions requestOptions) {
+        return this.serviceClient.beginPut201CreatingFailed200(requestOptions);
     }
 
     /**
@@ -521,15 +506,13 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPut200Acceptedcanceled200(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPut200Acceptedcanceled200(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPut200Acceptedcanceled200(RequestOptions requestOptions) {
+        return this.serviceClient.beginPut200Acceptedcanceled200(requestOptions);
     }
 
     /**
@@ -573,14 +556,13 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutNoHeaderInRetry(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPutNoHeaderInRetry(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPutNoHeaderInRetry(RequestOptions requestOptions) {
+        return this.serviceClient.beginPutNoHeaderInRetry(requestOptions);
     }
 
     /**
@@ -625,15 +607,13 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutAsyncRetrySucceeded(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPutAsyncRetrySucceeded(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPutAsyncRetrySucceeded(RequestOptions requestOptions) {
+        return this.serviceClient.beginPutAsyncRetrySucceeded(requestOptions);
     }
 
     /**
@@ -678,15 +658,13 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutAsyncNoRetrySucceeded(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPutAsyncNoRetrySucceeded(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPutAsyncNoRetrySucceeded(RequestOptions requestOptions) {
+        return this.serviceClient.beginPutAsyncNoRetrySucceeded(requestOptions);
     }
 
     /**
@@ -731,14 +709,13 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutAsyncRetryFailed(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPutAsyncRetryFailed(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPutAsyncRetryFailed(RequestOptions requestOptions) {
+        return this.serviceClient.beginPutAsyncRetryFailed(requestOptions);
     }
 
     /**
@@ -783,15 +760,13 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutAsyncNoRetrycanceled(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPutAsyncNoRetrycanceled(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPutAsyncNoRetrycanceled(RequestOptions requestOptions) {
+        return this.serviceClient.beginPutAsyncNoRetrycanceled(requestOptions);
     }
 
     /**
@@ -835,15 +810,13 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutAsyncNoHeaderInRetry(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPutAsyncNoHeaderInRetry(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPutAsyncNoHeaderInRetry(RequestOptions requestOptions) {
+        return this.serviceClient.beginPutAsyncNoHeaderInRetry(requestOptions);
     }
 
     /**
@@ -868,14 +841,13 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutNonResource(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPutNonResource(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPutNonResource(RequestOptions requestOptions) {
+        return this.serviceClient.beginPutNonResource(requestOptions);
     }
 
     /**
@@ -900,14 +872,13 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutAsyncNonResource(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPutAsyncNonResource(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPutAsyncNonResource(RequestOptions requestOptions) {
+        return this.serviceClient.beginPutAsyncNonResource(requestOptions);
     }
 
     /**
@@ -938,14 +909,13 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutSubResource(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPutSubResource(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPutSubResource(RequestOptions requestOptions) {
+        return this.serviceClient.beginPutSubResource(requestOptions);
     }
 
     /**
@@ -976,14 +946,13 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutAsyncSubResource(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPutAsyncSubResource(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPutAsyncSubResource(RequestOptions requestOptions) {
+        return this.serviceClient.beginPutAsyncSubResource(requestOptions);
     }
 
     /**
@@ -1010,15 +979,14 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
     public SyncPoller<BinaryData, BinaryData> beginDeleteProvisioning202Accepted200Succeeded(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginDeleteProvisioning202Accepted200Succeeded(requestOptions, context);
+            RequestOptions requestOptions) {
+        return this.serviceClient.beginDeleteProvisioning202Accepted200Succeeded(requestOptions);
     }
 
     /**
@@ -1045,15 +1013,14 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
     public SyncPoller<BinaryData, BinaryData> beginDeleteProvisioning202DeletingFailed200(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginDeleteProvisioning202DeletingFailed200(requestOptions, context);
+            RequestOptions requestOptions) {
+        return this.serviceClient.beginDeleteProvisioning202DeletingFailed200(requestOptions);
     }
 
     /**
@@ -1080,29 +1047,27 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
     public SyncPoller<BinaryData, BinaryData> beginDeleteProvisioning202Deletingcanceled200(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginDeleteProvisioning202Deletingcanceled200(requestOptions, context);
+            RequestOptions requestOptions) {
+        return this.serviceClient.beginDeleteProvisioning202Deletingcanceled200(requestOptions);
     }
 
     /**
      * Long running delete succeeds and returns right away.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginDelete204Succeeded(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginDelete204Succeeded(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginDelete204Succeeded(RequestOptions requestOptions) {
+        return this.serviceClient.beginDelete204Succeeded(requestOptions);
     }
 
     /**
@@ -1128,14 +1093,13 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginDelete202Retry200(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginDelete202Retry200(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginDelete202Retry200(RequestOptions requestOptions) {
+        return this.serviceClient.beginDelete202Retry200(requestOptions);
     }
 
     /**
@@ -1161,14 +1125,13 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginDelete202NoRetry204(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginDelete202NoRetry204(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginDelete202NoRetry204(RequestOptions requestOptions) {
+        return this.serviceClient.beginDelete202NoRetry204(requestOptions);
     }
 
     /**
@@ -1176,15 +1139,13 @@ public final class LROsClient {
      * operation status do not contain location header.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginDeleteNoHeaderInRetry(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginDeleteNoHeaderInRetry(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginDeleteNoHeaderInRetry(RequestOptions requestOptions) {
+        return this.serviceClient.beginDeleteNoHeaderInRetry(requestOptions);
     }
 
     /**
@@ -1192,15 +1153,13 @@ public final class LROsClient {
      * calls to operation status do not contain Azure-AsyncOperation header.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncNoHeaderInRetry(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginDeleteAsyncNoHeaderInRetry(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncNoHeaderInRetry(RequestOptions requestOptions) {
+        return this.serviceClient.beginDeleteAsyncNoHeaderInRetry(requestOptions);
     }
 
     /**
@@ -1208,15 +1167,13 @@ public final class LROsClient {
      * Azure-AsyncOperation header for operation status.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncRetrySucceeded(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginDeleteAsyncRetrySucceeded(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncRetrySucceeded(RequestOptions requestOptions) {
+        return this.serviceClient.beginDeleteAsyncRetrySucceeded(requestOptions);
     }
 
     /**
@@ -1224,15 +1181,13 @@ public final class LROsClient {
      * Azure-AsyncOperation header for operation status.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncNoRetrySucceeded(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginDeleteAsyncNoRetrySucceeded(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncNoRetrySucceeded(RequestOptions requestOptions) {
+        return this.serviceClient.beginDeleteAsyncNoRetrySucceeded(requestOptions);
     }
 
     /**
@@ -1240,15 +1195,13 @@ public final class LROsClient {
      * Azure-AsyncOperation header for operation status.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncRetryFailed(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginDeleteAsyncRetryFailed(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncRetryFailed(RequestOptions requestOptions) {
+        return this.serviceClient.beginDeleteAsyncRetryFailed(requestOptions);
     }
 
     /**
@@ -1256,15 +1209,13 @@ public final class LROsClient {
      * Azure-AsyncOperation header for operation status.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncRetrycanceled(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginDeleteAsyncRetrycanceled(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncRetrycanceled(RequestOptions requestOptions) {
+        return this.serviceClient.beginDeleteAsyncRetrycanceled(requestOptions);
     }
 
     /**
@@ -1281,14 +1232,13 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPost200WithPayload(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPost200WithPayload(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPost200WithPayload(RequestOptions requestOptions) {
+        return this.serviceClient.beginPost200WithPayload(requestOptions);
     }
 
     /**
@@ -1314,14 +1264,13 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPost202Retry200(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPost202Retry200(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPost202Retry200(RequestOptions requestOptions) {
+        return this.serviceClient.beginPost202Retry200(requestOptions);
     }
 
     /**
@@ -1365,14 +1314,13 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPost202NoRetry204(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPost202NoRetry204(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPost202NoRetry204(RequestOptions requestOptions) {
+        return this.serviceClient.beginPost202NoRetry204(requestOptions);
     }
 
     /**
@@ -1398,15 +1346,13 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPostDoubleHeadersFinalLocationGet(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPostDoubleHeadersFinalLocationGet(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPostDoubleHeadersFinalLocationGet(RequestOptions requestOptions) {
+        return this.serviceClient.beginPostDoubleHeadersFinalLocationGet(requestOptions);
     }
 
     /**
@@ -1432,15 +1378,13 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPostDoubleHeadersFinalAzureHeaderGet(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPostDoubleHeadersFinalAzureHeaderGet(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPostDoubleHeadersFinalAzureHeaderGet(RequestOptions requestOptions) {
+        return this.serviceClient.beginPostDoubleHeadersFinalAzureHeaderGet(requestOptions);
     }
 
     /**
@@ -1467,15 +1411,14 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
     public SyncPoller<BinaryData, BinaryData> beginPostDoubleHeadersFinalAzureHeaderGetDefault(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPostDoubleHeadersFinalAzureHeaderGetDefault(requestOptions, context);
+            RequestOptions requestOptions) {
+        return this.serviceClient.beginPostDoubleHeadersFinalAzureHeaderGetDefault(requestOptions);
     }
 
     /**
@@ -1520,15 +1463,13 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPostAsyncRetrySucceeded(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPostAsyncRetrySucceeded(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPostAsyncRetrySucceeded(RequestOptions requestOptions) {
+        return this.serviceClient.beginPostAsyncRetrySucceeded(requestOptions);
     }
 
     /**
@@ -1573,15 +1514,13 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPostAsyncNoRetrySucceeded(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPostAsyncNoRetrySucceeded(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPostAsyncNoRetrySucceeded(RequestOptions requestOptions) {
+        return this.serviceClient.beginPostAsyncNoRetrySucceeded(requestOptions);
     }
 
     /**
@@ -1608,15 +1547,13 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPostAsyncRetryFailed(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPostAsyncRetryFailed(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPostAsyncRetryFailed(RequestOptions requestOptions) {
+        return this.serviceClient.beginPostAsyncRetryFailed(requestOptions);
     }
 
     /**
@@ -1643,14 +1580,12 @@ public final class LROsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPostAsyncRetrycanceled(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPostAsyncRetrycanceled(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPostAsyncRetrycanceled(RequestOptions requestOptions) {
+        return this.serviceClient.beginPostAsyncRetrycanceled(requestOptions);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/lro/LROsCustomHeaderClient.java
+++ b/protocol-tests/src/main/java/fixtures/lro/LROsCustomHeaderClient.java
@@ -10,7 +10,6 @@ import com.azure.core.annotation.ServiceMethod;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.azure.core.util.polling.SyncPoller;
 import fixtures.lro.implementation.LROsCustomHeadersImpl;
 
@@ -71,15 +70,13 @@ public final class LROsCustomHeaderClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutAsyncRetrySucceeded(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPutAsyncRetrySucceeded(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPutAsyncRetrySucceeded(RequestOptions requestOptions) {
+        return this.serviceClient.beginPutAsyncRetrySucceeded(requestOptions);
     }
 
     /**
@@ -125,15 +122,13 @@ public final class LROsCustomHeaderClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPut201CreatingSucceeded200(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPut201CreatingSucceeded200(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPut201CreatingSucceeded200(RequestOptions requestOptions) {
+        return this.serviceClient.beginPut201CreatingSucceeded200(requestOptions);
     }
 
     /**
@@ -160,14 +155,13 @@ public final class LROsCustomHeaderClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPost202Retry200(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPost202Retry200(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPost202Retry200(RequestOptions requestOptions) {
+        return this.serviceClient.beginPost202Retry200(requestOptions);
     }
 
     /**
@@ -195,14 +189,12 @@ public final class LROsCustomHeaderClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPostAsyncRetrySucceeded(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPostAsyncRetrySucceeded(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPostAsyncRetrySucceeded(RequestOptions requestOptions) {
+        return this.serviceClient.beginPostAsyncRetrySucceeded(requestOptions);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/lro/LrosaDsClient.java
+++ b/protocol-tests/src/main/java/fixtures/lro/LrosaDsClient.java
@@ -10,7 +10,6 @@ import com.azure.core.annotation.ServiceMethod;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.azure.core.util.polling.SyncPoller;
 import fixtures.lro.implementation.LrosaDsImpl;
 
@@ -68,14 +67,13 @@ public final class LrosaDsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutNonRetry400(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPutNonRetry400(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPutNonRetry400(RequestOptions requestOptions) {
+        return this.serviceClient.beginPutNonRetry400(requestOptions);
     }
 
     /**
@@ -118,15 +116,13 @@ public final class LrosaDsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutNonRetry201Creating400(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPutNonRetry201Creating400(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPutNonRetry201Creating400(RequestOptions requestOptions) {
+        return this.serviceClient.beginPutNonRetry201Creating400(requestOptions);
     }
 
     /**
@@ -169,15 +165,13 @@ public final class LrosaDsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutNonRetry201Creating400InvalidJson(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPutNonRetry201Creating400InvalidJson(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPutNonRetry201Creating400InvalidJson(RequestOptions requestOptions) {
+        return this.serviceClient.beginPutNonRetry201Creating400InvalidJson(requestOptions);
     }
 
     /**
@@ -221,44 +215,39 @@ public final class LrosaDsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutAsyncRelativeRetry400(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPutAsyncRelativeRetry400(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPutAsyncRelativeRetry400(RequestOptions requestOptions) {
+        return this.serviceClient.beginPutAsyncRelativeRetry400(requestOptions);
     }
 
     /**
      * Long running delete request, service returns a 400 with an error body.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginDeleteNonRetry400(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginDeleteNonRetry400(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginDeleteNonRetry400(RequestOptions requestOptions) {
+        return this.serviceClient.beginDeleteNonRetry400(requestOptions);
     }
 
     /**
      * Long running delete request, service returns a 202 with a location header.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginDelete202NonRetry400(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginDelete202NonRetry400(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginDelete202NonRetry400(RequestOptions requestOptions) {
+        return this.serviceClient.beginDelete202NonRetry400(requestOptions);
     }
 
     /**
@@ -266,15 +255,13 @@ public final class LrosaDsClient {
      * Azure-AsyncOperation header for operation status.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncRelativeRetry400(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginDeleteAsyncRelativeRetry400(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncRelativeRetry400(RequestOptions requestOptions) {
+        return this.serviceClient.beginDeleteAsyncRelativeRetry400(requestOptions);
     }
 
     /**
@@ -299,14 +286,13 @@ public final class LrosaDsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPostNonRetry400(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPostNonRetry400(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPostNonRetry400(RequestOptions requestOptions) {
+        return this.serviceClient.beginPostNonRetry400(requestOptions);
     }
 
     /**
@@ -331,14 +317,13 @@ public final class LrosaDsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPost202NonRetry400(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPost202NonRetry400(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPost202NonRetry400(RequestOptions requestOptions) {
+        return this.serviceClient.beginPost202NonRetry400(requestOptions);
     }
 
     /**
@@ -364,15 +349,13 @@ public final class LrosaDsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPostAsyncRelativeRetry400(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPostAsyncRelativeRetry400(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPostAsyncRelativeRetry400(RequestOptions requestOptions) {
+        return this.serviceClient.beginPostAsyncRelativeRetry400(requestOptions);
     }
 
     /**
@@ -415,15 +398,14 @@ public final class LrosaDsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
     public SyncPoller<BinaryData, BinaryData> beginPutError201NoProvisioningStatePayload(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPutError201NoProvisioningStatePayload(requestOptions, context);
+            RequestOptions requestOptions) {
+        return this.serviceClient.beginPutError201NoProvisioningStatePayload(requestOptions);
     }
 
     /**
@@ -468,15 +450,13 @@ public final class LrosaDsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutAsyncRelativeRetryNoStatus(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPutAsyncRelativeRetryNoStatus(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPutAsyncRelativeRetryNoStatus(RequestOptions requestOptions) {
+        return this.serviceClient.beginPutAsyncRelativeRetryNoStatus(requestOptions);
     }
 
     /**
@@ -521,29 +501,26 @@ public final class LrosaDsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutAsyncRelativeRetryNoStatusPayload(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPutAsyncRelativeRetryNoStatusPayload(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPutAsyncRelativeRetryNoStatusPayload(RequestOptions requestOptions) {
+        return this.serviceClient.beginPutAsyncRelativeRetryNoStatusPayload(requestOptions);
     }
 
     /**
      * Long running delete request, service returns a 204 to the initial request, indicating success.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginDelete204Succeeded(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginDelete204Succeeded(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginDelete204Succeeded(RequestOptions requestOptions) {
+        return this.serviceClient.beginDelete204Succeeded(requestOptions);
     }
 
     /**
@@ -551,15 +528,13 @@ public final class LrosaDsClient {
      * Azure-AsyncOperation header for operation status.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncRelativeRetryNoStatus(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginDeleteAsyncRelativeRetryNoStatus(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncRelativeRetryNoStatus(RequestOptions requestOptions) {
+        return this.serviceClient.beginDeleteAsyncRelativeRetryNoStatus(requestOptions);
     }
 
     /**
@@ -584,14 +559,13 @@ public final class LrosaDsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPost202NoLocation(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPost202NoLocation(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPost202NoLocation(RequestOptions requestOptions) {
+        return this.serviceClient.beginPost202NoLocation(requestOptions);
     }
 
     /**
@@ -618,15 +592,13 @@ public final class LrosaDsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPostAsyncRelativeRetryNoPayload(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPostAsyncRelativeRetryNoPayload(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPostAsyncRelativeRetryNoPayload(RequestOptions requestOptions) {
+        return this.serviceClient.beginPostAsyncRelativeRetryNoPayload(requestOptions);
     }
 
     /**
@@ -669,14 +641,13 @@ public final class LrosaDsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPut200InvalidJson(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPut200InvalidJson(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPut200InvalidJson(RequestOptions requestOptions) {
+        return this.serviceClient.beginPut200InvalidJson(requestOptions);
     }
 
     /**
@@ -720,15 +691,13 @@ public final class LrosaDsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutAsyncRelativeRetryInvalidHeader(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPutAsyncRelativeRetryInvalidHeader(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPutAsyncRelativeRetryInvalidHeader(RequestOptions requestOptions) {
+        return this.serviceClient.beginPutAsyncRelativeRetryInvalidHeader(requestOptions);
     }
 
     /**
@@ -773,15 +742,14 @@ public final class LrosaDsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
     public SyncPoller<BinaryData, BinaryData> beginPutAsyncRelativeRetryInvalidJsonPolling(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPutAsyncRelativeRetryInvalidJsonPolling(requestOptions, context);
+            RequestOptions requestOptions) {
+        return this.serviceClient.beginPutAsyncRelativeRetryInvalidJsonPolling(requestOptions);
     }
 
     /**
@@ -789,15 +757,13 @@ public final class LrosaDsClient {
      * 'Location' and 'Retry-After' headers.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginDelete202RetryInvalidHeader(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginDelete202RetryInvalidHeader(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginDelete202RetryInvalidHeader(RequestOptions requestOptions) {
+        return this.serviceClient.beginDelete202RetryInvalidHeader(requestOptions);
     }
 
     /**
@@ -805,15 +771,14 @@ public final class LrosaDsClient {
      * Azure-AsyncOperation header is invalid.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
     public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncRelativeRetryInvalidHeader(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginDeleteAsyncRelativeRetryInvalidHeader(requestOptions, context);
+            RequestOptions requestOptions) {
+        return this.serviceClient.beginDeleteAsyncRelativeRetryInvalidHeader(requestOptions);
     }
 
     /**
@@ -821,15 +786,14 @@ public final class LrosaDsClient {
      * Azure-AsyncOperation header for operation status.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
     public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncRelativeRetryInvalidJsonPolling(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginDeleteAsyncRelativeRetryInvalidJsonPolling(requestOptions, context);
+            RequestOptions requestOptions) {
+        return this.serviceClient.beginDeleteAsyncRelativeRetryInvalidJsonPolling(requestOptions);
     }
 
     /**
@@ -855,15 +819,13 @@ public final class LrosaDsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPost202RetryInvalidHeader(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPost202RetryInvalidHeader(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPost202RetryInvalidHeader(RequestOptions requestOptions) {
+        return this.serviceClient.beginPost202RetryInvalidHeader(requestOptions);
     }
 
     /**
@@ -889,15 +851,13 @@ public final class LrosaDsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPostAsyncRelativeRetryInvalidHeader(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPostAsyncRelativeRetryInvalidHeader(requestOptions, context);
+    public SyncPoller<BinaryData, BinaryData> beginPostAsyncRelativeRetryInvalidHeader(RequestOptions requestOptions) {
+        return this.serviceClient.beginPostAsyncRelativeRetryInvalidHeader(requestOptions);
     }
 
     /**
@@ -924,14 +884,13 @@ public final class LrosaDsClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
     public SyncPoller<BinaryData, BinaryData> beginPostAsyncRelativeRetryInvalidJsonPolling(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.beginPostAsyncRelativeRetryInvalidJsonPolling(requestOptions, context);
+            RequestOptions requestOptions) {
+        return this.serviceClient.beginPostAsyncRelativeRetryInvalidJsonPolling(requestOptions);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/lro/implementation/LRORetrysImpl.java
+++ b/protocol-tests/src/main/java/fixtures/lro/implementation/LRORetrysImpl.java
@@ -342,15 +342,13 @@ public final class LRORetrysImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPut201CreatingSucceeded200(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPut201CreatingSucceeded200Async(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPut201CreatingSucceeded200(RequestOptions requestOptions) {
+        return this.beginPut201CreatingSucceeded200Async(requestOptions).getSyncPoller();
     }
 
     /**
@@ -614,15 +612,13 @@ public final class LRORetrysImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutAsyncRelativeRetrySucceeded(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPutAsyncRelativeRetrySucceededAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPutAsyncRelativeRetrySucceeded(RequestOptions requestOptions) {
+        return this.beginPutAsyncRelativeRetrySucceededAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -800,15 +796,14 @@ public final class LRORetrysImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
     public SyncPoller<BinaryData, BinaryData> beginDeleteProvisioning202Accepted200Succeeded(
-            RequestOptions requestOptions, Context context) {
-        return this.beginDeleteProvisioning202Accepted200SucceededAsync(requestOptions, context).getSyncPoller();
+            RequestOptions requestOptions) {
+        return this.beginDeleteProvisioning202Accepted200SucceededAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -886,14 +881,13 @@ public final class LRORetrysImpl {
      * until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginDelete202Retry200(RequestOptions requestOptions, Context context) {
-        return this.beginDelete202Retry200Async(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginDelete202Retry200(RequestOptions requestOptions) {
+        return this.beginDelete202Retry200Async(requestOptions).getSyncPoller();
     }
 
     /**
@@ -973,15 +967,13 @@ public final class LRORetrysImpl {
      * indicated in the Azure-AsyncOperation header for operation status.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncRelativeRetrySucceeded(
-            RequestOptions requestOptions, Context context) {
-        return this.beginDeleteAsyncRelativeRetrySucceededAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncRelativeRetrySucceeded(RequestOptions requestOptions) {
+        return this.beginDeleteAsyncRelativeRetrySucceededAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -1148,14 +1140,13 @@ public final class LRORetrysImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPost202Retry200(RequestOptions requestOptions, Context context) {
-        return this.beginPost202Retry200Async(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPost202Retry200(RequestOptions requestOptions) {
+        return this.beginPost202Retry200Async(requestOptions).getSyncPoller();
     }
 
     /**
@@ -1329,15 +1320,13 @@ public final class LRORetrysImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPostAsyncRelativeRetrySucceeded(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPostAsyncRelativeRetrySucceededAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPostAsyncRelativeRetrySucceeded(RequestOptions requestOptions) {
+        return this.beginPostAsyncRelativeRetrySucceededAsync(requestOptions).getSyncPoller();
     }
 
     private static final class TypeReferenceBinaryData extends TypeReference<BinaryData> {

--- a/protocol-tests/src/main/java/fixtures/lro/implementation/LROsCustomHeadersImpl.java
+++ b/protocol-tests/src/main/java/fixtures/lro/implementation/LROsCustomHeadersImpl.java
@@ -335,15 +335,13 @@ public final class LROsCustomHeadersImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutAsyncRetrySucceeded(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPutAsyncRetrySucceededAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPutAsyncRetrySucceeded(RequestOptions requestOptions) {
+        return this.beginPutAsyncRetrySucceededAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -612,15 +610,13 @@ public final class LROsCustomHeadersImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPut201CreatingSucceeded200(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPut201CreatingSucceeded200Async(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPut201CreatingSucceeded200(RequestOptions requestOptions) {
+        return this.beginPut201CreatingSucceeded200Async(requestOptions).getSyncPoller();
     }
 
     /**
@@ -792,14 +788,13 @@ public final class LROsCustomHeadersImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPost202Retry200(RequestOptions requestOptions, Context context) {
-        return this.beginPost202Retry200Async(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPost202Retry200(RequestOptions requestOptions) {
+        return this.beginPost202Retry200Async(requestOptions).getSyncPoller();
     }
 
     /**
@@ -978,15 +973,13 @@ public final class LROsCustomHeadersImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPostAsyncRetrySucceeded(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPostAsyncRetrySucceededAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPostAsyncRetrySucceeded(RequestOptions requestOptions) {
+        return this.beginPostAsyncRetrySucceededAsync(requestOptions).getSyncPoller();
     }
 
     private static final class TypeReferenceBinaryData extends TypeReference<BinaryData> {

--- a/protocol-tests/src/main/java/fixtures/lro/implementation/LROsImpl.java
+++ b/protocol-tests/src/main/java/fixtures/lro/implementation/LROsImpl.java
@@ -475,14 +475,13 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPut200Succeeded(RequestOptions requestOptions, Context context) {
-        return this.beginPut200SucceededAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPut200Succeeded(RequestOptions requestOptions) {
+        return this.beginPut200SucceededAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -741,15 +740,13 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPatch200SucceededIgnoreHeaders(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPatch200SucceededIgnoreHeadersAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPatch200SucceededIgnoreHeaders(RequestOptions requestOptions) {
+        return this.beginPatch200SucceededIgnoreHeadersAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -1006,14 +1003,13 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPut201Succeeded(RequestOptions requestOptions, Context context) {
-        return this.beginPut201SucceededAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPut201Succeeded(RequestOptions requestOptions) {
+        return this.beginPut201SucceededAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -1189,14 +1185,13 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return array of Product.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPost202List(RequestOptions requestOptions, Context context) {
-        return this.beginPost202ListAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPost202List(RequestOptions requestOptions) {
+        return this.beginPost202ListAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -1455,15 +1450,13 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPut200SucceededNoState(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPut200SucceededNoStateAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPut200SucceededNoState(RequestOptions requestOptions) {
+        return this.beginPut200SucceededNoStateAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -1719,14 +1712,13 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPut202Retry200(RequestOptions requestOptions, Context context) {
-        return this.beginPut202Retry200Async(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPut202Retry200(RequestOptions requestOptions) {
+        return this.beginPut202Retry200Async(requestOptions).getSyncPoller();
     }
 
     /**
@@ -1990,15 +1982,13 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPut201CreatingSucceeded200(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPut201CreatingSucceeded200Async(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPut201CreatingSucceeded200(RequestOptions requestOptions) {
+        return this.beginPut201CreatingSucceeded200Async(requestOptions).getSyncPoller();
     }
 
     /**
@@ -2262,15 +2252,13 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPut200UpdatingSucceeded204(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPut200UpdatingSucceeded204Async(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPut200UpdatingSucceeded204(RequestOptions requestOptions) {
+        return this.beginPut200UpdatingSucceeded204Async(requestOptions).getSyncPoller();
     }
 
     /**
@@ -2534,15 +2522,13 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPut201CreatingFailed200(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPut201CreatingFailed200Async(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPut201CreatingFailed200(RequestOptions requestOptions) {
+        return this.beginPut201CreatingFailed200Async(requestOptions).getSyncPoller();
     }
 
     /**
@@ -2806,15 +2792,13 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPut200Acceptedcanceled200(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPut200Acceptedcanceled200Async(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPut200Acceptedcanceled200(RequestOptions requestOptions) {
+        return this.beginPut200Acceptedcanceled200Async(requestOptions).getSyncPoller();
     }
 
     /**
@@ -3073,14 +3057,13 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutNoHeaderInRetry(RequestOptions requestOptions, Context context) {
-        return this.beginPutNoHeaderInRetryAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPutNoHeaderInRetry(RequestOptions requestOptions) {
+        return this.beginPutNoHeaderInRetryAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -3344,15 +3327,13 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutAsyncRetrySucceeded(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPutAsyncRetrySucceededAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPutAsyncRetrySucceeded(RequestOptions requestOptions) {
+        return this.beginPutAsyncRetrySucceededAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -3616,15 +3597,13 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutAsyncNoRetrySucceeded(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPutAsyncNoRetrySucceededAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPutAsyncNoRetrySucceeded(RequestOptions requestOptions) {
+        return this.beginPutAsyncNoRetrySucceededAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -3888,14 +3867,13 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutAsyncRetryFailed(RequestOptions requestOptions, Context context) {
-        return this.beginPutAsyncRetryFailedAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPutAsyncRetryFailed(RequestOptions requestOptions) {
+        return this.beginPutAsyncRetryFailedAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -4159,15 +4137,13 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutAsyncNoRetrycanceled(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPutAsyncNoRetrycanceledAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPutAsyncNoRetrycanceled(RequestOptions requestOptions) {
+        return this.beginPutAsyncNoRetrycanceledAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -4426,15 +4402,13 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutAsyncNoHeaderInRetry(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPutAsyncNoHeaderInRetryAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPutAsyncNoHeaderInRetry(RequestOptions requestOptions) {
+        return this.beginPutAsyncNoHeaderInRetryAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -4595,14 +4569,13 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutNonResource(RequestOptions requestOptions, Context context) {
-        return this.beginPutNonResourceAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPutNonResource(RequestOptions requestOptions) {
+        return this.beginPutNonResourceAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -4766,14 +4739,13 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutAsyncNonResource(RequestOptions requestOptions, Context context) {
-        return this.beginPutAsyncNonResourceAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPutAsyncNonResource(RequestOptions requestOptions) {
+        return this.beginPutAsyncNonResourceAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -4964,14 +4936,13 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutSubResource(RequestOptions requestOptions, Context context) {
-        return this.beginPutSubResourceAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPutSubResource(RequestOptions requestOptions) {
+        return this.beginPutSubResourceAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -5165,14 +5136,13 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutAsyncSubResource(RequestOptions requestOptions, Context context) {
-        return this.beginPutAsyncSubResourceAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPutAsyncSubResource(RequestOptions requestOptions) {
+        return this.beginPutAsyncSubResourceAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -5350,15 +5320,14 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
     public SyncPoller<BinaryData, BinaryData> beginDeleteProvisioning202Accepted200Succeeded(
-            RequestOptions requestOptions, Context context) {
-        return this.beginDeleteProvisioning202Accepted200SucceededAsync(requestOptions, context).getSyncPoller();
+            RequestOptions requestOptions) {
+        return this.beginDeleteProvisioning202Accepted200SucceededAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -5535,15 +5504,14 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
     public SyncPoller<BinaryData, BinaryData> beginDeleteProvisioning202DeletingFailed200(
-            RequestOptions requestOptions, Context context) {
-        return this.beginDeleteProvisioning202DeletingFailed200Async(requestOptions, context).getSyncPoller();
+            RequestOptions requestOptions) {
+        return this.beginDeleteProvisioning202DeletingFailed200Async(requestOptions).getSyncPoller();
     }
 
     /**
@@ -5721,15 +5689,14 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
     public SyncPoller<BinaryData, BinaryData> beginDeleteProvisioning202Deletingcanceled200(
-            RequestOptions requestOptions, Context context) {
-        return this.beginDeleteProvisioning202Deletingcanceled200Async(requestOptions, context).getSyncPoller();
+            RequestOptions requestOptions) {
+        return this.beginDeleteProvisioning202Deletingcanceled200Async(requestOptions).getSyncPoller();
     }
 
     /**
@@ -5802,14 +5769,13 @@ public final class LROsImpl {
      * Long running delete succeeds and returns right away.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginDelete204Succeeded(RequestOptions requestOptions, Context context) {
-        return this.beginDelete204SucceededAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginDelete204Succeeded(RequestOptions requestOptions) {
+        return this.beginDelete204SucceededAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -5978,14 +5944,13 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginDelete202Retry200(RequestOptions requestOptions, Context context) {
-        return this.beginDelete202Retry200Async(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginDelete202Retry200(RequestOptions requestOptions) {
+        return this.beginDelete202Retry200Async(requestOptions).getSyncPoller();
     }
 
     /**
@@ -6154,14 +6119,13 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginDelete202NoRetry204(RequestOptions requestOptions, Context context) {
-        return this.beginDelete202NoRetry204Async(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginDelete202NoRetry204(RequestOptions requestOptions) {
+        return this.beginDelete202NoRetry204Async(requestOptions).getSyncPoller();
     }
 
     /**
@@ -6239,15 +6203,13 @@ public final class LROsImpl {
      * operation status do not contain location header.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginDeleteNoHeaderInRetry(
-            RequestOptions requestOptions, Context context) {
-        return this.beginDeleteNoHeaderInRetryAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginDeleteNoHeaderInRetry(RequestOptions requestOptions) {
+        return this.beginDeleteNoHeaderInRetryAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -6326,15 +6288,13 @@ public final class LROsImpl {
      * calls to operation status do not contain Azure-AsyncOperation header.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncNoHeaderInRetry(
-            RequestOptions requestOptions, Context context) {
-        return this.beginDeleteAsyncNoHeaderInRetryAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncNoHeaderInRetry(RequestOptions requestOptions) {
+        return this.beginDeleteAsyncNoHeaderInRetryAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -6413,15 +6373,13 @@ public final class LROsImpl {
      * Azure-AsyncOperation header for operation status.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncRetrySucceeded(
-            RequestOptions requestOptions, Context context) {
-        return this.beginDeleteAsyncRetrySucceededAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncRetrySucceeded(RequestOptions requestOptions) {
+        return this.beginDeleteAsyncRetrySucceededAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -6500,15 +6458,13 @@ public final class LROsImpl {
      * Azure-AsyncOperation header for operation status.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncNoRetrySucceeded(
-            RequestOptions requestOptions, Context context) {
-        return this.beginDeleteAsyncNoRetrySucceededAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncNoRetrySucceeded(RequestOptions requestOptions) {
+        return this.beginDeleteAsyncNoRetrySucceededAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -6587,15 +6543,13 @@ public final class LROsImpl {
      * Azure-AsyncOperation header for operation status.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncRetryFailed(
-            RequestOptions requestOptions, Context context) {
-        return this.beginDeleteAsyncRetryFailedAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncRetryFailed(RequestOptions requestOptions) {
+        return this.beginDeleteAsyncRetryFailedAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -6674,15 +6628,13 @@ public final class LROsImpl {
      * Azure-AsyncOperation header for operation status.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncRetrycanceled(
-            RequestOptions requestOptions, Context context) {
-        return this.beginDeleteAsyncRetrycanceledAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncRetrycanceled(RequestOptions requestOptions) {
+        return this.beginDeleteAsyncRetrycanceledAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -6806,14 +6758,13 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPost200WithPayload(RequestOptions requestOptions, Context context) {
-        return this.beginPost200WithPayloadAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPost200WithPayload(RequestOptions requestOptions) {
+        return this.beginPost200WithPayloadAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -6980,14 +6931,13 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPost202Retry200(RequestOptions requestOptions, Context context) {
-        return this.beginPost202Retry200Async(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPost202Retry200(RequestOptions requestOptions) {
+        return this.beginPost202Retry200Async(requestOptions).getSyncPoller();
     }
 
     /**
@@ -7246,14 +7196,13 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPost202NoRetry204(RequestOptions requestOptions, Context context) {
-        return this.beginPost202NoRetry204Async(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPost202NoRetry204(RequestOptions requestOptions) {
+        return this.beginPost202NoRetry204Async(requestOptions).getSyncPoller();
     }
 
     /**
@@ -7424,15 +7373,13 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPostDoubleHeadersFinalLocationGet(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPostDoubleHeadersFinalLocationGetAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPostDoubleHeadersFinalLocationGet(RequestOptions requestOptions) {
+        return this.beginPostDoubleHeadersFinalLocationGetAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -7604,15 +7551,13 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPostDoubleHeadersFinalAzureHeaderGet(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPostDoubleHeadersFinalAzureHeaderGetAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPostDoubleHeadersFinalAzureHeaderGet(RequestOptions requestOptions) {
+        return this.beginPostDoubleHeadersFinalAzureHeaderGetAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -7790,15 +7735,14 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
     public SyncPoller<BinaryData, BinaryData> beginPostDoubleHeadersFinalAzureHeaderGetDefault(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPostDoubleHeadersFinalAzureHeaderGetDefaultAsync(requestOptions, context).getSyncPoller();
+            RequestOptions requestOptions) {
+        return this.beginPostDoubleHeadersFinalAzureHeaderGetDefaultAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -8062,15 +8006,13 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPostAsyncRetrySucceeded(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPostAsyncRetrySucceededAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPostAsyncRetrySucceeded(RequestOptions requestOptions) {
+        return this.beginPostAsyncRetrySucceededAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -8334,15 +8276,13 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPostAsyncNoRetrySucceeded(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPostAsyncNoRetrySucceededAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPostAsyncNoRetrySucceeded(RequestOptions requestOptions) {
+        return this.beginPostAsyncNoRetrySucceededAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -8515,15 +8455,13 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPostAsyncRetryFailed(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPostAsyncRetryFailedAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPostAsyncRetryFailed(RequestOptions requestOptions) {
+        return this.beginPostAsyncRetryFailedAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -8697,15 +8635,13 @@ public final class LROsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPostAsyncRetrycanceled(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPostAsyncRetrycanceledAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPostAsyncRetrycanceled(RequestOptions requestOptions) {
+        return this.beginPostAsyncRetrycanceledAsync(requestOptions).getSyncPoller();
     }
 
     private static final class TypeReferenceBinaryData extends TypeReference<BinaryData> {

--- a/protocol-tests/src/main/java/fixtures/lro/implementation/LrosaDsImpl.java
+++ b/protocol-tests/src/main/java/fixtures/lro/implementation/LrosaDsImpl.java
@@ -404,14 +404,13 @@ public final class LrosaDsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutNonRetry400(RequestOptions requestOptions, Context context) {
-        return this.beginPutNonRetry400Async(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPutNonRetry400(RequestOptions requestOptions) {
+        return this.beginPutNonRetry400Async(requestOptions).getSyncPoller();
     }
 
     /**
@@ -665,15 +664,13 @@ public final class LrosaDsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutNonRetry201Creating400(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPutNonRetry201Creating400Async(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPutNonRetry201Creating400(RequestOptions requestOptions) {
+        return this.beginPutNonRetry201Creating400Async(requestOptions).getSyncPoller();
     }
 
     /**
@@ -930,15 +927,13 @@ public final class LrosaDsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutNonRetry201Creating400InvalidJson(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPutNonRetry201Creating400InvalidJsonAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPutNonRetry201Creating400InvalidJson(RequestOptions requestOptions) {
+        return this.beginPutNonRetry201Creating400InvalidJsonAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -1197,15 +1192,13 @@ public final class LrosaDsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutAsyncRelativeRetry400(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPutAsyncRelativeRetry400Async(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPutAsyncRelativeRetry400(RequestOptions requestOptions) {
+        return this.beginPutAsyncRelativeRetry400Async(requestOptions).getSyncPoller();
     }
 
     /**
@@ -1278,14 +1271,13 @@ public final class LrosaDsImpl {
      * Long running delete request, service returns a 400 with an error body.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginDeleteNonRetry400(RequestOptions requestOptions, Context context) {
-        return this.beginDeleteNonRetry400Async(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginDeleteNonRetry400(RequestOptions requestOptions) {
+        return this.beginDeleteNonRetry400Async(requestOptions).getSyncPoller();
     }
 
     /**
@@ -1358,15 +1350,13 @@ public final class LrosaDsImpl {
      * Long running delete request, service returns a 202 with a location header.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginDelete202NonRetry400(
-            RequestOptions requestOptions, Context context) {
-        return this.beginDelete202NonRetry400Async(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginDelete202NonRetry400(RequestOptions requestOptions) {
+        return this.beginDelete202NonRetry400Async(requestOptions).getSyncPoller();
     }
 
     /**
@@ -1445,15 +1435,13 @@ public final class LrosaDsImpl {
      * Azure-AsyncOperation header for operation status.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncRelativeRetry400(
-            RequestOptions requestOptions, Context context) {
-        return this.beginDeleteAsyncRelativeRetry400Async(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncRelativeRetry400(RequestOptions requestOptions) {
+        return this.beginDeleteAsyncRelativeRetry400Async(requestOptions).getSyncPoller();
     }
 
     /**
@@ -1615,14 +1603,13 @@ public final class LrosaDsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPostNonRetry400(RequestOptions requestOptions, Context context) {
-        return this.beginPostNonRetry400Async(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPostNonRetry400(RequestOptions requestOptions) {
+        return this.beginPostNonRetry400Async(requestOptions).getSyncPoller();
     }
 
     /**
@@ -1785,14 +1772,13 @@ public final class LrosaDsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPost202NonRetry400(RequestOptions requestOptions, Context context) {
-        return this.beginPost202NonRetry400Async(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPost202NonRetry400(RequestOptions requestOptions) {
+        return this.beginPost202NonRetry400Async(requestOptions).getSyncPoller();
     }
 
     /**
@@ -1961,15 +1947,13 @@ public final class LrosaDsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPostAsyncRelativeRetry400(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPostAsyncRelativeRetry400Async(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPostAsyncRelativeRetry400(RequestOptions requestOptions) {
+        return this.beginPostAsyncRelativeRetry400Async(requestOptions).getSyncPoller();
     }
 
     /**
@@ -2226,15 +2210,14 @@ public final class LrosaDsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
     public SyncPoller<BinaryData, BinaryData> beginPutError201NoProvisioningStatePayload(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPutError201NoProvisioningStatePayloadAsync(requestOptions, context).getSyncPoller();
+            RequestOptions requestOptions) {
+        return this.beginPutError201NoProvisioningStatePayloadAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -2498,15 +2481,13 @@ public final class LrosaDsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutAsyncRelativeRetryNoStatus(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPutAsyncRelativeRetryNoStatusAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPutAsyncRelativeRetryNoStatus(RequestOptions requestOptions) {
+        return this.beginPutAsyncRelativeRetryNoStatusAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -2773,15 +2754,13 @@ public final class LrosaDsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutAsyncRelativeRetryNoStatusPayload(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPutAsyncRelativeRetryNoStatusPayloadAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPutAsyncRelativeRetryNoStatusPayload(RequestOptions requestOptions) {
+        return this.beginPutAsyncRelativeRetryNoStatusPayloadAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -2854,14 +2833,13 @@ public final class LrosaDsImpl {
      * Long running delete request, service returns a 204 to the initial request, indicating success.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginDelete204Succeeded(RequestOptions requestOptions, Context context) {
-        return this.beginDelete204SucceededAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginDelete204Succeeded(RequestOptions requestOptions) {
+        return this.beginDelete204SucceededAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -2941,15 +2919,13 @@ public final class LrosaDsImpl {
      * Azure-AsyncOperation header for operation status.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncRelativeRetryNoStatus(
-            RequestOptions requestOptions, Context context) {
-        return this.beginDeleteAsyncRelativeRetryNoStatusAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncRelativeRetryNoStatus(RequestOptions requestOptions) {
+        return this.beginDeleteAsyncRelativeRetryNoStatusAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -3112,14 +3088,13 @@ public final class LrosaDsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPost202NoLocation(RequestOptions requestOptions, Context context) {
-        return this.beginPost202NoLocationAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPost202NoLocation(RequestOptions requestOptions) {
+        return this.beginPost202NoLocationAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -3293,15 +3268,13 @@ public final class LrosaDsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPostAsyncRelativeRetryNoPayload(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPostAsyncRelativeRetryNoPayloadAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPostAsyncRelativeRetryNoPayload(RequestOptions requestOptions) {
+        return this.beginPostAsyncRelativeRetryNoPayloadAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -3555,14 +3528,13 @@ public final class LrosaDsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPut200InvalidJson(RequestOptions requestOptions, Context context) {
-        return this.beginPut200InvalidJsonAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPut200InvalidJson(RequestOptions requestOptions) {
+        return this.beginPut200InvalidJsonAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -3823,15 +3795,13 @@ public final class LrosaDsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPutAsyncRelativeRetryInvalidHeader(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPutAsyncRelativeRetryInvalidHeaderAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPutAsyncRelativeRetryInvalidHeader(RequestOptions requestOptions) {
+        return this.beginPutAsyncRelativeRetryInvalidHeaderAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -4099,15 +4069,14 @@ public final class LrosaDsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
     public SyncPoller<BinaryData, BinaryData> beginPutAsyncRelativeRetryInvalidJsonPolling(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPutAsyncRelativeRetryInvalidJsonPollingAsync(requestOptions, context).getSyncPoller();
+            RequestOptions requestOptions) {
+        return this.beginPutAsyncRelativeRetryInvalidJsonPollingAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -4186,15 +4155,13 @@ public final class LrosaDsImpl {
      * 'Location' and 'Retry-After' headers.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginDelete202RetryInvalidHeader(
-            RequestOptions requestOptions, Context context) {
-        return this.beginDelete202RetryInvalidHeaderAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginDelete202RetryInvalidHeader(RequestOptions requestOptions) {
+        return this.beginDelete202RetryInvalidHeaderAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -4275,15 +4242,14 @@ public final class LrosaDsImpl {
      * Azure-AsyncOperation header is invalid.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
     public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncRelativeRetryInvalidHeader(
-            RequestOptions requestOptions, Context context) {
-        return this.beginDeleteAsyncRelativeRetryInvalidHeaderAsync(requestOptions, context).getSyncPoller();
+            RequestOptions requestOptions) {
+        return this.beginDeleteAsyncRelativeRetryInvalidHeaderAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -4366,15 +4332,14 @@ public final class LrosaDsImpl {
      * Azure-AsyncOperation header for operation status.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
     public SyncPoller<BinaryData, BinaryData> beginDeleteAsyncRelativeRetryInvalidJsonPolling(
-            RequestOptions requestOptions, Context context) {
-        return this.beginDeleteAsyncRelativeRetryInvalidJsonPollingAsync(requestOptions, context).getSyncPoller();
+            RequestOptions requestOptions) {
+        return this.beginDeleteAsyncRelativeRetryInvalidJsonPollingAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -4543,15 +4508,13 @@ public final class LrosaDsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPost202RetryInvalidHeader(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPost202RetryInvalidHeaderAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPost202RetryInvalidHeader(RequestOptions requestOptions) {
+        return this.beginPost202RetryInvalidHeaderAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -4721,15 +4684,13 @@ public final class LrosaDsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
-    public SyncPoller<BinaryData, BinaryData> beginPostAsyncRelativeRetryInvalidHeader(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPostAsyncRelativeRetryInvalidHeaderAsync(requestOptions, context).getSyncPoller();
+    public SyncPoller<BinaryData, BinaryData> beginPostAsyncRelativeRetryInvalidHeader(RequestOptions requestOptions) {
+        return this.beginPostAsyncRelativeRetryInvalidHeaderAsync(requestOptions).getSyncPoller();
     }
 
     /**
@@ -4907,15 +4868,14 @@ public final class LrosaDsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
     public SyncPoller<BinaryData, BinaryData> beginPostAsyncRelativeRetryInvalidJsonPolling(
-            RequestOptions requestOptions, Context context) {
-        return this.beginPostAsyncRelativeRetryInvalidJsonPollingAsync(requestOptions, context).getSyncPoller();
+            RequestOptions requestOptions) {
+        return this.beginPostAsyncRelativeRetryInvalidJsonPollingAsync(requestOptions).getSyncPoller();
     }
 
     private static final class TypeReferenceBinaryData extends TypeReference<BinaryData> {

--- a/protocol-tests/src/main/java/fixtures/mediatypes/MediaTypesClient.java
+++ b/protocol-tests/src/main/java/fixtures/mediatypes/MediaTypesClient.java
@@ -11,7 +11,6 @@ import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import fixtures.mediatypes.implementation.MediaTypesClientImpl;
 
 /** Initializes a new instance of the synchronous MediaTypesClient type. */
@@ -53,14 +52,13 @@ public final class MediaTypesClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> analyzeBodyWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.analyzeBodyWithResponse(requestOptions, context);
+    public Response<BinaryData> analyzeBodyWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.analyzeBodyWithResponse(requestOptions);
     }
 
     /**
@@ -82,14 +80,13 @@ public final class MediaTypesClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> analyzeBodyNoAcceptHeaderWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.analyzeBodyNoAcceptHeaderWithResponse(requestOptions, context);
+    public Response<Void> analyzeBodyNoAcceptHeaderWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.analyzeBodyNoAcceptHeaderWithResponse(requestOptions);
     }
 
     /**
@@ -108,13 +105,12 @@ public final class MediaTypesClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> contentTypeWithEncodingWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.contentTypeWithEncodingWithResponse(requestOptions, context);
+    public Response<BinaryData> contentTypeWithEncodingWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.contentTypeWithEncodingWithResponse(requestOptions);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/mediatypes/implementation/MediaTypesClientImpl.java
+++ b/protocol-tests/src/main/java/fixtures/mediatypes/implementation/MediaTypesClientImpl.java
@@ -219,14 +219,13 @@ public final class MediaTypesClientImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> analyzeBodyWithResponse(RequestOptions requestOptions, Context context) {
-        return analyzeBodyWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> analyzeBodyWithResponse(RequestOptions requestOptions) {
+        return analyzeBodyWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -307,14 +306,13 @@ public final class MediaTypesClientImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> analyzeBodyNoAcceptHeaderWithResponse(RequestOptions requestOptions, Context context) {
-        return analyzeBodyNoAcceptHeaderWithResponseAsync(requestOptions, context).block();
+    public Response<Void> analyzeBodyNoAcceptHeaderWithResponse(RequestOptions requestOptions) {
+        return analyzeBodyNoAcceptHeaderWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -386,13 +384,12 @@ public final class MediaTypesClientImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> contentTypeWithEncodingWithResponse(RequestOptions requestOptions, Context context) {
-        return contentTypeWithEncodingWithResponseAsync(requestOptions, context).block();
+    public Response<BinaryData> contentTypeWithEncodingWithResponse(RequestOptions requestOptions) {
+        return contentTypeWithEncodingWithResponseAsync(requestOptions).block();
     }
 }

--- a/protocol-tests/src/main/java/fixtures/paging/AutoRestPagingTestServiceClient.java
+++ b/protocol-tests/src/main/java/fixtures/paging/AutoRestPagingTestServiceClient.java
@@ -11,7 +11,6 @@ import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.rest.PagedIterable;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import fixtures.paging.implementation.PagingsImpl;
 
 /** Initializes a new instance of the synchronous AutoRestPagingTestService type. */
@@ -48,14 +47,13 @@ public final class AutoRestPagingTestServiceClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> getNoItemNamePages(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getNoItemNamePages(requestOptions, context);
+    public PagedIterable<BinaryData> getNoItemNamePages(RequestOptions requestOptions) {
+        return this.serviceClient.getNoItemNamePages(requestOptions);
     }
 
     /**
@@ -78,14 +76,13 @@ public final class AutoRestPagingTestServiceClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> getNullNextLinkNamePages(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getNullNextLinkNamePages(requestOptions, context);
+    public PagedIterable<BinaryData> getNullNextLinkNamePages(RequestOptions requestOptions) {
+        return this.serviceClient.getNullNextLinkNamePages(requestOptions);
     }
 
     /**
@@ -108,14 +105,13 @@ public final class AutoRestPagingTestServiceClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> getSinglePages(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getSinglePages(requestOptions, context);
+    public PagedIterable<BinaryData> getSinglePages(RequestOptions requestOptions) {
+        return this.serviceClient.getSinglePages(requestOptions);
     }
 
     /**
@@ -139,14 +135,13 @@ public final class AutoRestPagingTestServiceClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> firstResponseEmpty(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.firstResponseEmpty(requestOptions, context);
+    public PagedIterable<BinaryData> firstResponseEmpty(RequestOptions requestOptions) {
+        return this.serviceClient.firstResponseEmpty(requestOptions);
     }
 
     /**
@@ -179,14 +174,13 @@ public final class AutoRestPagingTestServiceClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> getMultiplePages(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getMultiplePages(requestOptions, context);
+    public PagedIterable<BinaryData> getMultiplePages(RequestOptions requestOptions) {
+        return this.serviceClient.getMultiplePages(requestOptions);
     }
 
     /**
@@ -219,14 +213,13 @@ public final class AutoRestPagingTestServiceClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> getWithQueryParams(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getWithQueryParams(requestOptions, context);
+    public PagedIterable<BinaryData> getWithQueryParams(RequestOptions requestOptions) {
+        return this.serviceClient.getWithQueryParams(requestOptions);
     }
 
     /**
@@ -259,14 +252,13 @@ public final class AutoRestPagingTestServiceClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> getOdataMultiplePages(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getOdataMultiplePages(requestOptions, context);
+    public PagedIterable<BinaryData> getOdataMultiplePages(RequestOptions requestOptions) {
+        return this.serviceClient.getOdataMultiplePages(requestOptions);
     }
 
     /**
@@ -300,15 +292,13 @@ public final class AutoRestPagingTestServiceClient {
      *
      * @param offset Offset of return value.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> getMultiplePagesWithOffset(
-            int offset, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getMultiplePagesWithOffset(offset, requestOptions, context);
+    public PagedIterable<BinaryData> getMultiplePagesWithOffset(int offset, RequestOptions requestOptions) {
+        return this.serviceClient.getMultiplePagesWithOffset(offset, requestOptions);
     }
 
     /**
@@ -332,14 +322,13 @@ public final class AutoRestPagingTestServiceClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> getMultiplePagesRetryFirst(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getMultiplePagesRetryFirst(requestOptions, context);
+    public PagedIterable<BinaryData> getMultiplePagesRetryFirst(RequestOptions requestOptions) {
+        return this.serviceClient.getMultiplePagesRetryFirst(requestOptions);
     }
 
     /**
@@ -363,14 +352,13 @@ public final class AutoRestPagingTestServiceClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> getMultiplePagesRetrySecond(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getMultiplePagesRetrySecond(requestOptions, context);
+    public PagedIterable<BinaryData> getMultiplePagesRetrySecond(RequestOptions requestOptions) {
+        return this.serviceClient.getMultiplePagesRetrySecond(requestOptions);
     }
 
     /**
@@ -393,14 +381,13 @@ public final class AutoRestPagingTestServiceClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> getSinglePagesFailure(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getSinglePagesFailure(requestOptions, context);
+    public PagedIterable<BinaryData> getSinglePagesFailure(RequestOptions requestOptions) {
+        return this.serviceClient.getSinglePagesFailure(requestOptions);
     }
 
     /**
@@ -423,14 +410,13 @@ public final class AutoRestPagingTestServiceClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> getMultiplePagesFailure(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getMultiplePagesFailure(requestOptions, context);
+    public PagedIterable<BinaryData> getMultiplePagesFailure(RequestOptions requestOptions) {
+        return this.serviceClient.getMultiplePagesFailure(requestOptions);
     }
 
     /**
@@ -453,14 +439,13 @@ public final class AutoRestPagingTestServiceClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> getMultiplePagesFailureUri(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getMultiplePagesFailureUri(requestOptions, context);
+    public PagedIterable<BinaryData> getMultiplePagesFailureUri(RequestOptions requestOptions) {
+        return this.serviceClient.getMultiplePagesFailureUri(requestOptions);
     }
 
     /**
@@ -492,15 +477,13 @@ public final class AutoRestPagingTestServiceClient {
      *
      * @param tenant Sets the tenant to use.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> getMultiplePagesFragmentNextLink(
-            String tenant, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getMultiplePagesFragmentNextLink(tenant, requestOptions, context);
+    public PagedIterable<BinaryData> getMultiplePagesFragmentNextLink(String tenant, RequestOptions requestOptions) {
+        return this.serviceClient.getMultiplePagesFragmentNextLink(tenant, requestOptions);
     }
 
     /**
@@ -532,15 +515,14 @@ public final class AutoRestPagingTestServiceClient {
      *
      * @param tenant Sets the tenant to use.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
     public PagedIterable<BinaryData> getMultiplePagesFragmentWithGroupingNextLink(
-            String tenant, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getMultiplePagesFragmentWithGroupingNextLink(tenant, requestOptions, context);
+            String tenant, RequestOptions requestOptions) {
+        return this.serviceClient.getMultiplePagesFragmentWithGroupingNextLink(tenant, requestOptions);
     }
 
     /**
@@ -573,14 +555,13 @@ public final class AutoRestPagingTestServiceClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> getMultiplePagesLRO(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getMultiplePagesLRO(requestOptions, context);
+    public PagedIterable<BinaryData> getMultiplePagesLRO(RequestOptions requestOptions) {
+        return this.serviceClient.getMultiplePagesLRO(requestOptions);
     }
 
     /**
@@ -603,14 +584,12 @@ public final class AutoRestPagingTestServiceClient {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> getPagingModelWithItemNameWithXMSClientName(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getPagingModelWithItemNameWithXMSClientName(requestOptions, context);
+    public PagedIterable<BinaryData> getPagingModelWithItemNameWithXMSClientName(RequestOptions requestOptions) {
+        return this.serviceClient.getPagingModelWithItemNameWithXMSClientName(requestOptions);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/paging/implementation/PagingsImpl.java
+++ b/protocol-tests/src/main/java/fixtures/paging/implementation/PagingsImpl.java
@@ -404,14 +404,13 @@ public final class PagingsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> getNoItemNamePages(RequestOptions requestOptions, Context context) {
-        return new PagedIterable<>(getNoItemNamePagesAsync(requestOptions, context));
+    public PagedIterable<BinaryData> getNoItemNamePages(RequestOptions requestOptions) {
+        return new PagedIterable<>(getNoItemNamePagesAsync(requestOptions));
     }
 
     /**
@@ -572,14 +571,13 @@ public final class PagingsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> getNullNextLinkNamePages(RequestOptions requestOptions, Context context) {
-        return new PagedIterable<>(getNullNextLinkNamePagesAsync(requestOptions, context));
+    public PagedIterable<BinaryData> getNullNextLinkNamePages(RequestOptions requestOptions) {
+        return new PagedIterable<>(getNullNextLinkNamePagesAsync(requestOptions));
     }
 
     /**
@@ -743,14 +741,13 @@ public final class PagingsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> getSinglePages(RequestOptions requestOptions, Context context) {
-        return new PagedIterable<>(getSinglePagesAsync(requestOptions, context));
+    public PagedIterable<BinaryData> getSinglePages(RequestOptions requestOptions) {
+        return new PagedIterable<>(getSinglePagesAsync(requestOptions));
     }
 
     /**
@@ -920,14 +917,13 @@ public final class PagingsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> firstResponseEmpty(RequestOptions requestOptions, Context context) {
-        return new PagedIterable<>(firstResponseEmptyAsync(requestOptions, context));
+    public PagedIterable<BinaryData> firstResponseEmpty(RequestOptions requestOptions) {
+        return new PagedIterable<>(firstResponseEmptyAsync(requestOptions));
     }
 
     /**
@@ -1141,14 +1137,13 @@ public final class PagingsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> getMultiplePages(RequestOptions requestOptions, Context context) {
-        return new PagedIterable<>(getMultiplePagesAsync(requestOptions, context));
+    public PagedIterable<BinaryData> getMultiplePages(RequestOptions requestOptions) {
+        return new PagedIterable<>(getMultiplePagesAsync(requestOptions));
     }
 
     /**
@@ -1363,14 +1358,13 @@ public final class PagingsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> getWithQueryParams(RequestOptions requestOptions, Context context) {
-        return new PagedIterable<>(getWithQueryParamsAsync(requestOptions, context));
+    public PagedIterable<BinaryData> getWithQueryParams(RequestOptions requestOptions) {
+        return new PagedIterable<>(getWithQueryParamsAsync(requestOptions));
     }
 
     /**
@@ -1680,14 +1674,13 @@ public final class PagingsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> getOdataMultiplePages(RequestOptions requestOptions, Context context) {
-        return new PagedIterable<>(getOdataMultiplePagesAsync(requestOptions, context));
+    public PagedIterable<BinaryData> getOdataMultiplePages(RequestOptions requestOptions) {
+        return new PagedIterable<>(getOdataMultiplePagesAsync(requestOptions));
     }
 
     /**
@@ -1911,15 +1904,13 @@ public final class PagingsImpl {
      *
      * @param offset Offset of return value.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> getMultiplePagesWithOffset(
-            int offset, RequestOptions requestOptions, Context context) {
-        return new PagedIterable<>(getMultiplePagesWithOffsetAsync(offset, requestOptions, context));
+    public PagedIterable<BinaryData> getMultiplePagesWithOffset(int offset, RequestOptions requestOptions) {
+        return new PagedIterable<>(getMultiplePagesWithOffsetAsync(offset, requestOptions));
     }
 
     /**
@@ -2089,14 +2080,13 @@ public final class PagingsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> getMultiplePagesRetryFirst(RequestOptions requestOptions, Context context) {
-        return new PagedIterable<>(getMultiplePagesRetryFirstAsync(requestOptions, context));
+    public PagedIterable<BinaryData> getMultiplePagesRetryFirst(RequestOptions requestOptions) {
+        return new PagedIterable<>(getMultiplePagesRetryFirstAsync(requestOptions));
     }
 
     /**
@@ -2266,14 +2256,13 @@ public final class PagingsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> getMultiplePagesRetrySecond(RequestOptions requestOptions, Context context) {
-        return new PagedIterable<>(getMultiplePagesRetrySecondAsync(requestOptions, context));
+    public PagedIterable<BinaryData> getMultiplePagesRetrySecond(RequestOptions requestOptions) {
+        return new PagedIterable<>(getMultiplePagesRetrySecondAsync(requestOptions));
     }
 
     /**
@@ -2438,14 +2427,13 @@ public final class PagingsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> getSinglePagesFailure(RequestOptions requestOptions, Context context) {
-        return new PagedIterable<>(getSinglePagesFailureAsync(requestOptions, context));
+    public PagedIterable<BinaryData> getSinglePagesFailure(RequestOptions requestOptions) {
+        return new PagedIterable<>(getSinglePagesFailureAsync(requestOptions));
     }
 
     /**
@@ -2610,14 +2598,13 @@ public final class PagingsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> getMultiplePagesFailure(RequestOptions requestOptions, Context context) {
-        return new PagedIterable<>(getMultiplePagesFailureAsync(requestOptions, context));
+    public PagedIterable<BinaryData> getMultiplePagesFailure(RequestOptions requestOptions) {
+        return new PagedIterable<>(getMultiplePagesFailureAsync(requestOptions));
     }
 
     /**
@@ -2782,14 +2769,13 @@ public final class PagingsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> getMultiplePagesFailureUri(RequestOptions requestOptions, Context context) {
-        return new PagedIterable<>(getMultiplePagesFailureUriAsync(requestOptions, context));
+    public PagedIterable<BinaryData> getMultiplePagesFailureUri(RequestOptions requestOptions) {
+        return new PagedIterable<>(getMultiplePagesFailureUriAsync(requestOptions));
     }
 
     /**
@@ -3003,15 +2989,13 @@ public final class PagingsImpl {
      *
      * @param tenant Sets the tenant to use.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> getMultiplePagesFragmentNextLink(
-            String tenant, RequestOptions requestOptions, Context context) {
-        return new PagedIterable<>(getMultiplePagesFragmentNextLinkAsync(tenant, requestOptions, context));
+    public PagedIterable<BinaryData> getMultiplePagesFragmentNextLink(String tenant, RequestOptions requestOptions) {
+        return new PagedIterable<>(getMultiplePagesFragmentNextLinkAsync(tenant, requestOptions));
     }
 
     /**
@@ -3227,15 +3211,14 @@ public final class PagingsImpl {
      *
      * @param tenant Sets the tenant to use.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
     public PagedIterable<BinaryData> getMultiplePagesFragmentWithGroupingNextLink(
-            String tenant, RequestOptions requestOptions, Context context) {
-        return new PagedIterable<>(getMultiplePagesFragmentWithGroupingNextLinkAsync(tenant, requestOptions, context));
+            String tenant, RequestOptions requestOptions) {
+        return new PagedIterable<>(getMultiplePagesFragmentWithGroupingNextLinkAsync(tenant, requestOptions));
     }
 
     /**
@@ -3450,14 +3433,13 @@ public final class PagingsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> getMultiplePagesLRO(RequestOptions requestOptions, Context context) {
-        return new PagedIterable<>(getMultiplePagesLROAsync(requestOptions, context));
+    public PagedIterable<BinaryData> getMultiplePagesLRO(RequestOptions requestOptions) {
+        return new PagedIterable<>(getMultiplePagesLROAsync(requestOptions));
     }
 
     /**
@@ -3829,15 +3811,13 @@ public final class PagingsImpl {
      * }</pre>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<BinaryData> getPagingModelWithItemNameWithXMSClientName(
-            RequestOptions requestOptions, Context context) {
-        return new PagedIterable<>(getPagingModelWithItemNameWithXMSClientNameAsync(requestOptions, context));
+    public PagedIterable<BinaryData> getPagingModelWithItemNameWithXMSClientName(RequestOptions requestOptions) {
+        return new PagedIterable<>(getPagingModelWithItemNameWithXMSClientNameAsync(requestOptions));
     }
 
     /**

--- a/protocol-tests/src/main/java/fixtures/url/PathItemsClient.java
+++ b/protocol-tests/src/main/java/fixtures/url/PathItemsClient.java
@@ -10,7 +10,6 @@ import com.azure.core.annotation.ServiceMethod;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.util.Context;
 import fixtures.url.implementation.PathItemsImpl;
 
 /** Initializes a new instance of the synchronous AutoRestUrlTestService type. */
@@ -45,16 +44,14 @@ public final class PathItemsClient {
      * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path.
      * @param localStringPath should contain value 'localStringPath'.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> getAllWithValuesWithResponse(
-            String pathItemStringPath, String localStringPath, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getAllWithValuesWithResponse(
-                pathItemStringPath, localStringPath, requestOptions, context);
+            String pathItemStringPath, String localStringPath, RequestOptions requestOptions) {
+        return this.serviceClient.getAllWithValuesWithResponse(pathItemStringPath, localStringPath, requestOptions);
     }
 
     /**
@@ -75,16 +72,14 @@ public final class PathItemsClient {
      * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path.
      * @param localStringPath should contain value 'localStringPath'.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> getGlobalQueryNullWithResponse(
-            String pathItemStringPath, String localStringPath, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getGlobalQueryNullWithResponse(
-                pathItemStringPath, localStringPath, requestOptions, context);
+            String pathItemStringPath, String localStringPath, RequestOptions requestOptions) {
+        return this.serviceClient.getGlobalQueryNullWithResponse(pathItemStringPath, localStringPath, requestOptions);
     }
 
     /**
@@ -105,16 +100,15 @@ public final class PathItemsClient {
      * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path.
      * @param localStringPath should contain value 'localStringPath'.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> getGlobalAndLocalQueryNullWithResponse(
-            String pathItemStringPath, String localStringPath, RequestOptions requestOptions, Context context) {
+            String pathItemStringPath, String localStringPath, RequestOptions requestOptions) {
         return this.serviceClient.getGlobalAndLocalQueryNullWithResponse(
-                pathItemStringPath, localStringPath, requestOptions, context);
+                pathItemStringPath, localStringPath, requestOptions);
     }
 
     /**
@@ -135,15 +129,14 @@ public final class PathItemsClient {
      * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path.
      * @param localStringPath should contain value 'localStringPath'.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> getLocalPathItemQueryNullWithResponse(
-            String pathItemStringPath, String localStringPath, RequestOptions requestOptions, Context context) {
+            String pathItemStringPath, String localStringPath, RequestOptions requestOptions) {
         return this.serviceClient.getLocalPathItemQueryNullWithResponse(
-                pathItemStringPath, localStringPath, requestOptions, context);
+                pathItemStringPath, localStringPath, requestOptions);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/url/PathsClient.java
+++ b/protocol-tests/src/main/java/fixtures/url/PathsClient.java
@@ -10,7 +10,6 @@ import com.azure.core.annotation.ServiceMethod;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.util.Context;
 import fixtures.url.implementation.PathsImpl;
 
 /** Initializes a new instance of the synchronous AutoRestUrlTestService type. */
@@ -31,196 +30,182 @@ public final class PathsClient {
      * Get true Boolean value on path.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return true Boolean value on path.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getBooleanTrueWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getBooleanTrueWithResponse(requestOptions, context);
+    public Response<Void> getBooleanTrueWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getBooleanTrueWithResponse(requestOptions);
     }
 
     /**
      * Get false Boolean value on path.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return false Boolean value on path.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getBooleanFalseWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getBooleanFalseWithResponse(requestOptions, context);
+    public Response<Void> getBooleanFalseWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getBooleanFalseWithResponse(requestOptions);
     }
 
     /**
      * Get '1000000' integer value.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '1000000' integer value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getIntOneMillionWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getIntOneMillionWithResponse(requestOptions, context);
+    public Response<Void> getIntOneMillionWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getIntOneMillionWithResponse(requestOptions);
     }
 
     /**
      * Get '-1000000' integer value.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '-1000000' integer value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getIntNegativeOneMillionWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getIntNegativeOneMillionWithResponse(requestOptions, context);
+    public Response<Void> getIntNegativeOneMillionWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getIntNegativeOneMillionWithResponse(requestOptions);
     }
 
     /**
      * Get '10000000000' 64 bit integer value.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '10000000000' 64 bit integer value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getTenBillionWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getTenBillionWithResponse(requestOptions, context);
+    public Response<Void> getTenBillionWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getTenBillionWithResponse(requestOptions);
     }
 
     /**
      * Get '-10000000000' 64 bit integer value.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '-10000000000' 64 bit integer value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getNegativeTenBillionWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getNegativeTenBillionWithResponse(requestOptions, context);
+    public Response<Void> getNegativeTenBillionWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getNegativeTenBillionWithResponse(requestOptions);
     }
 
     /**
      * Get '1.034E+20' numeric value.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '1.034E+20' numeric value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> floatScientificPositiveWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.floatScientificPositiveWithResponse(requestOptions, context);
+    public Response<Void> floatScientificPositiveWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.floatScientificPositiveWithResponse(requestOptions);
     }
 
     /**
      * Get '-1.034E-20' numeric value.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '-1.034E-20' numeric value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> floatScientificNegativeWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.floatScientificNegativeWithResponse(requestOptions, context);
+    public Response<Void> floatScientificNegativeWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.floatScientificNegativeWithResponse(requestOptions);
     }
 
     /**
      * Get '9999999.999' numeric value.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '9999999.999' numeric value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> doubleDecimalPositiveWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.doubleDecimalPositiveWithResponse(requestOptions, context);
+    public Response<Void> doubleDecimalPositiveWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.doubleDecimalPositiveWithResponse(requestOptions);
     }
 
     /**
      * Get '-9999999.999' numeric value.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '-9999999.999' numeric value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> doubleDecimalNegativeWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.doubleDecimalNegativeWithResponse(requestOptions, context);
+    public Response<Void> doubleDecimalNegativeWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.doubleDecimalNegativeWithResponse(requestOptions);
     }
 
     /**
      * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> stringUnicodeWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.stringUnicodeWithResponse(requestOptions, context);
+    public Response<Void> stringUnicodeWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.stringUnicodeWithResponse(requestOptions);
     }
 
     /**
      * Get 'begin!*'();:@ &amp;=+$,/?#[]end.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return 'begin!*'();:@ &amp;=+$,/?#[]end.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> stringUrlEncodedWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.stringUrlEncodedWithResponse(requestOptions, context);
+    public Response<Void> stringUrlEncodedWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.stringUrlEncodedWithResponse(requestOptions);
     }
 
     /**
      * https://tools.ietf.org/html/rfc3986#appendix-A 'path' accept any 'pchar' not encoded.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> stringUrlNonEncodedWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.stringUrlNonEncodedWithResponse(requestOptions, context);
+    public Response<Void> stringUrlNonEncodedWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.stringUrlNonEncodedWithResponse(requestOptions);
     }
 
     /**
      * Get ''.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return ''.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> stringEmptyWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.stringEmptyWithResponse(requestOptions, context);
+    public Response<Void> stringEmptyWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.stringEmptyWithResponse(requestOptions);
     }
 
     /**
@@ -228,14 +213,13 @@ public final class PathsClient {
      *
      * @param stringPath null string value.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return null (should throw).
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> stringNullWithResponse(String stringPath, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.stringNullWithResponse(stringPath, requestOptions, context);
+    public Response<Void> stringNullWithResponse(String stringPath, RequestOptions requestOptions) {
+        return this.serviceClient.stringNullWithResponse(stringPath, requestOptions);
     }
 
     /**
@@ -243,14 +227,13 @@ public final class PathsClient {
      *
      * @param enumPath send the value green.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return using uri with 'green color' in path parameter.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> enumValidWithResponse(String enumPath, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.enumValidWithResponse(enumPath, requestOptions, context);
+    public Response<Void> enumValidWithResponse(String enumPath, RequestOptions requestOptions) {
+        return this.serviceClient.enumValidWithResponse(enumPath, requestOptions);
     }
 
     /**
@@ -258,14 +241,13 @@ public final class PathsClient {
      *
      * @param enumPath send null should throw.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return null (should throw on the client before the request is sent on wire).
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> enumNullWithResponse(String enumPath, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.enumNullWithResponse(enumPath, requestOptions, context);
+    public Response<Void> enumNullWithResponse(String enumPath, RequestOptions requestOptions) {
+        return this.serviceClient.enumNullWithResponse(enumPath, requestOptions);
     }
 
     /**
@@ -273,28 +255,26 @@ public final class PathsClient {
      *
      * @param bytePath '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> byteMultiByteWithResponse(String bytePath, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.byteMultiByteWithResponse(bytePath, requestOptions, context);
+    public Response<Void> byteMultiByteWithResponse(String bytePath, RequestOptions requestOptions) {
+        return this.serviceClient.byteMultiByteWithResponse(bytePath, requestOptions);
     }
 
     /**
      * Get '' as byte array.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '' as byte array.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> byteEmptyWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.byteEmptyWithResponse(requestOptions, context);
+    public Response<Void> byteEmptyWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.byteEmptyWithResponse(requestOptions);
     }
 
     /**
@@ -302,28 +282,26 @@ public final class PathsClient {
      *
      * @param bytePath null as byte array (should throw).
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return null as byte array (should throw).
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> byteNullWithResponse(String bytePath, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.byteNullWithResponse(bytePath, requestOptions, context);
+    public Response<Void> byteNullWithResponse(String bytePath, RequestOptions requestOptions) {
+        return this.serviceClient.byteNullWithResponse(bytePath, requestOptions);
     }
 
     /**
      * Get '2012-01-01' as date.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '2012-01-01' as date.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> dateValidWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.dateValidWithResponse(requestOptions, context);
+    public Response<Void> dateValidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.dateValidWithResponse(requestOptions);
     }
 
     /**
@@ -331,28 +309,26 @@ public final class PathsClient {
      *
      * @param datePath null as date (should throw).
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return null as date - this should throw or be unusable on the client side, depending on date representation.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> dateNullWithResponse(String datePath, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.dateNullWithResponse(datePath, requestOptions, context);
+    public Response<Void> dateNullWithResponse(String datePath, RequestOptions requestOptions) {
+        return this.serviceClient.dateNullWithResponse(datePath, requestOptions);
     }
 
     /**
      * Get '2012-01-01T01:01:01Z' as date-time.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '2012-01-01T01:01:01Z' as date-time.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> dateTimeValidWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.dateTimeValidWithResponse(requestOptions, context);
+    public Response<Void> dateTimeValidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.dateTimeValidWithResponse(requestOptions);
     }
 
     /**
@@ -360,15 +336,13 @@ public final class PathsClient {
      *
      * @param dateTimePath null as date-time.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return null as date-time, should be disallowed or throw depending on representation of date-time.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> dateTimeNullWithResponse(
-            String dateTimePath, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.dateTimeNullWithResponse(dateTimePath, requestOptions, context);
+    public Response<Void> dateTimeNullWithResponse(String dateTimePath, RequestOptions requestOptions) {
+        return this.serviceClient.dateTimeNullWithResponse(dateTimePath, requestOptions);
     }
 
     /**
@@ -376,14 +350,13 @@ public final class PathsClient {
      *
      * @param base64UrlPath base64url encoded value.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return 'lorem' encoded value as 'bG9yZW0' (base64url).
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> base64UrlWithResponse(String base64UrlPath, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.base64UrlWithResponse(base64UrlPath, requestOptions, context);
+    public Response<Void> base64UrlWithResponse(String base64UrlPath, RequestOptions requestOptions) {
+        return this.serviceClient.base64UrlWithResponse(base64UrlPath, requestOptions);
     }
 
     /**
@@ -392,15 +365,14 @@ public final class PathsClient {
      * @param arrayPath an array of string ['ArrayPath1', 'begin!*'();:@ &amp;amp;=+$,/?#[]end' , null, ''] using the
      *     csv-array format.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array
      *     format.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> arrayCsvInPathWithResponse(String arrayPath, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.arrayCsvInPathWithResponse(arrayPath, requestOptions, context);
+    public Response<Void> arrayCsvInPathWithResponse(String arrayPath, RequestOptions requestOptions) {
+        return this.serviceClient.arrayCsvInPathWithResponse(arrayPath, requestOptions);
     }
 
     /**
@@ -408,14 +380,12 @@ public final class PathsClient {
      *
      * @param unixTimeUrlPath Unix time encoded value.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the date 2016-04-13 encoded value as '1460505600' (Unix time).
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> unixTimeUrlWithResponse(
-            long unixTimeUrlPath, RequestOptions requestOptions, Context context) {
-        return this.serviceClient.unixTimeUrlWithResponse(unixTimeUrlPath, requestOptions, context);
+    public Response<Void> unixTimeUrlWithResponse(long unixTimeUrlPath, RequestOptions requestOptions) {
+        return this.serviceClient.unixTimeUrlWithResponse(unixTimeUrlPath, requestOptions);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/url/QueriesClient.java
+++ b/protocol-tests/src/main/java/fixtures/url/QueriesClient.java
@@ -10,7 +10,6 @@ import com.azure.core.annotation.ServiceMethod;
 import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.util.Context;
 import fixtures.url.implementation.QueriesImpl;
 
 /** Initializes a new instance of the synchronous AutoRestUrlTestService type. */
@@ -39,14 +38,13 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return true Boolean value on path.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getBooleanTrueWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getBooleanTrueWithResponse(requestOptions, context);
+    public Response<Void> getBooleanTrueWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getBooleanTrueWithResponse(requestOptions);
     }
 
     /**
@@ -61,14 +59,13 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return false Boolean value on path.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getBooleanFalseWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getBooleanFalseWithResponse(requestOptions, context);
+    public Response<Void> getBooleanFalseWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getBooleanFalseWithResponse(requestOptions);
     }
 
     /**
@@ -83,14 +80,13 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return null Boolean value on query (query string should be absent).
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getBooleanNullWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getBooleanNullWithResponse(requestOptions, context);
+    public Response<Void> getBooleanNullWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getBooleanNullWithResponse(requestOptions);
     }
 
     /**
@@ -105,14 +101,13 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '1000000' integer value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getIntOneMillionWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getIntOneMillionWithResponse(requestOptions, context);
+    public Response<Void> getIntOneMillionWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getIntOneMillionWithResponse(requestOptions);
     }
 
     /**
@@ -127,14 +122,13 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '-1000000' integer value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getIntNegativeOneMillionWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getIntNegativeOneMillionWithResponse(requestOptions, context);
+    public Response<Void> getIntNegativeOneMillionWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getIntNegativeOneMillionWithResponse(requestOptions);
     }
 
     /**
@@ -149,14 +143,13 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return null integer value (no query parameter).
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getIntNullWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getIntNullWithResponse(requestOptions, context);
+    public Response<Void> getIntNullWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getIntNullWithResponse(requestOptions);
     }
 
     /**
@@ -171,14 +164,13 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '10000000000' 64 bit integer value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getTenBillionWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getTenBillionWithResponse(requestOptions, context);
+    public Response<Void> getTenBillionWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getTenBillionWithResponse(requestOptions);
     }
 
     /**
@@ -193,14 +185,13 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '-10000000000' 64 bit integer value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getNegativeTenBillionWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getNegativeTenBillionWithResponse(requestOptions, context);
+    public Response<Void> getNegativeTenBillionWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getNegativeTenBillionWithResponse(requestOptions);
     }
 
     /**
@@ -215,14 +206,13 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return 'null 64 bit integer value (no query param in uri).
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getLongNullWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.getLongNullWithResponse(requestOptions, context);
+    public Response<Void> getLongNullWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getLongNullWithResponse(requestOptions);
     }
 
     /**
@@ -237,14 +227,13 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '1.034E+20' numeric value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> floatScientificPositiveWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.floatScientificPositiveWithResponse(requestOptions, context);
+    public Response<Void> floatScientificPositiveWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.floatScientificPositiveWithResponse(requestOptions);
     }
 
     /**
@@ -259,14 +248,13 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '-1.034E-20' numeric value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> floatScientificNegativeWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.floatScientificNegativeWithResponse(requestOptions, context);
+    public Response<Void> floatScientificNegativeWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.floatScientificNegativeWithResponse(requestOptions);
     }
 
     /**
@@ -281,14 +269,13 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return null numeric value (no query parameter).
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> floatNullWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.floatNullWithResponse(requestOptions, context);
+    public Response<Void> floatNullWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.floatNullWithResponse(requestOptions);
     }
 
     /**
@@ -303,14 +290,13 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '9999999.999' numeric value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> doubleDecimalPositiveWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.doubleDecimalPositiveWithResponse(requestOptions, context);
+    public Response<Void> doubleDecimalPositiveWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.doubleDecimalPositiveWithResponse(requestOptions);
     }
 
     /**
@@ -325,14 +311,13 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '-9999999.999' numeric value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> doubleDecimalNegativeWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.doubleDecimalNegativeWithResponse(requestOptions, context);
+    public Response<Void> doubleDecimalNegativeWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.doubleDecimalNegativeWithResponse(requestOptions);
     }
 
     /**
@@ -347,14 +332,13 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return null numeric value (no query parameter).
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> doubleNullWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.doubleNullWithResponse(requestOptions, context);
+    public Response<Void> doubleNullWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.doubleNullWithResponse(requestOptions);
     }
 
     /**
@@ -369,14 +353,13 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> stringUnicodeWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.stringUnicodeWithResponse(requestOptions, context);
+    public Response<Void> stringUnicodeWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.stringUnicodeWithResponse(requestOptions);
     }
 
     /**
@@ -391,14 +374,13 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return 'begin!*'();:@ &amp;=+$,/?#[]end.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> stringUrlEncodedWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.stringUrlEncodedWithResponse(requestOptions, context);
+    public Response<Void> stringUrlEncodedWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.stringUrlEncodedWithResponse(requestOptions);
     }
 
     /**
@@ -413,14 +395,13 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return ''.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> stringEmptyWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.stringEmptyWithResponse(requestOptions, context);
+    public Response<Void> stringEmptyWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.stringEmptyWithResponse(requestOptions);
     }
 
     /**
@@ -435,14 +416,13 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return null (no query parameter in url).
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> stringNullWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.stringNullWithResponse(requestOptions, context);
+    public Response<Void> stringNullWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.stringNullWithResponse(requestOptions);
     }
 
     /**
@@ -457,14 +437,13 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return using uri with query parameter 'green color'.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> enumValidWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.enumValidWithResponse(requestOptions, context);
+    public Response<Void> enumValidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.enumValidWithResponse(requestOptions);
     }
 
     /**
@@ -479,14 +458,13 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return null (no query parameter in url).
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> enumNullWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.enumNullWithResponse(requestOptions, context);
+    public Response<Void> enumNullWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.enumNullWithResponse(requestOptions);
     }
 
     /**
@@ -501,14 +479,13 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> byteMultiByteWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.byteMultiByteWithResponse(requestOptions, context);
+    public Response<Void> byteMultiByteWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.byteMultiByteWithResponse(requestOptions);
     }
 
     /**
@@ -523,14 +500,13 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '' as byte array.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> byteEmptyWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.byteEmptyWithResponse(requestOptions, context);
+    public Response<Void> byteEmptyWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.byteEmptyWithResponse(requestOptions);
     }
 
     /**
@@ -545,14 +521,13 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return null as byte array (no query parameters in uri).
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> byteNullWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.byteNullWithResponse(requestOptions, context);
+    public Response<Void> byteNullWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.byteNullWithResponse(requestOptions);
     }
 
     /**
@@ -567,14 +542,13 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '2012-01-01' as date.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> dateValidWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.dateValidWithResponse(requestOptions, context);
+    public Response<Void> dateValidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.dateValidWithResponse(requestOptions);
     }
 
     /**
@@ -589,14 +563,13 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return null as date - this should result in no query parameters in uri.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> dateNullWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.dateNullWithResponse(requestOptions, context);
+    public Response<Void> dateNullWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.dateNullWithResponse(requestOptions);
     }
 
     /**
@@ -611,14 +584,13 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '2012-01-01T01:01:01Z' as date-time.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> dateTimeValidWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.dateTimeValidWithResponse(requestOptions, context);
+    public Response<Void> dateTimeValidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.dateTimeValidWithResponse(requestOptions);
     }
 
     /**
@@ -633,14 +605,13 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return null as date-time, should result in no query parameters in uri.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> dateTimeNullWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.dateTimeNullWithResponse(requestOptions, context);
+    public Response<Void> dateTimeNullWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.dateTimeNullWithResponse(requestOptions);
     }
 
     /**
@@ -655,15 +626,14 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array
      *     format.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> arrayStringCsvValidWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.arrayStringCsvValidWithResponse(requestOptions, context);
+    public Response<Void> arrayStringCsvValidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.arrayStringCsvValidWithResponse(requestOptions);
     }
 
     /**
@@ -678,14 +648,13 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a null array of string using the csv-array format.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> arrayStringCsvNullWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.arrayStringCsvNullWithResponse(requestOptions, context);
+    public Response<Void> arrayStringCsvNullWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.arrayStringCsvNullWithResponse(requestOptions);
     }
 
     /**
@@ -700,14 +669,13 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return an empty array [] of string using the csv-array format.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> arrayStringCsvEmptyWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.arrayStringCsvEmptyWithResponse(requestOptions, context);
+    public Response<Void> arrayStringCsvEmptyWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.arrayStringCsvEmptyWithResponse(requestOptions);
     }
 
     /**
@@ -723,15 +691,13 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> arrayStringNoCollectionFormatEmptyWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return this.serviceClient.arrayStringNoCollectionFormatEmptyWithResponse(requestOptions, context);
+    public Response<Void> arrayStringNoCollectionFormatEmptyWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.arrayStringNoCollectionFormatEmptyWithResponse(requestOptions);
     }
 
     /**
@@ -746,15 +712,14 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array
      *     format.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> arrayStringSsvValidWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.arrayStringSsvValidWithResponse(requestOptions, context);
+    public Response<Void> arrayStringSsvValidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.arrayStringSsvValidWithResponse(requestOptions);
     }
 
     /**
@@ -769,15 +734,14 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array
      *     format.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> arrayStringTsvValidWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.arrayStringTsvValidWithResponse(requestOptions, context);
+    public Response<Void> arrayStringTsvValidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.arrayStringTsvValidWithResponse(requestOptions);
     }
 
     /**
@@ -793,14 +757,13 @@ public final class QueriesClient {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array
      *     format.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> arrayStringPipesValidWithResponse(RequestOptions requestOptions, Context context) {
-        return this.serviceClient.arrayStringPipesValidWithResponse(requestOptions, context);
+    public Response<Void> arrayStringPipesValidWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.arrayStringPipesValidWithResponse(requestOptions);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/url/implementation/PathItemsImpl.java
+++ b/protocol-tests/src/main/java/fixtures/url/implementation/PathItemsImpl.java
@@ -175,15 +175,14 @@ public final class PathItemsImpl {
      * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path.
      * @param localStringPath should contain value 'localStringPath'.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> getAllWithValuesWithResponse(
-            String pathItemStringPath, String localStringPath, RequestOptions requestOptions, Context context) {
-        return getAllWithValuesWithResponseAsync(pathItemStringPath, localStringPath, requestOptions, context).block();
+            String pathItemStringPath, String localStringPath, RequestOptions requestOptions) {
+        return getAllWithValuesWithResponseAsync(pathItemStringPath, localStringPath, requestOptions).block();
     }
 
     /**
@@ -275,16 +274,14 @@ public final class PathItemsImpl {
      * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path.
      * @param localStringPath should contain value 'localStringPath'.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> getGlobalQueryNullWithResponse(
-            String pathItemStringPath, String localStringPath, RequestOptions requestOptions, Context context) {
-        return getGlobalQueryNullWithResponseAsync(pathItemStringPath, localStringPath, requestOptions, context)
-                .block();
+            String pathItemStringPath, String localStringPath, RequestOptions requestOptions) {
+        return getGlobalQueryNullWithResponseAsync(pathItemStringPath, localStringPath, requestOptions).block();
     }
 
     /**
@@ -376,16 +373,14 @@ public final class PathItemsImpl {
      * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path.
      * @param localStringPath should contain value 'localStringPath'.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> getGlobalAndLocalQueryNullWithResponse(
-            String pathItemStringPath, String localStringPath, RequestOptions requestOptions, Context context) {
-        return getGlobalAndLocalQueryNullWithResponseAsync(pathItemStringPath, localStringPath, requestOptions, context)
-                .block();
+            String pathItemStringPath, String localStringPath, RequestOptions requestOptions) {
+        return getGlobalAndLocalQueryNullWithResponseAsync(pathItemStringPath, localStringPath, requestOptions).block();
     }
 
     /**
@@ -477,15 +472,13 @@ public final class PathItemsImpl {
      * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path.
      * @param localStringPath should contain value 'localStringPath'.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<Void> getLocalPathItemQueryNullWithResponse(
-            String pathItemStringPath, String localStringPath, RequestOptions requestOptions, Context context) {
-        return getLocalPathItemQueryNullWithResponseAsync(pathItemStringPath, localStringPath, requestOptions, context)
-                .block();
+            String pathItemStringPath, String localStringPath, RequestOptions requestOptions) {
+        return getLocalPathItemQueryNullWithResponseAsync(pathItemStringPath, localStringPath, requestOptions).block();
     }
 }

--- a/protocol-tests/src/main/java/fixtures/url/implementation/PathsImpl.java
+++ b/protocol-tests/src/main/java/fixtures/url/implementation/PathsImpl.java
@@ -269,14 +269,13 @@ public final class PathsImpl {
      * Get true Boolean value on path.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return true Boolean value on path.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getBooleanTrueWithResponse(RequestOptions requestOptions, Context context) {
-        return getBooleanTrueWithResponseAsync(requestOptions, context).block();
+    public Response<Void> getBooleanTrueWithResponse(RequestOptions requestOptions) {
+        return getBooleanTrueWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -313,14 +312,13 @@ public final class PathsImpl {
      * Get false Boolean value on path.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return false Boolean value on path.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getBooleanFalseWithResponse(RequestOptions requestOptions, Context context) {
-        return getBooleanFalseWithResponseAsync(requestOptions, context).block();
+    public Response<Void> getBooleanFalseWithResponse(RequestOptions requestOptions) {
+        return getBooleanFalseWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -357,14 +355,13 @@ public final class PathsImpl {
      * Get '1000000' integer value.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '1000000' integer value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getIntOneMillionWithResponse(RequestOptions requestOptions, Context context) {
-        return getIntOneMillionWithResponseAsync(requestOptions, context).block();
+    public Response<Void> getIntOneMillionWithResponse(RequestOptions requestOptions) {
+        return getIntOneMillionWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -402,14 +399,13 @@ public final class PathsImpl {
      * Get '-1000000' integer value.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '-1000000' integer value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getIntNegativeOneMillionWithResponse(RequestOptions requestOptions, Context context) {
-        return getIntNegativeOneMillionWithResponseAsync(requestOptions, context).block();
+    public Response<Void> getIntNegativeOneMillionWithResponse(RequestOptions requestOptions) {
+        return getIntNegativeOneMillionWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -446,14 +442,13 @@ public final class PathsImpl {
      * Get '10000000000' 64 bit integer value.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '10000000000' 64 bit integer value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getTenBillionWithResponse(RequestOptions requestOptions, Context context) {
-        return getTenBillionWithResponseAsync(requestOptions, context).block();
+    public Response<Void> getTenBillionWithResponse(RequestOptions requestOptions) {
+        return getTenBillionWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -490,14 +485,13 @@ public final class PathsImpl {
      * Get '-10000000000' 64 bit integer value.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '-10000000000' 64 bit integer value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getNegativeTenBillionWithResponse(RequestOptions requestOptions, Context context) {
-        return getNegativeTenBillionWithResponseAsync(requestOptions, context).block();
+    public Response<Void> getNegativeTenBillionWithResponse(RequestOptions requestOptions) {
+        return getNegativeTenBillionWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -535,14 +529,13 @@ public final class PathsImpl {
      * Get '1.034E+20' numeric value.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '1.034E+20' numeric value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> floatScientificPositiveWithResponse(RequestOptions requestOptions, Context context) {
-        return floatScientificPositiveWithResponseAsync(requestOptions, context).block();
+    public Response<Void> floatScientificPositiveWithResponse(RequestOptions requestOptions) {
+        return floatScientificPositiveWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -580,14 +573,13 @@ public final class PathsImpl {
      * Get '-1.034E-20' numeric value.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '-1.034E-20' numeric value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> floatScientificNegativeWithResponse(RequestOptions requestOptions, Context context) {
-        return floatScientificNegativeWithResponseAsync(requestOptions, context).block();
+    public Response<Void> floatScientificNegativeWithResponse(RequestOptions requestOptions) {
+        return floatScientificNegativeWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -624,14 +616,13 @@ public final class PathsImpl {
      * Get '9999999.999' numeric value.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '9999999.999' numeric value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> doubleDecimalPositiveWithResponse(RequestOptions requestOptions, Context context) {
-        return doubleDecimalPositiveWithResponseAsync(requestOptions, context).block();
+    public Response<Void> doubleDecimalPositiveWithResponse(RequestOptions requestOptions) {
+        return doubleDecimalPositiveWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -668,14 +659,13 @@ public final class PathsImpl {
      * Get '-9999999.999' numeric value.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '-9999999.999' numeric value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> doubleDecimalNegativeWithResponse(RequestOptions requestOptions, Context context) {
-        return doubleDecimalNegativeWithResponseAsync(requestOptions, context).block();
+    public Response<Void> doubleDecimalNegativeWithResponse(RequestOptions requestOptions) {
+        return doubleDecimalNegativeWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -712,14 +702,13 @@ public final class PathsImpl {
      * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> stringUnicodeWithResponse(RequestOptions requestOptions, Context context) {
-        return stringUnicodeWithResponseAsync(requestOptions, context).block();
+    public Response<Void> stringUnicodeWithResponse(RequestOptions requestOptions) {
+        return stringUnicodeWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -756,14 +745,13 @@ public final class PathsImpl {
      * Get 'begin!*'();:@ &amp;=+$,/?#[]end.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return 'begin!*'();:@ &amp;=+$,/?#[]end.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> stringUrlEncodedWithResponse(RequestOptions requestOptions, Context context) {
-        return stringUrlEncodedWithResponseAsync(requestOptions, context).block();
+    public Response<Void> stringUrlEncodedWithResponse(RequestOptions requestOptions) {
+        return stringUrlEncodedWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -800,14 +788,13 @@ public final class PathsImpl {
      * https://tools.ietf.org/html/rfc3986#appendix-A 'path' accept any 'pchar' not encoded.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> stringUrlNonEncodedWithResponse(RequestOptions requestOptions, Context context) {
-        return stringUrlNonEncodedWithResponseAsync(requestOptions, context).block();
+    public Response<Void> stringUrlNonEncodedWithResponse(RequestOptions requestOptions) {
+        return stringUrlNonEncodedWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -844,14 +831,13 @@ public final class PathsImpl {
      * Get ''.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return ''.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> stringEmptyWithResponse(RequestOptions requestOptions, Context context) {
-        return stringEmptyWithResponseAsync(requestOptions, context).block();
+    public Response<Void> stringEmptyWithResponse(RequestOptions requestOptions) {
+        return stringEmptyWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -890,14 +876,13 @@ public final class PathsImpl {
      *
      * @param stringPath null string value.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return null (should throw).
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> stringNullWithResponse(String stringPath, RequestOptions requestOptions, Context context) {
-        return stringNullWithResponseAsync(stringPath, requestOptions, context).block();
+    public Response<Void> stringNullWithResponse(String stringPath, RequestOptions requestOptions) {
+        return stringNullWithResponseAsync(stringPath, requestOptions).block();
     }
 
     /**
@@ -936,14 +921,13 @@ public final class PathsImpl {
      *
      * @param enumPath send the value green.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return using uri with 'green color' in path parameter.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> enumValidWithResponse(String enumPath, RequestOptions requestOptions, Context context) {
-        return enumValidWithResponseAsync(enumPath, requestOptions, context).block();
+    public Response<Void> enumValidWithResponse(String enumPath, RequestOptions requestOptions) {
+        return enumValidWithResponseAsync(enumPath, requestOptions).block();
     }
 
     /**
@@ -982,14 +966,13 @@ public final class PathsImpl {
      *
      * @param enumPath send null should throw.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return null (should throw on the client before the request is sent on wire).
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> enumNullWithResponse(String enumPath, RequestOptions requestOptions, Context context) {
-        return enumNullWithResponseAsync(enumPath, requestOptions, context).block();
+    public Response<Void> enumNullWithResponse(String enumPath, RequestOptions requestOptions) {
+        return enumNullWithResponseAsync(enumPath, requestOptions).block();
     }
 
     /**
@@ -1028,14 +1011,13 @@ public final class PathsImpl {
      *
      * @param bytePath '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> byteMultiByteWithResponse(String bytePath, RequestOptions requestOptions, Context context) {
-        return byteMultiByteWithResponseAsync(bytePath, requestOptions, context).block();
+    public Response<Void> byteMultiByteWithResponse(String bytePath, RequestOptions requestOptions) {
+        return byteMultiByteWithResponseAsync(bytePath, requestOptions).block();
     }
 
     /**
@@ -1072,14 +1054,13 @@ public final class PathsImpl {
      * Get '' as byte array.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '' as byte array.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> byteEmptyWithResponse(RequestOptions requestOptions, Context context) {
-        return byteEmptyWithResponseAsync(requestOptions, context).block();
+    public Response<Void> byteEmptyWithResponse(RequestOptions requestOptions) {
+        return byteEmptyWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1118,14 +1099,13 @@ public final class PathsImpl {
      *
      * @param bytePath null as byte array (should throw).
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return null as byte array (should throw).
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> byteNullWithResponse(String bytePath, RequestOptions requestOptions, Context context) {
-        return byteNullWithResponseAsync(bytePath, requestOptions, context).block();
+    public Response<Void> byteNullWithResponse(String bytePath, RequestOptions requestOptions) {
+        return byteNullWithResponseAsync(bytePath, requestOptions).block();
     }
 
     /**
@@ -1162,14 +1142,13 @@ public final class PathsImpl {
      * Get '2012-01-01' as date.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '2012-01-01' as date.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> dateValidWithResponse(RequestOptions requestOptions, Context context) {
-        return dateValidWithResponseAsync(requestOptions, context).block();
+    public Response<Void> dateValidWithResponse(RequestOptions requestOptions) {
+        return dateValidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1208,14 +1187,13 @@ public final class PathsImpl {
      *
      * @param datePath null as date (should throw).
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return null as date - this should throw or be unusable on the client side, depending on date representation.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> dateNullWithResponse(String datePath, RequestOptions requestOptions, Context context) {
-        return dateNullWithResponseAsync(datePath, requestOptions, context).block();
+    public Response<Void> dateNullWithResponse(String datePath, RequestOptions requestOptions) {
+        return dateNullWithResponseAsync(datePath, requestOptions).block();
     }
 
     /**
@@ -1252,14 +1230,13 @@ public final class PathsImpl {
      * Get '2012-01-01T01:01:01Z' as date-time.
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '2012-01-01T01:01:01Z' as date-time.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> dateTimeValidWithResponse(RequestOptions requestOptions, Context context) {
-        return dateTimeValidWithResponseAsync(requestOptions, context).block();
+    public Response<Void> dateTimeValidWithResponse(RequestOptions requestOptions) {
+        return dateTimeValidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1298,15 +1275,13 @@ public final class PathsImpl {
      *
      * @param dateTimePath null as date-time.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return null as date-time, should be disallowed or throw depending on representation of date-time.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> dateTimeNullWithResponse(
-            String dateTimePath, RequestOptions requestOptions, Context context) {
-        return dateTimeNullWithResponseAsync(dateTimePath, requestOptions, context).block();
+    public Response<Void> dateTimeNullWithResponse(String dateTimePath, RequestOptions requestOptions) {
+        return dateTimeNullWithResponseAsync(dateTimePath, requestOptions).block();
     }
 
     /**
@@ -1345,14 +1320,13 @@ public final class PathsImpl {
      *
      * @param base64UrlPath base64url encoded value.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return 'lorem' encoded value as 'bG9yZW0' (base64url).
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> base64UrlWithResponse(String base64UrlPath, RequestOptions requestOptions, Context context) {
-        return base64UrlWithResponseAsync(base64UrlPath, requestOptions, context).block();
+    public Response<Void> base64UrlWithResponse(String base64UrlPath, RequestOptions requestOptions) {
+        return base64UrlWithResponseAsync(base64UrlPath, requestOptions).block();
     }
 
     /**
@@ -1396,15 +1370,14 @@ public final class PathsImpl {
      * @param arrayPath an array of string ['ArrayPath1', 'begin!*'();:@ &amp;amp;=+$,/?#[]end' , null, ''] using the
      *     csv-array format.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array
      *     format.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> arrayCsvInPathWithResponse(String arrayPath, RequestOptions requestOptions, Context context) {
-        return arrayCsvInPathWithResponseAsync(arrayPath, requestOptions, context).block();
+    public Response<Void> arrayCsvInPathWithResponse(String arrayPath, RequestOptions requestOptions) {
+        return arrayCsvInPathWithResponseAsync(arrayPath, requestOptions).block();
     }
 
     /**
@@ -1443,14 +1416,12 @@ public final class PathsImpl {
      *
      * @param unixTimeUrlPath Unix time encoded value.
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the date 2016-04-13 encoded value as '1460505600' (Unix time).
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> unixTimeUrlWithResponse(
-            long unixTimeUrlPath, RequestOptions requestOptions, Context context) {
-        return unixTimeUrlWithResponseAsync(unixTimeUrlPath, requestOptions, context).block();
+    public Response<Void> unixTimeUrlWithResponse(long unixTimeUrlPath, RequestOptions requestOptions) {
+        return unixTimeUrlWithResponseAsync(unixTimeUrlPath, requestOptions).block();
     }
 }

--- a/protocol-tests/src/main/java/fixtures/url/implementation/QueriesImpl.java
+++ b/protocol-tests/src/main/java/fixtures/url/implementation/QueriesImpl.java
@@ -232,14 +232,13 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return true Boolean value on path.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getBooleanTrueWithResponse(RequestOptions requestOptions, Context context) {
-        return getBooleanTrueWithResponseAsync(requestOptions, context).block();
+    public Response<Void> getBooleanTrueWithResponse(RequestOptions requestOptions) {
+        return getBooleanTrueWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -297,14 +296,13 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return false Boolean value on path.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getBooleanFalseWithResponse(RequestOptions requestOptions, Context context) {
-        return getBooleanFalseWithResponseAsync(requestOptions, context).block();
+    public Response<Void> getBooleanFalseWithResponse(RequestOptions requestOptions) {
+        return getBooleanFalseWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -362,14 +360,13 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return null Boolean value on query (query string should be absent).
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getBooleanNullWithResponse(RequestOptions requestOptions, Context context) {
-        return getBooleanNullWithResponseAsync(requestOptions, context).block();
+    public Response<Void> getBooleanNullWithResponse(RequestOptions requestOptions) {
+        return getBooleanNullWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -428,14 +425,13 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '1000000' integer value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getIntOneMillionWithResponse(RequestOptions requestOptions, Context context) {
-        return getIntOneMillionWithResponseAsync(requestOptions, context).block();
+    public Response<Void> getIntOneMillionWithResponse(RequestOptions requestOptions) {
+        return getIntOneMillionWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -495,14 +491,13 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '-1000000' integer value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getIntNegativeOneMillionWithResponse(RequestOptions requestOptions, Context context) {
-        return getIntNegativeOneMillionWithResponseAsync(requestOptions, context).block();
+    public Response<Void> getIntNegativeOneMillionWithResponse(RequestOptions requestOptions) {
+        return getIntNegativeOneMillionWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -560,14 +555,13 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return null integer value (no query parameter).
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getIntNullWithResponse(RequestOptions requestOptions, Context context) {
-        return getIntNullWithResponseAsync(requestOptions, context).block();
+    public Response<Void> getIntNullWithResponse(RequestOptions requestOptions) {
+        return getIntNullWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -625,14 +619,13 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '10000000000' 64 bit integer value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getTenBillionWithResponse(RequestOptions requestOptions, Context context) {
-        return getTenBillionWithResponseAsync(requestOptions, context).block();
+    public Response<Void> getTenBillionWithResponse(RequestOptions requestOptions) {
+        return getTenBillionWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -691,14 +684,13 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '-10000000000' 64 bit integer value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getNegativeTenBillionWithResponse(RequestOptions requestOptions, Context context) {
-        return getNegativeTenBillionWithResponseAsync(requestOptions, context).block();
+    public Response<Void> getNegativeTenBillionWithResponse(RequestOptions requestOptions) {
+        return getNegativeTenBillionWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -756,14 +748,13 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return 'null 64 bit integer value (no query param in uri).
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getLongNullWithResponse(RequestOptions requestOptions, Context context) {
-        return getLongNullWithResponseAsync(requestOptions, context).block();
+    public Response<Void> getLongNullWithResponse(RequestOptions requestOptions) {
+        return getLongNullWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -823,14 +814,13 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '1.034E+20' numeric value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> floatScientificPositiveWithResponse(RequestOptions requestOptions, Context context) {
-        return floatScientificPositiveWithResponseAsync(requestOptions, context).block();
+    public Response<Void> floatScientificPositiveWithResponse(RequestOptions requestOptions) {
+        return floatScientificPositiveWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -890,14 +880,13 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '-1.034E-20' numeric value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> floatScientificNegativeWithResponse(RequestOptions requestOptions, Context context) {
-        return floatScientificNegativeWithResponseAsync(requestOptions, context).block();
+    public Response<Void> floatScientificNegativeWithResponse(RequestOptions requestOptions) {
+        return floatScientificNegativeWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -955,14 +944,13 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return null numeric value (no query parameter).
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> floatNullWithResponse(RequestOptions requestOptions, Context context) {
-        return floatNullWithResponseAsync(requestOptions, context).block();
+    public Response<Void> floatNullWithResponse(RequestOptions requestOptions) {
+        return floatNullWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1021,14 +1009,13 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '9999999.999' numeric value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> doubleDecimalPositiveWithResponse(RequestOptions requestOptions, Context context) {
-        return doubleDecimalPositiveWithResponseAsync(requestOptions, context).block();
+    public Response<Void> doubleDecimalPositiveWithResponse(RequestOptions requestOptions) {
+        return doubleDecimalPositiveWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1087,14 +1074,13 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '-9999999.999' numeric value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> doubleDecimalNegativeWithResponse(RequestOptions requestOptions, Context context) {
-        return doubleDecimalNegativeWithResponseAsync(requestOptions, context).block();
+    public Response<Void> doubleDecimalNegativeWithResponse(RequestOptions requestOptions) {
+        return doubleDecimalNegativeWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1152,14 +1138,13 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return null numeric value (no query parameter).
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> doubleNullWithResponse(RequestOptions requestOptions, Context context) {
-        return doubleNullWithResponseAsync(requestOptions, context).block();
+    public Response<Void> doubleNullWithResponse(RequestOptions requestOptions) {
+        return doubleNullWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1217,14 +1202,13 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> stringUnicodeWithResponse(RequestOptions requestOptions, Context context) {
-        return stringUnicodeWithResponseAsync(requestOptions, context).block();
+    public Response<Void> stringUnicodeWithResponse(RequestOptions requestOptions) {
+        return stringUnicodeWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1283,14 +1267,13 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return 'begin!*'();:@ &amp;=+$,/?#[]end.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> stringUrlEncodedWithResponse(RequestOptions requestOptions, Context context) {
-        return stringUrlEncodedWithResponseAsync(requestOptions, context).block();
+    public Response<Void> stringUrlEncodedWithResponse(RequestOptions requestOptions) {
+        return stringUrlEncodedWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1348,14 +1331,13 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return ''.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> stringEmptyWithResponse(RequestOptions requestOptions, Context context) {
-        return stringEmptyWithResponseAsync(requestOptions, context).block();
+    public Response<Void> stringEmptyWithResponse(RequestOptions requestOptions) {
+        return stringEmptyWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1413,14 +1395,13 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return null (no query parameter in url).
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> stringNullWithResponse(RequestOptions requestOptions, Context context) {
-        return stringNullWithResponseAsync(requestOptions, context).block();
+    public Response<Void> stringNullWithResponse(RequestOptions requestOptions) {
+        return stringNullWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1478,14 +1459,13 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return using uri with query parameter 'green color'.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> enumValidWithResponse(RequestOptions requestOptions, Context context) {
-        return enumValidWithResponseAsync(requestOptions, context).block();
+    public Response<Void> enumValidWithResponse(RequestOptions requestOptions) {
+        return enumValidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1543,14 +1523,13 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return null (no query parameter in url).
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> enumNullWithResponse(RequestOptions requestOptions, Context context) {
-        return enumNullWithResponseAsync(requestOptions, context).block();
+    public Response<Void> enumNullWithResponse(RequestOptions requestOptions) {
+        return enumNullWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1608,14 +1587,13 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> byteMultiByteWithResponse(RequestOptions requestOptions, Context context) {
-        return byteMultiByteWithResponseAsync(requestOptions, context).block();
+    public Response<Void> byteMultiByteWithResponse(RequestOptions requestOptions) {
+        return byteMultiByteWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1673,14 +1651,13 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '' as byte array.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> byteEmptyWithResponse(RequestOptions requestOptions, Context context) {
-        return byteEmptyWithResponseAsync(requestOptions, context).block();
+    public Response<Void> byteEmptyWithResponse(RequestOptions requestOptions) {
+        return byteEmptyWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1738,14 +1715,13 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return null as byte array (no query parameters in uri).
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> byteNullWithResponse(RequestOptions requestOptions, Context context) {
-        return byteNullWithResponseAsync(requestOptions, context).block();
+    public Response<Void> byteNullWithResponse(RequestOptions requestOptions) {
+        return byteNullWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1803,14 +1779,13 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '2012-01-01' as date.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> dateValidWithResponse(RequestOptions requestOptions, Context context) {
-        return dateValidWithResponseAsync(requestOptions, context).block();
+    public Response<Void> dateValidWithResponse(RequestOptions requestOptions) {
+        return dateValidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1868,14 +1843,13 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return null as date - this should result in no query parameters in uri.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> dateNullWithResponse(RequestOptions requestOptions, Context context) {
-        return dateNullWithResponseAsync(requestOptions, context).block();
+    public Response<Void> dateNullWithResponse(RequestOptions requestOptions) {
+        return dateNullWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1933,14 +1907,13 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return '2012-01-01T01:01:01Z' as date-time.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> dateTimeValidWithResponse(RequestOptions requestOptions, Context context) {
-        return dateTimeValidWithResponseAsync(requestOptions, context).block();
+    public Response<Void> dateTimeValidWithResponse(RequestOptions requestOptions) {
+        return dateTimeValidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -1998,14 +1971,13 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return null as date-time, should result in no query parameters in uri.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> dateTimeNullWithResponse(RequestOptions requestOptions, Context context) {
-        return dateTimeNullWithResponseAsync(requestOptions, context).block();
+    public Response<Void> dateTimeNullWithResponse(RequestOptions requestOptions) {
+        return dateTimeNullWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -2066,15 +2038,14 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the csv-array
      *     format.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> arrayStringCsvValidWithResponse(RequestOptions requestOptions, Context context) {
-        return arrayStringCsvValidWithResponseAsync(requestOptions, context).block();
+    public Response<Void> arrayStringCsvValidWithResponse(RequestOptions requestOptions) {
+        return arrayStringCsvValidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -2133,14 +2104,13 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return a null array of string using the csv-array format.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> arrayStringCsvNullWithResponse(RequestOptions requestOptions, Context context) {
-        return arrayStringCsvNullWithResponseAsync(requestOptions, context).block();
+    public Response<Void> arrayStringCsvNullWithResponse(RequestOptions requestOptions) {
+        return arrayStringCsvNullWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -2199,14 +2169,13 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return an empty array [] of string using the csv-array format.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> arrayStringCsvEmptyWithResponse(RequestOptions requestOptions, Context context) {
-        return arrayStringCsvEmptyWithResponseAsync(requestOptions, context).block();
+    public Response<Void> arrayStringCsvEmptyWithResponse(RequestOptions requestOptions) {
+        return arrayStringCsvEmptyWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -2269,15 +2238,13 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> arrayStringNoCollectionFormatEmptyWithResponse(
-            RequestOptions requestOptions, Context context) {
-        return arrayStringNoCollectionFormatEmptyWithResponseAsync(requestOptions, context).block();
+    public Response<Void> arrayStringNoCollectionFormatEmptyWithResponse(RequestOptions requestOptions) {
+        return arrayStringNoCollectionFormatEmptyWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -2338,15 +2305,14 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the ssv-array
      *     format.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> arrayStringSsvValidWithResponse(RequestOptions requestOptions, Context context) {
-        return arrayStringSsvValidWithResponseAsync(requestOptions, context).block();
+    public Response<Void> arrayStringSsvValidWithResponse(RequestOptions requestOptions) {
+        return arrayStringSsvValidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -2407,15 +2373,14 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the tsv-array
      *     format.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> arrayStringTsvValidWithResponse(RequestOptions requestOptions, Context context) {
-        return arrayStringTsvValidWithResponseAsync(requestOptions, context).block();
+    public Response<Void> arrayStringTsvValidWithResponse(RequestOptions requestOptions) {
+        return arrayStringTsvValidWithResponseAsync(requestOptions).block();
     }
 
     /**
@@ -2479,14 +2444,13 @@ public final class QueriesImpl {
      * </table>
      *
      * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @param context The context to associate with this operation.
      * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
      *     false.
      * @return an array of string ['ArrayQuery1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null, ''] using the pipes-array
      *     format.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> arrayStringPipesValidWithResponse(RequestOptions requestOptions, Context context) {
-        return arrayStringPipesValidWithResponseAsync(requestOptions, context).block();
+    public Response<Void> arrayStringPipesValidWithResponse(RequestOptions requestOptions) {
+        return arrayStringPipesValidWithResponseAsync(requestOptions).block();
     }
 }

--- a/protocol-tests/src/samples/java/fixtures/bodystring/generated/EnumGetNotExpandable.java
+++ b/protocol-tests/src/samples/java/fixtures/bodystring/generated/EnumGetNotExpandable.java
@@ -6,7 +6,6 @@ package fixtures.bodystring.generated;
 
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.util.Context;
 import fixtures.bodystring.AutoRestSwaggerBATServiceBuilder;
 import fixtures.bodystring.EnumClient;
 
@@ -14,6 +13,6 @@ public class EnumGetNotExpandable {
     public static void main(String[] args) {
         EnumClient client = new AutoRestSwaggerBATServiceBuilder().host("http://localhost:3000").buildEnumClient();
         RequestOptions requestOptions = new RequestOptions();
-        Response<String> response = client.getNotExpandableWithResponse(requestOptions, Context.NONE);
+        Response<String> response = client.getNotExpandableWithResponse(requestOptions);
     }
 }

--- a/protocol-tests/src/samples/java/fixtures/bodystring/generated/EnumGetReferenced.java
+++ b/protocol-tests/src/samples/java/fixtures/bodystring/generated/EnumGetReferenced.java
@@ -6,7 +6,6 @@ package fixtures.bodystring.generated;
 
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.util.Context;
 import fixtures.bodystring.AutoRestSwaggerBATServiceBuilder;
 import fixtures.bodystring.EnumClient;
 
@@ -14,6 +13,6 @@ public class EnumGetReferenced {
     public static void main(String[] args) {
         EnumClient client = new AutoRestSwaggerBATServiceBuilder().host("http://localhost:3000").buildEnumClient();
         RequestOptions requestOptions = new RequestOptions();
-        Response<String> response = client.getReferencedWithResponse(requestOptions, Context.NONE);
+        Response<String> response = client.getReferencedWithResponse(requestOptions);
     }
 }

--- a/protocol-tests/src/samples/java/fixtures/bodystring/generated/EnumGetReferencedConstant.java
+++ b/protocol-tests/src/samples/java/fixtures/bodystring/generated/EnumGetReferencedConstant.java
@@ -7,7 +7,6 @@ package fixtures.bodystring.generated;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import fixtures.bodystring.AutoRestSwaggerBATServiceBuilder;
 import fixtures.bodystring.EnumClient;
 
@@ -15,6 +14,6 @@ public class EnumGetReferencedConstant {
     public static void main(String[] args) {
         EnumClient client = new AutoRestSwaggerBATServiceBuilder().host("http://localhost:3000").buildEnumClient();
         RequestOptions requestOptions = new RequestOptions();
-        Response<BinaryData> response = client.getReferencedConstantWithResponse(requestOptions, Context.NONE);
+        Response<BinaryData> response = client.getReferencedConstantWithResponse(requestOptions);
     }
 }

--- a/protocol-tests/src/samples/java/fixtures/bodystring/generated/EnumPutNotExpandable.java
+++ b/protocol-tests/src/samples/java/fixtures/bodystring/generated/EnumPutNotExpandable.java
@@ -7,7 +7,6 @@ package fixtures.bodystring.generated;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import fixtures.bodystring.AutoRestSwaggerBATServiceBuilder;
 import fixtures.bodystring.EnumClient;
 
@@ -16,6 +15,6 @@ public class EnumPutNotExpandable {
         EnumClient client = new AutoRestSwaggerBATServiceBuilder().host("http://localhost:3000").buildEnumClient();
         BinaryData stringBody = BinaryData.fromString("\"red color\"");
         RequestOptions requestOptions = new RequestOptions();
-        Response<Void> response = client.putNotExpandableWithResponse(stringBody, requestOptions, Context.NONE);
+        Response<Void> response = client.putNotExpandableWithResponse(stringBody, requestOptions);
     }
 }

--- a/protocol-tests/src/samples/java/fixtures/bodystring/generated/EnumPutReferenced.java
+++ b/protocol-tests/src/samples/java/fixtures/bodystring/generated/EnumPutReferenced.java
@@ -7,7 +7,6 @@ package fixtures.bodystring.generated;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import fixtures.bodystring.AutoRestSwaggerBATServiceBuilder;
 import fixtures.bodystring.EnumClient;
 
@@ -16,6 +15,6 @@ public class EnumPutReferenced {
         EnumClient client = new AutoRestSwaggerBATServiceBuilder().host("http://localhost:3000").buildEnumClient();
         BinaryData enumStringBody = BinaryData.fromString("\"red color\"");
         RequestOptions requestOptions = new RequestOptions();
-        Response<Void> response = client.putReferencedWithResponse(enumStringBody, requestOptions, Context.NONE);
+        Response<Void> response = client.putReferencedWithResponse(enumStringBody, requestOptions);
     }
 }

--- a/protocol-tests/src/samples/java/fixtures/bodystring/generated/EnumPutReferencedConstant.java
+++ b/protocol-tests/src/samples/java/fixtures/bodystring/generated/EnumPutReferencedConstant.java
@@ -7,7 +7,6 @@ package fixtures.bodystring.generated;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import fixtures.bodystring.AutoRestSwaggerBATServiceBuilder;
 import fixtures.bodystring.EnumClient;
 
@@ -16,7 +15,6 @@ public class EnumPutReferencedConstant {
         EnumClient client = new AutoRestSwaggerBATServiceBuilder().host("http://localhost:3000").buildEnumClient();
         BinaryData enumStringBody = BinaryData.fromString("\"green-color\"");
         RequestOptions requestOptions = new RequestOptions();
-        Response<Void> response =
-                client.putReferencedConstantWithResponse(enumStringBody, requestOptions, Context.NONE);
+        Response<Void> response = client.putReferencedConstantWithResponse(enumStringBody, requestOptions);
     }
 }

--- a/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringGetEmpty.java
+++ b/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringGetEmpty.java
@@ -7,7 +7,6 @@ package fixtures.bodystring.generated;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import fixtures.bodystring.AutoRestSwaggerBATServiceBuilder;
 import fixtures.bodystring.StringOperationClient;
 
@@ -16,6 +15,6 @@ public class StringGetEmpty {
         StringOperationClient client =
                 new AutoRestSwaggerBATServiceBuilder().host("http://localhost:3000").buildStringOperationClient();
         RequestOptions requestOptions = new RequestOptions();
-        Response<BinaryData> response = client.getEmptyWithResponse(requestOptions, Context.NONE);
+        Response<BinaryData> response = client.getEmptyWithResponse(requestOptions);
     }
 }

--- a/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringGetMbcs.java
+++ b/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringGetMbcs.java
@@ -7,7 +7,6 @@ package fixtures.bodystring.generated;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import fixtures.bodystring.AutoRestSwaggerBATServiceBuilder;
 import fixtures.bodystring.StringOperationClient;
 
@@ -16,6 +15,6 @@ public class StringGetMbcs {
         StringOperationClient client =
                 new AutoRestSwaggerBATServiceBuilder().host("http://localhost:3000").buildStringOperationClient();
         RequestOptions requestOptions = new RequestOptions();
-        Response<BinaryData> response = client.getMbcsWithResponse(requestOptions, Context.NONE);
+        Response<BinaryData> response = client.getMbcsWithResponse(requestOptions);
     }
 }

--- a/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringGetNotProvided.java
+++ b/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringGetNotProvided.java
@@ -7,7 +7,6 @@ package fixtures.bodystring.generated;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import fixtures.bodystring.AutoRestSwaggerBATServiceBuilder;
 import fixtures.bodystring.StringOperationClient;
 
@@ -16,6 +15,6 @@ public class StringGetNotProvided {
         StringOperationClient client =
                 new AutoRestSwaggerBATServiceBuilder().host("http://localhost:3000").buildStringOperationClient();
         RequestOptions requestOptions = new RequestOptions();
-        Response<BinaryData> response = client.getNotProvidedWithResponse(requestOptions, Context.NONE);
+        Response<BinaryData> response = client.getNotProvidedWithResponse(requestOptions);
     }
 }

--- a/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringGetNull.java
+++ b/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringGetNull.java
@@ -7,7 +7,6 @@ package fixtures.bodystring.generated;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import fixtures.bodystring.AutoRestSwaggerBATServiceBuilder;
 import fixtures.bodystring.StringOperationClient;
 
@@ -16,6 +15,6 @@ public class StringGetNull {
         StringOperationClient client =
                 new AutoRestSwaggerBATServiceBuilder().host("http://localhost:3000").buildStringOperationClient();
         RequestOptions requestOptions = new RequestOptions();
-        Response<BinaryData> response = client.getNullWithResponse(requestOptions, Context.NONE);
+        Response<BinaryData> response = client.getNullWithResponse(requestOptions);
     }
 }

--- a/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringGetWhitespace.java
+++ b/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringGetWhitespace.java
@@ -7,7 +7,6 @@ package fixtures.bodystring.generated;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import fixtures.bodystring.AutoRestSwaggerBATServiceBuilder;
 import fixtures.bodystring.StringOperationClient;
 
@@ -16,6 +15,6 @@ public class StringGetWhitespace {
         StringOperationClient client =
                 new AutoRestSwaggerBATServiceBuilder().host("http://localhost:3000").buildStringOperationClient();
         RequestOptions requestOptions = new RequestOptions();
-        Response<BinaryData> response = client.getWhitespaceWithResponse(requestOptions, Context.NONE);
+        Response<BinaryData> response = client.getWhitespaceWithResponse(requestOptions);
     }
 }

--- a/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringPutEmpty.java
+++ b/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringPutEmpty.java
@@ -7,7 +7,6 @@ package fixtures.bodystring.generated;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import fixtures.bodystring.AutoRestSwaggerBATServiceBuilder;
 import fixtures.bodystring.StringOperationClient;
 
@@ -17,6 +16,6 @@ public class StringPutEmpty {
                 new AutoRestSwaggerBATServiceBuilder().host("http://localhost:3000").buildStringOperationClient();
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.setBody(BinaryData.fromString("\"\""));
-        Response<Void> response = client.putEmptyWithResponse(requestOptions, Context.NONE);
+        Response<Void> response = client.putEmptyWithResponse(requestOptions);
     }
 }

--- a/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringPutMbcs.java
+++ b/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringPutMbcs.java
@@ -7,7 +7,6 @@ package fixtures.bodystring.generated;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import fixtures.bodystring.AutoRestSwaggerBATServiceBuilder;
 import fixtures.bodystring.StringOperationClient;
 
@@ -18,6 +17,6 @@ public class StringPutMbcs {
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.setBody(
                 BinaryData.fromString("\"啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€\""));
-        Response<Void> response = client.putMbcsWithResponse(requestOptions, Context.NONE);
+        Response<Void> response = client.putMbcsWithResponse(requestOptions);
     }
 }

--- a/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringPutNull.java
+++ b/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringPutNull.java
@@ -6,7 +6,6 @@ package fixtures.bodystring.generated;
 
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.util.Context;
 import fixtures.bodystring.AutoRestSwaggerBATServiceBuilder;
 import fixtures.bodystring.StringOperationClient;
 
@@ -15,6 +14,6 @@ public class StringPutNull {
         StringOperationClient client =
                 new AutoRestSwaggerBATServiceBuilder().host("http://localhost:3000").buildStringOperationClient();
         RequestOptions requestOptions = new RequestOptions();
-        Response<Void> response = client.putNullWithResponse(requestOptions, Context.NONE);
+        Response<Void> response = client.putNullWithResponse(requestOptions);
     }
 }

--- a/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringPutWhitespace.java
+++ b/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringPutWhitespace.java
@@ -7,7 +7,6 @@ package fixtures.bodystring.generated;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import fixtures.bodystring.AutoRestSwaggerBATServiceBuilder;
 import fixtures.bodystring.StringOperationClient;
 
@@ -19,6 +18,6 @@ public class StringPutWhitespace {
         requestOptions.setBody(
                 BinaryData.fromString(
                         "\"<tab><space><space>Now is the time for all good men to come to the aid of their country<tab><space><space>\""));
-        Response<Void> response = client.putWhitespaceWithResponse(requestOptions, Context.NONE);
+        Response<Void> response = client.putWhitespaceWithResponse(requestOptions);
     }
 }

--- a/protocol-tests/src/test/java/fixtures/bodycomplex/ArrayTests.java
+++ b/protocol-tests/src/test/java/fixtures/bodycomplex/ArrayTests.java
@@ -21,7 +21,7 @@ public class ArrayTests {
 
     @Test
     public void getValid() throws Exception {
-        BinaryData binaryData = client.getValidWithResponse(null, null).getValue();
+        BinaryData binaryData = client.getValidWithResponse(null).getValue();
         List<String> list = (List)binaryData.toObject(Map.class).get("array");
         Assertions.assertEquals(5, list.size());
         Assertions.assertEquals("&S#$(*Y", list.get(3));
@@ -30,12 +30,12 @@ public class ArrayTests {
     @Test
     public void putValid() throws Exception {
         BinaryData binaryData = BinaryData.fromString("{\"array\":[\"1, 2, 3, 4\",\"\",null,\"&S#$(*Y\",\"The quick brown fox jumps over the lazy dog\"]}");
-        client.putValidWithResponse(binaryData, null, null);
+        client.putValidWithResponse(binaryData, null);
     }
 
     @Test
     public void getEmpty() throws Exception {
-        BinaryData binaryData = client.getEmptyWithResponse(null, null).getValue();
+        BinaryData binaryData = client.getEmptyWithResponse(null).getValue();
         List<String> list = (List)binaryData.toObject(Map.class).get("array");
         Assertions.assertEquals(0, list.size());
     }
@@ -48,7 +48,7 @@ public class ArrayTests {
 
     @Test
     public void getNotProvided() throws Exception {
-        BinaryData binaryData = client.getNotProvidedWithResponse(null, null).getValue();
+        BinaryData binaryData = client.getNotProvidedWithResponse(null).getValue();
         List<String> list = (List)binaryData.toObject(Map.class).get("array");
         Assertions.assertNull(list);
     }

--- a/protocol-tests/src/test/java/fixtures/bodycomplex/BasicTests.java
+++ b/protocol-tests/src/test/java/fixtures/bodycomplex/BasicTests.java
@@ -20,7 +20,7 @@ public class BasicTests {
 
     @Test
     public void getValid() throws Exception {
-        BinaryData binaryData = client.getValidWithResponse(null, null).getValue();
+        BinaryData binaryData = client.getValidWithResponse(null).getValue();
         Map<?, ?> map = binaryData.toObject(Map.class);
         Assertions.assertEquals(2, map.get("id"));
         Assertions.assertEquals("abc", map.get("name"));
@@ -35,14 +35,14 @@ public class BasicTests {
 
     @Test
     public void getEmpty() throws Exception {
-        BinaryData binaryData = client.getEmptyWithResponse(null, null).getValue();
+        BinaryData binaryData = client.getEmptyWithResponse(null).getValue();
         Map<?, ?> map = binaryData.toObject(Map.class);
         Assertions.assertTrue(map.isEmpty());
     }
 
     @Test
     public void getNull() throws Exception {
-        BinaryData binaryData = client.getNullWithResponse(null, null).getValue();
+        BinaryData binaryData = client.getNullWithResponse(null).getValue();
         Map<?, ?> map = binaryData.toObject(Map.class);
         Assertions.assertNull(map.get("id"));
         Assertions.assertNull(map.get("name"));
@@ -50,6 +50,6 @@ public class BasicTests {
 
     @Test
     public void getNotProvided() throws Exception {
-        Assertions.assertEquals("", client.getNotProvidedWithResponse(null, null).getValue().toString());
+        Assertions.assertEquals("", client.getNotProvidedWithResponse(null).getValue().toString());
     }
 }

--- a/protocol-tests/src/test/java/fixtures/bodycomplex/DictionaryTests.java
+++ b/protocol-tests/src/test/java/fixtures/bodycomplex/DictionaryTests.java
@@ -20,7 +20,7 @@ public class DictionaryTests {
 
     @Test
     public void getValid() throws Exception {
-        BinaryData binaryData = client.getValidWithResponse(null, null).getValue();
+        BinaryData binaryData = client.getValidWithResponse(null).getValue();
         Map map = (Map)binaryData.toObject(Map.class).get("defaultProgram");
         Assertions.assertEquals(5, map.size());
         Assertions.assertEquals("", map.get("exe"));
@@ -35,7 +35,7 @@ public class DictionaryTests {
 
     @Test
     public void getEmpty() throws Exception {
-        BinaryData binaryData = client.getEmptyWithResponse(null, null).getValue();
+        BinaryData binaryData = client.getEmptyWithResponse(null).getValue();
         Map map = binaryData.toObject(Map.class);
         Map program = (Map)map.get("defaultProgram");
         Assertions.assertEquals(0, program.size());
@@ -49,14 +49,14 @@ public class DictionaryTests {
 
     @Test
     public void getNull() throws Exception {
-        BinaryData binaryData = client.getNullWithResponse(null, null).getValue();
+        BinaryData binaryData = client.getNullWithResponse(null).getValue();
         Map map = binaryData.toObject(Map.class);
         Assertions.assertNull(map.get("defaultProgram"));
     }
 
     @Test
     public void getNotProvided() throws Exception {
-        BinaryData binaryData = client.getNotProvidedWithResponse(null, null).getValue();
+        BinaryData binaryData = client.getNotProvidedWithResponse(null).getValue();
         Map map = binaryData.toObject(Map.class);
         Assertions.assertEquals(0, map.size());
     }

--- a/protocol-tests/src/test/java/fixtures/bodycomplex/PrimitiveTests.java
+++ b/protocol-tests/src/test/java/fixtures/bodycomplex/PrimitiveTests.java
@@ -20,7 +20,7 @@ public class PrimitiveTests {
 
     @Test
     public void getInt() throws Exception {
-        BinaryData binaryData = client.getIntWithResponse(null, null).getValue();
+        BinaryData binaryData = client.getIntWithResponse(null).getValue();
         Map map = binaryData.toObject(Map.class);
         Assertions.assertEquals(-1, map.get("field1"));
         Assertions.assertEquals(2, map.get("field2"));
@@ -34,7 +34,7 @@ public class PrimitiveTests {
 
     @Test
     public void getLong() throws Exception {
-        BinaryData binaryData = client.getLongWithResponse(null, null).getValue();
+        BinaryData binaryData = client.getLongWithResponse(null).getValue();
         Map map = binaryData.toObject(Map.class);
         Assertions.assertEquals(1099511627775L, map.get("field1"));
         Assertions.assertEquals(-999511627788L, map.get("field2"));
@@ -48,7 +48,7 @@ public class PrimitiveTests {
 
     @Test
     public void getFloat() throws Exception {
-        BinaryData binaryData = client.getFloatWithResponse(null, null).getValue();
+        BinaryData binaryData = client.getFloatWithResponse(null).getValue();
         Map map = binaryData.toObject(Map.class);
         Assertions.assertEquals(1.05, map.get("field1"));
         Assertions.assertEquals(-0.003, map.get("field2"));
@@ -62,7 +62,7 @@ public class PrimitiveTests {
 
     @Test
     public void getDouble() throws Exception {
-        BinaryData binaryData = client.getDoubleWithResponse(null, null).getValue();
+        BinaryData binaryData = client.getDoubleWithResponse(null).getValue();
         Map map = binaryData.toObject(Map.class);
         Assertions.assertEquals(3e-100, map.get("field1"));
         Assertions.assertEquals(-0.000000000000000000000000000000000000000000000000000000005,
@@ -77,7 +77,7 @@ public class PrimitiveTests {
 
     @Test
     public void getBool() throws Exception {
-        BinaryData binaryData = client.getBoolWithResponse(null, null).getValue();
+        BinaryData binaryData = client.getBoolWithResponse(null).getValue();
         Map map = binaryData.toObject(Map.class);
         Assertions.assertEquals(true, map.get("field_true"));
         Assertions.assertEquals(false, map.get("field_false"));
@@ -91,7 +91,7 @@ public class PrimitiveTests {
 
     @Test
     public void getString() throws Exception {
-        BinaryData binaryData = client.getStringWithResponse(null, null).getValue();
+        BinaryData binaryData = client.getStringWithResponse(null).getValue();
         Map map = binaryData.toObject(Map.class);
         Assertions.assertEquals("goodrequest", map.get("field"));
         Assertions.assertEquals("", map.get("empty"));

--- a/protocol-tests/src/test/java/fixtures/bodystring/EnumOperationsTests.java
+++ b/protocol-tests/src/test/java/fixtures/bodystring/EnumOperationsTests.java
@@ -22,29 +22,29 @@ public class EnumOperationsTests {
 
     @Test
     public void getNotExpandable() throws Exception {
-        String result = client.getNotExpandableWithResponse(null, null).getValue();
+        String result = client.getNotExpandableWithResponse(null).getValue();
         Assertions.assertEquals("red color", result);
     }
 
     @Test
     public void putNotExpandable() throws Exception {
-        client.putNotExpandableWithResponse(BinaryData.fromObject("red color"), null, null);
+        client.putNotExpandableWithResponse(BinaryData.fromObject("red color"), null);
     }
 
     @Test
     public void getReferenced() throws Exception {
-        String actual = client.getReferencedWithResponse(null, null).getValue();
+        String actual = client.getReferencedWithResponse(null).getValue();
         Assertions.assertEquals("red color", actual);
     }
 
     @Test
     public void putReferenced() throws Exception {
-        client.putReferencedWithResponse(BinaryData.fromObject("red color"), null, null);
+        client.putReferencedWithResponse(BinaryData.fromObject("red color"), null);
     }
 
     @Test
     public void getReferencedConstant() throws Exception {
-        String res = client.getReferencedConstantWithResponse(null, null).getValue().toString();
+        String res = client.getReferencedConstantWithResponse(null).getValue().toString();
         JsonReader jsonReader = Json.createReader(new StringReader(res));
         JsonObject result = jsonReader.readObject();
         Assertions.assertFalse(result.containsKey("ColorConstant"));
@@ -55,6 +55,6 @@ public class EnumOperationsTests {
         JsonObject farm = Json.createObjectBuilder()
                 .add("ColorConstant", "green-color")
                 .build();
-        client.putReferencedConstantWithResponse(BinaryData.fromString(farm.toString()), null, null);
+        client.putReferencedConstantWithResponse(BinaryData.fromString(farm.toString()), null);
     }
 }

--- a/protocol-tests/src/test/java/fixtures/bodystring/StringOperationsTests.java
+++ b/protocol-tests/src/test/java/fixtures/bodystring/StringOperationsTests.java
@@ -26,14 +26,14 @@ public class StringOperationsTests {
 
     @Test
     public void getNull() throws Exception {
-        String result = client.getNullWithResponse(null, null).getValue().toObject(String.class);
+        String result = client.getNullWithResponse(null).getValue().toObject(String.class);
         Assertions.assertNull(result);
     }
 
     @Test
     public void putNull() throws Exception {
         try {
-            client.putNullWithResponse(null, null).getValue();
+            client.putNullWithResponse(null).getValue();
         } catch (Exception ex) {
             Assertions.assertEquals(IllegalArgumentException.class, ex.getClass());
             Assertions.assertTrue(ex.getMessage().contains("Argument for @BodyParam parameter must be non-null"));
@@ -42,7 +42,7 @@ public class StringOperationsTests {
 
     @Test
     public void getEmpty() throws Exception {
-        String result = client.getEmptyWithResponse(null, null).getValue().toObject(String.class);
+        String result = client.getEmptyWithResponse(null).getValue().toObject(String.class);
         Assertions.assertEquals("", result);
     }
 
@@ -55,31 +55,31 @@ public class StringOperationsTests {
 
     @Test
     public void getMbcs() throws Exception {
-        String result = client.getMbcsWithResponse(null, null).getValue().toObject(String.class);
+        String result = client.getMbcsWithResponse(null).getValue().toObject(String.class);
         String expected = "啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑ\uE7C7ɡ〇〾⿻⺁\uE843䜣\uE864€";
         Assertions.assertEquals(expected, result);
     }
 
     @Test
     public void putMbcs() throws Exception {
-        client.putMbcsWithResponse(null, null).getValue();
+        client.putMbcsWithResponse(null).getValue();
     }
 
     @Test
     public void getWhitespace() throws Exception {
-        String result = client.getWhitespaceWithResponse(null, null).getValue().toObject(String.class);
+        String result = client.getWhitespaceWithResponse(null).getValue().toObject(String.class);
         Assertions.assertEquals("    Now is the time for all good men to come to the aid of their country    ", result);
     }
 
     @Test
     public void putWhitespace() throws Exception {
-        client.putWhitespaceWithResponse(null, null).getValue();
+        client.putWhitespaceWithResponse(null).getValue();
     }
 
     @Test
     public void getNotProvided() throws Exception {
         try {
-            client.getNotProvidedWithResponse(null, null).getValue();
+            client.getNotProvidedWithResponse(null).getValue();
         } catch (Exception ex) {
             Assertions.assertEquals(HttpResponseException.class, ex.getClass());
             Assertions.assertTrue(ex.getMessage().contains("JsonMappingException"));
@@ -88,7 +88,7 @@ public class StringOperationsTests {
 
     @Test
     public void getBase64Encoded() throws Exception {
-        byte[] result = client.getBase64EncodedWithResponse(null, null).getValue();
+        byte[] result = client.getBase64EncodedWithResponse(null).getValue();
         Assertions.assertEquals("a string that gets encoded with base64",
             new String(Base64.getDecoder().decode(unquote(new String(result, StandardCharsets.UTF_8))), StandardCharsets.UTF_8));
     }
@@ -110,14 +110,14 @@ public class StringOperationsTests {
 
     @Test
     public void getBase64UrlEncoded() throws Exception {
-        String result = client.getBase64UrlEncodedWithResponse(null, null).getValue().toObject(String.class);
+        String result = client.getBase64UrlEncodedWithResponse(null).getValue().toObject(String.class);
         Assertions.assertEquals("a string that gets encoded with base64url",
                 new String(Base64Util.decodeURL(result.getBytes(StandardCharsets.UTF_8))));
     }
 
     @Test
     public void getNullBase64UrlEncoded() throws Exception {
-        byte[] result = client.getNullBase64UrlEncodedWithResponse(null, null).getValue().toBytes();
+        byte[] result = client.getNullBase64UrlEncodedWithResponse(null).getValue().toBytes();
         Assertions.assertEquals(0, result.length);
     }
 
@@ -126,7 +126,6 @@ public class StringOperationsTests {
         client.putBase64UrlEncodedWithResponse(
                 BinaryData.fromObject(new String(Base64Util.encodeURLWithoutPadding(
                 "a string that gets encoded with base64url".getBytes(StandardCharsets.UTF_8)))),
-                null,
                 null
         );
     }

--- a/protocol-tests/src/test/java/fixtures/header/HeaderOperationsTests.java
+++ b/protocol-tests/src/test/java/fixtures/header/HeaderOperationsTests.java
@@ -22,12 +22,12 @@ public class HeaderOperationsTests {
     public void paramExistingKey() {
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.addHeader("User-Agent", "overwrite");
-        client.paramExistingKeyWithResponse(requestOptions, null);
+        client.paramExistingKeyWithResponse(requestOptions);
     }
 
     @Test
     public void responseExistingKey() throws Exception {
-        Response<Void> response = client.responseExistingKeyWithResponse(null, null);
+        Response<Void> response = client.responseExistingKeyWithResponse(null);
         Assertions.assertEquals("overwrite", response.getHeaders().getValue("User-Agent"));
     }
 
@@ -40,7 +40,7 @@ public class HeaderOperationsTests {
 
     @Test
     public void responseProtectedKey() throws Exception {
-        Response<Void> response = client.responseProtectedKeyWithResponse(null, null);
+        Response<Void> response = client.responseProtectedKeyWithResponse(null);
         Assertions.assertTrue(response.getHeaders().getValue("Content-Type").contains("text/html"));
     }
 
@@ -48,23 +48,23 @@ public class HeaderOperationsTests {
     public void paramInteger() {
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.addHeader("scenario", "positive").addHeader("value", "1");
-        client.paramIntegerWithResponse(requestOptions, null);
+        client.paramIntegerWithResponse(requestOptions);
 
         requestOptions = new RequestOptions();
         requestOptions.addHeader("scenario", "negative").addHeader("value", "-2");
-        client.paramIntegerWithResponse(requestOptions, null);
+        client.paramIntegerWithResponse(requestOptions);
     }
 
     @Test
     public void responseInteger() throws Exception {
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.addHeader("scenario", "positive");
-        Response<Void> response = client.responseIntegerWithResponse(requestOptions, null);
+        Response<Void> response = client.responseIntegerWithResponse(requestOptions);
         Assertions.assertEquals("1", response.getHeaders().getValue("value"));
 
         requestOptions = new RequestOptions();
         requestOptions.addHeader("scenario", "negative");
-        response = client.responseIntegerWithResponse(requestOptions, null);
+        response = client.responseIntegerWithResponse(requestOptions);
         Assertions.assertEquals("-2", response.getHeaders().getValue("value"));
     }
 
@@ -72,6 +72,6 @@ public class HeaderOperationsTests {
     public void customRequestId() {
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.addHeader("x-ms-client-request-id", "9C4D50EE-2D56-4CD3-8152-34347DC9F2B0");
-        client.customRequestIdWithResponse(requestOptions, null);
+        client.customRequestIdWithResponse(requestOptions);
     }
 }

--- a/protocol-tests/src/test/java/fixtures/httpinfrastructure/HttpClientFailuresTests.java
+++ b/protocol-tests/src/test/java/fixtures/httpinfrastructure/HttpClientFailuresTests.java
@@ -19,7 +19,7 @@ public class HttpClientFailuresTests {
     @Test
     public void head400() throws Exception {
         try {
-            client.head400WithResponse(null, null).getValue();
+            client.head400WithResponse(null).getValue();
             Assertions.fail();
         } catch (HttpResponseException e) {
             Assertions.assertEquals(400, e.getResponse().getStatusCode());
@@ -29,7 +29,7 @@ public class HttpClientFailuresTests {
     @Test
     public void get400() throws Exception {
         try {
-            client.get400WithResponse(null, null).getValue();
+            client.get400WithResponse(null).getValue();
             Assertions.fail();
         } catch (HttpResponseException e) {
             Assertions.assertEquals(400, e.getResponse().getStatusCode());
@@ -39,7 +39,7 @@ public class HttpClientFailuresTests {
     @Test
     public void put400() throws Exception {
         try {
-            client.put400WithResponse(null, null).getValue();
+            client.put400WithResponse(null).getValue();
             Assertions.fail();
         } catch (HttpResponseException e) {
             Assertions.assertEquals(400, e.getResponse().getStatusCode());
@@ -49,7 +49,7 @@ public class HttpClientFailuresTests {
     @Test
     public void patch400() throws Exception {
         try {
-            client.patch400WithResponse(null, null).getValue();
+            client.patch400WithResponse(null).getValue();
             Assertions.fail();
         } catch (HttpResponseException e) {
             Assertions.assertEquals(400, e.getResponse().getStatusCode());
@@ -59,7 +59,7 @@ public class HttpClientFailuresTests {
     @Test
     public void post400() throws Exception {
         try {
-            client.post400WithResponse(null, null).getValue();
+            client.post400WithResponse(null).getValue();
             Assertions.fail();
         } catch (HttpResponseException e) {
             Assertions.assertEquals(400, e.getResponse().getStatusCode());
@@ -69,7 +69,7 @@ public class HttpClientFailuresTests {
     @Test
     public void delete400() throws Exception {
         try {
-            client.delete400WithResponse(null, null).getValue();
+            client.delete400WithResponse(null).getValue();
             Assertions.fail();
         } catch (HttpResponseException e) {
             Assertions.assertEquals(400, e.getResponse().getStatusCode());
@@ -79,7 +79,7 @@ public class HttpClientFailuresTests {
     @Test
     public void head401() throws Exception {
         try {
-            client.head401WithResponse(null, null).getValue();
+            client.head401WithResponse(null).getValue();
             Assertions.fail();
         } catch (HttpResponseException e) {
             Assertions.assertEquals(401, e.getResponse().getStatusCode());
@@ -89,7 +89,7 @@ public class HttpClientFailuresTests {
     @Test
     public void get402() throws Exception {
         try {
-            client.get402WithResponse(null, null).getValue();
+            client.get402WithResponse(null).getValue();
             Assertions.fail();
         } catch (HttpResponseException e) {
             Assertions.assertEquals(402, e.getResponse().getStatusCode());
@@ -99,7 +99,7 @@ public class HttpClientFailuresTests {
     @Test
     public void get403() throws Exception {
         try {
-            client.get403WithResponse(null, null).getValue();
+            client.get403WithResponse(null).getValue();
             Assertions.fail();
         } catch (HttpResponseException e) {
             Assertions.assertEquals(403, e.getResponse().getStatusCode());
@@ -109,7 +109,7 @@ public class HttpClientFailuresTests {
     @Test
     public void put404() throws Exception {
         try {
-            client.put404WithResponse(null, null).getValue();
+            client.put404WithResponse(null).getValue();
             Assertions.fail();
         } catch (HttpResponseException e) {
             Assertions.assertEquals(404, e.getResponse().getStatusCode());

--- a/protocol-tests/src/test/java/fixtures/llcupdate/LLCUpdateTests.java
+++ b/protocol-tests/src/test/java/fixtures/llcupdate/LLCUpdateTests.java
@@ -31,7 +31,7 @@ public class LLCUpdateTests {
         requestOptions.addHeader("parameter2", "2");
         requestOptions.addHeader("parameter3", "3");
 
-        client.getRequiredWithResponse(requestOptions, null);
-        client2.getRequiredWithResponse(requestOptions, null);
+        client.getRequiredWithResponse(requestOptions);
+        client2.getRequiredWithResponse(requestOptions);
     }
 }

--- a/protocol-tests/src/test/java/fixtures/lro/LROsTests.java
+++ b/protocol-tests/src/test/java/fixtures/lro/LROsTests.java
@@ -27,7 +27,7 @@ public class LROsTests {
     public void beginPut200Succeeded() throws Exception {
         RequestOptions requestOptions = new RequestOptions()
                 .setBody(BinaryData.fromString("{\"location\": \"West US\"}"));
-        SyncPoller<BinaryData, BinaryData> poller =  client.beginPut200Succeeded(requestOptions, Context.NONE);
+        SyncPoller<BinaryData, BinaryData> poller =  client.beginPut200Succeeded(requestOptions);
         PollResponse<BinaryData> pollResponse = poller.waitForCompletion();
         Assertions.assertEquals(LongRunningOperationStatus.SUCCESSFULLY_COMPLETED, pollResponse.getStatus());
         Assertions.assertTrue(poller.getFinalResult().toString().contains("\"provisioningState\": \"Succeeded\""));

--- a/protocol-tests/src/test/java/fixtures/mediatypes/MediaTypesTests.java
+++ b/protocol-tests/src/test/java/fixtures/mediatypes/MediaTypesTests.java
@@ -21,7 +21,7 @@ public class MediaTypesTests {
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.addHeader("Content-Type", "application/json");
         requestOptions.setBody(BinaryData.fromString("{\"source\": \"source\"}"));
-        client.analyzeBodyWithResponse(requestOptions, null);
+        client.analyzeBodyWithResponse(requestOptions);
     }
 
     @Test
@@ -30,6 +30,6 @@ public class MediaTypesTests {
         requestOptions.addHeader("Content-Type", "application/pdf");
         requestOptions.addHeader("Content-Length", "3");
         requestOptions.setBody(BinaryData.fromString("PDF"));
-        client.analyzeBodyWithResponse(requestOptions, null);
+        client.analyzeBodyWithResponse(requestOptions);
     }
 }

--- a/protocol-tests/src/test/java/fixtures/paging/PagingTests.java
+++ b/protocol-tests/src/test/java/fixtures/paging/PagingTests.java
@@ -29,27 +29,27 @@ public class PagingTests {
 
     @Test
     public void getSinglePages() {
-        PagedIterable<BinaryData> response = client.getSinglePages(null, Context.NONE);
+        PagedIterable<BinaryData> response = client.getSinglePages(null);
         Assertions.assertEquals(1, response.stream().count());
     }
 
     @Test
     public void getMultiplePages() {
-        PagedIterable<BinaryData> response = client.getMultiplePages(null, Context.NONE);
+        PagedIterable<BinaryData> response = client.getMultiplePages(null);
         List<BinaryData> list = response.stream().collect(Collectors.toList());
         Assertions.assertEquals(10, list.size());
     }
 
     @Test
     public void getOdataMultiplePages() {
-        PagedIterable<BinaryData> response = client.getOdataMultiplePages(null, Context.NONE);
+        PagedIterable<BinaryData> response = client.getOdataMultiplePages(null);
         List<BinaryData> list = response.stream().collect(Collectors.toList());
         Assertions.assertEquals(10, list.size());
     }
 
     @Test
     public void getMultiplePagesWithOffset() throws Exception {
-        PagedIterable<BinaryData> response = client.getMultiplePagesWithOffset(100, null, Context.NONE);
+        PagedIterable<BinaryData> response = client.getMultiplePagesWithOffset(100, null);
         List<BinaryData> list = response.stream().collect(Collectors.toList());
         Assertions.assertEquals(10, list.size());
         Assertions.assertEquals("{\"properties\":{\"id\":110,\"name\":\"product\"}}", list.get(list.size() - 1).toString());
@@ -70,14 +70,14 @@ public class PagingTests {
 
     @Test
     public void getMultiplePagesRetryFirst() throws Exception {
-        PagedIterable<BinaryData> response = client.getMultiplePagesRetryFirst(null, Context.NONE);
+        PagedIterable<BinaryData> response = client.getMultiplePagesRetryFirst(null);
         List<BinaryData> list = response.stream().collect(Collectors.toList());
         Assertions.assertEquals(10, list.size());
     }
 
     @Test
     public void getMultiplePagesRetrySecond() throws Exception {
-        PagedIterable<BinaryData> response = client.getMultiplePagesRetrySecond(null, Context.NONE);
+        PagedIterable<BinaryData> response = client.getMultiplePagesRetrySecond(null);
         List<BinaryData> list = response.stream().collect(Collectors.toList());
         Assertions.assertEquals(10, list.size());
     }
@@ -85,7 +85,7 @@ public class PagingTests {
     @Test
     public void getSinglePagesFailure() throws Exception {
         try {
-            PagedIterable<BinaryData> response  = client.getSinglePagesFailure(null, Context.NONE);
+            PagedIterable<BinaryData> response  = client.getSinglePagesFailure(null);
             List<BinaryData> list = response.stream().collect(Collectors.toList());
             Assertions.fail();
         } catch (HttpResponseException ex) {
@@ -96,7 +96,7 @@ public class PagingTests {
     @Test
     public void getMultiplePagesFailure() throws Exception {
         try {
-            List<BinaryData> list = client.getMultiplePagesFailure(null, Context.NONE).stream().collect(Collectors.toList());
+            List<BinaryData> list = client.getMultiplePagesFailure(null).stream().collect(Collectors.toList());
             Assertions.fail();
         } catch (HttpResponseException ex) {
             Assertions.assertNotNull(ex.getResponse());
@@ -106,7 +106,7 @@ public class PagingTests {
     @Test
     public void getMultiplePagesFailureUri() {
         try {
-            client.getMultiplePagesFailureUri(null, Context.NONE).stream().collect(Collectors.toList());
+            client.getMultiplePagesFailureUri(null).stream().collect(Collectors.toList());
             Assertions.fail();
         } catch (Exception e) {
             Assertions.assertTrue(e instanceof HttpResponseException);
@@ -119,7 +119,7 @@ public class PagingTests {
     public void getMultiplePagesFragmentNextLink() throws Exception {
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.addQueryParam("api_version", "1.6");
-        PagedIterable<BinaryData> response = client.getMultiplePagesFragmentNextLink("test_user", requestOptions, Context.NONE);
+        PagedIterable<BinaryData> response = client.getMultiplePagesFragmentNextLink("test_user", requestOptions);
         Assertions.assertEquals(10, response.stream().count());
     }
 
@@ -127,19 +127,19 @@ public class PagingTests {
     public void getMultiplePagesFragmentWithGroupingNextLink() throws Exception {
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.addQueryParam("api_version", "1.6");
-        PagedIterable<BinaryData> response = client.getMultiplePagesFragmentWithGroupingNextLink("test_user", requestOptions, Context.NONE);
+        PagedIterable<BinaryData> response = client.getMultiplePagesFragmentWithGroupingNextLink("test_user", requestOptions);
         Assertions.assertEquals(10, response.stream().count());
     }
 
     @Test
     public void getNoItemNamePages() {
-        long count = client.getNoItemNamePages(null, Context.NONE).stream().count();
+        long count = client.getNoItemNamePages(null).stream().count();
         Assertions.assertEquals(1, count);
     }
 
     @Test
     public void getNullNextLinkNamePages() {
-        long count = client.getNullNextLinkNamePages(null, Context.NONE).stream().count();
+        long count = client.getNullNextLinkNamePages(null).stream().count();
         Assertions.assertEquals(1, count);
     }
 
@@ -147,19 +147,19 @@ public class PagingTests {
     public void getWithQueryParams() {
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.addQueryParam("requiredQueryParameter", "100").addQueryParam("queryConstant", "true");
-        long count = client.getWithQueryParams(requestOptions, Context.NONE).stream().count();
+        long count = client.getWithQueryParams(requestOptions).stream().count();
         Assertions.assertEquals(2, count);
     }
 
     @Test
     public void getPagingModelWithItemNameWithXMSClientName() {
-        long count = client.getPagingModelWithItemNameWithXMSClientName(null, Context.NONE).stream().count();
+        long count = client.getPagingModelWithItemNameWithXMSClientName(null).stream().count();
         Assertions.assertEquals(1, count);
     }
 
     @Test
     public void firstResponseEmpty() {
-        long count = client.firstResponseEmpty(null, Context.NONE).stream().count();
+        long count = client.firstResponseEmpty(null).stream().count();
         Assertions.assertEquals(1, count);
     }
 }

--- a/protocol-tests/src/test/java/fixtures/url/PathItemsTests.java
+++ b/protocol-tests/src/test/java/fixtures/url/PathItemsTests.java
@@ -23,7 +23,7 @@ public class PathItemsTests {
         requestOptions.addQueryParam("globalStringQuery", "globalStringQuery");
         requestOptions.addQueryParam("pathItemStringQuery", "pathItemStringQuery");
         requestOptions.addQueryParam("localStringQuery", "localStringQuery");
-        client.getAllWithValuesWithResponse("pathItemStringPath", "localStringPath", requestOptions, null);
+        client.getAllWithValuesWithResponse("pathItemStringPath", "localStringPath", requestOptions);
     }
 
     @Test
@@ -31,20 +31,20 @@ public class PathItemsTests {
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.addQueryParam("pathItemStringQuery", "pathItemStringQuery");
         requestOptions.addQueryParam("localStringQuery", "localStringQuery");
-        client.getGlobalQueryNullWithResponse("pathItemStringPath", "localStringPath", requestOptions, null);
+        client.getGlobalQueryNullWithResponse("pathItemStringPath", "localStringPath", requestOptions);
     }
 
     @Test
     public void getGlobalAndLocalQueryNull() {
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.addQueryParam("pathItemStringQuery", "pathItemStringQuery");
-        client.getGlobalAndLocalQueryNullWithResponse("pathItemStringPath", "localStringPath", requestOptions, null);
+        client.getGlobalAndLocalQueryNullWithResponse("pathItemStringPath", "localStringPath", requestOptions);
     }
 
     @Test
     public void getLocalPathItemQueryNull() {
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.addQueryParam("globalStringQuery", "globalStringQuery");
-        client.getLocalPathItemQueryNullWithResponse("pathItemStringPath", "localStringPath", requestOptions, null);
+        client.getLocalPathItemQueryNullWithResponse("pathItemStringPath", "localStringPath", requestOptions);
     }
 }

--- a/protocol-tests/src/test/java/fixtures/url/PathsTests.java
+++ b/protocol-tests/src/test/java/fixtures/url/PathsTests.java
@@ -27,78 +27,78 @@ public class PathsTests {
 
     @Test
     public void getBooleanTrue() {
-        client.getBooleanTrueWithResponse(null, null);
+        client.getBooleanTrueWithResponse(null);
     }
 
     @Test
     public void getBooleanFalse() {
-        client.getBooleanTrueWithResponse(null, null);
+        client.getBooleanTrueWithResponse(null);
     }
 
     @Test
     public void getIntOneMillion() {
-        client.getIntOneMillionWithResponse(null, null);
+        client.getIntOneMillionWithResponse(null);
     }
 
     @Test
     public void getIntNegativeOneMillion() {
-        client.getIntNegativeOneMillionWithResponse(null, null).getValue();
+        client.getIntNegativeOneMillionWithResponse(null).getValue();
     }
 
     @Test
     public void getTenBillion() {
-        client.getTenBillionWithResponse(null, null);
+        client.getTenBillionWithResponse(null);
     }
 
     @Test
     public void getNegativeTenBillion() {
-        client.getNegativeTenBillionWithResponse(null, null);
+        client.getNegativeTenBillionWithResponse(null);
     }
 
     @Test
     public void floatScientificPositive() {
-        client.floatScientificPositiveWithResponse(null, null);
+        client.floatScientificPositiveWithResponse(null);
     }
 
     @Test
     public void floatScientificNegative() {
-        client.floatScientificNegativeWithResponse(null, null);
+        client.floatScientificNegativeWithResponse(null);
     }
 
     @Test
     public void doubleDecimalPositive() {
-        client.doubleDecimalPositiveWithResponse(null, null);
+        client.doubleDecimalPositiveWithResponse(null);
     }
 
     @Test
     public void doubleDecimalNegative() {
-        client.doubleDecimalNegativeWithResponse(null, null);
+        client.doubleDecimalNegativeWithResponse(null);
     }
 
     @Test
     public void stringUnicode() {
-        client.stringUnicodeWithResponse(null, null);
+        client.stringUnicodeWithResponse(null);
     }
 
     @Test
     public void stringUrlEncoded() {
-        client.stringUrlEncodedWithResponse(null, null);
+        client.stringUrlEncodedWithResponse(null);
     }
 
     @Test
     public void stringUrlNonEncoded() {
-        client.stringUrlNonEncodedWithResponse(null, null);
+        client.stringUrlNonEncodedWithResponse(null);
     }
 
     @Test
     public void stringEmpty() {
-        client.stringEmptyWithResponse(null, null);
+        client.stringEmptyWithResponse(null);
     }
 
     @Test
     public void stringNull() {
         try {
-            client.stringNullWithResponse(null, null, null);
+            client.stringNullWithResponse(null, null);
         } catch (HttpResponseException e) {
             Assertions.assertEquals(404, e.getResponse().getStatusCode());
         }
@@ -106,13 +106,13 @@ public class PathsTests {
 
     @Test
     public void enumValid() {
-        client.enumValidWithResponse("green color", null, null);
+        client.enumValidWithResponse("green color", null);
     }
 
     @Test
     public void enumNull() {
         try {
-            client.enumNullWithResponse(null, null, null);
+            client.enumNullWithResponse(null, null);
         } catch (HttpResponseException e) {
             Assertions.assertEquals(404, e.getResponse().getStatusCode());
         }
@@ -120,18 +120,18 @@ public class PathsTests {
 
     @Test
     public void byteMultiByte() {
-        client.byteMultiByteWithResponse(Base64Util.encodeToString("啊齄丂狛狜隣郎隣兀﨩".getBytes(StandardCharsets.UTF_8)), null, null);
+        client.byteMultiByteWithResponse(Base64Util.encodeToString("啊齄丂狛狜隣郎隣兀﨩".getBytes(StandardCharsets.UTF_8)), null);
     }
 
     @Test
     public void byteEmpty() {
-        client.byteEmptyWithResponse(null, null).getValue();
+        client.byteEmptyWithResponse(null).getValue();
     }
 
     @Test
     public void byteNull() {
         try {
-            client.byteNullWithResponse(null, null, null);
+            client.byteNullWithResponse(null, null);
         } catch (HttpResponseException e) {
             Assertions.assertEquals(404, e.getResponse().getStatusCode());
         }
@@ -139,13 +139,13 @@ public class PathsTests {
 
     @Test
     public void dateValid() {
-        client.dateValidWithResponse(null, null).getValue();
+        client.dateValidWithResponse(null).getValue();
     }
 
     @Test
     public void dateNull() {
         try {
-            client.dateNullWithResponse(null, null, null);
+            client.dateNullWithResponse(null, null);
         } catch (HttpResponseException e) {
             Assertions.assertEquals(404, e.getResponse().getStatusCode());
         }
@@ -153,13 +153,13 @@ public class PathsTests {
 
     @Test
     public void dateTimeValid() {
-        client.dateTimeValidWithResponse(null, null).getValue();
+        client.dateTimeValidWithResponse(null).getValue();
     }
 
     @Test
     public void dateTimeNull() {
         try {
-            client.dateTimeNullWithResponse(null, null, null);
+            client.dateTimeNullWithResponse(null, null);
         } catch (HttpResponseException e) {
             Assertions.assertEquals(404, e.getResponse().getStatusCode());
         }
@@ -167,7 +167,7 @@ public class PathsTests {
 
     @Test
     public void base64Url() {
-        client.base64UrlWithResponse(Base64Url.encode("lorem".getBytes(StandardCharsets.UTF_8)).toString(), null, null);
+        client.base64UrlWithResponse(Base64Url.encode("lorem".getBytes(StandardCharsets.UTF_8)).toString(), null);
     }
 
     @Test
@@ -179,11 +179,11 @@ public class PathsTests {
         list.add(null);
         list.add("");
         String path = JacksonAdapter.createDefaultSerializerAdapter().serializeList(list, CollectionFormat.CSV);
-        client.arrayCsvInPathWithResponse(path, null, null);
+        client.arrayCsvInPathWithResponse(path, null);
     }
 
     @Test
     public void unixTimeUrl() {
-        client.unixTimeUrlWithResponse(1460505600, null, null);
+        client.unixTimeUrlWithResponse(1460505600, null);
     }
 }

--- a/protocol-tests/src/test/java/fixtures/url/QueriesTests.java
+++ b/protocol-tests/src/test/java/fixtures/url/QueriesTests.java
@@ -27,176 +27,176 @@ public class QueriesTests {
     public void getBooleanTrue() {
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.addQueryParam("boolQuery", "true");
-        client.getBooleanTrueWithResponse(requestOptions, null);
+        client.getBooleanTrueWithResponse(requestOptions);
     }
 
     @Test
     public void getBooleanFalse() {
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.addQueryParam("boolQuery", "false");
-        client.getBooleanFalseWithResponse(requestOptions, null);
+        client.getBooleanFalseWithResponse(requestOptions);
     }
 
     @Test
     public void getBooleanNull() {
-        client.getBooleanNullWithResponse(null, null);
+        client.getBooleanNullWithResponse(null);
     }
 
     @Test
     public void getIntOneMillion() {
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.addQueryParam("intQuery", "1000000");
-        client.getIntOneMillionWithResponse(requestOptions, null);
+        client.getIntOneMillionWithResponse(requestOptions);
     }
 
     @Test
     public void getIntNegativeOneMillion() {
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.addQueryParam("intQuery", "-1000000");
-        client.getIntNegativeOneMillionWithResponse(requestOptions, null);
+        client.getIntNegativeOneMillionWithResponse(requestOptions);
     }
 
     @Test
     public void getIntNull() {
-        client.getIntNullWithResponse(null, null);
+        client.getIntNullWithResponse(null);
     }
 
     @Test
     public void getTenBillion() {
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.addQueryParam("longQuery", "10000000000");
-        client.getTenBillionWithResponse(requestOptions, null);
+        client.getTenBillionWithResponse(requestOptions);
     }
 
     @Test
     public void getNegativeTenBillion() {
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.addQueryParam("longQuery", "-10000000000");
-        client.getNegativeTenBillionWithResponse(requestOptions, null);
+        client.getNegativeTenBillionWithResponse(requestOptions);
     }
 
     @Test
     public void getLongNull() {
-        client.getLongNullWithResponse(null, null);
+        client.getLongNullWithResponse(null);
     }
 
     @Test
     public void floatScientificPositive() {
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.addQueryParam("floatQuery", "1.034E+20");
-        client.floatScientificPositiveWithResponse(requestOptions, null);
+        client.floatScientificPositiveWithResponse(requestOptions);
     }
 
     @Test
     public void floatScientificNegative() {
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.addQueryParam("floatQuery", "-1.034E-20");
-        client.floatScientificNegativeWithResponse(requestOptions, null);
+        client.floatScientificNegativeWithResponse(requestOptions);
     }
 
     @Test
     public void floatNull() {
-        client.floatNullWithResponse(null, null);
+        client.floatNullWithResponse(null);
     }
 
     @Test
     public void doubleDecimalPositive() {
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.addQueryParam("doubleQuery", "9999999.999");
-        client.doubleDecimalPositiveWithResponse(requestOptions, null);
+        client.doubleDecimalPositiveWithResponse(requestOptions);
     }
 
     @Test
     public void doubleDecimalNegative() {
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.addQueryParam("doubleQuery", "-9999999.999");
-        client.doubleDecimalNegativeWithResponse(requestOptions, null);
+        client.doubleDecimalNegativeWithResponse(requestOptions);
     }
 
     @Test
     public void doubleNull() {
-        client.doubleNullWithResponse(null, null);
+        client.doubleNullWithResponse(null);
     }
 
     @Test
     public void stringUnicode() {
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.addQueryParam("stringQuery", "啊齄丂狛狜隣郎隣兀﨩");
-        client.stringUnicodeWithResponse(requestOptions, null);
+        client.stringUnicodeWithResponse(requestOptions);
     }
 
     @Test
     public void stringUrlEncoded() {
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.addQueryParam("stringQuery", "begin!*'();:@ &=+$,/?#[]end");
-        client.stringUrlEncodedWithResponse(requestOptions, null);
+        client.stringUrlEncodedWithResponse(requestOptions);
     }
 
     @Test
     public void stringEmpty() {
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.addQueryParam("stringQuery", "");
-        client.stringEmptyWithResponse(requestOptions, null);
+        client.stringEmptyWithResponse(requestOptions);
     }
 
     @Test
     public void stringNull() {
-        client.stringNullWithResponse(null, null);
+        client.stringNullWithResponse(null);
     }
 
     @Test
     public void enumValid() {
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.addQueryParam("enumQuery", "green color");
-        client.enumValidWithResponse(requestOptions, null);
+        client.enumValidWithResponse(requestOptions);
     }
 
     @Test
     public void enumNull() {
-        client.enumNullWithResponse(null, null);
+        client.enumNullWithResponse(null);
     }
 
     @Test
     public void byteMultiByte() {
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.addQueryParam("byteQuery", Base64Util.encodeToString("啊齄丂狛狜隣郎隣兀﨩".getBytes(StandardCharsets.UTF_8)));
-        client.byteMultiByteWithResponse(requestOptions, null);
+        client.byteMultiByteWithResponse(requestOptions);
     }
 
     @Test
     public void byteEmpty() {
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.addQueryParam("byteQuery", "");
-        client.byteEmptyWithResponse(requestOptions, null);
+        client.byteEmptyWithResponse(requestOptions);
     }
 
     @Test
     public void byteNull() {
-        client.byteNullWithResponse(null, null);
+        client.byteNullWithResponse(null);
     }
 
     @Test
     public void dateValid() {
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.addQueryParam("dateQuery", "2012-01-01");
-        client.dateValidWithResponse(requestOptions, null);
+        client.dateValidWithResponse(requestOptions);
     }
 
     @Test
     public void dateNull() {
-        client.dateNullWithResponse(null, null);
+        client.dateNullWithResponse(null);
     }
 
     @Test
     public void dateTimeValid() {
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.addQueryParam("dateTimeQuery", "2012-01-01T01:01:01Z");
-        client.dateTimeValidWithResponse(requestOptions, null);
+        client.dateTimeValidWithResponse(requestOptions);
     }
 
     @Test
     public void dateTimeNull() {
-        client.dateTimeNullWithResponse(null, null);
+        client.dateTimeNullWithResponse(null);
     }
 
     @Test
@@ -209,12 +209,12 @@ public class QueriesTests {
         list.add("");
         String query = JacksonAdapter.createDefaultSerializerAdapter().serializeList(list, CollectionFormat.CSV);
         requestOptions.addQueryParam("arrayQuery", query);
-        client.arrayStringCsvValidWithResponse(requestOptions, null);
+        client.arrayStringCsvValidWithResponse(requestOptions);
     }
 
     @Test
     public void arrayStringCsvNull() {
-        client.arrayStringCsvNullWithResponse(null, null);
+        client.arrayStringCsvNullWithResponse(null);
     }
 
     @Test
@@ -222,7 +222,7 @@ public class QueriesTests {
         RequestOptions requestOptions = new RequestOptions();
         String query = JacksonAdapter.createDefaultSerializerAdapter().serializeList(Collections.emptyList(), CollectionFormat.CSV);
         requestOptions.addQueryParam("arrayQuery", query);
-        client.arrayStringCsvEmptyWithResponse(requestOptions, null);
+        client.arrayStringCsvEmptyWithResponse(requestOptions);
     }
 
     @Test
@@ -235,7 +235,7 @@ public class QueriesTests {
         list.add("");
         String query = JacksonAdapter.createDefaultSerializerAdapter().serializeList(list, CollectionFormat.SSV);
         requestOptions.addQueryParam("arrayQuery", query);
-        client.arrayStringSsvValidWithResponse(requestOptions, null);
+        client.arrayStringSsvValidWithResponse(requestOptions);
     }
 
     @Test
@@ -248,7 +248,7 @@ public class QueriesTests {
         list.add("");
         String query = JacksonAdapter.createDefaultSerializerAdapter().serializeList(list, CollectionFormat.TSV);
         requestOptions.addQueryParam("arrayQuery", query);
-        client.arrayStringTsvValidWithResponse(requestOptions, null);
+        client.arrayStringTsvValidWithResponse(requestOptions);
     }
 
     @Test
@@ -261,6 +261,6 @@ public class QueriesTests {
         list.add("");
         String query = JacksonAdapter.createDefaultSerializerAdapter().serializeList(list, CollectionFormat.PIPES);
         requestOptions.addQueryParam("arrayQuery", query);
-        client.arrayStringPipesValidWithResponse(requestOptions, null);
+        client.arrayStringPipesValidWithResponse(requestOptions);
     }
 }


### PR DESCRIPTION
azure-core will add `setContext` to `RequestOptions`, hence the `context` parameter here on sync method will be redundent.

fix https://github.com/Azure/autorest.java/issues/1240