### PR TITLE
Generate Strongly-Typed Headers Classes with Deferred Deserialization

### DIFF
--- a/androidgen/src/main/java/com/azure/autorest/android/model/clientmodel/AndroidClientModel.java
+++ b/androidgen/src/main/java/com/azure/autorest/android/model/clientmodel/AndroidClientModel.java
@@ -12,7 +12,7 @@ public class AndroidClientModel extends ClientModel {
                                  boolean isPolymorphic, String polymorphicDiscriminator, String serializedName, boolean needsFlatten,
                                  String parentModelName, java.util.List<com.azure.autorest.model.clientmodel.ClientModel> derivedModels, String xmlName, String xmlNamespace,
                                  java.util.List<com.azure.autorest.model.clientmodel.ClientModelProperty> properties, java.util.List<com.azure.autorest.model.clientmodel.ClientModelPropertyReference> propertyReferences,
-                                 IType modelType) {
+                                 IType modelType, boolean stronglyTypedHeader) {
         super(package_Keyword,
                 name,
                 imports,
@@ -27,7 +27,8 @@ public class AndroidClientModel extends ClientModel {
                 xmlNamespace,
                 properties,
                 propertyReferences,
-                modelType);
+                modelType,
+                stronglyTypedHeader);
     }
 
     @Override
