### PR TITLE
Add Support for Custom Http Exception Type Mappings

### DIFF
--- a/androidgen/src/main/java/com/azure/autorest/android/mapper/AndroidProxyMethodMapper.java
+++ b/androidgen/src/main/java/com/azure/autorest/android/mapper/AndroidProxyMethodMapper.java
@@ -8,8 +8,11 @@ import com.azure.autorest.model.clientmodel.IType;
 import com.azure.autorest.model.clientmodel.PrimitiveType;
 import com.azure.autorest.model.clientmodel.ProxyMethod;
 import com.azure.autorest.model.clientmodel.ProxyMethodParameter;
+import io.netty.handler.codec.http.HttpResponseStatus;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static com.azure.autorest.extension.base.model.codemodel.RequestParameterLocation.None;
 
@@ -51,6 +54,11 @@ public class AndroidProxyMethodMapper extends ProxyMethodMapper {
     @Override
     protected ClassType getContextClass() {
         return ClassType.AndroidContext;
+    }
+
+    @Override
+    protected Map<HttpResponseStatus, ClassType> getDefaultHttpStatusCodeToExceptionTypeMapping() {
+        return new HashMap<>();
     }
 
     @Override

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
@@ -128,7 +128,11 @@ public class JavaSettings {
                 }.getType(), "polling"),
                 getBooleanValue(host, "generate-samples", false),
                 getBooleanValue(host, "pass-discriminator-to-child-deserialization", false),
-                getBooleanValue(host, "annotate-getters-and-setters-for-serialization", false));
+                getBooleanValue(host, "annotate-getters-and-setters-for-serialization", false),
+                getStringValue(host, "default-http-exception-type"),
+                getBooleanValue(host, "use-default-http-status-code-to-exception-type-mapping", false),
+                host.getValue(new TypeReference<Map<Integer, String>>() {}.getType(),
+                    "http-status-code-to-exception-type-mapping"));
         }
         return _instance;
     }
