### PR TITLE
use latest autorest.core, m4, and testserver

### DIFF
--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Parameter.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Parameter.java
@@ -17,6 +17,7 @@ public class Parameter extends Value {
     private Parameter originalParameter;
     private Parameter groupedBy;
     private Property targetProperty;
+    private String origin;
 
     public String getClientDefaultValue() {
         return clientDefaultValue;
@@ -72,6 +73,14 @@ public class Parameter extends Value {
 
     public void setGroupedBy(Parameter groupedBy) {
         this.groupedBy = groupedBy;
+    }
+
+    public String getOrigin() {
+        return origin;
+    }
+
+    public void setOrigin(String origin) {
+        this.origin = origin;
     }
 
     public enum ImplementationLocation {

--- a/fluent-tests/prepare-tests.bat
+++ b/fluent-tests/prepare-tests.bat
@@ -11,7 +11,7 @@ RMDIR /S /Q "src\main\java\com\azure\mgmttest"
 RMDIR /S /Q "src\main\java\com\azure\mgmtlitetest"
 RMDIR /S /Q "src\samples"
 
-SET AUTOREST_CORE_VERSION=3.6.0
+SET AUTOREST_CORE_VERSION=3.6.6
 SET MODELERFOUR_ARGUMENTS=--pipeline.modelerfour.additional-checks=false --pipeline.modelerfour.lenient-model-deduplication=true
 SET COMMON_ARGUMENTS=--java --use=../ --java.output-folder=./ %MODELERFOUR_ARGUMENTS% --azure-arm --java.license-header=MICROSOFT_MIT_SMALL
 SET FLUENT_ARGUMENTS=%COMMON_ARGUMENTS% --fluent

--- a/fluentnamer/readme.md
+++ b/fluentnamer/readme.md
@@ -6,7 +6,7 @@ pass-thru:
   - subset-reducer
 
 use-extension:
-  "@autorest/modelerfour": "4.21.0"
+  "@autorest/modelerfour": "4.21.4"
 
 pipeline:
 

--- a/generate
+++ b/generate
@@ -1,13 +1,13 @@
 #!/bin/bash --verbose
 
-VANILLA_ARGUMENTS='--version=3.4.5 --java --use=./ --output-folder=vanilla-tests --sync-methods=all --client-side-validations --add-context-parameter --required-parameter-client-methods'
-AZURE_ARGUMENTS='--version=3.4.5 --java --use=./ --output-folder=azure-tests --sync-methods=all --client-side-validations --add-context-parameter --required-parameter-client-methods'
-ARM_ARGUMENTS='--version=3.4.5 --java --use=./ --output-folder=azure-tests --azure-arm --fluent=lite --regenerate-pom=false'
-PROTOCOL_ARGUMENTS='--version=3.4.5 --java --use=./ --output-folder=protocol-tests --low-level-client --generate-samples'
-PROTOCOL_RESILIENCE_ARGUMENTS='--version=3.4.5 --java --use=./ --low-level-client'
+VANILLA_ARGUMENTS='--version=3.6.6 --java --use=./ --output-folder=vanilla-tests --sync-methods=all --client-side-validations --add-context-parameter --required-parameter-client-methods'
+AZURE_ARGUMENTS='--version=3.6.6 --java --use=./ --output-folder=azure-tests --sync-methods=all --client-side-validations --add-context-parameter --required-parameter-client-methods'
+ARM_ARGUMENTS='--version=3.6.6 --java --use=./ --output-folder=azure-tests --azure-arm --fluent=lite --regenerate-pom=false'
+PROTOCOL_ARGUMENTS='--version=3.6.6 --java --use=./ --output-folder=protocol-tests --low-level-client --generate-samples'
+PROTOCOL_RESILIENCE_ARGUMENTS='--version=3.6.6 --java --use=./ --low-level-client'
 
-# 3.0.37
-TEST_SERVER_COMMIT=c4d01ebca63c339b059a996deaa9ddca5887a099
+# latest
+TEST_SERVER_COMMIT=main
 
 # Vanilla
 autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/$TEST_SERVER_COMMIT/swagger/additionalProperties.json --namespace=fixtures.additionalproperties
@@ -44,7 +44,7 @@ autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure
 autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/$TEST_SERVER_COMMIT/swagger/multiple-inheritance.json --namespace=fixtures.multipleinheritance
 autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/$TEST_SERVER_COMMIT/swagger/report.json --namespace=fixtures.report --payload-flattening-threshold=1
 autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/$TEST_SERVER_COMMIT/swagger/body-formdata-urlencoded.json --namespace=fixtures.bodyformdataurlencoded
-autorest --version=3.4.5 --use=./ vanilla-tests/swagger/lro.md
+autorest --version=3.6.6 --use=./ vanilla-tests/swagger/lro.md
 
 # local swagger
 autorest $VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/discriminator-flattening.json --namespace=fixtures.discriminatorflattening --client-flattened-annotation-target=FIELD
@@ -90,4 +90,4 @@ rm ./protocol-resilience-test/llcinitial/src/main/java/module-info.java
 rm ./protocol-resilience-test/llcupdate1/src/main/java/module-info.java
 
 # customization
-autorest --version=3.4.5 --use:. customization-tests/swagger
+autorest --version=3.6.6 --use:. customization-tests/swagger

--- a/generate.bat
+++ b/generate.bat
@@ -1,11 +1,11 @@
-set VANILLA_ARGUMENTS=--version=3.4.5 --java --use=. --output-folder=vanilla-tests --sync-methods=all --client-side-validations --add-context-parameter --required-parameter-client-methods
-set AZURE_ARGUMENTS=--version=3.4.5 --java --use=. --output-folder=azure-tests --sync-methods=all --client-side-validations --add-context-parameter --required-parameter-client-methods
-set ARM_ARGUMENTS=--version=3.4.5 --java --use=. --output-folder=azure-tests --azure-arm --fluent=lite --regenerate-pom=false
-set PROTOCOL_ARGUMENTS=--version=3.4.5 --java --use=. --output-folder=protocol-tests --low-level-client --generate-samples
-set PROTOCOL_RESILIENCE_ARGUMENTS=--version=3.4.5 --java --use=. --low-level-client
+set VANILLA_ARGUMENTS=--version=3.6.6 --java --use=. --output-folder=vanilla-tests --sync-methods=all --client-side-validations --add-context-parameter --required-parameter-client-methods
+set AZURE_ARGUMENTS=--version=3.6.6 --java --use=. --output-folder=azure-tests --sync-methods=all --client-side-validations --add-context-parameter --required-parameter-client-methods
+set ARM_ARGUMENTS=--version=3.6.6 --java --use=. --output-folder=azure-tests --azure-arm --fluent=lite --regenerate-pom=false
+set PROTOCOL_ARGUMENTS=--version=3.6.6 --java --use=. --output-folder=protocol-tests --low-level-client --generate-samples
+set PROTOCOL_RESILIENCE_ARGUMENTS=--version=3.6.6 --java --use=. --low-level-client
 
-rem 3.0.37
-set TEST_SERVER_COMMIT=c4d01ebca63c339b059a996deaa9ddca5887a099
+rem latest
+set TEST_SERVER_COMMIT=main
 
 call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/%TEST_SERVER_COMMIT%/swagger/additionalProperties.json --namespace=fixtures.additionalproperties
 call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/%TEST_SERVER_COMMIT%/swagger/body-array.json --namespace=fixtures.bodyarray
@@ -41,7 +41,7 @@ call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com
 call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/%TEST_SERVER_COMMIT%/swagger/multiple-inheritance.json --namespace=fixtures.multipleinheritance
 call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/%TEST_SERVER_COMMIT%/swagger/report.json --namespace=fixtures.report --payload-flattening-threshold=1
 call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/%TEST_SERVER_COMMIT%/swagger/body-formdata-urlencoded.json --namespace=fixtures.bodyformdataurlencoded
-call autorest --version=3.4.5 --use=./ vanilla-tests/swagger/lro.md
+call autorest --version=3.6.6 --use=./ vanilla-tests/swagger/lro.md
 
 rem local swagger
 call autorest %VANILLA_ARGUMENTS% --input-file=vanilla-tests/swagger/discriminator-flattening.json --namespace=fixtures.discriminatorflattening --client-flattened-annotation-target=FIELD
@@ -90,7 +90,7 @@ del protocol-resilience-test\llcinitial\src\main\java\module-info.java
 del protocol-resilience-test\llcupdate1\src\main\java\module-info.java
 
 rem customization
-call autorest --version=3.4.5 --use:. customization-tests/swagger
+call autorest --version=3.6.6 --use:. customization-tests/swagger
 
 call autorest --use:. docs/samples/specification/azure_key_credential/readme.md
 call autorest --use:. docs/samples/specification/basic/readme.md

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   "homepage": "https://github.com/Azure/autorest.java/blob/main/readme.md",
   "devDependencies": {
     "autorest": "^3.0.0",
-    "@microsoft.azure/autorest.testserver": "3.0.37"
+    "@microsoft.azure/autorest.testserver": "^3.0.37"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   "homepage": "https://github.com/Azure/autorest.java/blob/main/readme.md",
   "devDependencies": {
     "autorest": "^3.0.0",
-    "@microsoft.azure/autorest.testserver": "^3.0.37"
+    "@microsoft.azure/autorest.testserver": "^3.1.6"
   }
 }

--- a/preprocessor/readme.md
+++ b/preprocessor/readme.md
@@ -6,7 +6,7 @@ pass-thru:
   - subset-reducer
 
 use-extension:
-  "@autorest/modelerfour": "4.18.1"
+  "@autorest/modelerfour": "4.21.4"
 
 pipeline:
 
@@ -15,7 +15,9 @@ pipeline:
   # "Shake the tree", and normalize the model
   modelerfour:
     input: openapi-document/multi-api/identity     # the plugin where we get inputs from
-  
+
+    seal-single-value-enum-by-default: true
+
   # allow developer to do transformations on the code model.
   modelerfour/new-transform:
     input: modelerfour

--- a/protocol-tests/src/main/java/fixtures/llcinitial/LLCAsyncClient.java
+++ b/protocol-tests/src/main/java/fixtures/llcinitial/LLCAsyncClient.java
@@ -38,9 +38,7 @@ public final class LLCAsyncClient {
      * <table border="1">
      *     <caption>Query Parameters</caption>
      *     <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th></tr>
-     *     <tr><td>parameter1</td><td>String</td><td>Yes</td><td>I am a required parameter</td></tr>
-     *     <tr><td>parameter2</td><td>String</td><td>Yes</td><td>I am a required parameter</td></tr>
-     *     <tr><td>parameter3</td><td>String</td><td>Yes</td><td>I am a required parameter and I'm last in Swagger</td></tr>
+     *     <tr><td>parameter</td><td>String</td><td>Yes</td><td>I am a required parameter</td></tr>
      * </table>
      *
      * <p><strong>Response Body Schema</strong>
@@ -58,5 +56,34 @@ public final class LLCAsyncClient {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<BinaryData>> getRequiredWithResponse(RequestOptions requestOptions) {
         return this.serviceClient.getRequiredWithResponseAsync(requestOptions);
+    }
+
+    /**
+     * POST a JSON.
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     url: String
+     * }
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * Object
+     * }</pre>
+     *
+     * @param parameter I am a body parameter. My only valid JSON entry is { url: "http://example.org/myimage.jpeg" }.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return any object.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BinaryData>> postParametersWithResponse(BinaryData parameter, RequestOptions requestOptions) {
+        return this.serviceClient.postParametersWithResponseAsync(parameter, requestOptions);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/llcinitial/LLCClient.java
+++ b/protocol-tests/src/main/java/fixtures/llcinitial/LLCClient.java
@@ -37,9 +37,7 @@ public final class LLCClient {
      * <table border="1">
      *     <caption>Query Parameters</caption>
      *     <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th></tr>
-     *     <tr><td>parameter1</td><td>String</td><td>Yes</td><td>I am a required parameter</td></tr>
-     *     <tr><td>parameter2</td><td>String</td><td>Yes</td><td>I am a required parameter</td></tr>
-     *     <tr><td>parameter3</td><td>String</td><td>Yes</td><td>I am a required parameter and I'm last in Swagger</td></tr>
+     *     <tr><td>parameter</td><td>String</td><td>Yes</td><td>I am a required parameter</td></tr>
      * </table>
      *
      * <p><strong>Response Body Schema</strong>
@@ -57,5 +55,34 @@ public final class LLCClient {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<BinaryData> getRequiredWithResponse(RequestOptions requestOptions) {
         return this.serviceClient.getRequiredWithResponse(requestOptions);
+    }
+
+    /**
+     * POST a JSON.
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     url: String
+     * }
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * Object
+     * }</pre>
+     *
+     * @param parameter I am a body parameter. My only valid JSON entry is { url: "http://example.org/myimage.jpeg" }.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return any object.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<BinaryData> postParametersWithResponse(BinaryData parameter, RequestOptions requestOptions) {
+        return this.serviceClient.postParametersWithResponse(parameter, requestOptions);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/llcinitial/implementation/ParamsImpl.java
+++ b/protocol-tests/src/main/java/fixtures/llcinitial/implementation/ParamsImpl.java
@@ -4,9 +4,11 @@
 
 package fixtures.llcinitial.implementation;
 
+import com.azure.core.annotation.BodyParam;
 import com.azure.core.annotation.Get;
 import com.azure.core.annotation.Host;
 import com.azure.core.annotation.HostParam;
+import com.azure.core.annotation.Post;
 import com.azure.core.annotation.ReturnType;
 import com.azure.core.annotation.ServiceInterface;
 import com.azure.core.annotation.ServiceMethod;
@@ -44,9 +46,16 @@ public final class ParamsImpl {
     @Host("{$host}")
     @ServiceInterface(name = "LLCClientParams")
     private interface ParamsService {
-        @Get("/llc/parameters")
+        @Get("/servicedriven/parameters")
         Mono<Response<BinaryData>> getRequired(
                 @HostParam("$host") String host, RequestOptions requestOptions, Context context);
+
+        @Post("/servicedriven/parameters")
+        Mono<Response<BinaryData>> postParameters(
+                @HostParam("$host") String host,
+                @BodyParam("application/json") BinaryData parameter,
+                RequestOptions requestOptions,
+                Context context);
     }
 
     /**
@@ -57,9 +66,7 @@ public final class ParamsImpl {
      * <table border="1">
      *     <caption>Query Parameters</caption>
      *     <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th></tr>
-     *     <tr><td>parameter1</td><td>String</td><td>Yes</td><td>I am a required parameter</td></tr>
-     *     <tr><td>parameter2</td><td>String</td><td>Yes</td><td>I am a required parameter</td></tr>
-     *     <tr><td>parameter3</td><td>String</td><td>Yes</td><td>I am a required parameter and I'm last in Swagger</td></tr>
+     *     <tr><td>parameter</td><td>String</td><td>Yes</td><td>I am a required parameter</td></tr>
      * </table>
      *
      * <p><strong>Response Body Schema</strong>
@@ -86,9 +93,7 @@ public final class ParamsImpl {
      * <table border="1">
      *     <caption>Query Parameters</caption>
      *     <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th></tr>
-     *     <tr><td>parameter1</td><td>String</td><td>Yes</td><td>I am a required parameter</td></tr>
-     *     <tr><td>parameter2</td><td>String</td><td>Yes</td><td>I am a required parameter</td></tr>
-     *     <tr><td>parameter3</td><td>String</td><td>Yes</td><td>I am a required parameter and I'm last in Swagger</td></tr>
+     *     <tr><td>parameter</td><td>String</td><td>Yes</td><td>I am a required parameter</td></tr>
      * </table>
      *
      * <p><strong>Response Body Schema</strong>
@@ -116,9 +121,7 @@ public final class ParamsImpl {
      * <table border="1">
      *     <caption>Query Parameters</caption>
      *     <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th></tr>
-     *     <tr><td>parameter1</td><td>String</td><td>Yes</td><td>I am a required parameter</td></tr>
-     *     <tr><td>parameter2</td><td>String</td><td>Yes</td><td>I am a required parameter</td></tr>
-     *     <tr><td>parameter3</td><td>String</td><td>Yes</td><td>I am a required parameter and I'm last in Swagger</td></tr>
+     *     <tr><td>parameter</td><td>String</td><td>Yes</td><td>I am a required parameter</td></tr>
      * </table>
      *
      * <p><strong>Response Body Schema</strong>
@@ -135,5 +138,93 @@ public final class ParamsImpl {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<BinaryData> getRequiredWithResponse(RequestOptions requestOptions) {
         return getRequiredWithResponseAsync(requestOptions).block();
+    }
+
+    /**
+     * POST a JSON.
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     url: String
+     * }
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * Object
+     * }</pre>
+     *
+     * @param parameter I am a body parameter. My only valid JSON entry is { url: "http://example.org/myimage.jpeg" }.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return any object.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BinaryData>> postParametersWithResponseAsync(
+            BinaryData parameter, RequestOptions requestOptions) {
+        return FluxUtil.withContext(
+                context -> service.postParameters(this.client.getHost(), parameter, requestOptions, context));
+    }
+
+    /**
+     * POST a JSON.
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     url: String
+     * }
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * Object
+     * }</pre>
+     *
+     * @param parameter I am a body parameter. My only valid JSON entry is { url: "http://example.org/myimage.jpeg" }.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @param context The context to associate with this operation.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return any object.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BinaryData>> postParametersWithResponseAsync(
+            BinaryData parameter, RequestOptions requestOptions, Context context) {
+        return service.postParameters(this.client.getHost(), parameter, requestOptions, context);
+    }
+
+    /**
+     * POST a JSON.
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     url: String
+     * }
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * Object
+     * }</pre>
+     *
+     * @param parameter I am a body parameter. My only valid JSON entry is { url: "http://example.org/myimage.jpeg" }.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return any object.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<BinaryData> postParametersWithResponse(BinaryData parameter, RequestOptions requestOptions) {
+        return postParametersWithResponseAsync(parameter, requestOptions).block();
     }
 }

--- a/protocol-tests/src/main/java/fixtures/llcupdate1/LLCAsyncClient.java
+++ b/protocol-tests/src/main/java/fixtures/llcupdate1/LLCAsyncClient.java
@@ -38,9 +38,8 @@ public final class LLCAsyncClient {
      * <table border="1">
      *     <caption>Query Parameters</caption>
      *     <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th></tr>
-     *     <tr><td>parameter1</td><td>String</td><td>Yes</td><td>I am a required parameter with a client default value</td></tr>
-     *     <tr><td>parameter2</td><td>String</td><td>No</td><td>I was a required parameter, but now I'm optional</td></tr>
-     *     <tr><td>parameter3</td><td>String</td><td>Yes</td><td>I am a required parameter and I'm last in Swagger</td></tr>
+     *     <tr><td>parameter</td><td>String</td><td>Yes</td><td>I am a required parameter</td></tr>
+     *     <tr><td>newParameter</td><td>String</td><td>No</td><td>I'm a new input optional parameter</td></tr>
      * </table>
      *
      * <p><strong>Response Body Schema</strong>
@@ -58,5 +57,75 @@ public final class LLCAsyncClient {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<BinaryData>> getRequiredWithResponse(RequestOptions requestOptions) {
         return this.serviceClient.getRequiredWithResponseAsync(requestOptions);
+    }
+
+    /**
+     * POST a JSON or a JPEG.
+     *
+     * <p><strong>Header Parameters</strong>
+     *
+     * <table border="1">
+     *     <caption>Header Parameters</caption>
+     *     <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th></tr>
+     *     <tr><td>contentLength</td><td>long</td><td>Yes</td><td>The contentLength parameter</td></tr>
+     * </table>
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * Flux<ByteBuffer>
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * Object
+     * }</pre>
+     *
+     * @param parameter I am a body parameter with a new content type. My only valid JSON entry is { url:
+     *     "http://example.org/myimage.jpeg" }.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return any object.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BinaryData>> postParametersWithResponse(BinaryData parameter, RequestOptions requestOptions) {
+        return this.serviceClient.postParametersWithResponseAsync(parameter, requestOptions);
+    }
+
+    /**
+     * Delete something.
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return the completion.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> deleteParametersWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.deleteParametersWithResponseAsync(requestOptions);
+    }
+
+    /**
+     * I'm a new operation.
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * Object
+     * }</pre>
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return any object.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BinaryData>> getNewOperationWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getNewOperationWithResponseAsync(requestOptions);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/llcupdate1/LLCClient.java
+++ b/protocol-tests/src/main/java/fixtures/llcupdate1/LLCClient.java
@@ -37,9 +37,8 @@ public final class LLCClient {
      * <table border="1">
      *     <caption>Query Parameters</caption>
      *     <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th></tr>
-     *     <tr><td>parameter1</td><td>String</td><td>Yes</td><td>I am a required parameter with a client default value</td></tr>
-     *     <tr><td>parameter2</td><td>String</td><td>No</td><td>I was a required parameter, but now I'm optional</td></tr>
-     *     <tr><td>parameter3</td><td>String</td><td>Yes</td><td>I am a required parameter and I'm last in Swagger</td></tr>
+     *     <tr><td>parameter</td><td>String</td><td>Yes</td><td>I am a required parameter</td></tr>
+     *     <tr><td>newParameter</td><td>String</td><td>No</td><td>I'm a new input optional parameter</td></tr>
      * </table>
      *
      * <p><strong>Response Body Schema</strong>
@@ -57,5 +56,75 @@ public final class LLCClient {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<BinaryData> getRequiredWithResponse(RequestOptions requestOptions) {
         return this.serviceClient.getRequiredWithResponse(requestOptions);
+    }
+
+    /**
+     * POST a JSON or a JPEG.
+     *
+     * <p><strong>Header Parameters</strong>
+     *
+     * <table border="1">
+     *     <caption>Header Parameters</caption>
+     *     <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th></tr>
+     *     <tr><td>contentLength</td><td>long</td><td>Yes</td><td>The contentLength parameter</td></tr>
+     * </table>
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * Flux<ByteBuffer>
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * Object
+     * }</pre>
+     *
+     * @param parameter I am a body parameter with a new content type. My only valid JSON entry is { url:
+     *     "http://example.org/myimage.jpeg" }.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return any object.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<BinaryData> postParametersWithResponse(BinaryData parameter, RequestOptions requestOptions) {
+        return this.serviceClient.postParametersWithResponse(parameter, requestOptions);
+    }
+
+    /**
+     * Delete something.
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return the response.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> deleteParametersWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.deleteParametersWithResponse(requestOptions);
+    }
+
+    /**
+     * I'm a new operation.
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * Object
+     * }</pre>
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return any object.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<BinaryData> getNewOperationWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.getNewOperationWithResponse(requestOptions);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/llcupdate1/implementation/ParamsImpl.java
+++ b/protocol-tests/src/main/java/fixtures/llcupdate1/implementation/ParamsImpl.java
@@ -4,9 +4,12 @@
 
 package fixtures.llcupdate1.implementation;
 
+import com.azure.core.annotation.BodyParam;
+import com.azure.core.annotation.Delete;
 import com.azure.core.annotation.Get;
 import com.azure.core.annotation.Host;
 import com.azure.core.annotation.HostParam;
+import com.azure.core.annotation.Post;
 import com.azure.core.annotation.ReturnType;
 import com.azure.core.annotation.ServiceInterface;
 import com.azure.core.annotation.ServiceMethod;
@@ -44,8 +47,23 @@ public final class ParamsImpl {
     @Host("{$host}")
     @ServiceInterface(name = "LLCClientParams")
     private interface ParamsService {
-        @Get("/llc/parameters")
+        @Get("/servicedriven/parameters")
         Mono<Response<BinaryData>> getRequired(
+                @HostParam("$host") String host, RequestOptions requestOptions, Context context);
+
+        @Post("/servicedriven/parameters")
+        Mono<Response<BinaryData>> postParameters(
+                @HostParam("$host") String host,
+                @BodyParam("image/jpeg") BinaryData parameter,
+                RequestOptions requestOptions,
+                Context context);
+
+        @Delete("/servicedriven/parameters")
+        Mono<Response<Void>> deleteParameters(
+                @HostParam("$host") String host, RequestOptions requestOptions, Context context);
+
+        @Get("/servicedriven/newpath")
+        Mono<Response<BinaryData>> getNewOperation(
                 @HostParam("$host") String host, RequestOptions requestOptions, Context context);
     }
 
@@ -57,9 +75,8 @@ public final class ParamsImpl {
      * <table border="1">
      *     <caption>Query Parameters</caption>
      *     <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th></tr>
-     *     <tr><td>parameter1</td><td>String</td><td>Yes</td><td>I am a required parameter with a client default value</td></tr>
-     *     <tr><td>parameter2</td><td>String</td><td>No</td><td>I was a required parameter, but now I'm optional</td></tr>
-     *     <tr><td>parameter3</td><td>String</td><td>Yes</td><td>I am a required parameter and I'm last in Swagger</td></tr>
+     *     <tr><td>parameter</td><td>String</td><td>Yes</td><td>I am a required parameter</td></tr>
+     *     <tr><td>newParameter</td><td>String</td><td>No</td><td>I'm a new input optional parameter</td></tr>
      * </table>
      *
      * <p><strong>Response Body Schema</strong>
@@ -86,9 +103,8 @@ public final class ParamsImpl {
      * <table border="1">
      *     <caption>Query Parameters</caption>
      *     <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th></tr>
-     *     <tr><td>parameter1</td><td>String</td><td>Yes</td><td>I am a required parameter with a client default value</td></tr>
-     *     <tr><td>parameter2</td><td>String</td><td>No</td><td>I was a required parameter, but now I'm optional</td></tr>
-     *     <tr><td>parameter3</td><td>String</td><td>Yes</td><td>I am a required parameter and I'm last in Swagger</td></tr>
+     *     <tr><td>parameter</td><td>String</td><td>Yes</td><td>I am a required parameter</td></tr>
+     *     <tr><td>newParameter</td><td>String</td><td>No</td><td>I'm a new input optional parameter</td></tr>
      * </table>
      *
      * <p><strong>Response Body Schema</strong>
@@ -116,9 +132,8 @@ public final class ParamsImpl {
      * <table border="1">
      *     <caption>Query Parameters</caption>
      *     <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th></tr>
-     *     <tr><td>parameter1</td><td>String</td><td>Yes</td><td>I am a required parameter with a client default value</td></tr>
-     *     <tr><td>parameter2</td><td>String</td><td>No</td><td>I was a required parameter, but now I'm optional</td></tr>
-     *     <tr><td>parameter3</td><td>String</td><td>Yes</td><td>I am a required parameter and I'm last in Swagger</td></tr>
+     *     <tr><td>parameter</td><td>String</td><td>Yes</td><td>I am a required parameter</td></tr>
+     *     <tr><td>newParameter</td><td>String</td><td>No</td><td>I'm a new input optional parameter</td></tr>
      * </table>
      *
      * <p><strong>Response Body Schema</strong>
@@ -135,5 +150,213 @@ public final class ParamsImpl {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<BinaryData> getRequiredWithResponse(RequestOptions requestOptions) {
         return getRequiredWithResponseAsync(requestOptions).block();
+    }
+
+    /**
+     * POST a JSON or a JPEG.
+     *
+     * <p><strong>Header Parameters</strong>
+     *
+     * <table border="1">
+     *     <caption>Header Parameters</caption>
+     *     <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th></tr>
+     *     <tr><td>contentLength</td><td>long</td><td>Yes</td><td>The contentLength parameter</td></tr>
+     * </table>
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * Flux<ByteBuffer>
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * Object
+     * }</pre>
+     *
+     * @param parameter I am a body parameter with a new content type. My only valid JSON entry is { url:
+     *     "http://example.org/myimage.jpeg" }.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return any object.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BinaryData>> postParametersWithResponseAsync(
+            BinaryData parameter, RequestOptions requestOptions) {
+        return FluxUtil.withContext(
+                context -> service.postParameters(this.client.getHost(), parameter, requestOptions, context));
+    }
+
+    /**
+     * POST a JSON or a JPEG.
+     *
+     * <p><strong>Header Parameters</strong>
+     *
+     * <table border="1">
+     *     <caption>Header Parameters</caption>
+     *     <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th></tr>
+     *     <tr><td>contentLength</td><td>long</td><td>Yes</td><td>The contentLength parameter</td></tr>
+     * </table>
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * Flux<ByteBuffer>
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * Object
+     * }</pre>
+     *
+     * @param parameter I am a body parameter with a new content type. My only valid JSON entry is { url:
+     *     "http://example.org/myimage.jpeg" }.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @param context The context to associate with this operation.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return any object.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BinaryData>> postParametersWithResponseAsync(
+            BinaryData parameter, RequestOptions requestOptions, Context context) {
+        return service.postParameters(this.client.getHost(), parameter, requestOptions, context);
+    }
+
+    /**
+     * POST a JSON or a JPEG.
+     *
+     * <p><strong>Header Parameters</strong>
+     *
+     * <table border="1">
+     *     <caption>Header Parameters</caption>
+     *     <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th></tr>
+     *     <tr><td>contentLength</td><td>long</td><td>Yes</td><td>The contentLength parameter</td></tr>
+     * </table>
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * Flux<ByteBuffer>
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * Object
+     * }</pre>
+     *
+     * @param parameter I am a body parameter with a new content type. My only valid JSON entry is { url:
+     *     "http://example.org/myimage.jpeg" }.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return any object.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<BinaryData> postParametersWithResponse(BinaryData parameter, RequestOptions requestOptions) {
+        return postParametersWithResponseAsync(parameter, requestOptions).block();
+    }
+
+    /**
+     * Delete something.
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> deleteParametersWithResponseAsync(RequestOptions requestOptions) {
+        return FluxUtil.withContext(
+                context -> service.deleteParameters(this.client.getHost(), requestOptions, context));
+    }
+
+    /**
+     * Delete something.
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @param context The context to associate with this operation.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> deleteParametersWithResponseAsync(RequestOptions requestOptions, Context context) {
+        return service.deleteParameters(this.client.getHost(), requestOptions, context);
+    }
+
+    /**
+     * Delete something.
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> deleteParametersWithResponse(RequestOptions requestOptions) {
+        return deleteParametersWithResponseAsync(requestOptions).block();
+    }
+
+    /**
+     * I'm a new operation.
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * Object
+     * }</pre>
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return any object.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BinaryData>> getNewOperationWithResponseAsync(RequestOptions requestOptions) {
+        return FluxUtil.withContext(context -> service.getNewOperation(this.client.getHost(), requestOptions, context));
+    }
+
+    /**
+     * I'm a new operation.
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * Object
+     * }</pre>
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @param context The context to associate with this operation.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return any object.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BinaryData>> getNewOperationWithResponseAsync(RequestOptions requestOptions, Context context) {
+        return service.getNewOperation(this.client.getHost(), requestOptions, context);
+    }
+
+    /**
+     * I'm a new operation.
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * Object
+     * }</pre>
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return any object.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<BinaryData> getNewOperationWithResponse(RequestOptions requestOptions) {
+        return getNewOperationWithResponseAsync(requestOptions).block();
     }
 }

--- a/protocol-tests/src/main/java/fixtures/mediatypes/MediaTypesAsyncClient.java
+++ b/protocol-tests/src/main/java/fixtures/mediatypes/MediaTypesAsyncClient.java
@@ -119,4 +119,108 @@ public final class MediaTypesAsyncClient {
     public Mono<Response<BinaryData>> contentTypeWithEncodingWithResponse(RequestOptions requestOptions) {
         return this.serviceClient.contentTypeWithEncodingWithResponseAsync(requestOptions);
     }
+
+    /**
+     * Binary body with two content types. Pass in of {'hello': 'world'} for the application/json content type, and a
+     * byte stream of 'hello, world!' for application/octet-stream.
+     *
+     * <p><strong>Header Parameters</strong>
+     *
+     * <table border="1">
+     *     <caption>Header Parameters</caption>
+     *     <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th></tr>
+     *     <tr><td>contentType</td><td>String</td><td>Yes</td><td>Upload file type</td></tr>
+     *     <tr><td>contentLength</td><td>long</td><td>Yes</td><td>The contentLength parameter</td></tr>
+     * </table>
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * Flux<ByteBuffer>
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * String
+     * }</pre>
+     *
+     * @param message The payload body.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return the response.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BinaryData>> binaryBodyWithTwoContentTypesWithResponse(
+            BinaryData message, RequestOptions requestOptions) {
+        return this.serviceClient.binaryBodyWithTwoContentTypesWithResponseAsync(message, requestOptions);
+    }
+
+    /**
+     * Binary body with three content types. Pass in string 'hello, world' with content type 'text/plain', {'hello':
+     * world'} with content type 'application/json' and a byte string for 'application/octet-stream'.
+     *
+     * <p><strong>Header Parameters</strong>
+     *
+     * <table border="1">
+     *     <caption>Header Parameters</caption>
+     *     <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th></tr>
+     *     <tr><td>contentType</td><td>String</td><td>Yes</td><td>Upload file type</td></tr>
+     *     <tr><td>contentLength</td><td>long</td><td>Yes</td><td>The contentLength parameter</td></tr>
+     * </table>
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * Flux<ByteBuffer>
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * String
+     * }</pre>
+     *
+     * @param message The payload body.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return the response.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BinaryData>> binaryBodyWithThreeContentTypesWithResponse(
+            BinaryData message, RequestOptions requestOptions) {
+        return this.serviceClient.binaryBodyWithThreeContentTypesWithResponseAsync(message, requestOptions);
+    }
+
+    /**
+     * Body that's either text/plain or application/json.
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * String
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * String
+     * }</pre>
+     *
+     * @param message The payload body.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return the response.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BinaryData>> putTextAndJsonBodyWithResponse(
+            BinaryData message, RequestOptions requestOptions) {
+        return this.serviceClient.putTextAndJsonBodyWithResponseAsync(message, requestOptions);
+    }
 }

--- a/protocol-tests/src/main/java/fixtures/mediatypes/MediaTypesClient.java
+++ b/protocol-tests/src/main/java/fixtures/mediatypes/MediaTypesClient.java
@@ -118,4 +118,107 @@ public final class MediaTypesClient {
     public Response<BinaryData> contentTypeWithEncodingWithResponse(RequestOptions requestOptions) {
         return this.serviceClient.contentTypeWithEncodingWithResponse(requestOptions);
     }
+
+    /**
+     * Binary body with two content types. Pass in of {'hello': 'world'} for the application/json content type, and a
+     * byte stream of 'hello, world!' for application/octet-stream.
+     *
+     * <p><strong>Header Parameters</strong>
+     *
+     * <table border="1">
+     *     <caption>Header Parameters</caption>
+     *     <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th></tr>
+     *     <tr><td>contentType</td><td>String</td><td>Yes</td><td>Upload file type</td></tr>
+     *     <tr><td>contentLength</td><td>long</td><td>Yes</td><td>The contentLength parameter</td></tr>
+     * </table>
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * Flux<ByteBuffer>
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * String
+     * }</pre>
+     *
+     * @param message The payload body.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return the response.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<BinaryData> binaryBodyWithTwoContentTypesWithResponse(
+            BinaryData message, RequestOptions requestOptions) {
+        return this.serviceClient.binaryBodyWithTwoContentTypesWithResponse(message, requestOptions);
+    }
+
+    /**
+     * Binary body with three content types. Pass in string 'hello, world' with content type 'text/plain', {'hello':
+     * world'} with content type 'application/json' and a byte string for 'application/octet-stream'.
+     *
+     * <p><strong>Header Parameters</strong>
+     *
+     * <table border="1">
+     *     <caption>Header Parameters</caption>
+     *     <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th></tr>
+     *     <tr><td>contentType</td><td>String</td><td>Yes</td><td>Upload file type</td></tr>
+     *     <tr><td>contentLength</td><td>long</td><td>Yes</td><td>The contentLength parameter</td></tr>
+     * </table>
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * Flux<ByteBuffer>
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * String
+     * }</pre>
+     *
+     * @param message The payload body.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return the response.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<BinaryData> binaryBodyWithThreeContentTypesWithResponse(
+            BinaryData message, RequestOptions requestOptions) {
+        return this.serviceClient.binaryBodyWithThreeContentTypesWithResponse(message, requestOptions);
+    }
+
+    /**
+     * Body that's either text/plain or application/json.
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * String
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * String
+     * }</pre>
+     *
+     * @param message The payload body.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return the response.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<BinaryData> putTextAndJsonBodyWithResponse(BinaryData message, RequestOptions requestOptions) {
+        return this.serviceClient.putTextAndJsonBodyWithResponse(message, requestOptions);
+    }
 }

--- a/protocol-tests/src/main/java/fixtures/mediatypes/implementation/MediaTypesClientImpl.java
+++ b/protocol-tests/src/main/java/fixtures/mediatypes/implementation/MediaTypesClientImpl.java
@@ -4,6 +4,7 @@
 
 package fixtures.mediatypes.implementation;
 
+import com.azure.core.annotation.BodyParam;
 import com.azure.core.annotation.Host;
 import com.azure.core.annotation.HostParam;
 import com.azure.core.annotation.Post;
@@ -123,6 +124,27 @@ public final class MediaTypesClientImpl {
         @Post("/mediatypes/contentTypeWithEncoding")
         Mono<Response<BinaryData>> contentTypeWithEncoding(
                 @HostParam("$host") String host, RequestOptions requestOptions, Context context);
+
+        @Post("/mediatypes/binaryBodyTwoContentTypes")
+        Mono<Response<BinaryData>> binaryBodyWithTwoContentTypes(
+                @HostParam("$host") String host,
+                @BodyParam("application/octet-stream") BinaryData message,
+                RequestOptions requestOptions,
+                Context context);
+
+        @Post("/mediatypes/binaryBodyThreeContentTypes")
+        Mono<Response<BinaryData>> binaryBodyWithThreeContentTypes(
+                @HostParam("$host") String host,
+                @BodyParam("application/octet-stream") BinaryData message,
+                RequestOptions requestOptions,
+                Context context);
+
+        @Post("/mediatypes/textAndJson")
+        Mono<Response<BinaryData>> putTextAndJsonBody(
+                @HostParam("$host") String host,
+                @BodyParam("text/plain") BinaryData message,
+                RequestOptions requestOptions,
+                Context context);
     }
 
     /**
@@ -391,5 +413,313 @@ public final class MediaTypesClientImpl {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<BinaryData> contentTypeWithEncodingWithResponse(RequestOptions requestOptions) {
         return contentTypeWithEncodingWithResponseAsync(requestOptions).block();
+    }
+
+    /**
+     * Binary body with two content types. Pass in of {'hello': 'world'} for the application/json content type, and a
+     * byte stream of 'hello, world!' for application/octet-stream.
+     *
+     * <p><strong>Header Parameters</strong>
+     *
+     * <table border="1">
+     *     <caption>Header Parameters</caption>
+     *     <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th></tr>
+     *     <tr><td>contentType</td><td>String</td><td>Yes</td><td>Upload file type</td></tr>
+     *     <tr><td>contentLength</td><td>long</td><td>Yes</td><td>The contentLength parameter</td></tr>
+     * </table>
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * Flux<ByteBuffer>
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * String
+     * }</pre>
+     *
+     * @param message The payload body.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BinaryData>> binaryBodyWithTwoContentTypesWithResponseAsync(
+            BinaryData message, RequestOptions requestOptions) {
+        return FluxUtil.withContext(
+                context -> service.binaryBodyWithTwoContentTypes(this.getHost(), message, requestOptions, context));
+    }
+
+    /**
+     * Binary body with two content types. Pass in of {'hello': 'world'} for the application/json content type, and a
+     * byte stream of 'hello, world!' for application/octet-stream.
+     *
+     * <p><strong>Header Parameters</strong>
+     *
+     * <table border="1">
+     *     <caption>Header Parameters</caption>
+     *     <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th></tr>
+     *     <tr><td>contentType</td><td>String</td><td>Yes</td><td>Upload file type</td></tr>
+     *     <tr><td>contentLength</td><td>long</td><td>Yes</td><td>The contentLength parameter</td></tr>
+     * </table>
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * Flux<ByteBuffer>
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * String
+     * }</pre>
+     *
+     * @param message The payload body.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @param context The context to associate with this operation.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BinaryData>> binaryBodyWithTwoContentTypesWithResponseAsync(
+            BinaryData message, RequestOptions requestOptions, Context context) {
+        return service.binaryBodyWithTwoContentTypes(this.getHost(), message, requestOptions, context);
+    }
+
+    /**
+     * Binary body with two content types. Pass in of {'hello': 'world'} for the application/json content type, and a
+     * byte stream of 'hello, world!' for application/octet-stream.
+     *
+     * <p><strong>Header Parameters</strong>
+     *
+     * <table border="1">
+     *     <caption>Header Parameters</caption>
+     *     <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th></tr>
+     *     <tr><td>contentType</td><td>String</td><td>Yes</td><td>Upload file type</td></tr>
+     *     <tr><td>contentLength</td><td>long</td><td>Yes</td><td>The contentLength parameter</td></tr>
+     * </table>
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * Flux<ByteBuffer>
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * String
+     * }</pre>
+     *
+     * @param message The payload body.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<BinaryData> binaryBodyWithTwoContentTypesWithResponse(
+            BinaryData message, RequestOptions requestOptions) {
+        return binaryBodyWithTwoContentTypesWithResponseAsync(message, requestOptions).block();
+    }
+
+    /**
+     * Binary body with three content types. Pass in string 'hello, world' with content type 'text/plain', {'hello':
+     * world'} with content type 'application/json' and a byte string for 'application/octet-stream'.
+     *
+     * <p><strong>Header Parameters</strong>
+     *
+     * <table border="1">
+     *     <caption>Header Parameters</caption>
+     *     <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th></tr>
+     *     <tr><td>contentType</td><td>String</td><td>Yes</td><td>Upload file type</td></tr>
+     *     <tr><td>contentLength</td><td>long</td><td>Yes</td><td>The contentLength parameter</td></tr>
+     * </table>
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * Flux<ByteBuffer>
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * String
+     * }</pre>
+     *
+     * @param message The payload body.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BinaryData>> binaryBodyWithThreeContentTypesWithResponseAsync(
+            BinaryData message, RequestOptions requestOptions) {
+        return FluxUtil.withContext(
+                context -> service.binaryBodyWithThreeContentTypes(this.getHost(), message, requestOptions, context));
+    }
+
+    /**
+     * Binary body with three content types. Pass in string 'hello, world' with content type 'text/plain', {'hello':
+     * world'} with content type 'application/json' and a byte string for 'application/octet-stream'.
+     *
+     * <p><strong>Header Parameters</strong>
+     *
+     * <table border="1">
+     *     <caption>Header Parameters</caption>
+     *     <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th></tr>
+     *     <tr><td>contentType</td><td>String</td><td>Yes</td><td>Upload file type</td></tr>
+     *     <tr><td>contentLength</td><td>long</td><td>Yes</td><td>The contentLength parameter</td></tr>
+     * </table>
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * Flux<ByteBuffer>
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * String
+     * }</pre>
+     *
+     * @param message The payload body.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @param context The context to associate with this operation.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BinaryData>> binaryBodyWithThreeContentTypesWithResponseAsync(
+            BinaryData message, RequestOptions requestOptions, Context context) {
+        return service.binaryBodyWithThreeContentTypes(this.getHost(), message, requestOptions, context);
+    }
+
+    /**
+     * Binary body with three content types. Pass in string 'hello, world' with content type 'text/plain', {'hello':
+     * world'} with content type 'application/json' and a byte string for 'application/octet-stream'.
+     *
+     * <p><strong>Header Parameters</strong>
+     *
+     * <table border="1">
+     *     <caption>Header Parameters</caption>
+     *     <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th></tr>
+     *     <tr><td>contentType</td><td>String</td><td>Yes</td><td>Upload file type</td></tr>
+     *     <tr><td>contentLength</td><td>long</td><td>Yes</td><td>The contentLength parameter</td></tr>
+     * </table>
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * Flux<ByteBuffer>
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * String
+     * }</pre>
+     *
+     * @param message The payload body.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<BinaryData> binaryBodyWithThreeContentTypesWithResponse(
+            BinaryData message, RequestOptions requestOptions) {
+        return binaryBodyWithThreeContentTypesWithResponseAsync(message, requestOptions).block();
+    }
+
+    /**
+     * Body that's either text/plain or application/json.
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * String
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * String
+     * }</pre>
+     *
+     * @param message The payload body.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BinaryData>> putTextAndJsonBodyWithResponseAsync(
+            BinaryData message, RequestOptions requestOptions) {
+        return FluxUtil.withContext(
+                context -> service.putTextAndJsonBody(this.getHost(), message, requestOptions, context));
+    }
+
+    /**
+     * Body that's either text/plain or application/json.
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * String
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * String
+     * }</pre>
+     *
+     * @param message The payload body.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @param context The context to associate with this operation.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BinaryData>> putTextAndJsonBodyWithResponseAsync(
+            BinaryData message, RequestOptions requestOptions, Context context) {
+        return service.putTextAndJsonBody(this.getHost(), message, requestOptions, context);
+    }
+
+    /**
+     * Body that's either text/plain or application/json.
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * String
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * String
+     * }</pre>
+     *
+     * @param message The payload body.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if status code is 400 or above, if throwOnError in requestOptions is not
+     *     false.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<BinaryData> putTextAndJsonBodyWithResponse(BinaryData message, RequestOptions requestOptions) {
+        return putTextAndJsonBodyWithResponseAsync(message, requestOptions).block();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodyformdataurlencoded/Formdataurlencodeds.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyformdataurlencoded/Formdataurlencodeds.java
@@ -59,6 +59,17 @@ public final class Formdataurlencodeds {
                 @FormParam("name") String name,
                 @FormParam("status") String status,
                 Context context);
+
+        // @Multipart not supported by RestProxy
+        @Post("/formsdataurlencoded/partialConstantBody")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(HttpResponseException.class)
+        Mono<Response<Void>> partialConstantBody(
+                @HostParam("$host") String host,
+                @FormParam("grant_type") String grantType,
+                @FormParam("service") String service,
+                @FormParam("access_token") String accessToken,
+                Context context);
     }
 
     /**
@@ -169,5 +180,67 @@ public final class Formdataurlencodeds {
         final String name = null;
         final String status = null;
         updatePetWithFormAsync(petId, petType, petFood, petAge, name, status).block();
+    }
+
+    /**
+     * Test a partially constant formdata body. Pass in { grant_type: 'access_token', access_token: 'foo', service:
+     * 'bar' } to pass the test.
+     *
+     * @param serviceParam Indicates the name of your Azure container registry.
+     * @param accessToken AAD access token, mandatory when grant_type is access_token_refresh_token or access_token.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> partialConstantBodyWithResponseAsync(String serviceParam, String accessToken) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (serviceParam == null) {
+            return Mono.error(new IllegalArgumentException("Parameter serviceParam is required and cannot be null."));
+        }
+        if (accessToken == null) {
+            return Mono.error(new IllegalArgumentException("Parameter accessToken is required and cannot be null."));
+        }
+        final String grantType = "access_token";
+        return FluxUtil.withContext(
+                context ->
+                        service.partialConstantBody(
+                                this.client.getHost(), grantType, serviceParam, accessToken, context));
+    }
+
+    /**
+     * Test a partially constant formdata body. Pass in { grant_type: 'access_token', access_token: 'foo', service:
+     * 'bar' } to pass the test.
+     *
+     * @param serviceParam Indicates the name of your Azure container registry.
+     * @param accessToken AAD access token, mandatory when grant_type is access_token_refresh_token or access_token.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> partialConstantBodyAsync(String serviceParam, String accessToken) {
+        return partialConstantBodyWithResponseAsync(serviceParam, accessToken)
+                .flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Test a partially constant formdata body. Pass in { grant_type: 'access_token', access_token: 'foo', service:
+     * 'bar' } to pass the test.
+     *
+     * @param serviceParam Indicates the name of your Azure container registry.
+     * @param accessToken AAD access token, mandatory when grant_type is access_token_refresh_token or access_token.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void partialConstantBody(String serviceParam, String accessToken) {
+        partialConstantBodyAsync(serviceParam, accessToken).block();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodyformdataurlencoded/models/PathsPvivzlFormsdataurlencodedPartialconstantbodyPostRequestbodyContentApplicationXWwwFormUrlencodedSchema.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyformdataurlencoded/models/PathsPvivzlFormsdataurlencodedPartialconstantbodyPostRequestbodyContentApplicationXWwwFormUrlencodedSchema.java
@@ -1,0 +1,126 @@
+package fixtures.bodyformdataurlencoded.models;
+
+import com.azure.core.annotation.Fluent;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * The PathsPvivzlFormsdataurlencodedPartialconstantbodyPostRequestbodyContentApplicationXWwwFormUrlencodedSchema model.
+ */
+@Fluent
+public final
+class PathsPvivzlFormsdataurlencodedPartialconstantbodyPostRequestbodyContentApplicationXWwwFormUrlencodedSchema {
+    /*
+     * Constant part of a formdata body.
+     */
+    @JsonProperty(value = "grant_type", required = true)
+    private String grantType = "access_token";
+
+    /*
+     * Indicates the name of your Azure container registry.
+     */
+    @JsonProperty(value = "service", required = true)
+    private String service;
+
+    /*
+     * AAD access token, mandatory when grant_type is
+     * access_token_refresh_token or access_token.
+     */
+    @JsonProperty(value = "access_token", required = true)
+    private String aadAccessToken;
+
+    /**
+     * Creates an instance of
+     * PathsPvivzlFormsdataurlencodedPartialconstantbodyPostRequestbodyContentApplicationXWwwFormUrlencodedSchema class.
+     */
+    public
+    PathsPvivzlFormsdataurlencodedPartialconstantbodyPostRequestbodyContentApplicationXWwwFormUrlencodedSchema() {
+        grantType = "access_token";
+    }
+
+    /**
+     * Get the grantType property: Constant part of a formdata body.
+     *
+     * @return the grantType value.
+     */
+    public String getGrantType() {
+        return this.grantType;
+    }
+
+    /**
+     * Set the grantType property: Constant part of a formdata body.
+     *
+     * @param grantType the grantType value to set.
+     * @return the
+     *     PathsPvivzlFormsdataurlencodedPartialconstantbodyPostRequestbodyContentApplicationXWwwFormUrlencodedSchema
+     *     object itself.
+     */
+    public PathsPvivzlFormsdataurlencodedPartialconstantbodyPostRequestbodyContentApplicationXWwwFormUrlencodedSchema
+            setGrantType(String grantType) {
+        this.grantType = grantType;
+        return this;
+    }
+
+    /**
+     * Get the service property: Indicates the name of your Azure container registry.
+     *
+     * @return the service value.
+     */
+    public String getService() {
+        return this.service;
+    }
+
+    /**
+     * Set the service property: Indicates the name of your Azure container registry.
+     *
+     * @param service the service value to set.
+     * @return the
+     *     PathsPvivzlFormsdataurlencodedPartialconstantbodyPostRequestbodyContentApplicationXWwwFormUrlencodedSchema
+     *     object itself.
+     */
+    public PathsPvivzlFormsdataurlencodedPartialconstantbodyPostRequestbodyContentApplicationXWwwFormUrlencodedSchema
+            setService(String service) {
+        this.service = service;
+        return this;
+    }
+
+    /**
+     * Get the aadAccessToken property: AAD access token, mandatory when grant_type is access_token_refresh_token or
+     * access_token.
+     *
+     * @return the aadAccessToken value.
+     */
+    public String getAadAccessToken() {
+        return this.aadAccessToken;
+    }
+
+    /**
+     * Set the aadAccessToken property: AAD access token, mandatory when grant_type is access_token_refresh_token or
+     * access_token.
+     *
+     * @param aadAccessToken the aadAccessToken value to set.
+     * @return the
+     *     PathsPvivzlFormsdataurlencodedPartialconstantbodyPostRequestbodyContentApplicationXWwwFormUrlencodedSchema
+     *     object itself.
+     */
+    public PathsPvivzlFormsdataurlencodedPartialconstantbodyPostRequestbodyContentApplicationXWwwFormUrlencodedSchema
+            setAadAccessToken(String aadAccessToken) {
+        this.aadAccessToken = aadAccessToken;
+        return this;
+    }
+
+    /**
+     * Validates the instance.
+     *
+     * @throws IllegalArgumentException thrown if the instance is not valid.
+     */
+    public void validate() {
+        if (getService() == null) {
+            throw new IllegalArgumentException(
+                    "Missing required property service in model PathsPvivzlFormsdataurlencodedPartialconstantbodyPostRequestbodyContentApplicationXWwwFormUrlencodedSchema");
+        }
+        if (getAadAccessToken() == null) {
+            throw new IllegalArgumentException(
+                    "Missing required property aadAccessToken in model PathsPvivzlFormsdataurlencodedPartialconstantbodyPostRequestbodyContentApplicationXWwwFormUrlencodedSchema");
+        }
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClient.java
+++ b/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClient.java
@@ -23,6 +23,7 @@ import com.azure.core.util.FluxUtil;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.azure.core.util.serializer.SerializerAdapter;
 import fixtures.mediatypes.models.ContentType;
+import fixtures.mediatypes.models.ContentType1;
 import fixtures.mediatypes.models.SourcePath;
 import java.nio.ByteBuffer;
 import reactor.core.publisher.Flux;
@@ -156,6 +157,55 @@ public final class MediaTypesClient {
         Mono<Response<String>> contentTypeWithEncoding(
                 @HostParam("$host") String host,
                 @BodyParam("text/plain") String input,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Post("/mediatypes/binaryBodyTwoContentTypes")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(HttpResponseException.class)
+        Mono<Response<String>> binaryBodyWithTwoContentTypes(
+                @HostParam("$host") String host,
+                @HeaderParam("Content-Type") ContentType1 contentType,
+                @BodyParam("application/octet-stream") Flux<ByteBuffer> message,
+                @HeaderParam("Content-Length") long contentLength,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Post("/mediatypes/binaryBodyThreeContentTypes")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(HttpResponseException.class)
+        Mono<Response<String>> binaryBodyWithThreeContentTypes(
+                @HostParam("$host") String host,
+                @HeaderParam("Content-Type") ContentType1 contentType,
+                @BodyParam("application/octet-stream") Flux<ByteBuffer> message,
+                @HeaderParam("Content-Length") long contentLength,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Post("/mediatypes/binaryBodyThreeContentTypes")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(HttpResponseException.class)
+        Mono<Response<String>> binaryBodyWithThreeContentTypes(
+                @HostParam("$host") String host,
+                @BodyParam("text/plain") String message,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Post("/mediatypes/textAndJson")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(HttpResponseException.class)
+        Mono<Response<String>> putTextAndJsonBody(
+                @HostParam("$host") String host,
+                @BodyParam("text/plain") String message,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Post("/mediatypes/textAndJson")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(HttpResponseException.class)
+        Mono<Response<String>> putTextAndJsonBody(
+                @HostParam("$host") String host,
+                @BodyParam("application/json") String message,
                 @HeaderParam("Accept") String accept,
                 Context context);
     }
@@ -610,5 +660,330 @@ public final class MediaTypesClient {
     public String contentTypeWithEncoding() {
         final String input = null;
         return contentTypeWithEncodingAsync(input).block();
+    }
+
+    /**
+     * Binary body with two content types. Pass in of {'hello': 'world'} for the application/json content type, and a
+     * byte stream of 'hello, world!' for application/octet-stream.
+     *
+     * @param contentType Upload file type.
+     * @param message The payload body.
+     * @param contentLength The contentLength parameter.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> binaryBodyWithTwoContentTypesWithResponseAsync(
+            ContentType1 contentType, Flux<ByteBuffer> message, long contentLength) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        if (contentType == null) {
+            return Mono.error(new IllegalArgumentException("Parameter contentType is required and cannot be null."));
+        }
+        if (message == null) {
+            return Mono.error(new IllegalArgumentException("Parameter message is required and cannot be null."));
+        }
+        final String accept = "text/plain";
+        return FluxUtil.withContext(
+                context ->
+                        service.binaryBodyWithTwoContentTypes(
+                                this.getHost(), contentType, message, contentLength, accept, context));
+    }
+
+    /**
+     * Binary body with two content types. Pass in of {'hello': 'world'} for the application/json content type, and a
+     * byte stream of 'hello, world!' for application/octet-stream.
+     *
+     * @param contentType Upload file type.
+     * @param message The payload body.
+     * @param contentLength The contentLength parameter.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> binaryBodyWithTwoContentTypesAsync(
+            ContentType1 contentType, Flux<ByteBuffer> message, long contentLength) {
+        return binaryBodyWithTwoContentTypesWithResponseAsync(contentType, message, contentLength)
+                .flatMap(
+                        (Response<String> res) -> {
+                            if (res.getValue() != null) {
+                                return Mono.just(res.getValue());
+                            } else {
+                                return Mono.empty();
+                            }
+                        });
+    }
+
+    /**
+     * Binary body with two content types. Pass in of {'hello': 'world'} for the application/json content type, and a
+     * byte stream of 'hello, world!' for application/octet-stream.
+     *
+     * @param contentType Upload file type.
+     * @param message The payload body.
+     * @param contentLength The contentLength parameter.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public String binaryBodyWithTwoContentTypes(
+            ContentType1 contentType, Flux<ByteBuffer> message, long contentLength) {
+        return binaryBodyWithTwoContentTypesAsync(contentType, message, contentLength).block();
+    }
+
+    /**
+     * Binary body with three content types. Pass in string 'hello, world' with content type 'text/plain', {'hello':
+     * world'} with content type 'application/json' and a byte string for 'application/octet-stream'.
+     *
+     * @param contentType Upload file type.
+     * @param message The payload body.
+     * @param contentLength The contentLength parameter.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> binaryBodyWithThreeContentTypesWithResponseAsync(
+            ContentType1 contentType, Flux<ByteBuffer> message, long contentLength) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        if (contentType == null) {
+            return Mono.error(new IllegalArgumentException("Parameter contentType is required and cannot be null."));
+        }
+        if (message == null) {
+            return Mono.error(new IllegalArgumentException("Parameter message is required and cannot be null."));
+        }
+        final String accept = "text/plain";
+        return FluxUtil.withContext(
+                context ->
+                        service.binaryBodyWithThreeContentTypes(
+                                this.getHost(), contentType, message, contentLength, accept, context));
+    }
+
+    /**
+     * Binary body with three content types. Pass in string 'hello, world' with content type 'text/plain', {'hello':
+     * world'} with content type 'application/json' and a byte string for 'application/octet-stream'.
+     *
+     * @param contentType Upload file type.
+     * @param message The payload body.
+     * @param contentLength The contentLength parameter.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> binaryBodyWithThreeContentTypesAsync(
+            ContentType1 contentType, Flux<ByteBuffer> message, long contentLength) {
+        return binaryBodyWithThreeContentTypesWithResponseAsync(contentType, message, contentLength)
+                .flatMap(
+                        (Response<String> res) -> {
+                            if (res.getValue() != null) {
+                                return Mono.just(res.getValue());
+                            } else {
+                                return Mono.empty();
+                            }
+                        });
+    }
+
+    /**
+     * Binary body with three content types. Pass in string 'hello, world' with content type 'text/plain', {'hello':
+     * world'} with content type 'application/json' and a byte string for 'application/octet-stream'.
+     *
+     * @param contentType Upload file type.
+     * @param message The payload body.
+     * @param contentLength The contentLength parameter.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public String binaryBodyWithThreeContentTypes(
+            ContentType1 contentType, Flux<ByteBuffer> message, long contentLength) {
+        return binaryBodyWithThreeContentTypesAsync(contentType, message, contentLength).block();
+    }
+
+    /**
+     * Binary body with three content types. Pass in string 'hello, world' with content type 'text/plain', {'hello':
+     * world'} with content type 'application/json' and a byte string for 'application/octet-stream'.
+     *
+     * @param message The payload body.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> binaryBodyWithThreeContentTypesWithResponseAsync(String message) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        if (message == null) {
+            return Mono.error(new IllegalArgumentException("Parameter message is required and cannot be null."));
+        }
+        final String accept = "text/plain";
+        return FluxUtil.withContext(
+                context -> service.binaryBodyWithThreeContentTypes(this.getHost(), message, accept, context));
+    }
+
+    /**
+     * Binary body with three content types. Pass in string 'hello, world' with content type 'text/plain', {'hello':
+     * world'} with content type 'application/json' and a byte string for 'application/octet-stream'.
+     *
+     * @param message The payload body.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> binaryBodyWithThreeContentTypesAsync(String message) {
+        return binaryBodyWithThreeContentTypesWithResponseAsync(message)
+                .flatMap(
+                        (Response<String> res) -> {
+                            if (res.getValue() != null) {
+                                return Mono.just(res.getValue());
+                            } else {
+                                return Mono.empty();
+                            }
+                        });
+    }
+
+    /**
+     * Binary body with three content types. Pass in string 'hello, world' with content type 'text/plain', {'hello':
+     * world'} with content type 'application/json' and a byte string for 'application/octet-stream'.
+     *
+     * @param message The payload body.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public String binaryBodyWithThreeContentTypes(String message) {
+        return binaryBodyWithThreeContentTypesAsync(message).block();
+    }
+
+    /**
+     * Body that's either text/plain or application/json.
+     *
+     * @param message The payload body.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> putTextAndJsonBodyWithResponseAsync(String message) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        if (message == null) {
+            return Mono.error(new IllegalArgumentException("Parameter message is required and cannot be null."));
+        }
+        final String accept = "text/plain";
+        return FluxUtil.withContext(context -> service.putTextAndJsonBody(this.getHost(), message, accept, context));
+    }
+
+    /**
+     * Body that's either text/plain or application/json.
+     *
+     * @param message The payload body.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> putTextAndJsonBodyAsync(String message) {
+        return putTextAndJsonBodyWithResponseAsync(message)
+                .flatMap(
+                        (Response<String> res) -> {
+                            if (res.getValue() != null) {
+                                return Mono.just(res.getValue());
+                            } else {
+                                return Mono.empty();
+                            }
+                        });
+    }
+
+    /**
+     * Body that's either text/plain or application/json.
+     *
+     * @param message The payload body.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public String putTextAndJsonBody(String message) {
+        return putTextAndJsonBodyAsync(message).block();
+    }
+
+    /**
+     * Body that's either text/plain or application/json.
+     *
+     * @param message The payload body.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<String>> putTextAndJsonBodyWithResponseAsync(String message) {
+        if (this.getHost() == null) {
+            return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
+        }
+        if (message == null) {
+            return Mono.error(new IllegalArgumentException("Parameter message is required and cannot be null."));
+        }
+        final String accept = "text/plain";
+        return FluxUtil.withContext(context -> service.putTextAndJsonBody(this.getHost(), message, accept, context));
+    }
+
+    /**
+     * Body that's either text/plain or application/json.
+     *
+     * @param message The payload body.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<String> putTextAndJsonBodyAsync(String message) {
+        return putTextAndJsonBodyWithResponseAsync(message)
+                .flatMap(
+                        (Response<String> res) -> {
+                            if (res.getValue() != null) {
+                                return Mono.just(res.getValue());
+                            } else {
+                                return Mono.empty();
+                            }
+                        });
+    }
+
+    /**
+     * Body that's either text/plain or application/json.
+     *
+     * @param message The payload body.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public String putTextAndJsonBody(String message) {
+        return putTextAndJsonBodyAsync(message).block();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClient.java
+++ b/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClient.java
@@ -203,7 +203,7 @@ public final class MediaTypesClient {
         @Post("/mediatypes/textAndJson")
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(HttpResponseException.class)
-        Mono<Response<String>> putTextAndJsonBody(
+        Mono<Response<String>> putTextAndJsonBodyApplicationJson(
                 @HostParam("$host") String host,
                 @BodyParam("application/json") String message,
                 @HeaderParam("Accept") String accept,
@@ -940,7 +940,7 @@ public final class MediaTypesClient {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<Response<String>> putTextAndJsonBodyWithResponseAsync(String message) {
+    public Mono<Response<String>> putTextAndJsonBodyApplicationJsonWithResponseAsync(String message) {
         if (this.getHost() == null) {
             return Mono.error(new IllegalArgumentException("Parameter this.getHost() is required and cannot be null."));
         }
@@ -948,7 +948,8 @@ public final class MediaTypesClient {
             return Mono.error(new IllegalArgumentException("Parameter message is required and cannot be null."));
         }
         final String accept = "text/plain";
-        return FluxUtil.withContext(context -> service.putTextAndJsonBody(this.getHost(), message, accept, context));
+        return FluxUtil.withContext(
+                context -> service.putTextAndJsonBodyApplicationJson(this.getHost(), message, accept, context));
     }
 
     /**
@@ -961,8 +962,8 @@ public final class MediaTypesClient {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<String> putTextAndJsonBodyAsync(String message) {
-        return putTextAndJsonBodyWithResponseAsync(message)
+    public Mono<String> putTextAndJsonBodyApplicationJsonAsync(String message) {
+        return putTextAndJsonBodyApplicationJsonWithResponseAsync(message)
                 .flatMap(
                         (Response<String> res) -> {
                             if (res.getValue() != null) {
@@ -983,7 +984,7 @@ public final class MediaTypesClient {
      * @return the response.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public String putTextAndJsonBody(String message) {
-        return putTextAndJsonBodyAsync(message).block();
+    public String putTextAndJsonBodyApplicationJson(String message) {
+        return putTextAndJsonBodyApplicationJsonAsync(message).block();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/mediatypes/models/ContentType1.java
+++ b/vanilla-tests/src/main/java/fixtures/mediatypes/models/ContentType1.java
@@ -1,0 +1,43 @@
+package fixtures.mediatypes.models;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/** Defines values for ContentType1. */
+public enum ContentType1 {
+    /** Enum value application/json. */
+    APPLICATION_JSON("application/json"),
+
+    /** Enum value application/octet-stream. */
+    APPLICATION_OCTET_STREAM("application/octet-stream");
+
+    /** The actual serialized value for a ContentType1 instance. */
+    private final String value;
+
+    ContentType1(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Parses a serialized value to a ContentType1 instance.
+     *
+     * @param value the serialized value to parse.
+     * @return the parsed ContentType1 object, or null if unable to parse.
+     */
+    @JsonCreator
+    public static ContentType1 fromString(String value) {
+        ContentType1[] items = ContentType1.values();
+        for (ContentType1 item : items) {
+            if (item.toString().equalsIgnoreCase(value)) {
+                return item;
+            }
+        }
+        return null;
+    }
+
+    @JsonValue
+    @Override
+    public String toString() {
+        return this.value;
+    }
+}


### PR DESCRIPTION
`modelerfour.seal-single-value-enum-by-default=true` is added to data-plane, to keep m4 behavior unchanged (as 4.19.x).

deduplication for this case:
```java
        @Post("/mediatypes/textAndJson")
        @ExpectedResponses({200})
        @UnexpectedResponseExceptionType(HttpResponseException.class)
        Mono<Response<String>> putTextAndJsonBody(
                @HostParam("$host") String host,
                @BodyParam("text/plain") String message,
                @HeaderParam("Accept") String accept,
                Context context);

        @Post("/mediatypes/textAndJson")
        @ExpectedResponses({200})
        @UnexpectedResponseExceptionType(HttpResponseException.class)
        Mono<Response<String>> putTextAndJsonBody(
                @HostParam("$host") String host,
                @BodyParam("application/json") String message,
                @HeaderParam("Accept") String accept,
                Context context);
```

Codegen now append media type to name if conflict found, result in `putTextAndJsonBodyApplicationJson` (which might not be the best, but at least compiles). Warning is printed to log.