@@ -72,7 +73,8 @@ public class AndroidClientModel extends ClientModel {
                     xmlNamespace,
                     properties,
                     propertyReferences,
-                    modelType);
+                    modelType,
+                    stronglyTypedHeader);
         }
     }
 }

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ObjectSchema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/ObjectSchema.java
@@ -7,28 +7,28 @@ import java.util.List;
 
 /**
  * a schema that represents a type with child properties.
- * 
+ *
  */
 public class ObjectSchema extends ComplexSchema {
 
     /**
      * a property is a child value in an object
-     * 
+     *
      */
     private Discriminator discriminator;
     /**
      * the collection of properties that are in this object
-     * 
+     *
      */
     private List<Property> properties = new ArrayList<Property>();
     /**
      * maximum number of properties permitted
-     * 
+     *
      */
     private double maxProperties;
     /**
      * minimum number of properties permitted
-     * 
+     *
      */
     private double minProperties;
 
@@ -41,9 +41,12 @@ public class ObjectSchema extends ComplexSchema {
     // internal use, not from modelerfour
     private boolean flattenedSchema;
 
+    // internal use, not from modelerfour
+    private boolean stronglyTypedHeader;
+
     /**
      * a property is a child value in an object
-     * 
+     *
      */
     public Discriminator getDiscriminator() {
         return discriminator;
@@ -51,7 +54,7 @@ public class ObjectSchema extends ComplexSchema {
 
     /**
      * a property is a child value in an object
-     * 
+     *
      */
     public void setDiscriminator(Discriminator discriminator) {
         this.discriminator = discriminator;
@@ -59,7 +62,7 @@ public class ObjectSchema extends ComplexSchema {
 
     /**
      * the collection of properties that are in this object
-     * 
+     *
      */
     public List<Property> getProperties() {
         return properties;
@@ -67,7 +70,7 @@ public class ObjectSchema extends ComplexSchema {
 
     /**
      * the collection of properties that are in this object
-     * 
+     *
      */
     public void setProperties(List<Property> properties) {
         this.properties = properties;
@@ -75,7 +78,7 @@ public class ObjectSchema extends ComplexSchema {
 
     /**
      * maximum number of properties permitted
-     * 
+     *
      */
     public double getMaxProperties() {
         return maxProperties;
@@ -83,7 +86,7 @@ public class ObjectSchema extends ComplexSchema {
 
     /**
      * maximum number of properties permitted
-     * 
+     *
      */
     public void setMaxProperties(double maxProperties) {
         this.maxProperties = maxProperties;
@@ -91,7 +94,7 @@ public class ObjectSchema extends ComplexSchema {
 
     /**
      * minimum number of properties permitted
-     * 
+     *
      */
     public double getMinProperties() {
         return minProperties;
@@ -99,7 +102,7 @@ public class ObjectSchema extends ComplexSchema {
 
     /**
      * minimum number of properties permitted
-     * 
+     *
      */
     public void setMinProperties(double minProperties) {
         this.minProperties = minProperties;
@@ -135,5 +138,23 @@ public class ObjectSchema extends ComplexSchema {
 
     public void setFlattenedSchema(boolean flattenedSchema) {
         this.flattenedSchema = flattenedSchema;
+    }
+
+    /**
+     * Whether this schema represents a strongly-typed HTTP headers object.
+     *
+     * @return Whether this schema represents a strongly-typed HTTP headers object.
+     */
+    public boolean isStronglyTypedHeader() {
+        return stronglyTypedHeader;
+    }
+
+    /**
+     * Sets whether this schema represents a strongly-typed HTTP headers object.
+     *
+     * @param stronglyTypedHeader Whether this schema represents a strongly-typed HTTP headers object.
+     */
+    public void setStronglyTypedHeader(boolean stronglyTypedHeader) {
+        this.stronglyTypedHeader = stronglyTypedHeader;
     }
 }

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
@@ -128,7 +128,8 @@ public class JavaSettings {
                 }.getType(), "polling"),
                 getBooleanValue(host, "generate-samples", false),
                 getBooleanValue(host, "pass-discriminator-to-child-deserialization", false),
-                getBooleanValue(host, "annotate-getters-and-setters-for-serialization", false));
+                getBooleanValue(host, "annotate-getters-and-setters-for-serialization", false),
+                getBooleanValue(host, "defer-strongly-typed-header-deserialization", false));
         }
         return _instance;
     }
@@ -159,6 +160,8 @@ public class JavaSettings {
      * @param annotateGettersAndSettersForSerialization If set to true, Jackson JsonGetter and JsonSetter will annotate
      * getters and setters in generated models to handle serialization and deserialization. For now, fields will
      * continue being annotated to ensure that there are no backwards compatibility breaks.
+     * @param deferStronglyTypedHeaderDeserialization If set to true, strongly-typed HTTP header objects will lazily
+     * deserialize properties as they are accessed.
      */
     private JavaSettings(AutorestSettings autorestSettings,
         Map<String, Object> modelerSettings,
@@ -207,7 +210,8 @@ public class JavaSettings {
         Map<String, PollingDetails> pollingConfig,
         boolean generateSamples,
         boolean passDiscriminatorToChildDeserialization,
-        boolean annotateGettersAndSettersForSerialization) {
+        boolean annotateGettersAndSettersForSerialization,
+        boolean deferStronglyTypedHeaderDeserialization) {
 
         this.autorestSettings = autorestSettings;
         this.modelerSettings = new ModelerSettings(modelerSettings);
@@ -282,6 +286,8 @@ public class JavaSettings {
         this.generateSamples = generateSamples;
         this.passDiscriminatorToChildDeserialization = passDiscriminatorToChildDeserialization;
         this.annotateGettersAndSettersForSerialization = annotateGettersAndSettersForSerialization;
+
+        this.deferStronglyTypedHeaderDeserialization = deferStronglyTypedHeaderDeserialization;
     }
 
     private String keyCredentialHeaderName;
@@ -782,6 +788,17 @@ public class JavaSettings {
      */
     public boolean isGettersAndSettersAnnotatedForSerialization() {
         return annotateGettersAndSettersForSerialization;
+    }
+
+    private final boolean deferStronglyTypedHeaderDeserialization;
+
+    /**
+     * Whether strongly-typed HTTP header objects will be generated with lazy deserialization for properties.
+     *
+     * @return Whether strongly-typed HTTP header objects will be generated with lazy deserialization for properties.
+     */
+    public boolean isDeferStronglyTypedHeaderDeserialization() {
+        return deferStronglyTypedHeaderDeserialization;
     }
 
     public static final String DefaultCodeGenerationHeader = String.join("\r\n",

--- a/generate
+++ b/generate
@@ -22,6 +22,7 @@ autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure
 autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/$TEST_SERVER_COMMIT/swagger/head.json --namespace=fixtures.head
 autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/$TEST_SERVER_COMMIT/swagger/head-exceptions.json --namespace=fixtures.headexceptions
 autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/$TEST_SERVER_COMMIT/swagger/header.json --namespace=fixtures.header --context-client-method-parameter
+autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/$TEST_SERVER_COMMIT/swagger/header.json --namespace=fixtures.deferredheaderdeserialization --context-client-method-parameter --defer-strongly-typed-header-deserialization
 autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/$TEST_SERVER_COMMIT/swagger/body-dictionary.json --namespace=fixtures.bodydictionary --generate-sync-async-clients
 autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/$TEST_SERVER_COMMIT/swagger/body-duration.json --namespace=fixtures.bodyduration
 autorest $VANILLA_ARGUMENTS --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/$TEST_SERVER_COMMIT/swagger/body-integer.json --namespace=fixtures.bodyinteger

--- a/generate.bat
+++ b/generate.bat
@@ -19,6 +19,7 @@ call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com
 call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/%TEST_SERVER_COMMIT%/swagger/head.json --namespace=fixtures.head
 call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/%TEST_SERVER_COMMIT%/swagger/head-exceptions.json --namespace=fixtures.headexceptions
 call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/%TEST_SERVER_COMMIT%/swagger/header.json --namespace=fixtures.header --context-client-method-parameter
+call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/%TEST_SERVER_COMMIT%/swagger/header.json --namespace=fixtures.deferredheaderdeserialization --context-client-method-parameter --defer-strongly-typed-header-deserialization
 call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/%TEST_SERVER_COMMIT%/swagger/body-dictionary.json --namespace=fixtures.bodydictionary --generate-sync-async-clients
 call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/%TEST_SERVER_COMMIT%/swagger/body-duration.json --namespace=fixtures.bodyduration
 call autorest %VANILLA_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/autorest.testserver/%TEST_SERVER_COMMIT%/swagger/body-integer.json --namespace=fixtures.bodyinteger

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMapper.java
@@ -263,6 +263,7 @@ public class ClientMapper implements IMapper<CodeModel, Client> {
         headerSchema.getLanguage().setJava(new Language());
         headerSchema.getLanguage().getJava().setName(name);
         headerSchema.setProperties(new ArrayList<>());
+        headerSchema.setStronglyTypedHeader(true);
         for (Map.Entry<String, Schema> header : headerMap.entrySet()) {
             Property property = new Property();
             property.setSerializedName(header.getKey());

--- a/javagen/src/main/java/com/azure/autorest/mapper/ModelMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ModelMapper.java
@@ -62,7 +62,8 @@ public class ModelMapper implements IMapper<ObjectSchema, ClientModel> {
             ClientModel.Builder builder = createModelBuilder()
                     .name(modelName)
                     .packageName(modelType.getPackage())
-                    .type(modelType);
+                    .type(modelType)
+                    .isStronglyTypedHeader(compositeType.isStronglyTypedHeader());
 
             boolean isPolymorphic = compositeType.getDiscriminator() != null || compositeType.getDiscriminatorValue() != null;
             builder.isPolymorphic(isPolymorphic);

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
@@ -74,8 +74,9 @@ public class ClassType implements IType {
     public static final ClassType JsonPatchDocument =
             new ClassType.Builder().knownClass(com.azure.core.models.JsonPatchDocument.class).build();
     public static final ClassType BinaryData = new ClassType.Builder().knownClass(com.azure.core.util.BinaryData.class).defaultValueExpressionConverter((String defaultValueExpression) -> java.lang.String.format("BinaryData.fromObject(\"%s\")", defaultValueExpression)).build();
-    public static final ClassType RequestOptions = new Builder().packageName("com.azure.core.http.rest").name("RequestOptions").build();
+    public static final ClassType RequestOptions = new Builder().knownClass(com.azure.core.http.rest.RequestOptions.class).build();
     public static final ClassType ClientOptions = new Builder().knownClass(com.azure.core.util.ClientOptions.class).build();
+    public static final ClassType HttpHeaders = new Builder().knownClass(com.azure.core.http.HttpHeaders.class).build();
 
     private final String packageName;
     private final String name;
@@ -160,9 +161,7 @@ public class ClassType implements IType {
         }
 
         if (includeImplementationImports && getImplementationImports() != null) {
-            for (String implementationImport : getImplementationImports()) {
-                imports.add(implementationImport);
-            }
+            imports.addAll(getImplementationImports());
         }
     }
 
@@ -172,7 +171,7 @@ public class ClassType implements IType {
             if (getDefaultValueExpressionConverter() != null) {
                 result = defaultValueExpressionConverter.apply(sourceExpression);
             } else {
-                result = java.lang.String.format("new %1$s()", toString());
+                result = java.lang.String.format("new %1$s()", getName());
             }
         }
         return result;

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientModel.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientModel.java
@@ -31,7 +31,7 @@ public class ClientModel {
      */
     private String description;
     /**
-     * Get whether or not this model has model types that derive from it.
+     * Get whether this model has model types that derive from it.
      */
     private boolean isPolymorphic;
     /**
@@ -43,7 +43,7 @@ public class ClientModel {
      */
     private String serializedName;
     /**
-     * Get whether or not this model needs serialization flattening.
+     * Get whether this model needs serialization flattening.
      */
     private boolean needsFlatten;
     /**
@@ -74,26 +74,32 @@ public class ClientModel {
     private IType modelType;
 
     /**
+     * Whether this model is a strongly-typed HTTP headers class.
+     */
+    private final boolean stronglyTypedHeader;
+
+    /**
      * Create a new ServiceModel with the provided properties.
      * @param name The name of this model.
      * @param imports The imports for this model.
      * @param description The description of this model.
-     * @param isPolymorphic Whether or not this model has model types that derive from it.
+     * @param isPolymorphic Whether this model has model types that derive from it.
      * @param polymorphicDiscriminator The name of the property that determines which polymorphic model type to create.
      * @param serializedName The name that is used for this model when it is serialized.
-     * @param needsFlatten Whether or not this model needs serialization flattening.
+     * @param needsFlatten Whether this model needs serialization flattening.
      * @param parentModelName The parent model of this model.
      * @param derivedModels The models that derive from this model.
      * @param xmlName The name that will be used for this model's XML element representation.
      * @param properties The properties for this model.
      * @param propertyReferences
      * @param modelType the type of the model.
+     * @param stronglyTypedHeader Whether this model is a strongly-typed HTTP headers class.
      */
     protected ClientModel(String package_Keyword, String name, List<String> imports, String description,
             boolean isPolymorphic, String polymorphicDiscriminator, String serializedName, boolean needsFlatten,
             String parentModelName, List<ClientModel> derivedModels, String xmlName, String xmlNamespace,
             List<ClientModelProperty> properties, List<ClientModelPropertyReference> propertyReferences,
-            IType modelType) {
+            IType modelType, boolean stronglyTypedHeader) {
         packageName = package_Keyword;
         this.name = name;
         this.imports = imports;
@@ -109,6 +115,7 @@ public class ClientModel {
         this.properties = properties;
         this.propertyReferences = propertyReferences;
         this.modelType = modelType;
+        this.stronglyTypedHeader = stronglyTypedHeader;
     }
 
     public final String getPackage() {
@@ -176,6 +183,15 @@ public class ClientModel {
 
     public List<ClientModelPropertyReference> getPropertyReferences() {
         return propertyReferences == null ? Collections.emptyList() : propertyReferences;
+    }
+
+    /**
+     * Whether this model is a strongly-typed HTTP headers class.
+     *
+     * @return Whether this model is a strongly-typed HTTP headers class.
+     */
+    public boolean isStronglyTypedHeader() {
+        return stronglyTypedHeader;
     }
 
     /**
@@ -257,6 +273,7 @@ public class ClientModel {
         protected String xmlNamespace;
         protected List<ClientModelPropertyReference> propertyReferences;
         protected IType modelType;
+        protected boolean stronglyTypedHeader;
 
         /**
          * Sets the package that this model class belongs to.
@@ -299,8 +316,8 @@ public class ClientModel {
         }
 
         /**
-         * Sets whether or not this model has model types that derive from it.
-         * @param isPolymorphic whether or not this model has model types that derive from it
+         * Sets whether this model has model types that derive from it.
+         * @param isPolymorphic whether this model has model types that derive from it
          * @return the Builder itself
          */
         public Builder isPolymorphic(boolean isPolymorphic) {
@@ -329,8 +346,8 @@ public class ClientModel {
         }
 
         /**
-         * Sets whether or not this model needs serialization flattening.
-         * @param needsFlatten whether or not this model needs serialization flattening
+         * Sets whether this model needs serialization flattening.
+         * @param needsFlatten whether this model needs serialization flattening
          * @return the Builder itself
          */
         public Builder needsFlatten(boolean needsFlatten) {
@@ -409,6 +426,17 @@ public class ClientModel {
             return this;
         }
 
+        /**
+         * Sets whether this model is a strongly-typed HTTP headers class.
+         *
+         * @param stronglyTypedHeader Whether this model is a strongly-typed HTTP headers class.
+         * @return the Builder itself
+         */
+        public Builder isStronglyTypedHeader(boolean stronglyTypedHeader) {
+            this.stronglyTypedHeader = stronglyTypedHeader;
+            return this;
+        }
+
         public ClientModel build() {
             return new ClientModel(packageName,
                     name,
@@ -424,7 +452,8 @@ public class ClientModel {
                     xmlNamespace,
                     properties,
                     propertyReferences,
-                    modelType);
+                    modelType,
+                    stronglyTypedHeader);
         }
     }
 }

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/EnumType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/EnumType.java
@@ -16,26 +16,26 @@ public class EnumType implements IType {
     /**
      * The name of the new Enum.
      */
-    private String name;
+    private final String name;
     /**
      * The package that this enumeration belongs to.
      */
-    private String packageName;
+    private final String packageName;
     /**
-     * Whether or not this will be an ExpandableStringEnum type.
+     * Whether this will be an ExpandableStringEnum type.
      */
-    private boolean expandable;
+    private final boolean expandable;
     /**
      * The values of the Enum.
      */
-    private List<ClientEnumValue> values;
+    private final List<ClientEnumValue> values;
 
-    private IType elementType;
+    private final IType elementType;
 
     /**
      * Create a new Enum with the provided properties.
      * @param name The name of the new Enum.
-     * @param expandable Whether or not this will be an ExpandableStringEnum type.
+     * @param expandable Whether this will be an ExpandableStringEnum type.
      * @param values The values of the Enum.
      */
     private EnumType(String package_Keyword, String name, boolean expandable, List<ClientEnumValue> values, IType elementType) {
@@ -97,6 +97,14 @@ public class EnumType implements IType {
             }
             return null;
         }
+    }
+
+    public final String getFromJsonMethodName() {
+        return "from" + CodeNamer.toPascalCase(elementType.getClientType().toString());
+    }
+
+    public final String getToJsonMethodName() {
+        return "to" + CodeNamer.toPascalCase(elementType.getClientType().toString());
     }
 
     @Override

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/IType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/IType.java
@@ -35,17 +35,17 @@ public interface IType {
     IType asNullable();
 
     /**
-     * Get whether or not this IType contains (or is) the provided type.
+     * Get whether this IType contains (or is) the provided type.
      * @param type The type to search for.
      *
-     * @return Whether or not this IType contains (or is) the provided type.
+     * @return Whether this IType contains (or is) the provided type.
      */
     boolean contains(IType type);
 
     /**
      * Add this type's imports to the provided ISet of imports.
      * @param imports The set of imports to add to.
-     * @param includeImplementationImports Whether or not to include imports that are only necessary for method implementations.
+     * @param includeImplementationImports Whether to include imports that are only necessary for method implementations.
      */
     void addImportsTo(Set<String> imports, boolean includeImplementationImports);
 

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/PrimitiveType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/PrimitiveType.java
@@ -1,7 +1,5 @@
 package com.azure.autorest.model.clientmodel;
 
-import com.azure.autorest.extension.base.plugin.JavaSettings;
-
 import java.util.Set;
 import java.util.function.Function;
 
@@ -45,7 +43,7 @@ public class PrimitiveType implements IType {
     private PrimitiveType(String name, ClassType nullableType, java.util.function.Function<String, String> defaultValueExpressionConverter, String defaultValue) {
         this.name = name;
         this.nullableType = nullableType;
-        this.defaultValueExpressionConverter = (String arg) -> defaultValueExpressionConverter.apply(arg);
+        this.defaultValueExpressionConverter = defaultValueExpressionConverter;
         this.defaultValue = defaultValue;
     }
 

--- a/javagen/src/main/java/com/azure/autorest/model/javamodel/JavaBlock.java
+++ b/javagen/src/main/java/com/azure/autorest/model/javamodel/JavaBlock.java
@@ -29,6 +29,9 @@ public class JavaBlock implements JavaContext {
         contents.line(text, formattedArguments);
     }
 
+    /**
+     * Inserts an empty line.
+     */
     public final void line() {
         contents.line();
     }

--- a/javagen/src/main/java/com/azure/autorest/template/EnumTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/EnumTemplate.java
@@ -3,6 +3,7 @@ package com.azure.autorest.template;
 import com.azure.autorest.model.clientmodel.ClassType;
 import com.azure.autorest.model.clientmodel.ClientEnumValue;
 import com.azure.autorest.model.clientmodel.EnumType;
+import com.azure.autorest.model.clientmodel.IType;
 import com.azure.autorest.model.clientmodel.PrimitiveType;
 import com.azure.autorest.model.javamodel.JavaFile;
 import com.azure.autorest.util.CodeNamer;
@@ -18,30 +19,36 @@ import java.util.Set;
  * Writes a EnumType to a JavaFile.
  */
 public class EnumTemplate implements IJavaTemplate<EnumType, JavaFile> {
-    private static EnumTemplate _instance = new EnumTemplate();
+    private static final EnumTemplate INSTANCE = new EnumTemplate();
 
     protected EnumTemplate() {
     }
 
+    /**
+     * @return The global instance of {@link EnumTemplate}.
+     */
     public static EnumTemplate getInstance() {
-        return _instance;
+        return INSTANCE;
     }
 
+    /**
+     * Writes a declared enum to a specific Java file.
+     *
+     * @param enumType The enum.
+     * @param javaFile The Java file.
+     */
     public final void write(EnumType enumType, JavaFile javaFile) {
         String enumTypeComment = String.format("Defines values for %1$s.", enumType.getName());
         if (enumType.getExpandable()) {
             javaFile.declareImport("java.util.Collection", "com.fasterxml.jackson.annotation.JsonCreator", getStringEnumImport());
-            javaFile.javadocComment(comment ->
-            {
-                comment.description(enumTypeComment);
-            });
+            javaFile.javadocComment(comment -> comment.description(enumTypeComment));
             javaFile.publicFinalClass(String.format("%1$s extends ExpandableStringEnum<%2$s>", enumType.getName(), enumType.getName()), (classBlock) ->
             {
                 String typeName = enumType.getElementType().getClientType().toString();
                 for (ClientEnumValue enumValue : enumType.getValues()) {
                     classBlock.javadocComment(String.format("Static value %1$s for %2$s.", enumValue.getValue(), enumType.getName()));
-                    classBlock.publicStaticFinalVariable(String.format("%1$s %2$s = from%3$s(%4$s)",enumType.getName(), enumValue.getName(),
-                            CodeNamer.toPascalCase(typeName), enumType.getElementType().defaultValueExpression(enumValue.getValue())));
+                    classBlock.publicStaticFinalVariable(String.format("%1$s %2$s = from%3$s(%4$s)", enumType.getName(), enumValue.getName(),
+                        CodeNamer.toPascalCase(typeName), enumType.getElementType().defaultValueExpression(enumValue.getValue())));
                 }
 
                 classBlock.javadocComment((comment) ->
@@ -53,23 +60,14 @@ public class EnumTemplate implements IJavaTemplate<EnumType, JavaFile> {
                 classBlock.annotation("JsonCreator");
                 classBlock.publicStaticMethod(String.format("%1$s from%2$s(%3$s name)", enumType.getName(), CodeNamer.toPascalCase(typeName), typeName), (function) ->
                 {
-                    String stringValue;
-                    if (ClassType.String.equals(enumType.getElementType())) {
-                        stringValue = "name";
-                    } else {
-                        stringValue = "String.valueOf(name)";
-                    }
+                    String stringValue = ClassType.String.equals(enumType.getElementType()) ? "name" : "String.valueOf(name)";
                     function.methodReturn(String.format("fromString(%1$s, %2$s.class)", stringValue, enumType.getName()));
                 });
 
                 classBlock.javadocComment((comment) ->
-                {
-                    comment.methodReturns(String.format("known %1$s values", enumType.getName()));
-                });
+                    comment.methodReturns(String.format("known %1$s values", enumType.getName())));
                 classBlock.publicStaticMethod(String.format("Collection<%1$s> values()", enumType.getName()), (function) ->
-                {
-                    function.methodReturn(String.format("values(%1$s.class)", enumType.getName()));
-                });
+                    function.methodReturn(String.format("values(%1$s.class)", enumType.getName())));
             });
         } else {
             Set<String> imports = new HashSet<>();
@@ -78,10 +76,7 @@ public class EnumTemplate implements IJavaTemplate<EnumType, JavaFile> {
             enumType.getElementType().getClientType().addImportsTo(imports, false);
 
             javaFile.declareImport(imports);
-            javaFile.javadocComment(comment ->
-            {
-                comment.description(enumTypeComment);
-            });
+            javaFile.javadocComment(comment -> comment.description(enumTypeComment));
             javaFile.publicEnum(enumType.getName(), enumBlock ->
             {
                 for (ClientEnumValue value : enumType.getValues()) {
@@ -89,15 +84,13 @@ public class EnumTemplate implements IJavaTemplate<EnumType, JavaFile> {
                 }
 
                 String typeName = enumType.getElementType().getClientType().toString();
-                String converterName = CodeNamer.toPascalCase(typeName);
+                String converterName = enumType.getFromJsonMethodName();
 
                 enumBlock.javadocComment(String.format("The actual serialized value for a %1$s instance.", enumType.getName()));
                 enumBlock.privateFinalMemberVariable(typeName, "value");
 
                 enumBlock.constructor(String.format("%1$s(%2$s value)", enumType.getName(), typeName), (constructor) ->
-                {
-                    constructor.line("this.value = value;");
-                });
+                    constructor.line("this.value = value;"));
 
                 enumBlock.javadocComment((comment) ->
                 {
@@ -106,36 +99,12 @@ public class EnumTemplate implements IJavaTemplate<EnumType, JavaFile> {
                     comment.methodReturns(String.format("the parsed %1$s object, or null if unable to parse.", enumType.getName()));
                 });
                 enumBlock.annotation("JsonCreator");
-                enumBlock.PublicStaticMethod(String.format("%1$s from%2$s(%3$s value)", enumType.getName(), converterName, typeName), (function) ->
+                enumBlock.PublicStaticMethod(String.format("%1$s %2$s(%3$s value)", enumType.getName(), converterName, typeName), (function) ->
                 {
                     function.line(String.format("%1$s[] items = %2$s.values();", enumType.getName(), enumType.getName()));
                     function.block(String.format("for (%1$s item : items)", enumType.getName()), (foreachBlock) ->
-                    {
-                        String valueEqualsTest;
-                        if (enumType.getElementType() instanceof PrimitiveType) {
-                            PrimitiveType type = (PrimitiveType) enumType.getElementType();
-                            if (type == PrimitiveType.Float) {
-                                valueEqualsTest = String.format("Float.floatToIntBits(item.to%1$s()) == Float.floatToIntBits(value)", converterName);
-                            } else if (type == PrimitiveType.Double) {
-                                valueEqualsTest = String.format("Double.doubleToIntBits(item.to%1$s()) == Double.doubleToIntBits(value)", converterName);
-                            } else {
-                                valueEqualsTest = String.format("item.to%1$s() == value", converterName);
-                            }
-                        } else if (enumType.getElementType() instanceof ClassType) {
-                            ClassType type = (ClassType) enumType.getElementType();
-                            if (type == ClassType.String) {
-                                valueEqualsTest = String.format("item.to%1$s().equalsIgnoreCase(value)", converterName);
-                            } else {
-                                valueEqualsTest = String.format("item.to%1$s().equals(value)", converterName);
-                            }
-                        } else {
-                            valueEqualsTest = String.format("item.to%1$s().equals(value)", converterName);
-                        }
-                        foreachBlock.ifBlock(valueEqualsTest, (ifBlock) ->
-                        {
-                            ifBlock.methodReturn("item");
-                        });
-                    });
+                        foreachBlock.ifBlock(createEnumJsonCreatorIfCheck(enumType),
+                            ifBlock -> ifBlock.methodReturn("item")));
                     function.methodReturn("null");
                 });
 
@@ -144,20 +113,48 @@ public class EnumTemplate implements IJavaTemplate<EnumType, JavaFile> {
                 } else {
                     enumBlock.javadocComment(comment ->
                     {
-                        comment.description(String.format("De-serializes the instance to %1$s value.", enumType.getElementType().toString()));
-                        comment.methodReturns(String.format("the %1$s value", enumType.getElementType().toString()));
+                        comment.description(String.format("De-serializes the instance to %1$s value.", enumType.getElementType()));
+                        comment.methodReturns(String.format("the %1$s value", enumType.getElementType()));
                     });
                     enumBlock.annotation("JsonValue");
                 }
-                enumBlock.PublicMethod(String.format("%1$s to%2$s()", typeName, converterName), (function) ->
-                {
-                    function.methodReturn("this.value");
-                });
+                enumBlock.PublicMethod(String.format("%1$s %2$s()", typeName, enumType.getToJsonMethodName()), (function) ->
+                    function.methodReturn("this.value"));
             });
         }
     }
 
+    /**
+     * Gets required import needed to support an expandable string enum.
+     * <p>
+     * By default, this is {@code com.azure.core.util.ExpandableStringEnum}.
+     *
+     * @return The required expandable string enum import.
+     */
     protected String getStringEnumImport() {
         return "com.azure.core.util.ExpandableStringEnum";
+    }
+
+    // TODO: Should this be made into a method on EnumType?
+    /**
+     * Creates the if check used by the JsonCreator method used in the Enum type.
+     *
+     * @param enumType The enum type.
+     * @return The JsonCreator if check.
+     */
+    protected String createEnumJsonCreatorIfCheck(EnumType enumType) {
+        IType enumElementType = enumType.getElementType();
+        String toJsonMethodName = enumType.getToJsonMethodName();
+        if (enumElementType == PrimitiveType.Float) {
+            return String.format("Float.floatToIntBits(item.%1$s()) == Float.floatToIntBits(value)", toJsonMethodName);
+        } else if (enumElementType == PrimitiveType.Double) {
+            return String.format("Double.doubleToLongBits(item.%1$s()) == Double.doubleToLongBits(value)", toJsonMethodName);
+        } else if (enumElementType instanceof PrimitiveType) {
+            return String.format("item.%1$s() == value", toJsonMethodName);
+        } else if (enumElementType == ClassType.String) {
+            return String.format("item.%1$s().equalsIgnoreCase(value)", toJsonMethodName);
+        } else {
+            return String.format("item.%1$s().equals(value)", toJsonMethodName);
+        }
     }
 }

--- a/javagen/src/main/java/com/azure/autorest/template/ProxyTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ProxyTemplate.java
@@ -83,7 +83,7 @@ public class ProxyTemplate implements IJavaTemplate<Proxy, JavaClass> {
 
                     ArrayList<String> parameterDeclarationList = new ArrayList<String>();
                     if (restAPIMethod.isResumable()) {
-                        interfaceBlock.annotation(String.format("ResumeOperation"));
+                        interfaceBlock.annotation("ResumeOperation");
                     }
 
                     for (ProxyMethodParameter parameter : restAPIMethod.getParameters()) {

--- a/protocol-tests/src/main/java/fixtures/mediatypes/MediaTypesAsyncClient.java
+++ b/protocol-tests/src/main/java/fixtures/mediatypes/MediaTypesAsyncClient.java
@@ -93,7 +93,7 @@ public final class MediaTypesAsyncClient {
     }
 
     /**
-     * Pass in contentType 'text/plain; encoding=UTF-8' to pass test. Value for input does not matter.
+     * Pass in contentType 'text/plain; charset=UTF-8' to pass test. Value for input does not matter.
      *
      * <p><strong>Request Body Schema</strong>
      *

--- a/protocol-tests/src/main/java/fixtures/mediatypes/MediaTypesClient.java
+++ b/protocol-tests/src/main/java/fixtures/mediatypes/MediaTypesClient.java
@@ -92,7 +92,7 @@ public final class MediaTypesClient {
     }
 
     /**
-     * Pass in contentType 'text/plain; encoding=UTF-8' to pass test. Value for input does not matter.
+     * Pass in contentType 'text/plain; charset=UTF-8' to pass test. Value for input does not matter.
      *
      * <p><strong>Request Body Schema</strong>
      *

--- a/protocol-tests/src/main/java/fixtures/mediatypes/implementation/MediaTypesClientImpl.java
+++ b/protocol-tests/src/main/java/fixtures/mediatypes/implementation/MediaTypesClientImpl.java
@@ -339,7 +339,7 @@ public final class MediaTypesClientImpl {
     }
 
     /**
-     * Pass in contentType 'text/plain; encoding=UTF-8' to pass test. Value for input does not matter.
+     * Pass in contentType 'text/plain; charset=UTF-8' to pass test. Value for input does not matter.
      *
      * <p><strong>Request Body Schema</strong>
      *
@@ -364,7 +364,7 @@ public final class MediaTypesClientImpl {
     }
 
     /**
-     * Pass in contentType 'text/plain; encoding=UTF-8' to pass test. Value for input does not matter.
+     * Pass in contentType 'text/plain; charset=UTF-8' to pass test. Value for input does not matter.
      *
      * <p><strong>Request Body Schema</strong>
      *
@@ -390,7 +390,7 @@ public final class MediaTypesClientImpl {
     }
 
     /**
-     * Pass in contentType 'text/plain; encoding=UTF-8' to pass test. Value for input does not matter.
+     * Pass in contentType 'text/plain; charset=UTF-8' to pass test. Value for input does not matter.
      *
      * <p><strong>Request Body Schema</strong>
      *

--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,7 @@ Settings can be provided on the command line through `--name:value` or in a READ
 |`--polling`|Configures how to generate long running operations. See [Polling Configuration](#polling-configuration) to see more details on how to use this flag.|
 | `--service-name` | String. Service name used in Client class and other documentations. If not provided, service name is deduced from `title` configure (from swagger or readme). |
 |`--pass-discriminator-to-child-deserialization`|Indicates whether the discriminator property is passed to subclass deserialization. Default is false.|
+|`--defer-strongly-typed-header-deserialization`|Indicates whether strongly-typed HTTP header object will lazily deserialize its properties when accessed.|
 
 ## Settings for minimal clients (low-level clients)
 

--- a/readme.md
+++ b/readme.md
@@ -75,13 +75,10 @@ Settings can be provided on the command line through `--name:value` or in a READ
 |`--polling`|Configures how to generate long running operations. See [Polling Configuration](#polling-configuration) to see more details on how to use this flag.|
 | `--service-name` | String. Service name used in Client class and other documentations. If not provided, service name is deduced from `title` configure (from swagger or readme). |
 |`--pass-discriminator-to-child-deserialization`|Indicates whether the discriminator property is passed to subclass deserialization. Default is false.|
-<<<<<<< HEAD
-|`--defer-strongly-typed-header-deserialization`|Indicates whether strongly-typed HTTP header object will lazily deserialize its properties when accessed.|
-=======
 |`--default-http-exception-type`|Indicates the fully-qualified class name that should be used as the default HTTP exception type. The class must extend from `HttpResponseException`.|
 |`--use-default-http-status-code-to-exception-type-mapping`|Indicates whether a default HTTP status code to exception mapping should be used if one isn't provided.|
 |`--http-status-code-to-exception-type-mapping`|Indicates the HTTP status code to exception mapping that should be used. All exception types must be fully-qualified and extend from `HttpResponseException`.|
->>>>>>> b2c0b01a5f8163f5c0fc47bf9559880b4557616b
+|`--defer-strongly-typed-header-deserialization`|Indicates whether strongly-typed HTTP header object will lazily deserialize its properties when accessed.|
 
 ## Settings for minimal clients (low-level clients)
 

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/AutoRestSwaggerBATHeaderService.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/AutoRestSwaggerBATHeaderService.java
@@ -1,0 +1,98 @@
+package fixtures.deferredheaderdeserialization;
+
+import com.azure.core.http.HttpPipeline;
+import com.azure.core.http.HttpPipelineBuilder;
+import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.RetryPolicy;
+import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
+
+/** Initializes a new instance of the AutoRestSwaggerBATHeaderService type. */
+public final class AutoRestSwaggerBATHeaderService {
+    /** server parameter. */
+    private final String host;
+
+    /**
+     * Gets server parameter.
+     *
+     * @return the host value.
+     */
+    public String getHost() {
+        return this.host;
+    }
+
+    /** The HTTP pipeline to send requests through. */
+    private final HttpPipeline httpPipeline;
+
+    /**
+     * Gets The HTTP pipeline to send requests through.
+     *
+     * @return the httpPipeline value.
+     */
+    public HttpPipeline getHttpPipeline() {
+        return this.httpPipeline;
+    }
+
+    /** The serializer to serialize an object into a string. */
+    private final SerializerAdapter serializerAdapter;
+
+    /**
+     * Gets The serializer to serialize an object into a string.
+     *
+     * @return the serializerAdapter value.
+     */
+    public SerializerAdapter getSerializerAdapter() {
+        return this.serializerAdapter;
+    }
+
+    /** The Headers object to access its operations. */
+    private final Headers headers;
+
+    /**
+     * Gets the Headers object to access its operations.
+     *
+     * @return the Headers object.
+     */
+    public Headers getHeaders() {
+        return this.headers;
+    }
+
+    /**
+     * Initializes an instance of AutoRestSwaggerBATHeaderService client.
+     *
+     * @param host server parameter.
+     */
+    AutoRestSwaggerBATHeaderService(String host) {
+        this(
+                new HttpPipelineBuilder()
+                        .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
+                        .build(),
+                JacksonAdapter.createDefaultSerializerAdapter(),
+                host);
+    }
+
+    /**
+     * Initializes an instance of AutoRestSwaggerBATHeaderService client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param host server parameter.
+     */
+    AutoRestSwaggerBATHeaderService(HttpPipeline httpPipeline, String host) {
+        this(httpPipeline, JacksonAdapter.createDefaultSerializerAdapter(), host);
+    }
+
+    /**
+     * Initializes an instance of AutoRestSwaggerBATHeaderService client.
+     *
+     * @param httpPipeline The HTTP pipeline to send requests through.
+     * @param serializerAdapter The serializer to serialize an object into a string.
+     * @param host server parameter.
+     */
+    AutoRestSwaggerBATHeaderService(HttpPipeline httpPipeline, SerializerAdapter serializerAdapter, String host) {
+        this.httpPipeline = httpPipeline;
+        this.serializerAdapter = serializerAdapter;
+        this.host = host;
+        this.headers = new Headers(this);
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/AutoRestSwaggerBATHeaderServiceBuilder.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/AutoRestSwaggerBATHeaderServiceBuilder.java
@@ -1,0 +1,248 @@
+package fixtures.deferredheaderdeserialization;
+
+import com.azure.core.annotation.ServiceClientBuilder;
+import com.azure.core.http.HttpClient;
+import com.azure.core.http.HttpHeaders;
+import com.azure.core.http.HttpPipeline;
+import com.azure.core.http.HttpPipelineBuilder;
+import com.azure.core.http.HttpPipelinePosition;
+import com.azure.core.http.policy.AddHeadersPolicy;
+import com.azure.core.http.policy.CookiePolicy;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.HttpLoggingPolicy;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.policy.HttpPolicyProviders;
+import com.azure.core.http.policy.RetryPolicy;
+import com.azure.core.http.policy.UserAgentPolicy;
+import com.azure.core.util.ClientOptions;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.CoreUtils;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/** A builder for creating a new instance of the AutoRestSwaggerBATHeaderService type. */
+@ServiceClientBuilder(serviceClients = {AutoRestSwaggerBATHeaderService.class})
+public final class AutoRestSwaggerBATHeaderServiceBuilder {
+    private static final String SDK_NAME = "name";
+
+    private static final String SDK_VERSION = "version";
+
+    private final Map<String, String> properties = new HashMap<>();
+
+    /** Create an instance of the AutoRestSwaggerBATHeaderServiceBuilder. */
+    public AutoRestSwaggerBATHeaderServiceBuilder() {
+        this.pipelinePolicies = new ArrayList<>();
+    }
+
+    /*
+     * server parameter
+     */
+    private String host;
+
+    /**
+     * Sets server parameter.
+     *
+     * @param host the host value.
+     * @return the AutoRestSwaggerBATHeaderServiceBuilder.
+     */
+    public AutoRestSwaggerBATHeaderServiceBuilder host(String host) {
+        this.host = host;
+        return this;
+    }
+
+    /*
+     * The HTTP pipeline to send requests through
+     */
+    private HttpPipeline pipeline;
+
+    /**
+     * Sets The HTTP pipeline to send requests through.
+     *
+     * @param pipeline the pipeline value.
+     * @return the AutoRestSwaggerBATHeaderServiceBuilder.
+     */
+    public AutoRestSwaggerBATHeaderServiceBuilder pipeline(HttpPipeline pipeline) {
+        this.pipeline = pipeline;
+        return this;
+    }
+
+    /*
+     * The serializer to serialize an object into a string
+     */
+    private SerializerAdapter serializerAdapter;
+
+    /**
+     * Sets The serializer to serialize an object into a string.
+     *
+     * @param serializerAdapter the serializerAdapter value.
+     * @return the AutoRestSwaggerBATHeaderServiceBuilder.
+     */
+    public AutoRestSwaggerBATHeaderServiceBuilder serializerAdapter(SerializerAdapter serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
+    /*
+     * The HTTP client used to send the request.
+     */
+    private HttpClient httpClient;
+
+    /**
+     * Sets The HTTP client used to send the request.
+     *
+     * @param httpClient the httpClient value.
+     * @return the AutoRestSwaggerBATHeaderServiceBuilder.
+     */
+    public AutoRestSwaggerBATHeaderServiceBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /*
+     * The configuration store that is used during construction of the service
+     * client.
+     */
+    private Configuration configuration;
+
+    /**
+     * Sets The configuration store that is used during construction of the service client.
+     *
+     * @param configuration the configuration value.
+     * @return the AutoRestSwaggerBATHeaderServiceBuilder.
+     */
+    public AutoRestSwaggerBATHeaderServiceBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /*
+     * The logging configuration for HTTP requests and responses.
+     */
+    private HttpLogOptions httpLogOptions;
+
+    /**
+     * Sets The logging configuration for HTTP requests and responses.
+     *
+     * @param httpLogOptions the httpLogOptions value.
+     * @return the AutoRestSwaggerBATHeaderServiceBuilder.
+     */
+    public AutoRestSwaggerBATHeaderServiceBuilder httpLogOptions(HttpLogOptions httpLogOptions) {
+        this.httpLogOptions = httpLogOptions;
+        return this;
+    }
+
+    /*
+     * The retry policy that will attempt to retry failed requests, if
+     * applicable.
+     */
+    private RetryPolicy retryPolicy;
+
+    /**
+     * Sets The retry policy that will attempt to retry failed requests, if applicable.
+     *
+     * @param retryPolicy the retryPolicy value.
+     * @return the AutoRestSwaggerBATHeaderServiceBuilder.
+     */
+    public AutoRestSwaggerBATHeaderServiceBuilder retryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /*
+     * The list of Http pipeline policies to add.
+     */
+    private final List<HttpPipelinePolicy> pipelinePolicies;
+
+    /*
+     * The client options such as application ID and custom headers to set on a
+     * request.
+     */
+    private ClientOptions clientOptions;
+
+    /**
+     * Sets The client options such as application ID and custom headers to set on a request.
+     *
+     * @param clientOptions the clientOptions value.
+     * @return the AutoRestSwaggerBATHeaderServiceBuilder.
+     */
+    public AutoRestSwaggerBATHeaderServiceBuilder clientOptions(ClientOptions clientOptions) {
+        this.clientOptions = clientOptions;
+        return this;
+    }
+
+    /**
+     * Adds a custom Http pipeline policy.
+     *
+     * @param customPolicy The custom Http pipeline policy to add.
+     * @return the AutoRestSwaggerBATHeaderServiceBuilder.
+     */
+    public AutoRestSwaggerBATHeaderServiceBuilder addPolicy(HttpPipelinePolicy customPolicy) {
+        pipelinePolicies.add(customPolicy);
+        return this;
+    }
+
+    /**
+     * Builds an instance of AutoRestSwaggerBATHeaderService with the provided parameters.
+     *
+     * @return an instance of AutoRestSwaggerBATHeaderService.
+     */
+    public AutoRestSwaggerBATHeaderService buildClient() {
+        if (host == null) {
+            this.host = "http://localhost:3000";
+        }
+        if (pipeline == null) {
+            this.pipeline = createHttpPipeline();
+        }
+        if (serializerAdapter == null) {
+            this.serializerAdapter = JacksonAdapter.createDefaultSerializerAdapter();
+        }
+        AutoRestSwaggerBATHeaderService client = new AutoRestSwaggerBATHeaderService(pipeline, serializerAdapter, host);
+        return client;
+    }
+
+    private HttpPipeline createHttpPipeline() {
+        Configuration buildConfiguration =
+                (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+        if (httpLogOptions == null) {
+            httpLogOptions = new HttpLogOptions();
+        }
+        if (clientOptions == null) {
+            clientOptions = new ClientOptions();
+        }
+        List<HttpPipelinePolicy> policies = new ArrayList<>();
+        String clientName = properties.getOrDefault(SDK_NAME, "UnknownName");
+        String clientVersion = properties.getOrDefault(SDK_VERSION, "UnknownVersion");
+        String applicationId = CoreUtils.getApplicationId(clientOptions, httpLogOptions);
+        policies.add(new UserAgentPolicy(applicationId, clientName, clientVersion, buildConfiguration));
+        HttpHeaders headers = new HttpHeaders();
+        clientOptions.getHeaders().forEach(header -> headers.set(header.getName(), header.getValue()));
+        if (headers.getSize() > 0) {
+            policies.add(new AddHeadersPolicy(headers));
+        }
+        policies.addAll(
+                this.pipelinePolicies.stream()
+                        .filter(p -> p.getPipelinePosition() == HttpPipelinePosition.PER_CALL)
+                        .collect(Collectors.toList()));
+        HttpPolicyProviders.addBeforeRetryPolicies(policies);
+        policies.add(retryPolicy == null ? new RetryPolicy() : retryPolicy);
+        policies.add(new CookiePolicy());
+        policies.addAll(
+                this.pipelinePolicies.stream()
+                        .filter(p -> p.getPipelinePosition() == HttpPipelinePosition.PER_RETRY)
+                        .collect(Collectors.toList()));
+        HttpPolicyProviders.addAfterRetryPolicies(policies);
+        policies.add(new HttpLoggingPolicy(httpLogOptions));
+        HttpPipeline httpPipeline =
+                new HttpPipelineBuilder()
+                        .policies(policies.toArray(new HttpPipelinePolicy[0]))
+                        .httpClient(httpClient)
+                        .clientOptions(clientOptions)
+                        .build();
+        return httpPipeline;
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/Headers.java
@@ -1,0 +1,3523 @@
+package fixtures.deferredheaderdeserialization;
+
+import com.azure.core.annotation.ExpectedResponses;
+import com.azure.core.annotation.HeaderParam;
+import com.azure.core.annotation.Host;
+import com.azure.core.annotation.HostParam;
+import com.azure.core.annotation.Post;
+import com.azure.core.annotation.ReturnType;
+import com.azure.core.annotation.ServiceInterface;
+import com.azure.core.annotation.ServiceMethod;
+import com.azure.core.annotation.UnexpectedResponseExceptionType;
+import com.azure.core.http.rest.Response;
+import com.azure.core.http.rest.RestProxy;
+import com.azure.core.util.Base64Util;
+import com.azure.core.util.Context;
+import com.azure.core.util.DateTimeRfc1123;
+import com.azure.core.util.FluxUtil;
+import fixtures.deferredheaderdeserialization.models.ErrorException;
+import fixtures.deferredheaderdeserialization.models.GreyscaleColors;
+import fixtures.deferredheaderdeserialization.models.HeadersResponseBoolResponse;
+import fixtures.deferredheaderdeserialization.models.HeadersResponseByteResponse;
+import fixtures.deferredheaderdeserialization.models.HeadersResponseDateResponse;
+import fixtures.deferredheaderdeserialization.models.HeadersResponseDatetimeResponse;
+import fixtures.deferredheaderdeserialization.models.HeadersResponseDatetimeRfc1123Response;
+import fixtures.deferredheaderdeserialization.models.HeadersResponseDoubleResponse;
+import fixtures.deferredheaderdeserialization.models.HeadersResponseDurationResponse;
+import fixtures.deferredheaderdeserialization.models.HeadersResponseEnumResponse;
+import fixtures.deferredheaderdeserialization.models.HeadersResponseExistingKeyResponse;
+import fixtures.deferredheaderdeserialization.models.HeadersResponseFloatResponse;
+import fixtures.deferredheaderdeserialization.models.HeadersResponseIntegerResponse;
+import fixtures.deferredheaderdeserialization.models.HeadersResponseLongResponse;
+import fixtures.deferredheaderdeserialization.models.HeadersResponseProtectedKeyResponse;
+import fixtures.deferredheaderdeserialization.models.HeadersResponseStringResponse;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import reactor.core.publisher.Mono;
+
+/** An instance of this class provides access to all the operations defined in Headers. */
+public final class Headers {
+    /** The proxy service used to perform REST calls. */
+    private final HeadersService service;
+
+    /** The service client containing this operation class. */
+    private final AutoRestSwaggerBATHeaderService client;
+
+    /**
+     * Initializes an instance of Headers.
+     *
+     * @param client the instance of the service client containing this operation class.
+     */
+    Headers(AutoRestSwaggerBATHeaderService client) {
+        this.service = RestProxy.create(HeadersService.class, client.getHttpPipeline(), client.getSerializerAdapter());
+        this.client = client;
+    }
+
+    /**
+     * The interface defining all the services for AutoRestSwaggerBATHeaderServiceHeaders to be used by the proxy
+     * service to perform REST calls.
+     */
+    @Host("{$host}")
+    @ServiceInterface(name = "AutoRestSwaggerBATHe")
+    private interface HeadersService {
+        @Post("/header/param/existingkey")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<Void>> paramExistingKey(
+                @HostParam("$host") String host,
+                @HeaderParam("User-Agent") String userAgent,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Post("/header/response/existingkey")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<HeadersResponseExistingKeyResponse> responseExistingKey(
+                @HostParam("$host") String host, @HeaderParam("Accept") String accept, Context context);
+
+        @Post("/header/param/protectedkey")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<Void>> paramProtectedKey(
+                @HostParam("$host") String host,
+                @HeaderParam("Content-Type") String contentType,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Post("/header/response/protectedkey")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<HeadersResponseProtectedKeyResponse> responseProtectedKey(
+                @HostParam("$host") String host, @HeaderParam("Accept") String accept, Context context);
+
+        @Post("/header/param/prim/integer")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<Void>> paramInteger(
+                @HostParam("$host") String host,
+                @HeaderParam("scenario") String scenario,
+                @HeaderParam("value") int value,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Post("/header/response/prim/integer")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<HeadersResponseIntegerResponse> responseInteger(
+                @HostParam("$host") String host,
+                @HeaderParam("scenario") String scenario,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Post("/header/param/prim/long")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<Void>> paramLong(
+                @HostParam("$host") String host,
+                @HeaderParam("scenario") String scenario,
+                @HeaderParam("value") long value,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Post("/header/response/prim/long")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<HeadersResponseLongResponse> responseLong(
+                @HostParam("$host") String host,
+                @HeaderParam("scenario") String scenario,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Post("/header/param/prim/float")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<Void>> paramFloat(
+                @HostParam("$host") String host,
+                @HeaderParam("scenario") String scenario,
+                @HeaderParam("value") float value,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Post("/header/response/prim/float")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<HeadersResponseFloatResponse> responseFloat(
+                @HostParam("$host") String host,
+                @HeaderParam("scenario") String scenario,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Post("/header/param/prim/double")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<Void>> paramDouble(
+                @HostParam("$host") String host,
+                @HeaderParam("scenario") String scenario,
+                @HeaderParam("value") double value,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Post("/header/response/prim/double")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<HeadersResponseDoubleResponse> responseDouble(
+                @HostParam("$host") String host,
+                @HeaderParam("scenario") String scenario,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Post("/header/param/prim/bool")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<Void>> paramBool(
+                @HostParam("$host") String host,
+                @HeaderParam("scenario") String scenario,
+                @HeaderParam("value") boolean value,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Post("/header/response/prim/bool")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<HeadersResponseBoolResponse> responseBool(
+                @HostParam("$host") String host,
+                @HeaderParam("scenario") String scenario,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Post("/header/param/prim/string")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<Void>> paramString(
+                @HostParam("$host") String host,
+                @HeaderParam("scenario") String scenario,
+                @HeaderParam("value") String value,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Post("/header/response/prim/string")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<HeadersResponseStringResponse> responseString(
+                @HostParam("$host") String host,
+                @HeaderParam("scenario") String scenario,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Post("/header/param/prim/date")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<Void>> paramDate(
+                @HostParam("$host") String host,
+                @HeaderParam("scenario") String scenario,
+                @HeaderParam("value") LocalDate value,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Post("/header/response/prim/date")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<HeadersResponseDateResponse> responseDate(
+                @HostParam("$host") String host,
+                @HeaderParam("scenario") String scenario,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Post("/header/param/prim/datetime")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<Void>> paramDatetime(
+                @HostParam("$host") String host,
+                @HeaderParam("scenario") String scenario,
+                @HeaderParam("value") OffsetDateTime value,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Post("/header/response/prim/datetime")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<HeadersResponseDatetimeResponse> responseDatetime(
+                @HostParam("$host") String host,
+                @HeaderParam("scenario") String scenario,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Post("/header/param/prim/datetimerfc1123")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<Void>> paramDatetimeRfc1123(
+                @HostParam("$host") String host,
+                @HeaderParam("scenario") String scenario,
+                @HeaderParam("value") DateTimeRfc1123 value,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Post("/header/response/prim/datetimerfc1123")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<HeadersResponseDatetimeRfc1123Response> responseDatetimeRfc1123(
+                @HostParam("$host") String host,
+                @HeaderParam("scenario") String scenario,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Post("/header/param/prim/duration")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<Void>> paramDuration(
+                @HostParam("$host") String host,
+                @HeaderParam("scenario") String scenario,
+                @HeaderParam("value") Duration value,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Post("/header/response/prim/duration")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<HeadersResponseDurationResponse> responseDuration(
+                @HostParam("$host") String host,
+                @HeaderParam("scenario") String scenario,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Post("/header/param/prim/byte")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<Void>> paramByte(
+                @HostParam("$host") String host,
+                @HeaderParam("scenario") String scenario,
+                @HeaderParam("value") String value,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Post("/header/response/prim/byte")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<HeadersResponseByteResponse> responseByte(
+                @HostParam("$host") String host,
+                @HeaderParam("scenario") String scenario,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Post("/header/param/prim/enum")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<Void>> paramEnum(
+                @HostParam("$host") String host,
+                @HeaderParam("scenario") String scenario,
+                @HeaderParam("value") GreyscaleColors value,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Post("/header/response/prim/enum")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<HeadersResponseEnumResponse> responseEnum(
+                @HostParam("$host") String host,
+                @HeaderParam("scenario") String scenario,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Post("/header/custom/x-ms-client-request-id/9C4D50EE-2D56-4CD3-8152-34347DC9F2B0")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(ErrorException.class)
+        Mono<Response<Void>> customRequestId(
+                @HostParam("$host") String host, @HeaderParam("Accept") String accept, Context context);
+    }
+
+    /**
+     * Send a post request with header value "User-Agent": "overwrite".
+     *
+     * @param userAgent Send a post request with header value "User-Agent": "overwrite".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> paramExistingKeyWithResponseAsync(String userAgent) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (userAgent == null) {
+            return Mono.error(new IllegalArgumentException("Parameter userAgent is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return FluxUtil.withContext(
+                context -> service.paramExistingKey(this.client.getHost(), userAgent, accept, context));
+    }
+
+    /**
+     * Send a post request with header value "User-Agent": "overwrite".
+     *
+     * @param userAgent Send a post request with header value "User-Agent": "overwrite".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> paramExistingKeyWithResponseAsync(String userAgent, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (userAgent == null) {
+            return Mono.error(new IllegalArgumentException("Parameter userAgent is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.paramExistingKey(this.client.getHost(), userAgent, accept, context);
+    }
+
+    /**
+     * Send a post request with header value "User-Agent": "overwrite".
+     *
+     * @param userAgent Send a post request with header value "User-Agent": "overwrite".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> paramExistingKeyAsync(String userAgent) {
+        return paramExistingKeyWithResponseAsync(userAgent).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Send a post request with header value "User-Agent": "overwrite".
+     *
+     * @param userAgent Send a post request with header value "User-Agent": "overwrite".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> paramExistingKeyAsync(String userAgent, Context context) {
+        return paramExistingKeyWithResponseAsync(userAgent, context).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Send a post request with header value "User-Agent": "overwrite".
+     *
+     * @param userAgent Send a post request with header value "User-Agent": "overwrite".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void paramExistingKey(String userAgent) {
+        paramExistingKeyAsync(userAgent).block();
+    }
+
+    /**
+     * Send a post request with header value "User-Agent": "overwrite".
+     *
+     * @param userAgent Send a post request with header value "User-Agent": "overwrite".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> paramExistingKeyWithResponse(String userAgent, Context context) {
+        return paramExistingKeyWithResponseAsync(userAgent, context).block();
+    }
+
+    /**
+     * Get a response with header value "User-Agent": "overwrite".
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "User-Agent": "overwrite".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HeadersResponseExistingKeyResponse> responseExistingKeyWithResponseAsync() {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return FluxUtil.withContext(context -> service.responseExistingKey(this.client.getHost(), accept, context));
+    }
+
+    /**
+     * Get a response with header value "User-Agent": "overwrite".
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "User-Agent": "overwrite".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HeadersResponseExistingKeyResponse> responseExistingKeyWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.responseExistingKey(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get a response with header value "User-Agent": "overwrite".
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "User-Agent": "overwrite".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> responseExistingKeyAsync() {
+        return responseExistingKeyWithResponseAsync().flatMap((HeadersResponseExistingKeyResponse res) -> Mono.empty());
+    }
+
+    /**
+     * Get a response with header value "User-Agent": "overwrite".
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "User-Agent": "overwrite".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> responseExistingKeyAsync(Context context) {
+        return responseExistingKeyWithResponseAsync(context)
+                .flatMap((HeadersResponseExistingKeyResponse res) -> Mono.empty());
+    }
+
+    /**
+     * Get a response with header value "User-Agent": "overwrite".
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void responseExistingKey() {
+        responseExistingKeyAsync().block();
+    }
+
+    /**
+     * Get a response with header value "User-Agent": "overwrite".
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "User-Agent": "overwrite".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public HeadersResponseExistingKeyResponse responseExistingKeyWithResponse(Context context) {
+        return responseExistingKeyWithResponseAsync(context).block();
+    }
+
+    /**
+     * Send a post request with header value "Content-Type": "text/html".
+     *
+     * @param contentType Send a post request with header value "Content-Type": "text/html".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> paramProtectedKeyWithResponseAsync(String contentType) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (contentType == null) {
+            return Mono.error(new IllegalArgumentException("Parameter contentType is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return FluxUtil.withContext(
+                context -> service.paramProtectedKey(this.client.getHost(), contentType, accept, context));
+    }
+
+    /**
+     * Send a post request with header value "Content-Type": "text/html".
+     *
+     * @param contentType Send a post request with header value "Content-Type": "text/html".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> paramProtectedKeyWithResponseAsync(String contentType, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (contentType == null) {
+            return Mono.error(new IllegalArgumentException("Parameter contentType is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.paramProtectedKey(this.client.getHost(), contentType, accept, context);
+    }
+
+    /**
+     * Send a post request with header value "Content-Type": "text/html".
+     *
+     * @param contentType Send a post request with header value "Content-Type": "text/html".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> paramProtectedKeyAsync(String contentType) {
+        return paramProtectedKeyWithResponseAsync(contentType).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Send a post request with header value "Content-Type": "text/html".
+     *
+     * @param contentType Send a post request with header value "Content-Type": "text/html".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> paramProtectedKeyAsync(String contentType, Context context) {
+        return paramProtectedKeyWithResponseAsync(contentType, context).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Send a post request with header value "Content-Type": "text/html".
+     *
+     * @param contentType Send a post request with header value "Content-Type": "text/html".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void paramProtectedKey(String contentType) {
+        paramProtectedKeyAsync(contentType).block();
+    }
+
+    /**
+     * Send a post request with header value "Content-Type": "text/html".
+     *
+     * @param contentType Send a post request with header value "Content-Type": "text/html".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> paramProtectedKeyWithResponse(String contentType, Context context) {
+        return paramProtectedKeyWithResponseAsync(contentType, context).block();
+    }
+
+    /**
+     * Get a response with header value "Content-Type": "text/html".
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "Content-Type": "text/html".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HeadersResponseProtectedKeyResponse> responseProtectedKeyWithResponseAsync() {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return FluxUtil.withContext(context -> service.responseProtectedKey(this.client.getHost(), accept, context));
+    }
+
+    /**
+     * Get a response with header value "Content-Type": "text/html".
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "Content-Type": "text/html".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HeadersResponseProtectedKeyResponse> responseProtectedKeyWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.responseProtectedKey(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Get a response with header value "Content-Type": "text/html".
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "Content-Type": "text/html".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> responseProtectedKeyAsync() {
+        return responseProtectedKeyWithResponseAsync()
+                .flatMap((HeadersResponseProtectedKeyResponse res) -> Mono.empty());
+    }
+
+    /**
+     * Get a response with header value "Content-Type": "text/html".
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "Content-Type": "text/html".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> responseProtectedKeyAsync(Context context) {
+        return responseProtectedKeyWithResponseAsync(context)
+                .flatMap((HeadersResponseProtectedKeyResponse res) -> Mono.empty());
+    }
+
+    /**
+     * Get a response with header value "Content-Type": "text/html".
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void responseProtectedKey() {
+        responseProtectedKeyAsync().block();
+    }
+
+    /**
+     * Get a response with header value "Content-Type": "text/html".
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "Content-Type": "text/html".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public HeadersResponseProtectedKeyResponse responseProtectedKeyWithResponse(Context context) {
+        return responseProtectedKeyWithResponseAsync(context).block();
+    }
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 1 or "scenario": "negative", "value": -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param value Send a post request with header values 1 or -2.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> paramIntegerWithResponseAsync(String scenario, int value) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return FluxUtil.withContext(
+                context -> service.paramInteger(this.client.getHost(), scenario, value, accept, context));
+    }
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 1 or "scenario": "negative", "value": -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param value Send a post request with header values 1 or -2.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> paramIntegerWithResponseAsync(String scenario, int value, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.paramInteger(this.client.getHost(), scenario, value, accept, context);
+    }
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 1 or "scenario": "negative", "value": -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param value Send a post request with header values 1 or -2.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> paramIntegerAsync(String scenario, int value) {
+        return paramIntegerWithResponseAsync(scenario, value).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 1 or "scenario": "negative", "value": -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param value Send a post request with header values 1 or -2.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> paramIntegerAsync(String scenario, int value, Context context) {
+        return paramIntegerWithResponseAsync(scenario, value, context).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 1 or "scenario": "negative", "value": -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param value Send a post request with header values 1 or -2.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void paramInteger(String scenario, int value) {
+        paramIntegerAsync(scenario, value).block();
+    }
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 1 or "scenario": "negative", "value": -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param value Send a post request with header values 1 or -2.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> paramIntegerWithResponse(String scenario, int value, Context context) {
+        return paramIntegerWithResponseAsync(scenario, value, context).block();
+    }
+
+    /**
+     * Get a response with header value "value": 1 or -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "value": 1 or -2.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HeadersResponseIntegerResponse> responseIntegerWithResponseAsync(String scenario) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return FluxUtil.withContext(
+                context -> service.responseInteger(this.client.getHost(), scenario, accept, context));
+    }
+
+    /**
+     * Get a response with header value "value": 1 or -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "value": 1 or -2.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HeadersResponseIntegerResponse> responseIntegerWithResponseAsync(String scenario, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.responseInteger(this.client.getHost(), scenario, accept, context);
+    }
+
+    /**
+     * Get a response with header value "value": 1 or -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "value": 1 or -2.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> responseIntegerAsync(String scenario) {
+        return responseIntegerWithResponseAsync(scenario).flatMap((HeadersResponseIntegerResponse res) -> Mono.empty());
+    }
+
+    /**
+     * Get a response with header value "value": 1 or -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "value": 1 or -2.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> responseIntegerAsync(String scenario, Context context) {
+        return responseIntegerWithResponseAsync(scenario, context)
+                .flatMap((HeadersResponseIntegerResponse res) -> Mono.empty());
+    }
+
+    /**
+     * Get a response with header value "value": 1 or -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void responseInteger(String scenario) {
+        responseIntegerAsync(scenario).block();
+    }
+
+    /**
+     * Get a response with header value "value": 1 or -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "value": 1 or -2.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public HeadersResponseIntegerResponse responseIntegerWithResponse(String scenario, Context context) {
+        return responseIntegerWithResponseAsync(scenario, context).block();
+    }
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 105 or "scenario": "negative", "value":
+     * -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param value Send a post request with header values 105 or -2.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> paramLongWithResponseAsync(String scenario, long value) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return FluxUtil.withContext(
+                context -> service.paramLong(this.client.getHost(), scenario, value, accept, context));
+    }
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 105 or "scenario": "negative", "value":
+     * -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param value Send a post request with header values 105 or -2.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> paramLongWithResponseAsync(String scenario, long value, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.paramLong(this.client.getHost(), scenario, value, accept, context);
+    }
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 105 or "scenario": "negative", "value":
+     * -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param value Send a post request with header values 105 or -2.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> paramLongAsync(String scenario, long value) {
+        return paramLongWithResponseAsync(scenario, value).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 105 or "scenario": "negative", "value":
+     * -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param value Send a post request with header values 105 or -2.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> paramLongAsync(String scenario, long value, Context context) {
+        return paramLongWithResponseAsync(scenario, value, context).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 105 or "scenario": "negative", "value":
+     * -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param value Send a post request with header values 105 or -2.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void paramLong(String scenario, long value) {
+        paramLongAsync(scenario, value).block();
+    }
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 105 or "scenario": "negative", "value":
+     * -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param value Send a post request with header values 105 or -2.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> paramLongWithResponse(String scenario, long value, Context context) {
+        return paramLongWithResponseAsync(scenario, value, context).block();
+    }
+
+    /**
+     * Get a response with header value "value": 105 or -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "value": 105 or -2.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HeadersResponseLongResponse> responseLongWithResponseAsync(String scenario) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return FluxUtil.withContext(context -> service.responseLong(this.client.getHost(), scenario, accept, context));
+    }
+
+    /**
+     * Get a response with header value "value": 105 or -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "value": 105 or -2.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HeadersResponseLongResponse> responseLongWithResponseAsync(String scenario, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.responseLong(this.client.getHost(), scenario, accept, context);
+    }
+
+    /**
+     * Get a response with header value "value": 105 or -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "value": 105 or -2.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> responseLongAsync(String scenario) {
+        return responseLongWithResponseAsync(scenario).flatMap((HeadersResponseLongResponse res) -> Mono.empty());
+    }
+
+    /**
+     * Get a response with header value "value": 105 or -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "value": 105 or -2.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> responseLongAsync(String scenario, Context context) {
+        return responseLongWithResponseAsync(scenario, context)
+                .flatMap((HeadersResponseLongResponse res) -> Mono.empty());
+    }
+
+    /**
+     * Get a response with header value "value": 105 or -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void responseLong(String scenario) {
+        responseLongAsync(scenario).block();
+    }
+
+    /**
+     * Get a response with header value "value": 105 or -2.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "value": 105 or -2.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public HeadersResponseLongResponse responseLongWithResponse(String scenario, Context context) {
+        return responseLongWithResponseAsync(scenario, context).block();
+    }
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 0.07 or "scenario": "negative", "value":
+     * -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param value Send a post request with header values 0.07 or -3.0.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> paramFloatWithResponseAsync(String scenario, float value) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return FluxUtil.withContext(
+                context -> service.paramFloat(this.client.getHost(), scenario, value, accept, context));
+    }
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 0.07 or "scenario": "negative", "value":
+     * -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param value Send a post request with header values 0.07 or -3.0.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> paramFloatWithResponseAsync(String scenario, float value, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.paramFloat(this.client.getHost(), scenario, value, accept, context);
+    }
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 0.07 or "scenario": "negative", "value":
+     * -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param value Send a post request with header values 0.07 or -3.0.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> paramFloatAsync(String scenario, float value) {
+        return paramFloatWithResponseAsync(scenario, value).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 0.07 or "scenario": "negative", "value":
+     * -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param value Send a post request with header values 0.07 or -3.0.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> paramFloatAsync(String scenario, float value, Context context) {
+        return paramFloatWithResponseAsync(scenario, value, context).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 0.07 or "scenario": "negative", "value":
+     * -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param value Send a post request with header values 0.07 or -3.0.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void paramFloat(String scenario, float value) {
+        paramFloatAsync(scenario, value).block();
+    }
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 0.07 or "scenario": "negative", "value":
+     * -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param value Send a post request with header values 0.07 or -3.0.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> paramFloatWithResponse(String scenario, float value, Context context) {
+        return paramFloatWithResponseAsync(scenario, value, context).block();
+    }
+
+    /**
+     * Get a response with header value "value": 0.07 or -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "value": 0.07 or -3.0.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HeadersResponseFloatResponse> responseFloatWithResponseAsync(String scenario) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return FluxUtil.withContext(context -> service.responseFloat(this.client.getHost(), scenario, accept, context));
+    }
+
+    /**
+     * Get a response with header value "value": 0.07 or -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "value": 0.07 or -3.0.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HeadersResponseFloatResponse> responseFloatWithResponseAsync(String scenario, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.responseFloat(this.client.getHost(), scenario, accept, context);
+    }
+
+    /**
+     * Get a response with header value "value": 0.07 or -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "value": 0.07 or -3.0.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> responseFloatAsync(String scenario) {
+        return responseFloatWithResponseAsync(scenario).flatMap((HeadersResponseFloatResponse res) -> Mono.empty());
+    }
+
+    /**
+     * Get a response with header value "value": 0.07 or -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "value": 0.07 or -3.0.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> responseFloatAsync(String scenario, Context context) {
+        return responseFloatWithResponseAsync(scenario, context)
+                .flatMap((HeadersResponseFloatResponse res) -> Mono.empty());
+    }
+
+    /**
+     * Get a response with header value "value": 0.07 or -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void responseFloat(String scenario) {
+        responseFloatAsync(scenario).block();
+    }
+
+    /**
+     * Get a response with header value "value": 0.07 or -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "value": 0.07 or -3.0.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public HeadersResponseFloatResponse responseFloatWithResponse(String scenario, Context context) {
+        return responseFloatWithResponseAsync(scenario, context).block();
+    }
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 7e120 or "scenario": "negative", "value":
+     * -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param value Send a post request with header values 7e120 or -3.0.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> paramDoubleWithResponseAsync(String scenario, double value) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return FluxUtil.withContext(
+                context -> service.paramDouble(this.client.getHost(), scenario, value, accept, context));
+    }
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 7e120 or "scenario": "negative", "value":
+     * -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param value Send a post request with header values 7e120 or -3.0.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> paramDoubleWithResponseAsync(String scenario, double value, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.paramDouble(this.client.getHost(), scenario, value, accept, context);
+    }
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 7e120 or "scenario": "negative", "value":
+     * -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param value Send a post request with header values 7e120 or -3.0.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> paramDoubleAsync(String scenario, double value) {
+        return paramDoubleWithResponseAsync(scenario, value).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 7e120 or "scenario": "negative", "value":
+     * -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param value Send a post request with header values 7e120 or -3.0.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> paramDoubleAsync(String scenario, double value, Context context) {
+        return paramDoubleWithResponseAsync(scenario, value, context).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 7e120 or "scenario": "negative", "value":
+     * -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param value Send a post request with header values 7e120 or -3.0.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void paramDouble(String scenario, double value) {
+        paramDoubleAsync(scenario, value).block();
+    }
+
+    /**
+     * Send a post request with header values "scenario": "positive", "value": 7e120 or "scenario": "negative", "value":
+     * -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param value Send a post request with header values 7e120 or -3.0.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> paramDoubleWithResponse(String scenario, double value, Context context) {
+        return paramDoubleWithResponseAsync(scenario, value, context).block();
+    }
+
+    /**
+     * Get a response with header value "value": 7e120 or -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "value": 7e120 or -3.0.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HeadersResponseDoubleResponse> responseDoubleWithResponseAsync(String scenario) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return FluxUtil.withContext(
+                context -> service.responseDouble(this.client.getHost(), scenario, accept, context));
+    }
+
+    /**
+     * Get a response with header value "value": 7e120 or -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "value": 7e120 or -3.0.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HeadersResponseDoubleResponse> responseDoubleWithResponseAsync(String scenario, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.responseDouble(this.client.getHost(), scenario, accept, context);
+    }
+
+    /**
+     * Get a response with header value "value": 7e120 or -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "value": 7e120 or -3.0.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> responseDoubleAsync(String scenario) {
+        return responseDoubleWithResponseAsync(scenario).flatMap((HeadersResponseDoubleResponse res) -> Mono.empty());
+    }
+
+    /**
+     * Get a response with header value "value": 7e120 or -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "value": 7e120 or -3.0.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> responseDoubleAsync(String scenario, Context context) {
+        return responseDoubleWithResponseAsync(scenario, context)
+                .flatMap((HeadersResponseDoubleResponse res) -> Mono.empty());
+    }
+
+    /**
+     * Get a response with header value "value": 7e120 or -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void responseDouble(String scenario) {
+        responseDoubleAsync(scenario).block();
+    }
+
+    /**
+     * Get a response with header value "value": 7e120 or -3.0.
+     *
+     * @param scenario Send a post request with header values "scenario": "positive" or "negative".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "value": 7e120 or -3.0.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public HeadersResponseDoubleResponse responseDoubleWithResponse(String scenario, Context context) {
+        return responseDoubleWithResponseAsync(scenario, context).block();
+    }
+
+    /**
+     * Send a post request with header values "scenario": "true", "value": true or "scenario": "false", "value": false.
+     *
+     * @param scenario Send a post request with header values "scenario": "true" or "false".
+     * @param value Send a post request with header values true or false.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> paramBoolWithResponseAsync(String scenario, boolean value) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return FluxUtil.withContext(
+                context -> service.paramBool(this.client.getHost(), scenario, value, accept, context));
+    }
+
+    /**
+     * Send a post request with header values "scenario": "true", "value": true or "scenario": "false", "value": false.
+     *
+     * @param scenario Send a post request with header values "scenario": "true" or "false".
+     * @param value Send a post request with header values true or false.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> paramBoolWithResponseAsync(String scenario, boolean value, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.paramBool(this.client.getHost(), scenario, value, accept, context);
+    }
+
+    /**
+     * Send a post request with header values "scenario": "true", "value": true or "scenario": "false", "value": false.
+     *
+     * @param scenario Send a post request with header values "scenario": "true" or "false".
+     * @param value Send a post request with header values true or false.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> paramBoolAsync(String scenario, boolean value) {
+        return paramBoolWithResponseAsync(scenario, value).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Send a post request with header values "scenario": "true", "value": true or "scenario": "false", "value": false.
+     *
+     * @param scenario Send a post request with header values "scenario": "true" or "false".
+     * @param value Send a post request with header values true or false.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> paramBoolAsync(String scenario, boolean value, Context context) {
+        return paramBoolWithResponseAsync(scenario, value, context).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Send a post request with header values "scenario": "true", "value": true or "scenario": "false", "value": false.
+     *
+     * @param scenario Send a post request with header values "scenario": "true" or "false".
+     * @param value Send a post request with header values true or false.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void paramBool(String scenario, boolean value) {
+        paramBoolAsync(scenario, value).block();
+    }
+
+    /**
+     * Send a post request with header values "scenario": "true", "value": true or "scenario": "false", "value": false.
+     *
+     * @param scenario Send a post request with header values "scenario": "true" or "false".
+     * @param value Send a post request with header values true or false.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> paramBoolWithResponse(String scenario, boolean value, Context context) {
+        return paramBoolWithResponseAsync(scenario, value, context).block();
+    }
+
+    /**
+     * Get a response with header value "value": true or false.
+     *
+     * @param scenario Send a post request with header values "scenario": "true" or "false".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "value": true or false.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HeadersResponseBoolResponse> responseBoolWithResponseAsync(String scenario) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return FluxUtil.withContext(context -> service.responseBool(this.client.getHost(), scenario, accept, context));
+    }
+
+    /**
+     * Get a response with header value "value": true or false.
+     *
+     * @param scenario Send a post request with header values "scenario": "true" or "false".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "value": true or false.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HeadersResponseBoolResponse> responseBoolWithResponseAsync(String scenario, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.responseBool(this.client.getHost(), scenario, accept, context);
+    }
+
+    /**
+     * Get a response with header value "value": true or false.
+     *
+     * @param scenario Send a post request with header values "scenario": "true" or "false".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "value": true or false.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> responseBoolAsync(String scenario) {
+        return responseBoolWithResponseAsync(scenario).flatMap((HeadersResponseBoolResponse res) -> Mono.empty());
+    }
+
+    /**
+     * Get a response with header value "value": true or false.
+     *
+     * @param scenario Send a post request with header values "scenario": "true" or "false".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "value": true or false.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> responseBoolAsync(String scenario, Context context) {
+        return responseBoolWithResponseAsync(scenario, context)
+                .flatMap((HeadersResponseBoolResponse res) -> Mono.empty());
+    }
+
+    /**
+     * Get a response with header value "value": true or false.
+     *
+     * @param scenario Send a post request with header values "scenario": "true" or "false".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void responseBool(String scenario) {
+        responseBoolAsync(scenario).block();
+    }
+
+    /**
+     * Get a response with header value "value": true or false.
+     *
+     * @param scenario Send a post request with header values "scenario": "true" or "false".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header value "value": true or false.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public HeadersResponseBoolResponse responseBoolWithResponse(String scenario, Context context) {
+        return responseBoolWithResponseAsync(scenario, context).block();
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy
+     * dog" or "scenario": "null", "value": null or "scenario": "empty", "value": "".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty".
+     * @param value Send a post request with header values "The quick brown fox jumps over the lazy dog" or null or "".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> paramStringWithResponseAsync(String scenario, String value) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return FluxUtil.withContext(
+                context -> service.paramString(this.client.getHost(), scenario, value, accept, context));
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy
+     * dog" or "scenario": "null", "value": null or "scenario": "empty", "value": "".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty".
+     * @param value Send a post request with header values "The quick brown fox jumps over the lazy dog" or null or "".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> paramStringWithResponseAsync(String scenario, String value, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.paramString(this.client.getHost(), scenario, value, accept, context);
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy
+     * dog" or "scenario": "null", "value": null or "scenario": "empty", "value": "".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty".
+     * @param value Send a post request with header values "The quick brown fox jumps over the lazy dog" or null or "".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> paramStringAsync(String scenario, String value) {
+        return paramStringWithResponseAsync(scenario, value).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy
+     * dog" or "scenario": "null", "value": null or "scenario": "empty", "value": "".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> paramStringAsync(String scenario) {
+        final String value = null;
+        return paramStringWithResponseAsync(scenario, value).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy
+     * dog" or "scenario": "null", "value": null or "scenario": "empty", "value": "".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty".
+     * @param value Send a post request with header values "The quick brown fox jumps over the lazy dog" or null or "".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> paramStringAsync(String scenario, String value, Context context) {
+        return paramStringWithResponseAsync(scenario, value, context).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy
+     * dog" or "scenario": "null", "value": null or "scenario": "empty", "value": "".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty".
+     * @param value Send a post request with header values "The quick brown fox jumps over the lazy dog" or null or "".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void paramString(String scenario, String value) {
+        paramStringAsync(scenario, value).block();
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy
+     * dog" or "scenario": "null", "value": null or "scenario": "empty", "value": "".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void paramString(String scenario) {
+        final String value = null;
+        paramStringAsync(scenario, value).block();
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy
+     * dog" or "scenario": "null", "value": null or "scenario": "empty", "value": "".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty".
+     * @param value Send a post request with header values "The quick brown fox jumps over the lazy dog" or null or "".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> paramStringWithResponse(String scenario, String value, Context context) {
+        return paramStringWithResponseAsync(scenario, value, context).block();
+    }
+
+    /**
+     * Get a response with header values "The quick brown fox jumps over the lazy dog" or null or "".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "The quick brown fox jumps over the lazy dog" or null or "".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HeadersResponseStringResponse> responseStringWithResponseAsync(String scenario) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return FluxUtil.withContext(
+                context -> service.responseString(this.client.getHost(), scenario, accept, context));
+    }
+
+    /**
+     * Get a response with header values "The quick brown fox jumps over the lazy dog" or null or "".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "The quick brown fox jumps over the lazy dog" or null or "".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HeadersResponseStringResponse> responseStringWithResponseAsync(String scenario, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.responseString(this.client.getHost(), scenario, accept, context);
+    }
+
+    /**
+     * Get a response with header values "The quick brown fox jumps over the lazy dog" or null or "".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "The quick brown fox jumps over the lazy dog" or null or "".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> responseStringAsync(String scenario) {
+        return responseStringWithResponseAsync(scenario).flatMap((HeadersResponseStringResponse res) -> Mono.empty());
+    }
+
+    /**
+     * Get a response with header values "The quick brown fox jumps over the lazy dog" or null or "".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "The quick brown fox jumps over the lazy dog" or null or "".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> responseStringAsync(String scenario, Context context) {
+        return responseStringWithResponseAsync(scenario, context)
+                .flatMap((HeadersResponseStringResponse res) -> Mono.empty());
+    }
+
+    /**
+     * Get a response with header values "The quick brown fox jumps over the lazy dog" or null or "".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void responseString(String scenario) {
+        responseStringAsync(scenario).block();
+    }
+
+    /**
+     * Get a response with header values "The quick brown fox jumps over the lazy dog" or null or "".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "The quick brown fox jumps over the lazy dog" or null or "".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public HeadersResponseStringResponse responseStringWithResponse(String scenario, Context context) {
+        return responseStringWithResponseAsync(scenario, context).block();
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "2010-01-01" or "scenario": "min", "value":
+     * "0001-01-01".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @param value Send a post request with header values "2010-01-01" or "0001-01-01".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> paramDateWithResponseAsync(String scenario, LocalDate value) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        if (value == null) {
+            return Mono.error(new IllegalArgumentException("Parameter value is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return FluxUtil.withContext(
+                context -> service.paramDate(this.client.getHost(), scenario, value, accept, context));
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "2010-01-01" or "scenario": "min", "value":
+     * "0001-01-01".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @param value Send a post request with header values "2010-01-01" or "0001-01-01".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> paramDateWithResponseAsync(String scenario, LocalDate value, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        if (value == null) {
+            return Mono.error(new IllegalArgumentException("Parameter value is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.paramDate(this.client.getHost(), scenario, value, accept, context);
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "2010-01-01" or "scenario": "min", "value":
+     * "0001-01-01".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @param value Send a post request with header values "2010-01-01" or "0001-01-01".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> paramDateAsync(String scenario, LocalDate value) {
+        return paramDateWithResponseAsync(scenario, value).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "2010-01-01" or "scenario": "min", "value":
+     * "0001-01-01".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @param value Send a post request with header values "2010-01-01" or "0001-01-01".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> paramDateAsync(String scenario, LocalDate value, Context context) {
+        return paramDateWithResponseAsync(scenario, value, context).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "2010-01-01" or "scenario": "min", "value":
+     * "0001-01-01".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @param value Send a post request with header values "2010-01-01" or "0001-01-01".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void paramDate(String scenario, LocalDate value) {
+        paramDateAsync(scenario, value).block();
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "2010-01-01" or "scenario": "min", "value":
+     * "0001-01-01".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @param value Send a post request with header values "2010-01-01" or "0001-01-01".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> paramDateWithResponse(String scenario, LocalDate value, Context context) {
+        return paramDateWithResponseAsync(scenario, value, context).block();
+    }
+
+    /**
+     * Get a response with header values "2010-01-01" or "0001-01-01".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "2010-01-01" or "0001-01-01".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HeadersResponseDateResponse> responseDateWithResponseAsync(String scenario) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return FluxUtil.withContext(context -> service.responseDate(this.client.getHost(), scenario, accept, context));
+    }
+
+    /**
+     * Get a response with header values "2010-01-01" or "0001-01-01".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "2010-01-01" or "0001-01-01".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HeadersResponseDateResponse> responseDateWithResponseAsync(String scenario, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.responseDate(this.client.getHost(), scenario, accept, context);
+    }
+
+    /**
+     * Get a response with header values "2010-01-01" or "0001-01-01".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "2010-01-01" or "0001-01-01".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> responseDateAsync(String scenario) {
+        return responseDateWithResponseAsync(scenario).flatMap((HeadersResponseDateResponse res) -> Mono.empty());
+    }
+
+    /**
+     * Get a response with header values "2010-01-01" or "0001-01-01".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "2010-01-01" or "0001-01-01".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> responseDateAsync(String scenario, Context context) {
+        return responseDateWithResponseAsync(scenario, context)
+                .flatMap((HeadersResponseDateResponse res) -> Mono.empty());
+    }
+
+    /**
+     * Get a response with header values "2010-01-01" or "0001-01-01".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void responseDate(String scenario) {
+        responseDateAsync(scenario).block();
+    }
+
+    /**
+     * Get a response with header values "2010-01-01" or "0001-01-01".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "2010-01-01" or "0001-01-01".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public HeadersResponseDateResponse responseDateWithResponse(String scenario, Context context) {
+        return responseDateWithResponseAsync(scenario, context).block();
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "2010-01-01T12:34:56Z" or "scenario": "min",
+     * "value": "0001-01-01T00:00:00Z".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @param value Send a post request with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> paramDatetimeWithResponseAsync(String scenario, OffsetDateTime value) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        if (value == null) {
+            return Mono.error(new IllegalArgumentException("Parameter value is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return FluxUtil.withContext(
+                context -> service.paramDatetime(this.client.getHost(), scenario, value, accept, context));
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "2010-01-01T12:34:56Z" or "scenario": "min",
+     * "value": "0001-01-01T00:00:00Z".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @param value Send a post request with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> paramDatetimeWithResponseAsync(String scenario, OffsetDateTime value, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        if (value == null) {
+            return Mono.error(new IllegalArgumentException("Parameter value is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.paramDatetime(this.client.getHost(), scenario, value, accept, context);
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "2010-01-01T12:34:56Z" or "scenario": "min",
+     * "value": "0001-01-01T00:00:00Z".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @param value Send a post request with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> paramDatetimeAsync(String scenario, OffsetDateTime value) {
+        return paramDatetimeWithResponseAsync(scenario, value).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "2010-01-01T12:34:56Z" or "scenario": "min",
+     * "value": "0001-01-01T00:00:00Z".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @param value Send a post request with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> paramDatetimeAsync(String scenario, OffsetDateTime value, Context context) {
+        return paramDatetimeWithResponseAsync(scenario, value, context).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "2010-01-01T12:34:56Z" or "scenario": "min",
+     * "value": "0001-01-01T00:00:00Z".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @param value Send a post request with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void paramDatetime(String scenario, OffsetDateTime value) {
+        paramDatetimeAsync(scenario, value).block();
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "2010-01-01T12:34:56Z" or "scenario": "min",
+     * "value": "0001-01-01T00:00:00Z".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @param value Send a post request with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> paramDatetimeWithResponse(String scenario, OffsetDateTime value, Context context) {
+        return paramDatetimeWithResponseAsync(scenario, value, context).block();
+    }
+
+    /**
+     * Get a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HeadersResponseDatetimeResponse> responseDatetimeWithResponseAsync(String scenario) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return FluxUtil.withContext(
+                context -> service.responseDatetime(this.client.getHost(), scenario, accept, context));
+    }
+
+    /**
+     * Get a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HeadersResponseDatetimeResponse> responseDatetimeWithResponseAsync(String scenario, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.responseDatetime(this.client.getHost(), scenario, accept, context);
+    }
+
+    /**
+     * Get a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> responseDatetimeAsync(String scenario) {
+        return responseDatetimeWithResponseAsync(scenario)
+                .flatMap((HeadersResponseDatetimeResponse res) -> Mono.empty());
+    }
+
+    /**
+     * Get a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> responseDatetimeAsync(String scenario, Context context) {
+        return responseDatetimeWithResponseAsync(scenario, context)
+                .flatMap((HeadersResponseDatetimeResponse res) -> Mono.empty());
+    }
+
+    /**
+     * Get a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void responseDatetime(String scenario) {
+        responseDatetimeAsync(scenario).block();
+    }
+
+    /**
+     * Get a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public HeadersResponseDatetimeResponse responseDatetimeWithResponse(String scenario, Context context) {
+        return responseDatetimeWithResponseAsync(scenario, context).block();
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or
+     * "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @param value Send a post request with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00
+     *     GMT".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> paramDatetimeRfc1123WithResponseAsync(String scenario, OffsetDateTime value) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        DateTimeRfc1123 valueConverted = value == null ? null : new DateTimeRfc1123(value);
+        return FluxUtil.withContext(
+                context ->
+                        service.paramDatetimeRfc1123(this.client.getHost(), scenario, valueConverted, accept, context));
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or
+     * "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @param value Send a post request with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00
+     *     GMT".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> paramDatetimeRfc1123WithResponseAsync(
+            String scenario, OffsetDateTime value, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        DateTimeRfc1123 valueConverted = value == null ? null : new DateTimeRfc1123(value);
+        return service.paramDatetimeRfc1123(this.client.getHost(), scenario, valueConverted, accept, context);
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or
+     * "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @param value Send a post request with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00
+     *     GMT".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> paramDatetimeRfc1123Async(String scenario, OffsetDateTime value) {
+        return paramDatetimeRfc1123WithResponseAsync(scenario, value).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or
+     * "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> paramDatetimeRfc1123Async(String scenario) {
+        final OffsetDateTime value = null;
+        return paramDatetimeRfc1123WithResponseAsync(scenario, value).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or
+     * "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @param value Send a post request with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00
+     *     GMT".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> paramDatetimeRfc1123Async(String scenario, OffsetDateTime value, Context context) {
+        return paramDatetimeRfc1123WithResponseAsync(scenario, value, context)
+                .flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or
+     * "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @param value Send a post request with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00
+     *     GMT".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void paramDatetimeRfc1123(String scenario, OffsetDateTime value) {
+        paramDatetimeRfc1123Async(scenario, value).block();
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or
+     * "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void paramDatetimeRfc1123(String scenario) {
+        final OffsetDateTime value = null;
+        paramDatetimeRfc1123Async(scenario, value).block();
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or
+     * "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @param value Send a post request with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00
+     *     GMT".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> paramDatetimeRfc1123WithResponse(String scenario, OffsetDateTime value, Context context) {
+        return paramDatetimeRfc1123WithResponseAsync(scenario, value, context).block();
+    }
+
+    /**
+     * Get a response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HeadersResponseDatetimeRfc1123Response> responseDatetimeRfc1123WithResponseAsync(String scenario) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return FluxUtil.withContext(
+                context -> service.responseDatetimeRfc1123(this.client.getHost(), scenario, accept, context));
+    }
+
+    /**
+     * Get a response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HeadersResponseDatetimeRfc1123Response> responseDatetimeRfc1123WithResponseAsync(
+            String scenario, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.responseDatetimeRfc1123(this.client.getHost(), scenario, accept, context);
+    }
+
+    /**
+     * Get a response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> responseDatetimeRfc1123Async(String scenario) {
+        return responseDatetimeRfc1123WithResponseAsync(scenario)
+                .flatMap((HeadersResponseDatetimeRfc1123Response res) -> Mono.empty());
+    }
+
+    /**
+     * Get a response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> responseDatetimeRfc1123Async(String scenario, Context context) {
+        return responseDatetimeRfc1123WithResponseAsync(scenario, context)
+                .flatMap((HeadersResponseDatetimeRfc1123Response res) -> Mono.empty());
+    }
+
+    /**
+     * Get a response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void responseDatetimeRfc1123(String scenario) {
+        responseDatetimeRfc1123Async(scenario).block();
+    }
+
+    /**
+     * Get a response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "min".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public HeadersResponseDatetimeRfc1123Response responseDatetimeRfc1123WithResponse(
+            String scenario, Context context) {
+        return responseDatetimeRfc1123WithResponseAsync(scenario, context).block();
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "P123DT22H14M12.011S".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid".
+     * @param value Send a post request with header values "P123DT22H14M12.011S".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> paramDurationWithResponseAsync(String scenario, Duration value) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        if (value == null) {
+            return Mono.error(new IllegalArgumentException("Parameter value is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return FluxUtil.withContext(
+                context -> service.paramDuration(this.client.getHost(), scenario, value, accept, context));
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "P123DT22H14M12.011S".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid".
+     * @param value Send a post request with header values "P123DT22H14M12.011S".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> paramDurationWithResponseAsync(String scenario, Duration value, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        if (value == null) {
+            return Mono.error(new IllegalArgumentException("Parameter value is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.paramDuration(this.client.getHost(), scenario, value, accept, context);
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "P123DT22H14M12.011S".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid".
+     * @param value Send a post request with header values "P123DT22H14M12.011S".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> paramDurationAsync(String scenario, Duration value) {
+        return paramDurationWithResponseAsync(scenario, value).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "P123DT22H14M12.011S".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid".
+     * @param value Send a post request with header values "P123DT22H14M12.011S".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> paramDurationAsync(String scenario, Duration value, Context context) {
+        return paramDurationWithResponseAsync(scenario, value, context).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "P123DT22H14M12.011S".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid".
+     * @param value Send a post request with header values "P123DT22H14M12.011S".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void paramDuration(String scenario, Duration value) {
+        paramDurationAsync(scenario, value).block();
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "P123DT22H14M12.011S".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid".
+     * @param value Send a post request with header values "P123DT22H14M12.011S".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> paramDurationWithResponse(String scenario, Duration value, Context context) {
+        return paramDurationWithResponseAsync(scenario, value, context).block();
+    }
+
+    /**
+     * Get a response with header values "P123DT22H14M12.011S".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "P123DT22H14M12.011S".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HeadersResponseDurationResponse> responseDurationWithResponseAsync(String scenario) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return FluxUtil.withContext(
+                context -> service.responseDuration(this.client.getHost(), scenario, accept, context));
+    }
+
+    /**
+     * Get a response with header values "P123DT22H14M12.011S".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "P123DT22H14M12.011S".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HeadersResponseDurationResponse> responseDurationWithResponseAsync(String scenario, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.responseDuration(this.client.getHost(), scenario, accept, context);
+    }
+
+    /**
+     * Get a response with header values "P123DT22H14M12.011S".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "P123DT22H14M12.011S".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> responseDurationAsync(String scenario) {
+        return responseDurationWithResponseAsync(scenario)
+                .flatMap((HeadersResponseDurationResponse res) -> Mono.empty());
+    }
+
+    /**
+     * Get a response with header values "P123DT22H14M12.011S".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "P123DT22H14M12.011S".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> responseDurationAsync(String scenario, Context context) {
+        return responseDurationWithResponseAsync(scenario, context)
+                .flatMap((HeadersResponseDurationResponse res) -> Mono.empty());
+    }
+
+    /**
+     * Get a response with header values "P123DT22H14M12.011S".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void responseDuration(String scenario) {
+        responseDurationAsync(scenario).block();
+    }
+
+    /**
+     * Get a response with header values "P123DT22H14M12.011S".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "P123DT22H14M12.011S".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public HeadersResponseDurationResponse responseDurationWithResponse(String scenario, Context context) {
+        return responseDurationWithResponseAsync(scenario, context).block();
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "啊齄丂狛狜隣郎隣兀﨩".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid".
+     * @param value Send a post request with header values "啊齄丂狛狜隣郎隣兀﨩".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> paramByteWithResponseAsync(String scenario, byte[] value) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        if (value == null) {
+            return Mono.error(new IllegalArgumentException("Parameter value is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        String valueConverted = Base64Util.encodeToString(value);
+        return FluxUtil.withContext(
+                context -> service.paramByte(this.client.getHost(), scenario, valueConverted, accept, context));
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "啊齄丂狛狜隣郎隣兀﨩".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid".
+     * @param value Send a post request with header values "啊齄丂狛狜隣郎隣兀﨩".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> paramByteWithResponseAsync(String scenario, byte[] value, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        if (value == null) {
+            return Mono.error(new IllegalArgumentException("Parameter value is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        String valueConverted = Base64Util.encodeToString(value);
+        return service.paramByte(this.client.getHost(), scenario, valueConverted, accept, context);
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "啊齄丂狛狜隣郎隣兀﨩".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid".
+     * @param value Send a post request with header values "啊齄丂狛狜隣郎隣兀﨩".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> paramByteAsync(String scenario, byte[] value) {
+        return paramByteWithResponseAsync(scenario, value).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "啊齄丂狛狜隣郎隣兀﨩".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid".
+     * @param value Send a post request with header values "啊齄丂狛狜隣郎隣兀﨩".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> paramByteAsync(String scenario, byte[] value, Context context) {
+        return paramByteWithResponseAsync(scenario, value, context).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "啊齄丂狛狜隣郎隣兀﨩".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid".
+     * @param value Send a post request with header values "啊齄丂狛狜隣郎隣兀﨩".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void paramByte(String scenario, byte[] value) {
+        paramByteAsync(scenario, value).block();
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "啊齄丂狛狜隣郎隣兀﨩".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid".
+     * @param value Send a post request with header values "啊齄丂狛狜隣郎隣兀﨩".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> paramByteWithResponse(String scenario, byte[] value, Context context) {
+        return paramByteWithResponseAsync(scenario, value, context).block();
+    }
+
+    /**
+     * Get a response with header values "啊齄丂狛狜隣郎隣兀﨩".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "啊齄丂狛狜隣郎隣兀﨩".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HeadersResponseByteResponse> responseByteWithResponseAsync(String scenario) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return FluxUtil.withContext(context -> service.responseByte(this.client.getHost(), scenario, accept, context));
+    }
+
+    /**
+     * Get a response with header values "啊齄丂狛狜隣郎隣兀﨩".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "啊齄丂狛狜隣郎隣兀﨩".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HeadersResponseByteResponse> responseByteWithResponseAsync(String scenario, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.responseByte(this.client.getHost(), scenario, accept, context);
+    }
+
+    /**
+     * Get a response with header values "啊齄丂狛狜隣郎隣兀﨩".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "啊齄丂狛狜隣郎隣兀﨩".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> responseByteAsync(String scenario) {
+        return responseByteWithResponseAsync(scenario).flatMap((HeadersResponseByteResponse res) -> Mono.empty());
+    }
+
+    /**
+     * Get a response with header values "啊齄丂狛狜隣郎隣兀﨩".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "啊齄丂狛狜隣郎隣兀﨩".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> responseByteAsync(String scenario, Context context) {
+        return responseByteWithResponseAsync(scenario, context)
+                .flatMap((HeadersResponseByteResponse res) -> Mono.empty());
+    }
+
+    /**
+     * Get a response with header values "啊齄丂狛狜隣郎隣兀﨩".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void responseByte(String scenario) {
+        responseByteAsync(scenario).block();
+    }
+
+    /**
+     * Get a response with header values "啊齄丂狛狜隣郎隣兀﨩".
+     *
+     * @param scenario Send a post request with header values "scenario": "valid".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "啊齄丂狛狜隣郎隣兀﨩".
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public HeadersResponseByteResponse responseByteWithResponse(String scenario, Context context) {
+        return responseByteWithResponseAsync(scenario, context).block();
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null.
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty".
+     * @param value Send a post request with header values 'GREY'.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> paramEnumWithResponseAsync(String scenario, GreyscaleColors value) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return FluxUtil.withContext(
+                context -> service.paramEnum(this.client.getHost(), scenario, value, accept, context));
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null.
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty".
+     * @param value Send a post request with header values 'GREY'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> paramEnumWithResponseAsync(String scenario, GreyscaleColors value, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.paramEnum(this.client.getHost(), scenario, value, accept, context);
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null.
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty".
+     * @param value Send a post request with header values 'GREY'.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> paramEnumAsync(String scenario, GreyscaleColors value) {
+        return paramEnumWithResponseAsync(scenario, value).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null.
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> paramEnumAsync(String scenario) {
+        final GreyscaleColors value = null;
+        return paramEnumWithResponseAsync(scenario, value).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null.
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty".
+     * @param value Send a post request with header values 'GREY'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> paramEnumAsync(String scenario, GreyscaleColors value, Context context) {
+        return paramEnumWithResponseAsync(scenario, value, context).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null.
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty".
+     * @param value Send a post request with header values 'GREY'.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void paramEnum(String scenario, GreyscaleColors value) {
+        paramEnumAsync(scenario, value).block();
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null.
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void paramEnum(String scenario) {
+        final GreyscaleColors value = null;
+        paramEnumAsync(scenario, value).block();
+    }
+
+    /**
+     * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null.
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty".
+     * @param value Send a post request with header values 'GREY'.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> paramEnumWithResponse(String scenario, GreyscaleColors value, Context context) {
+        return paramEnumWithResponseAsync(scenario, value, context).block();
+    }
+
+    /**
+     * Get a response with header values "GREY" or null.
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "GREY" or null.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HeadersResponseEnumResponse> responseEnumWithResponseAsync(String scenario) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return FluxUtil.withContext(context -> service.responseEnum(this.client.getHost(), scenario, accept, context));
+    }
+
+    /**
+     * Get a response with header values "GREY" or null.
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "GREY" or null.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HeadersResponseEnumResponse> responseEnumWithResponseAsync(String scenario, Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (scenario == null) {
+            return Mono.error(new IllegalArgumentException("Parameter scenario is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.responseEnum(this.client.getHost(), scenario, accept, context);
+    }
+
+    /**
+     * Get a response with header values "GREY" or null.
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "GREY" or null.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> responseEnumAsync(String scenario) {
+        return responseEnumWithResponseAsync(scenario).flatMap((HeadersResponseEnumResponse res) -> Mono.empty());
+    }
+
+    /**
+     * Get a response with header values "GREY" or null.
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "GREY" or null.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> responseEnumAsync(String scenario, Context context) {
+        return responseEnumWithResponseAsync(scenario, context)
+                .flatMap((HeadersResponseEnumResponse res) -> Mono.empty());
+    }
+
+    /**
+     * Get a response with header values "GREY" or null.
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty".
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void responseEnum(String scenario) {
+        responseEnumAsync(scenario).block();
+    }
+
+    /**
+     * Get a response with header values "GREY" or null.
+     *
+     * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty".
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return a response with header values "GREY" or null.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public HeadersResponseEnumResponse responseEnumWithResponse(String scenario, Context context) {
+        return responseEnumWithResponseAsync(scenario, context).block();
+    }
+
+    /**
+     * Send x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> customRequestIdWithResponseAsync() {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return FluxUtil.withContext(context -> service.customRequestId(this.client.getHost(), accept, context));
+    }
+
+    /**
+     * Send x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<Void>> customRequestIdWithResponseAsync(Context context) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        final String accept = "application/json";
+        return service.customRequestId(this.client.getHost(), accept, context);
+    }
+
+    /**
+     * Send x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> customRequestIdAsync() {
+        return customRequestIdWithResponseAsync().flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Send x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the completion.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> customRequestIdAsync(Context context) {
+        return customRequestIdWithResponseAsync(context).flatMap((Response<Void> res) -> Mono.empty());
+    }
+
+    /**
+     * Send x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void customRequestId() {
+        customRequestIdAsync().block();
+    }
+
+    /**
+     * Send x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request.
+     *
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<Void> customRequestIdWithResponse(Context context) {
+        return customRequestIdWithResponseAsync(context).block();
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/Error.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/Error.java
@@ -1,0 +1,67 @@
+package fixtures.deferredheaderdeserialization.models;
+
+import com.azure.core.annotation.Fluent;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** The Error model. */
+@Fluent
+public final class Error {
+    /*
+     * The status property.
+     */
+    @JsonProperty(value = "status")
+    private Integer status;
+
+    /*
+     * The message property.
+     */
+    @JsonProperty(value = "message")
+    private String message;
+
+    /**
+     * Get the status property: The status property.
+     *
+     * @return the status value.
+     */
+    public Integer getStatus() {
+        return this.status;
+    }
+
+    /**
+     * Set the status property: The status property.
+     *
+     * @param status the status value to set.
+     * @return the Error object itself.
+     */
+    public Error setStatus(Integer status) {
+        this.status = status;
+        return this;
+    }
+
+    /**
+     * Get the message property: The message property.
+     *
+     * @return the message value.
+     */
+    public String getMessage() {
+        return this.message;
+    }
+
+    /**
+     * Set the message property: The message property.
+     *
+     * @param message the message value to set.
+     * @return the Error object itself.
+     */
+    public Error setMessage(String message) {
+        this.message = message;
+        return this;
+    }
+
+    /**
+     * Validates the instance.
+     *
+     * @throws IllegalArgumentException thrown if the instance is not valid.
+     */
+    public void validate() {}
+}

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/ErrorException.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/ErrorException.java
@@ -1,0 +1,33 @@
+package fixtures.deferredheaderdeserialization.models;
+
+import com.azure.core.exception.HttpResponseException;
+import com.azure.core.http.HttpResponse;
+
+/** Exception thrown for an invalid response with Error information. */
+public final class ErrorException extends HttpResponseException {
+    /**
+     * Initializes a new instance of the ErrorException class.
+     *
+     * @param message the exception message or the response content if a message is not available.
+     * @param response the HTTP response.
+     */
+    public ErrorException(String message, HttpResponse response) {
+        super(message, response);
+    }
+
+    /**
+     * Initializes a new instance of the ErrorException class.
+     *
+     * @param message the exception message or the response content if a message is not available.
+     * @param response the HTTP response.
+     * @param value the deserialized response value.
+     */
+    public ErrorException(String message, HttpResponse response, Error value) {
+        super(message, response, value);
+    }
+
+    @Override
+    public Error getValue() {
+        return (Error) super.getValue();
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/GreyscaleColors.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/GreyscaleColors.java
@@ -1,0 +1,46 @@
+package fixtures.deferredheaderdeserialization.models;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/** Defines values for GreyscaleColors. */
+public enum GreyscaleColors {
+    /** Enum value White. */
+    WHITE("White"),
+
+    /** Enum value black. */
+    BLACK("black"),
+
+    /** Enum value GREY. */
+    GREY("GREY");
+
+    /** The actual serialized value for a GreyscaleColors instance. */
+    private final String value;
+
+    GreyscaleColors(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Parses a serialized value to a GreyscaleColors instance.
+     *
+     * @param value the serialized value to parse.
+     * @return the parsed GreyscaleColors object, or null if unable to parse.
+     */
+    @JsonCreator
+    public static GreyscaleColors fromString(String value) {
+        GreyscaleColors[] items = GreyscaleColors.values();
+        for (GreyscaleColors item : items) {
+            if (item.toString().equalsIgnoreCase(value)) {
+                return item;
+            }
+        }
+        return null;
+    }
+
+    @JsonValue
+    @Override
+    public String toString() {
+        return this.value;
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseBoolHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseBoolHeaders.java
@@ -31,7 +31,9 @@ public final class HeadersResponseBoolHeaders {
      */
     public Boolean isValue() {
         if (!this.valueHasBeenDeserialized) {
-            this.value = Boolean.valueOf(rawHeaders.getValue("value"));
+            if (rawHeaders.getValue("value") != null) {
+                this.value = Boolean.valueOf(rawHeaders.getValue("value"));
+            }
             this.valueHasBeenDeserialized = true;
         }
         return this.value;

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseBoolHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseBoolHeaders.java
@@ -1,0 +1,57 @@
+package fixtures.deferredheaderdeserialization.models;
+
+import com.azure.core.annotation.Fluent;
+import com.azure.core.http.HttpHeaders;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** The HeadersResponseBoolHeaders model. */
+@Fluent
+public final class HeadersResponseBoolHeaders {
+    /*
+     * The value property.
+     */
+    @JsonProperty(value = "value")
+    private Boolean value;
+
+    // Maintains deserialization status for value.
+    private boolean valueHasBeenDeserialized;
+
+    // HttpHeaders containing the raw property values.
+    private final HttpHeaders rawHeaders;
+
+    /** Creates an instance of HeadersResponseBoolHeaders class. */
+    HeadersResponseBoolHeaders(HttpHeaders rawHeaders) {
+        this.rawHeaders = rawHeaders;
+    }
+
+    /**
+     * Get the value property: The value property.
+     *
+     * @return the value value.
+     */
+    public Boolean isValue() {
+        if (!this.valueHasBeenDeserialized) {
+            this.value = Boolean.valueOf(rawHeaders.getValue("value"));
+            this.valueHasBeenDeserialized = true;
+        }
+        return this.value;
+    }
+
+    /**
+     * Set the value property: The value property.
+     *
+     * @param value the value value to set.
+     * @return the HeadersResponseBoolHeaders object itself.
+     */
+    public HeadersResponseBoolHeaders setValue(Boolean value) {
+        this.value = value;
+        return this;
+    }
+
+    /**
+     * Validates the instance.
+     *
+     * @throws IllegalArgumentException thrown if the instance is not valid.
+     */
+    public void validate() {}
+}

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseBoolResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseBoolResponse.java
@@ -1,0 +1,26 @@
+package fixtures.deferredheaderdeserialization.models;
+
+import com.azure.core.http.HttpHeaders;
+import com.azure.core.http.HttpRequest;
+import com.azure.core.http.rest.ResponseBase;
+
+/** Contains all response data for the responseBool operation. */
+public final class HeadersResponseBoolResponse extends ResponseBase<HeadersResponseBoolHeaders, Void> {
+    /**
+     * Creates an instance of HeadersResponseBoolResponse.
+     *
+     * @param request the request which resulted in this HeadersResponseBoolResponse.
+     * @param statusCode the status code of the HTTP response.
+     * @param rawHeaders the raw headers of the HTTP response.
+     * @param value the deserialized value of the HTTP response.
+     * @param headers the deserialized headers of the HTTP response.
+     */
+    public HeadersResponseBoolResponse(
+            HttpRequest request,
+            int statusCode,
+            HttpHeaders rawHeaders,
+            Void value,
+            HeadersResponseBoolHeaders headers) {
+        super(request, statusCode, rawHeaders, value, headers);
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseByteHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseByteHeaders.java
@@ -33,7 +33,9 @@ public final class HeadersResponseByteHeaders {
      */
     public byte[] getValue() {
         if (!this.valueHasBeenDeserialized) {
-            this.value = Base64.getDecoder().decode(rawHeaders.getValue("value"));
+            if (rawHeaders.getValue("value") != null) {
+                this.value = Base64.getDecoder().decode(rawHeaders.getValue("value"));
+            }
             this.valueHasBeenDeserialized = true;
         }
         return CoreUtils.clone(this.value);

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseByteHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseByteHeaders.java
@@ -1,0 +1,59 @@
+package fixtures.deferredheaderdeserialization.models;
+
+import com.azure.core.annotation.Fluent;
+import com.azure.core.http.HttpHeaders;
+import com.azure.core.util.CoreUtils;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Base64;
+
+/** The HeadersResponseByteHeaders model. */
+@Fluent
+public final class HeadersResponseByteHeaders {
+    /*
+     * The value property.
+     */
+    @JsonProperty(value = "value")
+    private byte[] value;
+
+    // Maintains deserialization status for value.
+    private boolean valueHasBeenDeserialized;
+
+    // HttpHeaders containing the raw property values.
+    private final HttpHeaders rawHeaders;
+
+    /** Creates an instance of HeadersResponseByteHeaders class. */
+    HeadersResponseByteHeaders(HttpHeaders rawHeaders) {
+        this.rawHeaders = rawHeaders;
+    }
+
+    /**
+     * Get the value property: The value property.
+     *
+     * @return the value value.
+     */
+    public byte[] getValue() {
+        if (!this.valueHasBeenDeserialized) {
+            this.value = Base64.getDecoder().decode(rawHeaders.getValue("value"));
+            this.valueHasBeenDeserialized = true;
+        }
+        return CoreUtils.clone(this.value);
+    }
+
+    /**
+     * Set the value property: The value property.
+     *
+     * @param value the value value to set.
+     * @return the HeadersResponseByteHeaders object itself.
+     */
+    public HeadersResponseByteHeaders setValue(byte[] value) {
+        this.value = CoreUtils.clone(value);
+        return this;
+    }
+
+    /**
+     * Validates the instance.
+     *
+     * @throws IllegalArgumentException thrown if the instance is not valid.
+     */
+    public void validate() {}
+}

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseByteResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseByteResponse.java
@@ -1,0 +1,26 @@
+package fixtures.deferredheaderdeserialization.models;
+
+import com.azure.core.http.HttpHeaders;
+import com.azure.core.http.HttpRequest;
+import com.azure.core.http.rest.ResponseBase;
+
+/** Contains all response data for the responseByte operation. */
+public final class HeadersResponseByteResponse extends ResponseBase<HeadersResponseByteHeaders, Void> {
+    /**
+     * Creates an instance of HeadersResponseByteResponse.
+     *
+     * @param request the request which resulted in this HeadersResponseByteResponse.
+     * @param statusCode the status code of the HTTP response.
+     * @param rawHeaders the raw headers of the HTTP response.
+     * @param value the deserialized value of the HTTP response.
+     * @param headers the deserialized headers of the HTTP response.
+     */
+    public HeadersResponseByteResponse(
+            HttpRequest request,
+            int statusCode,
+            HttpHeaders rawHeaders,
+            Void value,
+            HeadersResponseByteHeaders headers) {
+        super(request, statusCode, rawHeaders, value, headers);
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseDateHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseDateHeaders.java
@@ -1,0 +1,58 @@
+package fixtures.deferredheaderdeserialization.models;
+
+import com.azure.core.annotation.Fluent;
+import com.azure.core.http.HttpHeaders;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDate;
+
+/** The HeadersResponseDateHeaders model. */
+@Fluent
+public final class HeadersResponseDateHeaders {
+    /*
+     * The value property.
+     */
+    @JsonProperty(value = "value")
+    private LocalDate value;
+
+    // Maintains deserialization status for value.
+    private boolean valueHasBeenDeserialized;
+
+    // HttpHeaders containing the raw property values.
+    private final HttpHeaders rawHeaders;
+
+    /** Creates an instance of HeadersResponseDateHeaders class. */
+    HeadersResponseDateHeaders(HttpHeaders rawHeaders) {
+        this.rawHeaders = rawHeaders;
+    }
+
+    /**
+     * Get the value property: The value property.
+     *
+     * @return the value value.
+     */
+    public LocalDate getValue() {
+        if (!this.valueHasBeenDeserialized) {
+            this.value = LocalDate.parse(rawHeaders.getValue("value"));
+            this.valueHasBeenDeserialized = true;
+        }
+        return this.value;
+    }
+
+    /**
+     * Set the value property: The value property.
+     *
+     * @param value the value value to set.
+     * @return the HeadersResponseDateHeaders object itself.
+     */
+    public HeadersResponseDateHeaders setValue(LocalDate value) {
+        this.value = value;
+        return this;
+    }
+
+    /**
+     * Validates the instance.
+     *
+     * @throws IllegalArgumentException thrown if the instance is not valid.
+     */
+    public void validate() {}
+}

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseDateHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseDateHeaders.java
@@ -32,7 +32,9 @@ public final class HeadersResponseDateHeaders {
      */
     public LocalDate getValue() {
         if (!this.valueHasBeenDeserialized) {
-            this.value = LocalDate.parse(rawHeaders.getValue("value"));
+            if (rawHeaders.getValue("value") != null) {
+                this.value = LocalDate.parse(rawHeaders.getValue("value"));
+            }
             this.valueHasBeenDeserialized = true;
         }
         return this.value;

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseDateResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseDateResponse.java
@@ -1,0 +1,26 @@
+package fixtures.deferredheaderdeserialization.models;
+
+import com.azure.core.http.HttpHeaders;
+import com.azure.core.http.HttpRequest;
+import com.azure.core.http.rest.ResponseBase;
+
+/** Contains all response data for the responseDate operation. */
+public final class HeadersResponseDateResponse extends ResponseBase<HeadersResponseDateHeaders, Void> {
+    /**
+     * Creates an instance of HeadersResponseDateResponse.
+     *
+     * @param request the request which resulted in this HeadersResponseDateResponse.
+     * @param statusCode the status code of the HTTP response.
+     * @param rawHeaders the raw headers of the HTTP response.
+     * @param value the deserialized value of the HTTP response.
+     * @param headers the deserialized headers of the HTTP response.
+     */
+    public HeadersResponseDateResponse(
+            HttpRequest request,
+            int statusCode,
+            HttpHeaders rawHeaders,
+            Void value,
+            HeadersResponseDateHeaders headers) {
+        super(request, statusCode, rawHeaders, value, headers);
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseDatetimeHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseDatetimeHeaders.java
@@ -32,7 +32,9 @@ public final class HeadersResponseDatetimeHeaders {
      */
     public OffsetDateTime getValue() {
         if (!this.valueHasBeenDeserialized) {
-            this.value = OffsetDateTime.parse(rawHeaders.getValue("value"));
+            if (rawHeaders.getValue("value") != null) {
+                this.value = OffsetDateTime.parse(rawHeaders.getValue("value"));
+            }
             this.valueHasBeenDeserialized = true;
         }
         return this.value;

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseDatetimeHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseDatetimeHeaders.java
@@ -1,0 +1,58 @@
+package fixtures.deferredheaderdeserialization.models;
+
+import com.azure.core.annotation.Fluent;
+import com.azure.core.http.HttpHeaders;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.OffsetDateTime;
+
+/** The HeadersResponseDatetimeHeaders model. */
+@Fluent
+public final class HeadersResponseDatetimeHeaders {
+    /*
+     * The value property.
+     */
+    @JsonProperty(value = "value")
+    private OffsetDateTime value;
+
+    // Maintains deserialization status for value.
+    private boolean valueHasBeenDeserialized;
+
+    // HttpHeaders containing the raw property values.
+    private final HttpHeaders rawHeaders;
+
+    /** Creates an instance of HeadersResponseDatetimeHeaders class. */
+    HeadersResponseDatetimeHeaders(HttpHeaders rawHeaders) {
+        this.rawHeaders = rawHeaders;
+    }
+
+    /**
+     * Get the value property: The value property.
+     *
+     * @return the value value.
+     */
+    public OffsetDateTime getValue() {
+        if (!this.valueHasBeenDeserialized) {
+            this.value = OffsetDateTime.parse(rawHeaders.getValue("value"));
+            this.valueHasBeenDeserialized = true;
+        }
+        return this.value;
+    }
+
+    /**
+     * Set the value property: The value property.
+     *
+     * @param value the value value to set.
+     * @return the HeadersResponseDatetimeHeaders object itself.
+     */
+    public HeadersResponseDatetimeHeaders setValue(OffsetDateTime value) {
+        this.value = value;
+        return this;
+    }
+
+    /**
+     * Validates the instance.
+     *
+     * @throws IllegalArgumentException thrown if the instance is not valid.
+     */
+    public void validate() {}
+}

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseDatetimeResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseDatetimeResponse.java
@@ -1,0 +1,26 @@
+package fixtures.deferredheaderdeserialization.models;
+
+import com.azure.core.http.HttpHeaders;
+import com.azure.core.http.HttpRequest;
+import com.azure.core.http.rest.ResponseBase;
+
+/** Contains all response data for the responseDatetime operation. */
+public final class HeadersResponseDatetimeResponse extends ResponseBase<HeadersResponseDatetimeHeaders, Void> {
+    /**
+     * Creates an instance of HeadersResponseDatetimeResponse.
+     *
+     * @param request the request which resulted in this HeadersResponseDatetimeResponse.
+     * @param statusCode the status code of the HTTP response.
+     * @param rawHeaders the raw headers of the HTTP response.
+     * @param value the deserialized value of the HTTP response.
+     * @param headers the deserialized headers of the HTTP response.
+     */
+    public HeadersResponseDatetimeResponse(
+            HttpRequest request,
+            int statusCode,
+            HttpHeaders rawHeaders,
+            Void value,
+            HeadersResponseDatetimeHeaders headers) {
+        super(request, statusCode, rawHeaders, value, headers);
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseDatetimeRfc1123Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseDatetimeRfc1123Headers.java
@@ -33,7 +33,9 @@ public final class HeadersResponseDatetimeRfc1123Headers {
      */
     public OffsetDateTime getValue() {
         if (!this.valueHasBeenDeserialized) {
-            this.value = new DateTimeRfc1123(rawHeaders.getValue("value"));
+            if (rawHeaders.getValue("value") != null) {
+                this.value = new DateTimeRfc1123(rawHeaders.getValue("value"));
+            }
             this.valueHasBeenDeserialized = true;
         }
         if (this.value == null) {

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseDatetimeRfc1123Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseDatetimeRfc1123Headers.java
@@ -1,0 +1,66 @@
+package fixtures.deferredheaderdeserialization.models;
+
+import com.azure.core.annotation.Fluent;
+import com.azure.core.http.HttpHeaders;
+import com.azure.core.util.DateTimeRfc1123;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.OffsetDateTime;
+
+/** The HeadersResponseDatetimeRfc1123Headers model. */
+@Fluent
+public final class HeadersResponseDatetimeRfc1123Headers {
+    /*
+     * The value property.
+     */
+    @JsonProperty(value = "value")
+    private DateTimeRfc1123 value;
+
+    // Maintains deserialization status for value.
+    private boolean valueHasBeenDeserialized;
+
+    // HttpHeaders containing the raw property values.
+    private final HttpHeaders rawHeaders;
+
+    /** Creates an instance of HeadersResponseDatetimeRfc1123Headers class. */
+    HeadersResponseDatetimeRfc1123Headers(HttpHeaders rawHeaders) {
+        this.rawHeaders = rawHeaders;
+    }
+
+    /**
+     * Get the value property: The value property.
+     *
+     * @return the value value.
+     */
+    public OffsetDateTime getValue() {
+        if (!this.valueHasBeenDeserialized) {
+            this.value = new DateTimeRfc1123(rawHeaders.getValue("value"));
+            this.valueHasBeenDeserialized = true;
+        }
+        if (this.value == null) {
+            return null;
+        }
+        return this.value.getDateTime();
+    }
+
+    /**
+     * Set the value property: The value property.
+     *
+     * @param value the value value to set.
+     * @return the HeadersResponseDatetimeRfc1123Headers object itself.
+     */
+    public HeadersResponseDatetimeRfc1123Headers setValue(OffsetDateTime value) {
+        if (value == null) {
+            this.value = null;
+        } else {
+            this.value = new DateTimeRfc1123(value);
+        }
+        return this;
+    }
+
+    /**
+     * Validates the instance.
+     *
+     * @throws IllegalArgumentException thrown if the instance is not valid.
+     */
+    public void validate() {}
+}

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseDatetimeRfc1123Response.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseDatetimeRfc1123Response.java
@@ -1,0 +1,27 @@
+package fixtures.deferredheaderdeserialization.models;
+
+import com.azure.core.http.HttpHeaders;
+import com.azure.core.http.HttpRequest;
+import com.azure.core.http.rest.ResponseBase;
+
+/** Contains all response data for the responseDatetimeRfc1123 operation. */
+public final class HeadersResponseDatetimeRfc1123Response
+        extends ResponseBase<HeadersResponseDatetimeRfc1123Headers, Void> {
+    /**
+     * Creates an instance of HeadersResponseDatetimeRfc1123Response.
+     *
+     * @param request the request which resulted in this HeadersResponseDatetimeRfc1123Response.
+     * @param statusCode the status code of the HTTP response.
+     * @param rawHeaders the raw headers of the HTTP response.
+     * @param value the deserialized value of the HTTP response.
+     * @param headers the deserialized headers of the HTTP response.
+     */
+    public HeadersResponseDatetimeRfc1123Response(
+            HttpRequest request,
+            int statusCode,
+            HttpHeaders rawHeaders,
+            Void value,
+            HeadersResponseDatetimeRfc1123Headers headers) {
+        super(request, statusCode, rawHeaders, value, headers);
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseDoubleHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseDoubleHeaders.java
@@ -1,0 +1,57 @@
+package fixtures.deferredheaderdeserialization.models;
+
+import com.azure.core.annotation.Fluent;
+import com.azure.core.http.HttpHeaders;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** The HeadersResponseDoubleHeaders model. */
+@Fluent
+public final class HeadersResponseDoubleHeaders {
+    /*
+     * The value property.
+     */
+    @JsonProperty(value = "value")
+    private Double value;
+
+    // Maintains deserialization status for value.
+    private boolean valueHasBeenDeserialized;
+
+    // HttpHeaders containing the raw property values.
+    private final HttpHeaders rawHeaders;
+
+    /** Creates an instance of HeadersResponseDoubleHeaders class. */
+    HeadersResponseDoubleHeaders(HttpHeaders rawHeaders) {
+        this.rawHeaders = rawHeaders;
+    }
+
+    /**
+     * Get the value property: The value property.
+     *
+     * @return the value value.
+     */
+    public Double getValue() {
+        if (!this.valueHasBeenDeserialized) {
+            this.value = Double.valueOf(rawHeaders.getValue("value"));
+            this.valueHasBeenDeserialized = true;
+        }
+        return this.value;
+    }
+
+    /**
+     * Set the value property: The value property.
+     *
+     * @param value the value value to set.
+     * @return the HeadersResponseDoubleHeaders object itself.
+     */
+    public HeadersResponseDoubleHeaders setValue(Double value) {
+        this.value = value;
+        return this;
+    }
+
+    /**
+     * Validates the instance.
+     *
+     * @throws IllegalArgumentException thrown if the instance is not valid.
+     */
+    public void validate() {}
+}

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseDoubleHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseDoubleHeaders.java
@@ -31,7 +31,9 @@ public final class HeadersResponseDoubleHeaders {
      */
     public Double getValue() {
         if (!this.valueHasBeenDeserialized) {
-            this.value = Double.valueOf(rawHeaders.getValue("value"));
+            if (rawHeaders.getValue("value") != null) {
+                this.value = Double.valueOf(rawHeaders.getValue("value"));
+            }
             this.valueHasBeenDeserialized = true;
         }
         return this.value;

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseDoubleResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseDoubleResponse.java
@@ -1,0 +1,26 @@
+package fixtures.deferredheaderdeserialization.models;
+
+import com.azure.core.http.HttpHeaders;
+import com.azure.core.http.HttpRequest;
+import com.azure.core.http.rest.ResponseBase;
+
+/** Contains all response data for the responseDouble operation. */
+public final class HeadersResponseDoubleResponse extends ResponseBase<HeadersResponseDoubleHeaders, Void> {
+    /**
+     * Creates an instance of HeadersResponseDoubleResponse.
+     *
+     * @param request the request which resulted in this HeadersResponseDoubleResponse.
+     * @param statusCode the status code of the HTTP response.
+     * @param rawHeaders the raw headers of the HTTP response.
+     * @param value the deserialized value of the HTTP response.
+     * @param headers the deserialized headers of the HTTP response.
+     */
+    public HeadersResponseDoubleResponse(
+            HttpRequest request,
+            int statusCode,
+            HttpHeaders rawHeaders,
+            Void value,
+            HeadersResponseDoubleHeaders headers) {
+        super(request, statusCode, rawHeaders, value, headers);
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseDurationHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseDurationHeaders.java
@@ -32,7 +32,9 @@ public final class HeadersResponseDurationHeaders {
      */
     public Duration getValue() {
         if (!this.valueHasBeenDeserialized) {
-            this.value = Duration.parse(rawHeaders.getValue("value"));
+            if (rawHeaders.getValue("value") != null) {
+                this.value = Duration.parse(rawHeaders.getValue("value"));
+            }
             this.valueHasBeenDeserialized = true;
         }
         return this.value;

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseDurationHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseDurationHeaders.java
@@ -1,0 +1,58 @@
+package fixtures.deferredheaderdeserialization.models;
+
+import com.azure.core.annotation.Fluent;
+import com.azure.core.http.HttpHeaders;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Duration;
+
+/** The HeadersResponseDurationHeaders model. */
+@Fluent
+public final class HeadersResponseDurationHeaders {
+    /*
+     * The value property.
+     */
+    @JsonProperty(value = "value")
+    private Duration value;
+
+    // Maintains deserialization status for value.
+    private boolean valueHasBeenDeserialized;
+
+    // HttpHeaders containing the raw property values.
+    private final HttpHeaders rawHeaders;
+
+    /** Creates an instance of HeadersResponseDurationHeaders class. */
+    HeadersResponseDurationHeaders(HttpHeaders rawHeaders) {
+        this.rawHeaders = rawHeaders;
+    }
+
+    /**
+     * Get the value property: The value property.
+     *
+     * @return the value value.
+     */
+    public Duration getValue() {
+        if (!this.valueHasBeenDeserialized) {
+            this.value = Duration.parse(rawHeaders.getValue("value"));
+            this.valueHasBeenDeserialized = true;
+        }
+        return this.value;
+    }
+
+    /**
+     * Set the value property: The value property.
+     *
+     * @param value the value value to set.
+     * @return the HeadersResponseDurationHeaders object itself.
+     */
+    public HeadersResponseDurationHeaders setValue(Duration value) {
+        this.value = value;
+        return this;
+    }
+
+    /**
+     * Validates the instance.
+     *
+     * @throws IllegalArgumentException thrown if the instance is not valid.
+     */
+    public void validate() {}
+}

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseDurationResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseDurationResponse.java
@@ -1,0 +1,26 @@
+package fixtures.deferredheaderdeserialization.models;
+
+import com.azure.core.http.HttpHeaders;
+import com.azure.core.http.HttpRequest;
+import com.azure.core.http.rest.ResponseBase;
+
+/** Contains all response data for the responseDuration operation. */
+public final class HeadersResponseDurationResponse extends ResponseBase<HeadersResponseDurationHeaders, Void> {
+    /**
+     * Creates an instance of HeadersResponseDurationResponse.
+     *
+     * @param request the request which resulted in this HeadersResponseDurationResponse.
+     * @param statusCode the status code of the HTTP response.
+     * @param rawHeaders the raw headers of the HTTP response.
+     * @param value the deserialized value of the HTTP response.
+     * @param headers the deserialized headers of the HTTP response.
+     */
+    public HeadersResponseDurationResponse(
+            HttpRequest request,
+            int statusCode,
+            HttpHeaders rawHeaders,
+            Void value,
+            HeadersResponseDurationHeaders headers) {
+        super(request, statusCode, rawHeaders, value, headers);
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseEnumHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseEnumHeaders.java
@@ -1,0 +1,57 @@
+package fixtures.deferredheaderdeserialization.models;
+
+import com.azure.core.annotation.Fluent;
+import com.azure.core.http.HttpHeaders;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** The HeadersResponseEnumHeaders model. */
+@Fluent
+public final class HeadersResponseEnumHeaders {
+    /*
+     * The value property.
+     */
+    @JsonProperty(value = "value")
+    private GreyscaleColors value;
+
+    // Maintains deserialization status for value.
+    private boolean valueHasBeenDeserialized;
+
+    // HttpHeaders containing the raw property values.
+    private final HttpHeaders rawHeaders;
+
+    /** Creates an instance of HeadersResponseEnumHeaders class. */
+    HeadersResponseEnumHeaders(HttpHeaders rawHeaders) {
+        this.rawHeaders = rawHeaders;
+    }
+
+    /**
+     * Get the value property: The value property.
+     *
+     * @return the value value.
+     */
+    public GreyscaleColors getValue() {
+        if (!this.valueHasBeenDeserialized) {
+            this.value = GreyscaleColors.fromString(rawHeaders.getValue("value"));
+            this.valueHasBeenDeserialized = true;
+        }
+        return this.value;
+    }
+
+    /**
+     * Set the value property: The value property.
+     *
+     * @param value the value value to set.
+     * @return the HeadersResponseEnumHeaders object itself.
+     */
+    public HeadersResponseEnumHeaders setValue(GreyscaleColors value) {
+        this.value = value;
+        return this;
+    }
+
+    /**
+     * Validates the instance.
+     *
+     * @throws IllegalArgumentException thrown if the instance is not valid.
+     */
+    public void validate() {}
+}

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseEnumHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseEnumHeaders.java
@@ -31,7 +31,9 @@ public final class HeadersResponseEnumHeaders {
      */
     public GreyscaleColors getValue() {
         if (!this.valueHasBeenDeserialized) {
-            this.value = GreyscaleColors.fromString(rawHeaders.getValue("value"));
+            if (rawHeaders.getValue("value") != null) {
+                this.value = GreyscaleColors.fromString(rawHeaders.getValue("value"));
+            }
             this.valueHasBeenDeserialized = true;
         }
         return this.value;

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseEnumResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseEnumResponse.java
@@ -1,0 +1,26 @@
+package fixtures.deferredheaderdeserialization.models;
+
+import com.azure.core.http.HttpHeaders;
+import com.azure.core.http.HttpRequest;
+import com.azure.core.http.rest.ResponseBase;
+
+/** Contains all response data for the responseEnum operation. */
+public final class HeadersResponseEnumResponse extends ResponseBase<HeadersResponseEnumHeaders, Void> {
+    /**
+     * Creates an instance of HeadersResponseEnumResponse.
+     *
+     * @param request the request which resulted in this HeadersResponseEnumResponse.
+     * @param statusCode the status code of the HTTP response.
+     * @param rawHeaders the raw headers of the HTTP response.
+     * @param value the deserialized value of the HTTP response.
+     * @param headers the deserialized headers of the HTTP response.
+     */
+    public HeadersResponseEnumResponse(
+            HttpRequest request,
+            int statusCode,
+            HttpHeaders rawHeaders,
+            Void value,
+            HeadersResponseEnumHeaders headers) {
+        super(request, statusCode, rawHeaders, value, headers);
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseExistingKeyHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseExistingKeyHeaders.java
@@ -1,0 +1,57 @@
+package fixtures.deferredheaderdeserialization.models;
+
+import com.azure.core.annotation.Fluent;
+import com.azure.core.http.HttpHeaders;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** The HeadersResponseExistingKeyHeaders model. */
+@Fluent
+public final class HeadersResponseExistingKeyHeaders {
+    /*
+     * The User-Agent property.
+     */
+    @JsonProperty(value = "User-Agent")
+    private String userAgent;
+
+    // Maintains deserialization status for userAgent.
+    private boolean userAgentHasBeenDeserialized;
+
+    // HttpHeaders containing the raw property values.
+    private final HttpHeaders rawHeaders;
+
+    /** Creates an instance of HeadersResponseExistingKeyHeaders class. */
+    HeadersResponseExistingKeyHeaders(HttpHeaders rawHeaders) {
+        this.rawHeaders = rawHeaders;
+    }
+
+    /**
+     * Get the userAgent property: The User-Agent property.
+     *
+     * @return the userAgent value.
+     */
+    public String getUserAgent() {
+        if (!this.userAgentHasBeenDeserialized) {
+            this.userAgent = rawHeaders.getValue("User-Agent");
+            this.userAgentHasBeenDeserialized = true;
+        }
+        return this.userAgent;
+    }
+
+    /**
+     * Set the userAgent property: The User-Agent property.
+     *
+     * @param userAgent the userAgent value to set.
+     * @return the HeadersResponseExistingKeyHeaders object itself.
+     */
+    public HeadersResponseExistingKeyHeaders setUserAgent(String userAgent) {
+        this.userAgent = userAgent;
+        return this;
+    }
+
+    /**
+     * Validates the instance.
+     *
+     * @throws IllegalArgumentException thrown if the instance is not valid.
+     */
+    public void validate() {}
+}

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseExistingKeyResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseExistingKeyResponse.java
@@ -1,0 +1,26 @@
+package fixtures.deferredheaderdeserialization.models;
+
+import com.azure.core.http.HttpHeaders;
+import com.azure.core.http.HttpRequest;
+import com.azure.core.http.rest.ResponseBase;
+
+/** Contains all response data for the responseExistingKey operation. */
+public final class HeadersResponseExistingKeyResponse extends ResponseBase<HeadersResponseExistingKeyHeaders, Void> {
+    /**
+     * Creates an instance of HeadersResponseExistingKeyResponse.
+     *
+     * @param request the request which resulted in this HeadersResponseExistingKeyResponse.
+     * @param statusCode the status code of the HTTP response.
+     * @param rawHeaders the raw headers of the HTTP response.
+     * @param value the deserialized value of the HTTP response.
+     * @param headers the deserialized headers of the HTTP response.
+     */
+    public HeadersResponseExistingKeyResponse(
+            HttpRequest request,
+            int statusCode,
+            HttpHeaders rawHeaders,
+            Void value,
+            HeadersResponseExistingKeyHeaders headers) {
+        super(request, statusCode, rawHeaders, value, headers);
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseFloatHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseFloatHeaders.java
@@ -31,7 +31,9 @@ public final class HeadersResponseFloatHeaders {
      */
     public Float getValue() {
         if (!this.valueHasBeenDeserialized) {
-            this.value = Float.valueOf(rawHeaders.getValue("value"));
+            if (rawHeaders.getValue("value") != null) {
+                this.value = Float.valueOf(rawHeaders.getValue("value"));
+            }
             this.valueHasBeenDeserialized = true;
         }
         return this.value;

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseFloatHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseFloatHeaders.java
@@ -1,0 +1,57 @@
+package fixtures.deferredheaderdeserialization.models;
+
+import com.azure.core.annotation.Fluent;
+import com.azure.core.http.HttpHeaders;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** The HeadersResponseFloatHeaders model. */
+@Fluent
+public final class HeadersResponseFloatHeaders {
+    /*
+     * The value property.
+     */
+    @JsonProperty(value = "value")
+    private Float value;
+
+    // Maintains deserialization status for value.
+    private boolean valueHasBeenDeserialized;
+
+    // HttpHeaders containing the raw property values.
+    private final HttpHeaders rawHeaders;
+
+    /** Creates an instance of HeadersResponseFloatHeaders class. */
+    HeadersResponseFloatHeaders(HttpHeaders rawHeaders) {
+        this.rawHeaders = rawHeaders;
+    }
+
+    /**
+     * Get the value property: The value property.
+     *
+     * @return the value value.
+     */
+    public Float getValue() {
+        if (!this.valueHasBeenDeserialized) {
+            this.value = Float.valueOf(rawHeaders.getValue("value"));
+            this.valueHasBeenDeserialized = true;
+        }
+        return this.value;
+    }
+
+    /**
+     * Set the value property: The value property.
+     *
+     * @param value the value value to set.
+     * @return the HeadersResponseFloatHeaders object itself.
+     */
+    public HeadersResponseFloatHeaders setValue(Float value) {
+        this.value = value;
+        return this;
+    }
+
+    /**
+     * Validates the instance.
+     *
+     * @throws IllegalArgumentException thrown if the instance is not valid.
+     */
+    public void validate() {}
+}

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseFloatResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseFloatResponse.java
@@ -1,0 +1,26 @@
+package fixtures.deferredheaderdeserialization.models;
+
+import com.azure.core.http.HttpHeaders;
+import com.azure.core.http.HttpRequest;
+import com.azure.core.http.rest.ResponseBase;
+
+/** Contains all response data for the responseFloat operation. */
+public final class HeadersResponseFloatResponse extends ResponseBase<HeadersResponseFloatHeaders, Void> {
+    /**
+     * Creates an instance of HeadersResponseFloatResponse.
+     *
+     * @param request the request which resulted in this HeadersResponseFloatResponse.
+     * @param statusCode the status code of the HTTP response.
+     * @param rawHeaders the raw headers of the HTTP response.
+     * @param value the deserialized value of the HTTP response.
+     * @param headers the deserialized headers of the HTTP response.
+     */
+    public HeadersResponseFloatResponse(
+            HttpRequest request,
+            int statusCode,
+            HttpHeaders rawHeaders,
+            Void value,
+            HeadersResponseFloatHeaders headers) {
+        super(request, statusCode, rawHeaders, value, headers);
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseIntegerHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseIntegerHeaders.java
@@ -1,0 +1,57 @@
+package fixtures.deferredheaderdeserialization.models;
+
+import com.azure.core.annotation.Fluent;
+import com.azure.core.http.HttpHeaders;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** The HeadersResponseIntegerHeaders model. */
+@Fluent
+public final class HeadersResponseIntegerHeaders {
+    /*
+     * The value property.
+     */
+    @JsonProperty(value = "value")
+    private Integer value;
+
+    // Maintains deserialization status for value.
+    private boolean valueHasBeenDeserialized;
+
+    // HttpHeaders containing the raw property values.
+    private final HttpHeaders rawHeaders;
+
+    /** Creates an instance of HeadersResponseIntegerHeaders class. */
+    HeadersResponseIntegerHeaders(HttpHeaders rawHeaders) {
+        this.rawHeaders = rawHeaders;
+    }
+
+    /**
+     * Get the value property: The value property.
+     *
+     * @return the value value.
+     */
+    public Integer getValue() {
+        if (!this.valueHasBeenDeserialized) {
+            this.value = Integer.valueOf(rawHeaders.getValue("value"));
+            this.valueHasBeenDeserialized = true;
+        }
+        return this.value;
+    }
+
+    /**
+     * Set the value property: The value property.
+     *
+     * @param value the value value to set.
+     * @return the HeadersResponseIntegerHeaders object itself.
+     */
+    public HeadersResponseIntegerHeaders setValue(Integer value) {
+        this.value = value;
+        return this;
+    }
+
+    /**
+     * Validates the instance.
+     *
+     * @throws IllegalArgumentException thrown if the instance is not valid.
+     */
+    public void validate() {}
+}

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseIntegerHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseIntegerHeaders.java
@@ -31,7 +31,9 @@ public final class HeadersResponseIntegerHeaders {
      */
     public Integer getValue() {
         if (!this.valueHasBeenDeserialized) {
-            this.value = Integer.valueOf(rawHeaders.getValue("value"));
+            if (rawHeaders.getValue("value") != null) {
+                this.value = Integer.valueOf(rawHeaders.getValue("value"));
+            }
             this.valueHasBeenDeserialized = true;
         }
         return this.value;

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseIntegerResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseIntegerResponse.java
@@ -1,0 +1,26 @@
+package fixtures.deferredheaderdeserialization.models;
+
+import com.azure.core.http.HttpHeaders;
+import com.azure.core.http.HttpRequest;
+import com.azure.core.http.rest.ResponseBase;
+
+/** Contains all response data for the responseInteger operation. */
+public final class HeadersResponseIntegerResponse extends ResponseBase<HeadersResponseIntegerHeaders, Void> {
+    /**
+     * Creates an instance of HeadersResponseIntegerResponse.
+     *
+     * @param request the request which resulted in this HeadersResponseIntegerResponse.
+     * @param statusCode the status code of the HTTP response.
+     * @param rawHeaders the raw headers of the HTTP response.
+     * @param value the deserialized value of the HTTP response.
+     * @param headers the deserialized headers of the HTTP response.
+     */
+    public HeadersResponseIntegerResponse(
+            HttpRequest request,
+            int statusCode,
+            HttpHeaders rawHeaders,
+            Void value,
+            HeadersResponseIntegerHeaders headers) {
+        super(request, statusCode, rawHeaders, value, headers);
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseLongHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseLongHeaders.java
@@ -1,0 +1,57 @@
+package fixtures.deferredheaderdeserialization.models;
+
+import com.azure.core.annotation.Fluent;
+import com.azure.core.http.HttpHeaders;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** The HeadersResponseLongHeaders model. */
+@Fluent
+public final class HeadersResponseLongHeaders {
+    /*
+     * The value property.
+     */
+    @JsonProperty(value = "value")
+    private Long value;
+
+    // Maintains deserialization status for value.
+    private boolean valueHasBeenDeserialized;
+
+    // HttpHeaders containing the raw property values.
+    private final HttpHeaders rawHeaders;
+
+    /** Creates an instance of HeadersResponseLongHeaders class. */
+    HeadersResponseLongHeaders(HttpHeaders rawHeaders) {
+        this.rawHeaders = rawHeaders;
+    }
+
+    /**
+     * Get the value property: The value property.
+     *
+     * @return the value value.
+     */
+    public Long getValue() {
+        if (!this.valueHasBeenDeserialized) {
+            this.value = Long.valueOf(rawHeaders.getValue("value"));
+            this.valueHasBeenDeserialized = true;
+        }
+        return this.value;
+    }
+
+    /**
+     * Set the value property: The value property.
+     *
+     * @param value the value value to set.
+     * @return the HeadersResponseLongHeaders object itself.
+     */
+    public HeadersResponseLongHeaders setValue(Long value) {
+        this.value = value;
+        return this;
+    }
+
+    /**
+     * Validates the instance.
+     *
+     * @throws IllegalArgumentException thrown if the instance is not valid.
+     */
+    public void validate() {}
+}

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseLongHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseLongHeaders.java
@@ -31,7 +31,9 @@ public final class HeadersResponseLongHeaders {
      */
     public Long getValue() {
         if (!this.valueHasBeenDeserialized) {
-            this.value = Long.valueOf(rawHeaders.getValue("value"));
+            if (rawHeaders.getValue("value") != null) {
+                this.value = Long.valueOf(rawHeaders.getValue("value"));
+            }
             this.valueHasBeenDeserialized = true;
         }
         return this.value;

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseLongResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseLongResponse.java
@@ -1,0 +1,26 @@
+package fixtures.deferredheaderdeserialization.models;
+
+import com.azure.core.http.HttpHeaders;
+import com.azure.core.http.HttpRequest;
+import com.azure.core.http.rest.ResponseBase;
+
+/** Contains all response data for the responseLong operation. */
+public final class HeadersResponseLongResponse extends ResponseBase<HeadersResponseLongHeaders, Void> {
+    /**
+     * Creates an instance of HeadersResponseLongResponse.
+     *
+     * @param request the request which resulted in this HeadersResponseLongResponse.
+     * @param statusCode the status code of the HTTP response.
+     * @param rawHeaders the raw headers of the HTTP response.
+     * @param value the deserialized value of the HTTP response.
+     * @param headers the deserialized headers of the HTTP response.
+     */
+    public HeadersResponseLongResponse(
+            HttpRequest request,
+            int statusCode,
+            HttpHeaders rawHeaders,
+            Void value,
+            HeadersResponseLongHeaders headers) {
+        super(request, statusCode, rawHeaders, value, headers);
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseProtectedKeyHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseProtectedKeyHeaders.java
@@ -1,0 +1,57 @@
+package fixtures.deferredheaderdeserialization.models;
+
+import com.azure.core.annotation.Fluent;
+import com.azure.core.http.HttpHeaders;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** The HeadersResponseProtectedKeyHeaders model. */
+@Fluent
+public final class HeadersResponseProtectedKeyHeaders {
+    /*
+     * The Content-Type property.
+     */
+    @JsonProperty(value = "Content-Type")
+    private String contentType;
+
+    // Maintains deserialization status for contentType.
+    private boolean contentTypeHasBeenDeserialized;
+
+    // HttpHeaders containing the raw property values.
+    private final HttpHeaders rawHeaders;
+
+    /** Creates an instance of HeadersResponseProtectedKeyHeaders class. */
+    HeadersResponseProtectedKeyHeaders(HttpHeaders rawHeaders) {
+        this.rawHeaders = rawHeaders;
+    }
+
+    /**
+     * Get the contentType property: The Content-Type property.
+     *
+     * @return the contentType value.
+     */
+    public String getContentType() {
+        if (!this.contentTypeHasBeenDeserialized) {
+            this.contentType = rawHeaders.getValue("Content-Type");
+            this.contentTypeHasBeenDeserialized = true;
+        }
+        return this.contentType;
+    }
+
+    /**
+     * Set the contentType property: The Content-Type property.
+     *
+     * @param contentType the contentType value to set.
+     * @return the HeadersResponseProtectedKeyHeaders object itself.
+     */
+    public HeadersResponseProtectedKeyHeaders setContentType(String contentType) {
+        this.contentType = contentType;
+        return this;
+    }
+
+    /**
+     * Validates the instance.
+     *
+     * @throws IllegalArgumentException thrown if the instance is not valid.
+     */
+    public void validate() {}
+}

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseProtectedKeyResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseProtectedKeyResponse.java
@@ -1,0 +1,26 @@
+package fixtures.deferredheaderdeserialization.models;
+
+import com.azure.core.http.HttpHeaders;
+import com.azure.core.http.HttpRequest;
+import com.azure.core.http.rest.ResponseBase;
+
+/** Contains all response data for the responseProtectedKey operation. */
+public final class HeadersResponseProtectedKeyResponse extends ResponseBase<HeadersResponseProtectedKeyHeaders, Void> {
+    /**
+     * Creates an instance of HeadersResponseProtectedKeyResponse.
+     *
+     * @param request the request which resulted in this HeadersResponseProtectedKeyResponse.
+     * @param statusCode the status code of the HTTP response.
+     * @param rawHeaders the raw headers of the HTTP response.
+     * @param value the deserialized value of the HTTP response.
+     * @param headers the deserialized headers of the HTTP response.
+     */
+    public HeadersResponseProtectedKeyResponse(
+            HttpRequest request,
+            int statusCode,
+            HttpHeaders rawHeaders,
+            Void value,
+            HeadersResponseProtectedKeyHeaders headers) {
+        super(request, statusCode, rawHeaders, value, headers);
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseStringHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseStringHeaders.java
@@ -1,0 +1,57 @@
+package fixtures.deferredheaderdeserialization.models;
+
+import com.azure.core.annotation.Fluent;
+import com.azure.core.http.HttpHeaders;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** The HeadersResponseStringHeaders model. */
+@Fluent
+public final class HeadersResponseStringHeaders {
+    /*
+     * The value property.
+     */
+    @JsonProperty(value = "value")
+    private String value;
+
+    // Maintains deserialization status for value.
+    private boolean valueHasBeenDeserialized;
+
+    // HttpHeaders containing the raw property values.
+    private final HttpHeaders rawHeaders;
+
+    /** Creates an instance of HeadersResponseStringHeaders class. */
+    HeadersResponseStringHeaders(HttpHeaders rawHeaders) {
+        this.rawHeaders = rawHeaders;
+    }
+
+    /**
+     * Get the value property: The value property.
+     *
+     * @return the value value.
+     */
+    public String getValue() {
+        if (!this.valueHasBeenDeserialized) {
+            this.value = rawHeaders.getValue("value");
+            this.valueHasBeenDeserialized = true;
+        }
+        return this.value;
+    }
+
+    /**
+     * Set the value property: The value property.
+     *
+     * @param value the value value to set.
+     * @return the HeadersResponseStringHeaders object itself.
+     */
+    public HeadersResponseStringHeaders setValue(String value) {
+        this.value = value;
+        return this;
+    }
+
+    /**
+     * Validates the instance.
+     *
+     * @throws IllegalArgumentException thrown if the instance is not valid.
+     */
+    public void validate() {}
+}

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseStringResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/HeadersResponseStringResponse.java
@@ -1,0 +1,26 @@
+package fixtures.deferredheaderdeserialization.models;
+
+import com.azure.core.http.HttpHeaders;
+import com.azure.core.http.HttpRequest;
+import com.azure.core.http.rest.ResponseBase;
+
+/** Contains all response data for the responseString operation. */
+public final class HeadersResponseStringResponse extends ResponseBase<HeadersResponseStringHeaders, Void> {
+    /**
+     * Creates an instance of HeadersResponseStringResponse.
+     *
+     * @param request the request which resulted in this HeadersResponseStringResponse.
+     * @param statusCode the status code of the HTTP response.
+     * @param rawHeaders the raw headers of the HTTP response.
+     * @param value the deserialized value of the HTTP response.
+     * @param headers the deserialized headers of the HTTP response.
+     */
+    public HeadersResponseStringResponse(
+            HttpRequest request,
+            int statusCode,
+            HttpHeaders rawHeaders,
+            Void value,
+            HeadersResponseStringHeaders headers) {
+        super(request, statusCode, rawHeaders, value, headers);
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/package-info.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/models/package-info.java
@@ -1,0 +1,2 @@
+/** Package containing the data models for AutoRestSwaggerBATHeaderService. Test Infrastructure for AutoRest. */
+package fixtures.deferredheaderdeserialization.models;

--- a/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/package-info.java
+++ b/vanilla-tests/src/main/java/fixtures/deferredheaderdeserialization/package-info.java
@@ -1,0 +1,2 @@
+/** Package containing the classes for AutoRestSwaggerBATHeaderService. Test Infrastructure for AutoRest. */
+package fixtures.deferredheaderdeserialization;

--- a/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClient.java
+++ b/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClient.java
@@ -156,7 +156,7 @@ public final class MediaTypesClient {
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Mono<Response<String>> contentTypeWithEncoding(
                 @HostParam("$host") String host,
-                @BodyParam("text/plain") String input,
+                @BodyParam("text/plain; charset=UTF-8") String input,
                 @HeaderParam("Accept") String accept,
                 Context context);
 
@@ -575,7 +575,7 @@ public final class MediaTypesClient {
     }
 
     /**
-     * Pass in contentType 'text/plain; encoding=UTF-8' to pass test. Value for input does not matter.
+     * Pass in contentType 'text/plain; charset=UTF-8' to pass test. Value for input does not matter.
      *
      * @param input Input parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
@@ -593,7 +593,7 @@ public final class MediaTypesClient {
     }
 
     /**
-     * Pass in contentType 'text/plain; encoding=UTF-8' to pass test. Value for input does not matter.
+     * Pass in contentType 'text/plain; charset=UTF-8' to pass test. Value for input does not matter.
      *
      * @param input Input parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
@@ -615,7 +615,7 @@ public final class MediaTypesClient {
     }
 
     /**
-     * Pass in contentType 'text/plain; encoding=UTF-8' to pass test. Value for input does not matter.
+     * Pass in contentType 'text/plain; charset=UTF-8' to pass test. Value for input does not matter.
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -636,7 +636,7 @@ public final class MediaTypesClient {
     }
 
     /**
-     * Pass in contentType 'text/plain; encoding=UTF-8' to pass test. Value for input does not matter.
+     * Pass in contentType 'text/plain; charset=UTF-8' to pass test. Value for input does not matter.
      *
      * @param input Input parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
@@ -650,7 +650,7 @@ public final class MediaTypesClient {
     }
 
     /**
-     * Pass in contentType 'text/plain; encoding=UTF-8' to pass test. Value for input does not matter.
+     * Pass in contentType 'text/plain; charset=UTF-8' to pass test. Value for input does not matter.
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.


### PR DESCRIPTION
This PR contains a major update with how strongly-typed headers classes are handled during deserialization. A new AutoRest flag `defer-strongly-typed-header-deserialization` has been added that indicates to code generation to generate header classes with deferred deserialization. Before this change, ever response with strongly-typed headers would serialize the HTTP headers to JSON to deserialize the JSON into the strongly-typed headers object. Now, when this flag is enabled the strongly-typed headers will skips that serialization-deserialization and retain a pointer to the HTTP headers returned in the response. When the properties on the headers class are accessed a check will be made if the property has been deserialized in the past and if it hasn't the backing header will be converted to the property type and cached. So, for cases where the deserialized headers aren't returned to the caller or aren't regularly used by the caller there is no additional conversion overhead.