@@ -159,6 +163,13 @@ public class JavaSettings {
      * @param annotateGettersAndSettersForSerialization If set to true, Jackson JsonGetter and JsonSetter will annotate
      * getters and setters in generated models to handle serialization and deserialization. For now, fields will
      * continue being annotated to ensure that there are no backwards compatibility breaks.
+     * @param defaultHttpExceptionType The fully-qualified class that should be used as the default exception type. This
+     * class must extend from HttpResponseException.
+     * @param useDefaultHttpStatusCodeToExceptionTypeMapping Determines whether a well-known HTTP status code to exception type mapping
+     * should be used if an HTTP status code-exception mapping isn't provided.
+     * @param httpStatusCodeToExceptionTypeMapping A mapping of HTTP response status code to the exception type that should be
+     * thrown if that status code is seen. All exception types must be fully-qualified and extend from
+     * HttpResponseException.
      */
     private JavaSettings(AutorestSettings autorestSettings,
         Map<String, Object> modelerSettings,
@@ -207,7 +218,10 @@ public class JavaSettings {
         Map<String, PollingDetails> pollingConfig,
         boolean generateSamples,
         boolean passDiscriminatorToChildDeserialization,
-        boolean annotateGettersAndSettersForSerialization) {
+        boolean annotateGettersAndSettersForSerialization,
+        String defaultHttpExceptionType,
+        boolean useDefaultHttpStatusCodeToExceptionTypeMapping,
+        Map<Integer, String> httpStatusCodeToExceptionTypeMapping) {
 
         this.autorestSettings = autorestSettings;
         this.modelerSettings = new ModelerSettings(modelerSettings);
@@ -282,6 +296,11 @@ public class JavaSettings {
         this.generateSamples = generateSamples;
         this.passDiscriminatorToChildDeserialization = passDiscriminatorToChildDeserialization;
         this.annotateGettersAndSettersForSerialization = annotateGettersAndSettersForSerialization;
+
+        // Error HTTP status code exception type handling.
+        this.defaultHttpExceptionType = defaultHttpExceptionType;
+        this.useDefaultHttpStatusCodeToExceptionTypeMapping = useDefaultHttpStatusCodeToExceptionTypeMapping;
+        this.httpStatusCodeToExceptionTypeMapping = httpStatusCodeToExceptionTypeMapping;
     }
 
     private String keyCredentialHeaderName;
@@ -782,6 +801,39 @@ public class JavaSettings {
      */
     public boolean isGettersAndSettersAnnotatedForSerialization() {
         return annotateGettersAndSettersForSerialization;
+    }
+
+    private final String defaultHttpExceptionType;
+
+    /**
+     * Gets the fully-qualified exception type that is used for error HTTP status codes.
+     *
+     * @return The fully-qualified exception type.
+     */
+    public String getDefaultHttpExceptionType() {
+        return defaultHttpExceptionType;
+    }
+
+    private final boolean useDefaultHttpStatusCodeToExceptionTypeMapping;
+
+    /**
+     * Whether to use the default error HTTP status code to exception type mapping.
+     *
+     * @return Whether to use the default error HTTP status code to exception type mapping.
+     */
+    public boolean isUseDefaultHttpStatusCodeToExceptionTypeMapping() {
+        return useDefaultHttpStatusCodeToExceptionTypeMapping;
+    }
+
+    private final Map<Integer, String> httpStatusCodeToExceptionTypeMapping;
+
+    /**
+     * Gets a read-only view of the custom error HTTP status code to exception type mapping.
+     *
+     * @return A read-only view of the custom error HTTP status code to exception type mapping.
+     */
+    public Map<Integer, String> getHttpStatusCodeToExceptionTypeMapping() {
+        return Collections.unmodifiableMap(httpStatusCodeToExceptionTypeMapping);
     }
 
     public static final String DefaultCodeGenerationHeader = String.join("\r\n",

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
@@ -833,7 +833,8 @@ public class JavaSettings {
      * @return A read-only view of the custom error HTTP status code to exception type mapping.
      */
     public Map<Integer, String> getHttpStatusCodeToExceptionTypeMapping() {
-        return Collections.unmodifiableMap(httpStatusCodeToExceptionTypeMapping);
+        return httpStatusCodeToExceptionTypeMapping == null
+            ? null : Collections.unmodifiableMap(httpStatusCodeToExceptionTypeMapping);
     }
 
     public static final String DefaultCodeGenerationHeader = String.join("\r\n",

--- a/generate
+++ b/generate
@@ -45,6 +45,7 @@ autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure
 autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/$TEST_SERVER_COMMIT/swagger/report.json --namespace=fixtures.report --payload-flattening-threshold=1
 autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/$TEST_SERVER_COMMIT/swagger/body-formdata-urlencoded.json --namespace=fixtures.bodyformdataurlencoded
 autorest --version=3.6.6 --use=./ vanilla-tests/swagger/lro.md
+autorest --version=3.6.6 --use=./ vanilla-tests/swagger/custom-http-exception-mapping.md
 
 # local swagger
 autorest $VANILLA_ARGUMENTS --input-file=vanilla-tests/swagger/discriminator-flattening.json --namespace=fixtures.discriminatorflattening --client-flattened-annotation-target=FIELD

--- a/generate.bat
+++ b/generate.bat
@@ -42,6 +42,7 @@ call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com
 call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/%TEST_SERVER_COMMIT%/swagger/report.json --namespace=fixtures.report --payload-flattening-threshold=1
 call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/%TEST_SERVER_COMMIT%/swagger/body-formdata-urlencoded.json --namespace=fixtures.bodyformdataurlencoded
 call autorest --version=3.6.6 --use=./ vanilla-tests/swagger/lro.md
+call autorest --version=3.6.6 --use=./ vanilla-tests/swagger/custom-http-exception-mapping.md
 
 rem local swagger
 call autorest %VANILLA_ARGUMENTS% --input-file=vanilla-tests/swagger/discriminator-flattening.json --namespace=fixtures.discriminatorflattening --client-flattened-annotation-target=FIELD

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
@@ -38,7 +38,6 @@ public class ClassType implements IType {
     public static final ClassType UUID = new ClassType.Builder().knownClass(java.util.UUID.class).defaultValueExpressionConverter((String defaultValueExpression) -> java.lang.String.format("UUID.fromString(\"%1$s\")", defaultValueExpression)).build();
     public static final ClassType Object = new ClassType.Builder().knownClass(java.lang.Object.class).build();
     public static final ClassType TokenCredential = new ClassType.Builder().knownClass(com.azure.core.credential.TokenCredential.class).build();
-    public static final ClassType HttpResponseException = new ClassType.Builder().knownClass(com.azure.core.exception.HttpResponseException.class).build();
     public static final ClassType AndroidHttpResponseException = new ClassType.Builder().packageName("com.azure.android.core.http.exception").name("HttpResponseException").build();
     public static final ClassType UnixTime = new ClassType.Builder().knownClass(com.azure.core.implementation.UnixTime.class).build();
     public static final ClassType UnixTimeDateTime = new ClassType.Builder().knownClass(java.time.OffsetDateTime.class).build();
@@ -71,11 +70,18 @@ public class ClassType implements IType {
     public static final ClassType AzureKeyCredential = new ClassType.Builder().knownClass(com.azure.core.credential.AzureKeyCredential.class).build();
     public static final ClassType RetryPolicy = new ClassType.Builder().knownClass(com.azure.core.http.policy.RetryPolicy.class).build();
     public static final ClassType AndroidRetryPolicy = new ClassType.Builder().packageName("com.azure.android.core.http.policy").name("RetryPolicy").build();
-    public static final ClassType JsonPatchDocument =
-            new ClassType.Builder().knownClass(com.azure.core.models.JsonPatchDocument.class).build();
+    public static final ClassType JsonPatchDocument = new ClassType.Builder().knownClass(com.azure.core.models.JsonPatchDocument.class).build();
     public static final ClassType BinaryData = new ClassType.Builder().knownClass(com.azure.core.util.BinaryData.class).defaultValueExpressionConverter((String defaultValueExpression) -> java.lang.String.format("BinaryData.fromObject(\"%s\")", defaultValueExpression)).build();
     public static final ClassType RequestOptions = new Builder().packageName("com.azure.core.http.rest").name("RequestOptions").build();
     public static final ClassType ClientOptions = new Builder().knownClass(com.azure.core.util.ClientOptions.class).build();
+
+    // Java exception types
+    public static final ClassType HttpResponseException = new Builder().knownClass(com.azure.core.exception.HttpResponseException.class).build();
+    public static final ClassType ClientAuthenticationException = new Builder().knownClass(com.azure.core.exception.ClientAuthenticationException.class).build();
+    public static final ClassType ResourceExistsException = new Builder().knownClass(com.azure.core.exception.ResourceExistsException.class).build();
+    public static final ClassType ResourceModifiedException = new Builder().knownClass(com.azure.core.exception.ResourceModifiedException.class).build();
+    public static final ClassType ResourceNotFoundException = new Builder().knownClass(com.azure.core.exception.ResourceNotFoundException.class).build();
+    public static final ClassType TooManyRedirectsException = new Builder().knownClass(com.azure.core.exception.TooManyRedirectsException.class).build();
 
     private final String packageName;
     private final String name;

--- a/vanilla-tests/src/main/java/fixtures/customhttpexceptionmapping/AutoRestHeadExceptionTestService.java
+++ b/vanilla-tests/src/main/java/fixtures/customhttpexceptionmapping/AutoRestHeadExceptionTestService.java
@@ -1,0 +1,98 @@
+package fixtures.customhttpexceptionmapping;
+
+import com.azure.core.http.HttpPipeline;
+import com.azure.core.http.HttpPipelineBuilder;
+import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.RetryPolicy;
+import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
+
+/** Initializes a new instance of the AutoRestHeadExceptionTestService type. */
+public final class AutoRestHeadExceptionTestService {
+    /** server parameter. */
+    private final String host;
+
+    /**
+     * Gets server parameter.
+     *
+     * @return the host value.
+     */
+    public String getHost() {
+        return this.host;
+    }
+
+    /** The HTTP pipeline to send requests through. */
+    private final HttpPipeline httpPipeline;
+
+    /**
+     * Gets The HTTP pipeline to send requests through.
+     *
+     * @return the httpPipeline value.
+     */
+    public HttpPipeline getHttpPipeline() {
+        return this.httpPipeline;
+    }
+
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
+    /** The HeadExceptions object to access its operations. */
+    private final HeadExceptions headExceptions;
+
+    /**
+     * Gets the HeadExceptions object to access its operations.
+     *
+     * @return the HeadExceptions object.
+     */
+    public HeadExceptions getHeadExceptions() {
+        return this.headExceptions;
+    }
+
+    /**
+     * Initializes an instance of AutoRestHeadExceptionTestService client.
+     *
+     * @param host server parameter.
+     */
+    AutoRestHeadExceptionTestService(String host) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
+                host);
+    }
+
+    /**
+     * Initializes an instance of AutoRestHeadExceptionTestService client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param host server parameter.
+     */
+    AutoRestHeadExceptionTestService(HttpPipeline httpPipeline, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    }
+
+    /**
+     * Initializes an instance of AutoRestHeadExceptionTestService client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     * @param host server parameter.
+     */
+    AutoRestHeadExceptionTestService(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
+        this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
+        this.host = host;
+        this.headExceptions = new HeadExceptions(this);
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/customhttpexceptionmapping/AutoRestHeadExceptionTestServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/customhttpexceptionmapping/AutoRestHeadExceptionTestServiceBuilder.java
@@ -1,0 +1,249 @@
+package fixtures.customhttpexceptionmapping;
+
+import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
+import com.azure.core.http.HttpHeaders;
+import com.azure.core.http.HttpPipeline;
+import com.azure.core.http.HttpPipelineBuilder;
+import com.azure.core.http.HttpPipelinePosition;
+import com.azure.core.http.policy.AddHeadersPolicy;
+import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
+import com.azure.core.http.policy.RetryPolicy;
+import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.ClientOptions;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.CoreUtils;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/** A builder for creating a new instance of the AutoRestHeadExceptionTestService type. */
+@ServiceClientBuilder(serviceClients = {AutoRestHeadExceptionTestService.class})
+public final class AutoRestHeadExceptionTestServiceBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
+    /** Create an instance of the AutoRestHeadExceptionTestServiceBuilder. */
+    public AutoRestHeadExceptionTestServiceBuilder() {
+        this.pipelinePolicies = new ArrayList<>();
+    }
+
+    /*
+     * server parameter
+     */
+    private String host;
+
+    /**
+     * Sets server parameter.
+     *
+     * @param host the host value.
+     * @return the AutoRestHeadExceptionTestServiceBuilder.
+     */
+    public AutoRestHeadExceptionTestServiceBuilder host(String host) {
+        this.host = host;
+        return this;
+    }
+
+    /*
+     * The HTTP pipeline to send requests through
+     */
+    private HttpPipeline pipeline;
+
+    /**
+     * Sets The HTTP pipeline to send requests through.
+     *
+     * @param pipeline the pipeline value.
+     * @return the AutoRestHeadExceptionTestServiceBuilder.
+     */
+    public AutoRestHeadExceptionTestServiceBuilder pipeline(HttpPipeline pipeline) {
+        this.pipeline = pipeline;
+        return this;
+    }
+
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the AutoRestHeadExceptionTestServiceBuilder.
+     */
+    public AutoRestHeadExceptionTestServiceBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the AutoRestHeadExceptionTestServiceBuilder.
+     */
+    public AutoRestHeadExceptionTestServiceBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the AutoRestHeadExceptionTestServiceBuilder.
+     */
+    public AutoRestHeadExceptionTestServiceBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the AutoRestHeadExceptionTestServiceBuilder.
+     */
+    public AutoRestHeadExceptionTestServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the AutoRestHeadExceptionTestServiceBuilder.
+     */
+    public AutoRestHeadExceptionTestServiceBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private final List<HttpPipelinePolicy> pipelinePolicies;
+
+    /*
+     * The client options such as application ID and custom headers to set on a
+     * request.
+     */
+    private ClientOptions clientOptions;
+
+    /**
+     * Sets The client options such as application ID and custom headers to set on a request.
+     *
+     * @param clientOptions the clientOptions value.
+     * @return the AutoRestHeadExceptionTestServiceBuilder.
+     */
+    public AutoRestHeadExceptionTestServiceBuilder clientOptions(ClientOptions clientOptions) {
+        this.clientOptions = clientOptions;
+        return this;
+    }
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the AutoRestHeadExceptionTestServiceBuilder.
+     */
+    public AutoRestHeadExceptionTestServiceBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
+    /**
+     * Builds an instance of AutoRestHeadExceptionTestService with the provided parameters.
+     *
+     * @return an instance of AutoRestHeadExceptionTestService.
+     */
+    public AutoRestHeadExceptionTestService buildClient() {
+        if (host == null) {
+            this.host = "http://localhost:3000";
+        }
+        if (pipeline == null) {
+            this.pipeline = createHttpPipeline();
+        }
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        AutoRestHeadExceptionTestService client =
+                new AutoRestHeadExceptionTestService(pipeline, serializerAdapter, host);
+        return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        if (clientOptions == null) {
+            clientOptions = new ClientOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        String applicationId = CoreUtils.getApplicationId(clientOptions, httpLogOptions);
+        policies.add(new UserAgentPolicy(applicationId, clientName, clientVersion, buildConfiguration));
+        HttpHeaders headers = new HttpHeaders();
+        clientOptions.getHeaders().forEach(header -> headers.set(header.getName(), header.getValue()));
+        if (headers.getSize() > 0) {
+            policies.add(new AddHeadersPolicy(headers));
+        }
+        policies.addAll(
+                this.pipelinePolicies.stream()
+                        .filter(p -> p.getPipelinePosition() == HttpPipelinePosition.PER_CALL)
+                        .collect(Collectors.toList()));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(
+                this.pipelinePolicies.stream()
+                        .filter(p -> p.getPipelinePosition() == HttpPipelinePosition.PER_RETRY)
+                        .collect(Collectors.toList()));
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .clientOptions(clientOptions)
+                        .build();
+        return httpPipeline;
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/customhttpexceptionmapping/HeadExceptions.java
+++ b/vanilla-tests/src/main/java/fixtures/customhttpexceptionmapping/HeadExceptions.java
@@ -1,0 +1,195 @@
+package fixtures.customhttpexceptionmapping;
+
+import com.azure.core.annotation.ExpectedResponses;
+import com.azure.core.annotation.Head;
+import com.azure.core.annotation.Host;
+import com.azure.core.annotation.HostParam;
+import com.azure.core.annotation.ReturnType;
+import com.azure.core.annotation.ServiceInterface;
+import com.azure.core.annotation.ServiceMethod;
+import com.azure.core.annotation.UnexpectedResponseExceptionType;
+import com.azure.core.exception.ResourceExistsException;
+import com.azure.core.exception.ResourceNotFoundException;
+import com.azure.core.http.rest.Response;
+import com.azure.core.http.rest.RestProxy;
+import com.azure.core.util.Context;
+import com.azure.core.util.FluxUtil;
+import reactor.core.publisher.Mono;
+
+/** An instance of this class provides access to all the operations defined in HeadExceptions. */
+public final class HeadExceptions {
+    /** The proxy service used to perform REST calls. */
+    private final HeadExceptionsService service;
+
+    /** The service client containing this operation class. */
+    private final AutoRestHeadExceptionTestService client;
+
+    /**
+     * Initializes an instance of HeadExceptions.
+     *
+     * @param client the instance of the service client containing this operation class.
+     */
+    HeadExceptions(AutoRestHeadExceptionTestService client) {
+        this.service =
+                RestProxy.create(HeadExceptionsService.class, client.getHttpPipeline(), client.getSerializerAdapter());
+        this.client = client;
+    }
+
+    /**
+     * The interface defining all the services for AutoRestHeadExceptionTestServiceHeadExceptions to be used by the
+     * proxy service to perform REST calls.
+     */
+    @Host("{$host}")
+    @ServiceInterface(name = "AutoRestHeadExceptio")
+    public interface HeadExceptionsService {
+        @Head("/http/success/200")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(
+                value = ResourceExistsException.class,
+                code = {404})
+        @UnexpectedResponseExceptionType(ResourceNotFoundException.class)
+        Mono<Response<Void>> head200(@HostParam("$host") String host, Context context);
+
+        @Head("/http/success/204")
+        @ExpectedResponses({204})
+        @UnexpectedResponseExceptionType(
+                value = ResourceExistsException.class,
+                code = {404})
+        @UnexpectedResponseExceptionType(ResourceNotFoundException.class)
+        Mono<Response<Void>> head204(@HostParam("$host") String host, Context context);
+
+        @Head("/http/success/404")
+        @ExpectedResponses({204})
+        @UnexpectedResponseExceptionType(
+                value = ResourceExistsException.class,
+                code = {404})
+        @UnexpectedResponseExceptionType(ResourceNotFoundException.class)
+        Mono<Response<Void>> head404(@HostParam("$host") String host, Context context);
+    }
+
+    /**
+     * Return 200 status code if successful.
+     *
+     * @throws ResourceNotFoundException thrown if the request is rejected by server.
+     * @throws ResourceExistsException thrown if the request is rejected by server on status code 404.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> head200WithResponseAsync() {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return FluxUtil.withContext(context -> service.head200(this.client.getHost(), context));
+    }
+
+    /**
+     * Return 200 status code if successful.
+     *
+     * @throws ResourceNotFoundException thrown if the request is rejected by server.
+     * @throws ResourceExistsException thrown if the request is rejected by server on status code 404.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> head200Async() {
+        return head200WithResponseAsync().flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Return 200 status code if successful.
+     *
+     * @throws ResourceNotFoundException thrown if the request is rejected by server.
+     * @throws ResourceExistsException thrown if the request is rejected by server on status code 404.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void head200() {
+        head200Async().block();
+    }
+
+    /**
+     * Return 204 status code if successful.
+     *
+     * @throws ResourceNotFoundException thrown if the request is rejected by server.
+     * @throws ResourceExistsException thrown if the request is rejected by server on status code 404.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> head204WithResponseAsync() {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return FluxUtil.withContext(context -> service.head204(this.client.getHost(), context));
+    }
+
+    /**
+     * Return 204 status code if successful.
+     *
+     * @throws ResourceNotFoundException thrown if the request is rejected by server.
+     * @throws ResourceExistsException thrown if the request is rejected by server on status code 404.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> head204Async() {
+        return head204WithResponseAsync().flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Return 204 status code if successful.
+     *
+     * @throws ResourceNotFoundException thrown if the request is rejected by server.
+     * @throws ResourceExistsException thrown if the request is rejected by server on status code 404.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void head204() {
+        head204Async().block();
+    }
+
+    /**
+     * Return 404 status code if successful.
+     *
+     * @throws ResourceNotFoundException thrown if the request is rejected by server.
+     * @throws ResourceExistsException thrown if the request is rejected by server on status code 404.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> head404WithResponseAsync() {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        return FluxUtil.withContext(context -> service.head404(this.client.getHost(), context));
+    }
+
+    /**
+     * Return 404 status code if successful.
+     *
+     * @throws ResourceNotFoundException thrown if the request is rejected by server.
+     * @throws ResourceExistsException thrown if the request is rejected by server on status code 404.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> head404Async() {
+        return head404WithResponseAsync().flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Return 404 status code if successful.
+     *
+     * @throws ResourceNotFoundException thrown if the request is rejected by server.
+     * @throws ResourceExistsException thrown if the request is rejected by server on status code 404.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void head404() {
+        head404Async().block();
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/customhttpexceptionmapping/package-info.java
+++ b/vanilla-tests/src/main/java/fixtures/customhttpexceptionmapping/package-info.java
@@ -1,0 +1,2 @@
+/** Package containing the classes for AutoRestHeadExceptionTestService. Test Infrastructure for AutoRest. */
+package fixtures.customhttpexceptionmapping;

--- a/vanilla-tests/src/test/java/fixtures/customhttpexceptionmapping/ValidateExceptionMappingTests.java
+++ b/vanilla-tests/src/test/java/fixtures/customhttpexceptionmapping/ValidateExceptionMappingTests.java
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package fixtures.customhttpexceptionmapping;
+
+import com.azure.core.annotation.UnexpectedResponseExceptionType;
+import com.azure.core.exception.ResourceExistsException;
+import com.azure.core.exception.ResourceNotFoundException;
+import com.azure.core.util.CoreUtils;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Validates the unexpected exception type mapping.
+ */
+public class ValidateExceptionMappingTests {
+
+    /**
+     * Expected default exception for all methods is com.azure.core.exception.ResourceNotFoundException.
+     */
+    @Test
+    public void validateDefaultExceptionType() {
+        for (Method method : HeadExceptions.HeadExceptionsService.class.getDeclaredMethods()) {
+            UnexpectedResponseExceptionType[] exceptionTypes = method
+                .getAnnotationsByType(UnexpectedResponseExceptionType.class);
+
+            // If the method isn't annotated with UnexpectedResponseExceptionType skip it.
+            if (CoreUtils.isNullOrEmpty(exceptionTypes)) {
+                continue;
+            }
+
+            assertTrue(Arrays.stream(exceptionTypes).anyMatch(uret ->
+                (uret.code() == null || uret.code().length == 0) && uret.value() == ResourceNotFoundException.class));
+        }
+    }
+
+    /**
+     * 404 uses a custom mapping of com.azure.core.exception.ResourceExistsException that should take priority over
+     * everything else.
+     */
+    @Test
+    public void validate404UsesResourceExistsException() {
+        for (Method method : HeadExceptions.HeadExceptionsService.class.getDeclaredMethods()) {
+            UnexpectedResponseExceptionType[] exceptionTypes = method
+                .getAnnotationsByType(UnexpectedResponseExceptionType.class);
+
+            // If the method isn't annotated with UnexpectedResponseExceptionType skip it.
+            if (CoreUtils.isNullOrEmpty(exceptionTypes)) {
+                continue;
+            }
+
+            assertTrue(Arrays.stream(exceptionTypes).anyMatch(uret ->
+                (uret.code() != null && Arrays.stream(uret.code()).anyMatch(code -> code == 404))
+                    && uret.value() == ResourceExistsException.class));
+        }
+    }
+}

--- a/vanilla-tests/swagger/custom-http-exception-mapping.md
+++ b/vanilla-tests/swagger/custom-http-exception-mapping.md
@@ -1,0 +1,16 @@
+## Generate code with custom http exception mapping
+
+```yaml
+java: true
+input-file: https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/head-exceptions.json
+output-folder: ..
+namespace: fixtures.customhttpexceptionmapping
+required-parameter-client-methods: true
+sync-methods: all
+client-side-validations: true
+add-context-parameter: true
+service-interface-as-public: true
+default-http-exception-type: com.azure.core.exception.ResourceNotFoundException
+http-status-code-to-exception-type-mapping:
+  404: com.azure.core.exception.ResourceExistsException
+```


### PR DESCRIPTION
This PR adds new configurations to AutoRest to enable supporting custom HTTP exception type mappings.

- `--default-http-exception-type` allows for the configuration of the default HTTP exception type.
- `--use-default-http-status-code-to-exception-type-mapping` adds support for a default status code to exception type mapping based on well-known status code to `azure-core` exception types.
- `--http-status-code-to-exception-type-mapping` allows for the configuration of a custom status code to exception type mapping.