### PR TITLE
Use JacksonXmlText when Swagger Contains x-ms-text: true in XML Section

### DIFF
--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/XmlSerlializationFormat.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/XmlSerlializationFormat.java
@@ -2,23 +2,23 @@
 package com.azure.autorest.extension.base.model.codemodel;
 
 
+import java.util.Objects;
+
 public class XmlSerlializationFormat extends SerializationFormat {
 
     private String name;
     private String namespace;
     private String prefix;
     /**
-     * 
      * (Required)
-     * 
      */
     private boolean attribute;
     /**
-     * 
      * (Required)
-     * 
      */
     private boolean wrapped;
+
+    private boolean text;
 
     public String getName() {
         return name;
@@ -45,39 +45,39 @@ public class XmlSerlializationFormat extends SerializationFormat {
     }
 
     /**
-     * 
      * (Required)
-     * 
      */
     public boolean isAttribute() {
         return attribute;
     }
 
     /**
-     * 
      * (Required)
-     * 
      */
     public void setAttribute(boolean attribute) {
         this.attribute = attribute;
     }
 
     /**
-     * 
      * (Required)
-     * 
      */
     public boolean isWrapped() {
         return wrapped;
     }
 
     /**
-     * 
      * (Required)
-     * 
      */
     public void setWrapped(boolean wrapped) {
         this.wrapped = wrapped;
+    }
+
+    public boolean isText() {
+        return text;
+    }
+
+    public void setText(boolean text) {
+        this.text = text;
     }
 
     @Override
@@ -86,15 +86,15 @@ public class XmlSerlializationFormat extends SerializationFormat {
         sb.append(XmlSerlializationFormat.class.getName()).append('@').append(Integer.toHexString(System.identityHashCode(this))).append('[');
         sb.append("name");
         sb.append('=');
-        sb.append(((this.name == null)?"<null>":this.name));
+        sb.append(((this.name == null) ? "<null>" : this.name));
         sb.append(',');
         sb.append("namespace");
         sb.append('=');
-        sb.append(((this.namespace == null)?"<null>":this.namespace));
+        sb.append(((this.namespace == null) ? "<null>" : this.namespace));
         sb.append(',');
         sb.append("prefix");
         sb.append('=');
-        sb.append(((this.prefix == null)?"<null>":this.prefix));
+        sb.append(((this.prefix == null) ? "<null>" : this.prefix));
         sb.append(',');
         sb.append("attribute");
         sb.append('=');
@@ -104,8 +104,10 @@ public class XmlSerlializationFormat extends SerializationFormat {
         sb.append('=');
         sb.append(this.wrapped);
         sb.append(',');
-        if (sb.charAt((sb.length()- 1)) == ',') {
-            sb.setCharAt((sb.length()- 1), ']');
+        sb.append("text");
+        sb.append(this.text);
+        if (sb.charAt((sb.length() - 1)) == ',') {
+            sb.setCharAt((sb.length() - 1), ']');
         } else {
             sb.append(']');
         }
@@ -115,11 +117,12 @@ public class XmlSerlializationFormat extends SerializationFormat {
     @Override
     public int hashCode() {
         int result = 1;
-        result = ((result* 31)+((this.name == null)? 0 :this.name.hashCode()));
-        result = ((result* 31)+((this.namespace == null)? 0 :this.namespace.hashCode()));
-        result = ((result* 31)+(this.attribute? 1 : 0));
-        result = ((result* 31)+(this.wrapped? 1 : 0));
-        result = ((result* 31)+((this.prefix == null)? 0 :this.prefix.hashCode()));
+        result = ((result * 31) + ((this.name == null) ? 0 : this.name.hashCode()));
+        result = ((result * 31) + ((this.namespace == null) ? 0 : this.namespace.hashCode()));
+        result = ((result * 31) + (this.attribute ? 1 : 0));
+        result = ((result * 31) + (this.wrapped ? 1 : 0));
+        result = ((result * 31) + ((this.prefix == null) ? 0 : this.prefix.hashCode()));
+        result = ((result * 31) + (this.text ? 1 : 0));
         return result;
     }
 
@@ -128,11 +131,16 @@ public class XmlSerlializationFormat extends SerializationFormat {
         if (other == this) {
             return true;
         }
-        if ((other instanceof XmlSerlializationFormat) == false) {
+        if (!(other instanceof XmlSerlializationFormat)) {
             return false;
         }
         XmlSerlializationFormat rhs = ((XmlSerlializationFormat) other);
-        return ((((((this.name == rhs.name)||((this.name!= null)&&this.name.equals(rhs.name)))&&((this.namespace == rhs.namespace)||((this.namespace!= null)&&this.namespace.equals(rhs.namespace))))&&(this.attribute == rhs.attribute))&&(this.wrapped == rhs.wrapped))&&((this.prefix == rhs.prefix)||((this.prefix!= null)&&this.prefix.equals(rhs.prefix))));
+        return Objects.equals(this.name, rhs.name)
+            && Objects.equals(this.namespace, rhs.namespace)
+            && this.attribute == rhs.attribute
+            && this.wrapped == rhs.wrapped
+            && Objects.equals(this.prefix, rhs.prefix)
+            && this.text == rhs.text;
     }
 
 }

--- a/generate
+++ b/generate
@@ -55,6 +55,7 @@ autorest $VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/discriminator-fla
 autorest $VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/discriminator-flattening.json --namespace=fixtures.inheritance.passdiscriminator --pass-discriminator-to-child-deserialization=true
 autorest $VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/client-default-value.json --namespace=fixtures.clientdefaultvalue --pipeline.modelerfour.flatten-models=false
 autorest $VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/client-default-value.json --namespace=fixtures.annotatedgettersandsetters --annotate-getters-and-setters-for-serialization=true
+autorest $VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/xml-tag-with-attribute-and-value.json --namespace=fixtures.complexxmltag --enable-xml
 
 # Azure
 autorest $AZURE_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/$TEST_SERVER_COMMIT/swagger/paging.json --namespace=fixtures.paging --payload-flattening-threshold=1

--- a/generate.bat
+++ b/generate.bat
@@ -52,6 +52,7 @@ call autorest %VANILLA_ARGUMENTS% --input-file=vanilla-tests/swagger/client-defa
 call autorest %VANILLA_ARGUMENTS% --input-file=vanilla-tests/swagger/discriminator-flattening.json --namespace=fixtures.inheritance.donotpassdiscriminator
 call autorest %VANILLA_ARGUMENTS% --input-file=vanilla-tests/swagger/discriminator-flattening.json --namespace=fixtures.inheritance.passdiscriminator --pass-discriminator-to-child-deserialization=true
 call autorest %VANILLA_ARGUMENTS% --input-file=vanilla-tests/swagger/client-default-value.json --namespace=fixtures.annotatedgettersandsetters --annotate-getters-and-setters-for-serialization=true
+call autorest %VANILLA_ARGUMENTS% --input-file=vanilla-tests/swagger/xml-tag-with-attribute-and-value.json --namespace=fixtures.complexxmltag --enable-xml
 
 rem Azure
 call autorest %AZURE_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/%TEST_SERVER_COMMIT%/swagger/paging.json --namespace=fixtures.paging --payload-flattening-threshold=1

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMapper.java
@@ -27,6 +27,11 @@ import com.azure.autorest.model.clientmodel.XmlSequenceWrapper;
 import com.azure.autorest.util.CodeNamer;
 import com.azure.autorest.util.SchemaUtil;
 import com.azure.core.util.CoreUtils;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlText;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -216,10 +221,11 @@ public class ClientMapper implements IMapper<CodeModel, Client> {
                             xmlSequenceWrapper -> xmlSequenceWrapper.getXmlListElementName().equals(xmlListElementName)
                                 && xmlSequenceWrapper.getXmlRootElementName().equals(xmlRootElementName))) {
                             Set<String> packageImports = new HashSet<>();
-                            packageImports.add("com.fasterxml.jackson.annotation.JsonCreator");
-                            packageImports.add("com.fasterxml.jackson.annotation.JsonProperty");
-                            packageImports.add("com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty");
-                            packageImports.add("com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement");
+                            packageImports.add(JsonCreator.class.getName());
+                            packageImports.add(JsonProperty.class.getName());
+                            packageImports.add(JacksonXmlProperty.class.getName());
+                            packageImports.add(JacksonXmlRootElement.class.getName());
+                            packageImports.add(JacksonXmlText.class.getName());
 
                             type.addImportsTo(packageImports, true);
                             boolean isCustomType = settings

--- a/javagen/src/main/java/com/azure/autorest/mapper/ModelPropertyMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ModelPropertyMapper.java
@@ -102,18 +102,21 @@ public class ModelPropertyMapper implements IMapper<Property, ClientModelPropert
         String xmlNamespace = null;
         boolean isXmlWrapper = false;
         boolean isXmlAttribute = false;
+        boolean isXmlText = false;
         if (xmlSerlializationFormat != null) {
             isXmlWrapper = xmlSerlializationFormat.isWrapped();
             isXmlAttribute = xmlSerlializationFormat.isAttribute();
             xmlName = xmlSerlializationFormat.getName();
             xmlNamespace = xmlSerlializationFormat.getNamespace();
+            isXmlText = xmlSerlializationFormat.isText();
         }
 
         final String xmlParamName = xmlName == null ? serializedName.toString() : xmlName;
         builder.xmlName(xmlParamName)
                 .isXmlWrapper(isXmlWrapper)
                 .isXmlAttribute(isXmlAttribute)
-                .xmlNamespace(xmlNamespace);
+                .xmlNamespace(xmlNamespace)
+                .isXmlText(isXmlText);
 
         List<String> annotationArgumentList = new ArrayList<String>() {{
             add(String.format("value = \"%s\"", xmlParamName));

--- a/vanilla-tests/src/main/java/fixtures/complexxmltag/DefaultValueClient.java
+++ b/vanilla-tests/src/main/java/fixtures/complexxmltag/DefaultValueClient.java
@@ -1,0 +1,65 @@
+package fixtures.complexxmltag;
+
+import com.azure.core.http.HttpPipeline;
+import com.azure.core.http.HttpPipelineBuilder;
+import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.RetryPolicy;
+import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
+
+/** Initializes a new instance of the DefaultValueClient type. */
+public final class DefaultValueClient {
+    /** The HTTP pipeline to send requests through. */
+    private final HttpPipeline httpPipeline;
+
+    /**
+     * Gets The HTTP pipeline to send requests through.
+     *
+     * @return the httpPipeline value.
+     */
+    public HttpPipeline getHttpPipeline() {
+        return this.httpPipeline;
+    }
+
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
+    /** Initializes an instance of DefaultValueClient client. */
+    DefaultValueClient() {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                JacksonAdapter.createDefaultSerializerAdapter());
+    }
+
+    /**
+     * Initializes an instance of DefaultValueClient client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     */
+    DefaultValueClient(HttpPipeline httpPipeline) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter());
+    }
+
+    /**
+     * Initializes an instance of DefaultValueClient client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     */
+    DefaultValueClient(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter) {
+        this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/complexxmltag/DefaultValueClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/complexxmltag/DefaultValueClientBuilder.java
@@ -1,0 +1,219 @@
+package fixtures.complexxmltag;
+
+import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
+import com.azure.core.http.HttpHeaders;
+import com.azure.core.http.HttpPipeline;
+import com.azure.core.http.HttpPipelineBuilder;
+import com.azure.core.http.policy.AddHeadersPolicy;
+import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
+import com.azure.core.http.policy.RetryPolicy;
+import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.ClientOptions;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.CoreUtils;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/** A builder for creating a new instance of the DefaultValueClient type. */
+@ServiceClientBuilder(serviceClients = {DefaultValueClient.class})
+public final class DefaultValueClientBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
+    /** Create an instance of the DefaultValueClientBuilder. */
+    public DefaultValueClientBuilder() {
+        this.pipelinePolicies = new ArrayList<>();
+    }
+
+    /*
+     * The HTTP pipeline to send requests through
+     */
+    private HttpPipeline pipeline;
+
+    /**
+     * Sets The HTTP pipeline to send requests through.
+     *
+     * @param pipeline the pipeline value.
+     * @return the DefaultValueClientBuilder.
+     */
+    public DefaultValueClientBuilder pipeline(HttpPipeline pipeline) {
+        this.pipeline = pipeline;
+        return this;
+    }
+
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the DefaultValueClientBuilder.
+     */
+    public DefaultValueClientBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the DefaultValueClientBuilder.
+     */
+    public DefaultValueClientBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the DefaultValueClientBuilder.
+     */
+    public DefaultValueClientBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the DefaultValueClientBuilder.
+     */
+    public DefaultValueClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the DefaultValueClientBuilder.
+     */
+    public DefaultValueClientBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private final List<HttpPipelinePolicy> pipelinePolicies;
+
+    /*
+     * The client options such as application ID and custom headers to set on a
+     * request.
+     */
+    private ClientOptions clientOptions;
+
+    /**
+     * Sets The client options such as application ID and custom headers to set on a request.
+     *
+     * @param clientOptions the clientOptions value.
+     * @return the DefaultValueClientBuilder.
+     */
+    public DefaultValueClientBuilder clientOptions(ClientOptions clientOptions) {
+        this.clientOptions = clientOptions;
+        return this;
+    }
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the DefaultValueClientBuilder.
+     */
+    public DefaultValueClientBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
+    /**
+     * Builds an instance of DefaultValueClient with the provided parameters.
+     *
+     * @return an instance of DefaultValueClient.
+     */
+    public DefaultValueClient buildClient() {
+        if (pipeline == null) {
+            this.pipeline = createHttpPipeline();
+        }
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        DefaultValueClient client = new DefaultValueClient(pipeline, serializerAdapter);
+        return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        if (clientOptions == null) {
+            clientOptions = new ClientOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        String applicationId = CoreUtils.getApplicationId(clientOptions, httpLogOptions);
+        policies.add(new UserAgentPolicy(applicationId, clientName, clientVersion, buildConfiguration));
+        HttpHeaders headers = new HttpHeaders();
+        clientOptions.getHeaders().forEach(header -> headers.set(header.getName(), header.getValue()));
+        if (headers.getSize() > 0) {
+            policies.add(new AddHeadersPolicy(headers));
+        }
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(this.pipelinePolicies);
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .build();
+        return httpPipeline;
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/complexxmltag/DefaultValueClientBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/complexxmltag/DefaultValueClientBuilder.java
@@ -5,6 +5,7 @@ import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpHeaders;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
+import com.azure.core.http.HttpPipelinePosition;
 import com.azure.core.http.policy.AddHeadersPolicy;
 import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.HttpLogOptions;
@@ -22,6 +23,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /** A builder for creating a new instance of the DefaultValueClient type. */
 @ServiceClientBuilder(serviceClients = {DefaultValueClient.class})
@@ -203,16 +205,24 @@ public final class DefaultValueClientBuilder {
         if (headers.getSize() > 0) {
             policies.add(new AddHeadersPolicy(headers));
         }
+        policies.addAll(
+                this.pipelinePolicies.stream()
+                        .filter(p -> p.getPipelinePosition() == HttpPipelinePosition.PER_CALL)
+                        .collect(Collectors.toList()));
         HttpPolicyProviders.addBeforeRetryPolicies(policies);
         policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
         policies.add(new CookiePolicy());
-        policies.addAll(this.pipelinePolicies);
+        policies.addAll(
+                this.pipelinePolicies.stream()
+                        .filter(p -> p.getPipelinePosition() == HttpPipelinePosition.PER_RETRY)
+                        .collect(Collectors.toList()));
         HttpPolicyProviders.addAfterRetryPolicies(policies);
         policies.add(new HttpLoggingPolicy(httpLogOptions));
         HttpPipeline httpPipeline =
                 new HttpPipelineBuilder()
                         .policies(policies.toArray(new HttpPipelinePolicy[0]))
                         .httpClient(httpClient)
+                        .clientOptions(clientOptions)
                         .build();
         return httpPipeline;
     }

--- a/vanilla-tests/src/main/java/fixtures/complexxmltag/models/BlobName.java
+++ b/vanilla-tests/src/main/java/fixtures/complexxmltag/models/BlobName.java
@@ -1,0 +1,69 @@
+package fixtures.complexxmltag.models;
+
+import com.azure.core.annotation.Fluent;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlText;
+
+/** The BlobName model. */
+@JacksonXmlRootElement(localName = "BlobName")
+@Fluent
+public final class BlobName {
+    /*
+     * Indicates if the blob name is encoded.
+     */
+    @JacksonXmlProperty(localName = "Encoded", isAttribute = true)
+    private Boolean encoded;
+
+    /*
+     * The name of the blob.
+     */
+    @JacksonXmlText private String content;
+
+    /**
+     * Get the encoded property: Indicates if the blob name is encoded.
+     *
+     * @return the encoded value.
+     */
+    public Boolean isEncoded() {
+        return this.encoded;
+    }
+
+    /**
+     * Set the encoded property: Indicates if the blob name is encoded.
+     *
+     * @param encoded the encoded value to set.
+     * @return the BlobName object itself.
+     */
+    public BlobName setEncoded(Boolean encoded) {
+        this.encoded = encoded;
+        return this;
+    }
+
+    /**
+     * Get the content property: The name of the blob.
+     *
+     * @return the content value.
+     */
+    public String getContent() {
+        return this.content;
+    }
+
+    /**
+     * Set the content property: The name of the blob.
+     *
+     * @param content the content value to set.
+     * @return the BlobName object itself.
+     */
+    public BlobName setContent(String content) {
+        this.content = content;
+        return this;
+    }
+
+    /**
+     * Validates the instance.
+     *
+     * @throws IllegalArgumentException thrown if the instance is not valid.
+     */
+    public void validate() {}
+}

--- a/vanilla-tests/src/main/java/fixtures/complexxmltag/models/package-info.java
+++ b/vanilla-tests/src/main/java/fixtures/complexxmltag/models/package-info.java
@@ -1,0 +1,2 @@
+/** Package containing the data models for DefaultValueClient. default value client. */
+package fixtures.complexxmltag.models;

--- a/vanilla-tests/src/main/java/fixtures/complexxmltag/package-info.java
+++ b/vanilla-tests/src/main/java/fixtures/complexxmltag/package-info.java
@@ -1,0 +1,2 @@
+/** Package containing the classes for DefaultValueClient. default value client. */
+package fixtures.complexxmltag;

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/ObjectWithXMsTextProperty.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/ObjectWithXMsTextProperty.java
@@ -1,9 +1,9 @@
 package fixtures.xmlservice.models;
 
 import com.azure.core.annotation.Fluent;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlText;
 
 /** Contans property. */
 @JacksonXmlRootElement(localName = "Data")
@@ -18,8 +18,7 @@ public final class ObjectWithXMsTextProperty {
     /*
      * Returned value should be 'I am text'
      */
-    @JsonProperty(value = "content")
-    private String content;
+    @JacksonXmlText private String content;
 
     /**
      * Get the language property: Returned value should be 'english'.

--- a/vanilla-tests/src/test/java/fixtures/complexxmltag/ComplexXmlTagTests.java
+++ b/vanilla-tests/src/test/java/fixtures/complexxmltag/ComplexXmlTagTests.java
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package fixtures.complexxmltag;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlText;
+import fixtures.complexxmltag.models.BlobName;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.Assert.assertTrue;
+
+public class ComplexXmlTagTests {
+    @Test
+    public void xmlPropertyIsProperlyAnnotated() throws NoSuchFieldException {
+        Field field = BlobName.class.getDeclaredField("content");
+        assertTrue("Expected 'content' field to be annotated with 'JacksonXmlText' but it wasn't.",
+            field.isAnnotationPresent(JacksonXmlText.class));
+    }
+}

--- a/vanilla-tests/swagger/xml-tag-with-attribute-and-value.json
+++ b/vanilla-tests/swagger/xml-tag-with-attribute-and-value.json
@@ -1,0 +1,45 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "2021-09-15",
+    "title": "DefaultValueClient",
+    "x-ms-code-generation-settings": {
+      "name": "DefaultValueClient"
+    },
+    "description": "default value client"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/xml"
+  ],
+  "produces": [
+    "application/xml"
+  ],
+  "paths": {
+  },
+  "definitions": {
+    "BlobName": {
+      "type": "object",
+      "properties": {
+        "Encoded": {
+          "xml": {
+            "attribute": true,
+            "name": "Encoded"
+          },
+          "type": "boolean",
+          "description": "Indicates if the blob name is encoded."
+        },
+        "content": {
+          "xml": {
+            "x-ms-text": true
+          },
+          "type": "string",
+          "description": "The name of the blob."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #1238 

This PR resolves a code generation issue where Swagger `xml` configurations with `x-ms-test: true` were being improperly generated with `JsonProperty` instead of `JacksonXmlText`. This resulted in improper serialization and deserialization behaviors.