### PR TITLE
Use JacksonXmlElementWrapper Instead of a Static Inner Wrapper Class

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
@@ -76,10 +77,11 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
         imports.add(JsonCreator.class.getName());
         imports.add(JacksonXmlElementWrapper.class.getName());
         imports.add(JacksonXmlProperty.class.getName());
+        imports.add(JsonSetter.class.getName());
+        imports.add(Nulls.class.getName());
 
         if (settings.isGettersAndSettersAnnotatedForSerialization()) {
             imports.add(JsonGetter.class.getName());
-            imports.add(JsonSetter.class.getName());
         }
 
         String lastParentName = model.getName();
@@ -236,6 +238,10 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                     // Use JacksonXmlElementWrapper to indicate to Jackson that the current node contains a list
                     // of values to be used as the property value.
                     classBlock.annotation(String.format("JacksonXmlElementWrapper(localName = \"%1$s\")", property.getXmlName()));
+
+                    // Due to how the private inner class previously worked a JsonSetter annotation is also required
+                    // to configure Jackson to deserialize null into an empty collection.
+                    classBlock.annotation("JsonSetter(nulls = Nulls.AS_EMPTY)");
                 } else if (settings.shouldGenerateXmlSerialization() && property.getWireType() instanceof ListType) {
                     // The property is a list, but it isn't an XML wrapper. Use the XML node with no special
                     // handling.

--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -12,7 +12,6 @@ import com.azure.autorest.model.clientmodel.ClientModelPropertyAccess;
 import com.azure.autorest.model.clientmodel.ClientModelPropertyReference;
 import com.azure.autorest.model.clientmodel.ClientModels;
 import com.azure.autorest.model.clientmodel.IType;
-import com.azure.autorest.model.clientmodel.IterableType;
 import com.azure.autorest.model.clientmodel.ListType;
 import com.azure.autorest.model.clientmodel.MapType;
 import com.azure.autorest.model.clientmodel.PrimitiveType;
@@ -28,6 +27,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -73,6 +74,8 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
 
         // TODO: Determine whether imports should be added here.
         imports.add(JsonCreator.class.getName());
+        imports.add(JacksonXmlElementWrapper.class.getName());
+        imports.add(JacksonXmlProperty.class.getName());
 
         if (settings.isGettersAndSettersAnnotatedForSerialization()) {
             imports.add(JsonGetter.class.getName());
@@ -159,7 +162,7 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
         if (settings.shouldGenerateXmlSerialization()) {
             if (model.getXmlNamespace() != null && !model.getXmlNamespace().isEmpty()) {
                 javaFile.annotation(String.format("JacksonXmlRootElement(localName = \"%1$s\", namespace = \"%2$s\")",
-                        model.getXmlName(), model.getXmlNamespace()));
+                    model.getXmlName(), model.getXmlNamespace()));
             } else {
                 javaFile.annotation(String.format("JacksonXmlRootElement(localName = \"%1$s\")", model.getXmlName()));
             }
@@ -181,7 +184,7 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
             classNameWithBaseType += String.format(" extends %1$s", model.getParentModelName());
         }
         if (model.getProperties().stream().anyMatch(p -> !p.getIsReadOnly())
-                || propertyReferences.stream().anyMatch(p -> !p.getIsReadOnly())) {
+            || propertyReferences.stream().anyMatch(p -> !p.getIsReadOnly())) {
             javaFile.annotation("Fluent");
         } else {
             javaFile.annotation("Immutable");
@@ -193,29 +196,7 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                 classBlock.privateFinalMemberVariable(ClassType.ClientLogger.toString(), String.format("logger = new ClientLogger(%1$s.class)", model.getName()));
             }
 
-            Function<ClientModelProperty, String> propertyXmlWrapperClassName = (ClientModelProperty property) -> property.getXmlName() + "Wrapper";
-
             for (ClientModelProperty property : model.getProperties()) {
-                String xmlWrapperClassName = propertyXmlWrapperClassName.apply(property);
-                if (settings.shouldGenerateXmlSerialization() && property.getIsXmlWrapper()) {
-                    classBlock.privateStaticFinalClass(xmlWrapperClassName, innerClass ->
-                    {
-                        IType propertyClientType = property.getWireType().getClientType();
-
-                        String listElementName = property.getXmlListElementName();
-                        String jacksonAnnotation = String.format("JacksonXmlProperty(localName = \"%1$s\")", listElementName);
-                        if (property.getXmlNamespace() != null && !property.getXmlNamespace().isEmpty()) {
-                            jacksonAnnotation = String.format("JacksonXmlProperty(localName = \"%1$s\", namespace = " +
-                                            "\"%2$s\")", listElementName, property.getXmlNamespace());
-                        }
-                        innerClass.annotation(jacksonAnnotation);
-                        innerClass.privateFinalMemberVariable(propertyClientType.toString(), "items");
-
-                        innerClass.annotation("JsonCreator");
-                        innerClass.privateConstructor(String.format("%1$s(@%2$s %3$s items)", xmlWrapperClassName, jacksonAnnotation, propertyClientType), constructor -> constructor.line("this.items = items;"));
-                    });
-                }
-
                 classBlock.blockComment(settings.getMaximumJavadocCommentWidth(), (comment) ->
                     comment.line(property.getDescription()));
 
@@ -232,27 +213,40 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                 }
 
                 if (property.getHeaderCollectionPrefix() != null && !property.getHeaderCollectionPrefix().isEmpty()) {
+                    // If the property is a header collection use @HeaderCollection. azure-core will handle this
+                    // separately from other deserialization as it requires packing multiple HTTP headers into a map.
                     classBlock.annotation("HeaderCollection(\"" + property.getHeaderCollectionPrefix() + "\")");
-                } else if (settings.shouldGenerateXmlSerialization() && property.getIsXmlAttribute()) {
-                    classBlock.annotation(String.format("JacksonXmlProperty(localName = \"%1$s\", isAttribute = true)",
-                            property.getXmlName()));
-                } else if (settings.shouldGenerateXmlSerialization() && property.getXmlNamespace() != null && !property.getXmlNamespace().isEmpty()) {
-                    classBlock.annotation(String.format("JacksonXmlProperty(localName = \"%1$s\", namespace = \"%2$s\")",
-                            property.getXmlName(), property.getXmlNamespace()));
-                } else if (settings.shouldGenerateXmlSerialization() && property.isXmlText()) {
-                    classBlock.annotation("JacksonXmlText");
                 } else if (property.isAdditionalProperties()) {
                     classBlock.annotation("JsonIgnore");
-                } else if (settings.shouldGenerateXmlSerialization() && property.getWireType() instanceof ListType && !property.getIsXmlWrapper()) {
+                } else if (settings.shouldGenerateXmlSerialization() && property.getIsXmlAttribute()) {
+                    // Property is an attribute on the current XML node. Indicate to Jackson that it needs to
+                    // inspect the XML node attributes for the property value.
+                    classBlock.annotation(String.format("JacksonXmlProperty(localName = \"%1$s\", isAttribute = true)",
+                        property.getXmlName()));
+                } else if (settings.shouldGenerateXmlSerialization() && !CoreUtils.isNullOrEmpty(property.getXmlNamespace())) {
+                    // Property has a namespace, include it in the JacksonXmlProperty.
+                    classBlock.annotation(String.format("JacksonXmlProperty(localName = \"%1$s\", namespace = \"%2$s\")",
+                        property.getXmlName(), property.getXmlNamespace()));
+                } else if (settings.shouldGenerateXmlSerialization() && property.isXmlText()) {
+                    // Property is the raw text value of the XML node containing it. Use JacksonXmlText to indicate
+                    // to Jackson to extract the current XML node's value as the property value.
+                    classBlock.annotation("JacksonXmlText");
+                } else if (settings.shouldGenerateXmlSerialization() && property.getIsXmlWrapper()) {
+                    // Property is an XML wrapper, or simply put a node that contains a list of XML nodes.
+                    // Use JacksonXmlElementWrapper to indicate to Jackson that the current node contains a list
+                    // of values to be used as the property value.
+                    classBlock.annotation(String.format("JacksonXmlElementWrapper(localName = \"%1$s\")", property.getXmlName()));
+                } else if (settings.shouldGenerateXmlSerialization() && property.getWireType() instanceof ListType) {
+                    // The property is a list, but it isn't an XML wrapper. Use the XML node with no special
+                    // handling.
                     classBlock.annotation(String.format("JsonProperty(\"%1$s\")", property.getXmlListElementName()));
-                } else if (property.getAnnotationArguments() != null && !property.getAnnotationArguments().isEmpty()) {
+                } else if (!CoreUtils.isNullOrEmpty(property.getAnnotationArguments())) {
+                    // Otherwise, use the basic Jackson annotation.
                     classBlock.annotation(String.format("JsonProperty(%1$s)", property.getAnnotationArguments()));
                 }
 
                 if (settings.shouldGenerateXmlSerialization()) {
-                    if (property.getIsXmlWrapper()) {
-                        classBlock.privateMemberVariable(String.format("%1$s %2$s", xmlWrapperClassName, property.getName()));
-                    } else if (property.getWireType() instanceof ListType) {
+                    if (property.getWireType() instanceof ListType) {
                         classBlock.privateMemberVariable(String.format("%1$s %2$s = new ArrayList<>()", property.getWireType(), property.getName()));
                     } else {
                         classBlock.privateMemberVariable(String.format("%1$s %2$s", property.getWireType(), property.getName()));
@@ -276,8 +270,8 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
             }
 
             List<ClientModelProperty> constantProperties = model.getProperties().stream()
-                    .filter(clientModelProperty -> clientModelProperty.getIsConstant() && clientModelProperty.isRequired())
-                    .collect(Collectors.toList());
+                .filter(clientModelProperty -> clientModelProperty.getIsConstant() && clientModelProperty.isRequired())
+                .collect(Collectors.toList());
             List<ClientModelProperty> requiredProperties =
                 model.getProperties().stream().filter(ClientModelProperty::isRequired).collect(Collectors.toList());
 
@@ -305,23 +299,7 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                         expression = String.format("CoreUtils.clone(%s)", expression);
                     }
                     if (sourceTypeName.equals(targetTypeName)) {
-                        if (settings.shouldGenerateXmlSerialization() && property.getIsXmlWrapper() && property.getWireType() instanceof ListType) {
-                            methodBlock.ifBlock(String.format("this.%s == null", property.getName()), ifBlock ->
-                                    ifBlock.line("this.%s = new %s(new ArrayList<%s>());",
-                                            property.getName(),
-                                            propertyXmlWrapperClassName.apply(property),
-                                            ((ListType) property.getWireType()).getElementType()));
-                            methodBlock.methodReturn(String.format("this.%s.items", property.getName()));
-                        } else if (settings.shouldGenerateXmlSerialization() && property.getIsXmlWrapper() && property.getWireType() instanceof IterableType) {
-                            methodBlock.ifBlock(String.format("this.%s == null", property.getName()), ifBlock ->
-                                    ifBlock.line("this.%s = new %s(new ArrayList<%s>());",
-                                            property.getName(),
-                                            propertyXmlWrapperClassName.apply(property),
-                                            ((IterableType) property.getWireType()).getElementType()));
-                            methodBlock.methodReturn(String.format("this.%s.items", property.getName()));
-                        } else {
-                            methodBlock.methodReturn(expression);
-                        }
+                        methodBlock.methodReturn(expression);
                     } else {
                         methodBlock.ifBlock(String.format("%s == null", expression), (ifBlock) -> ifBlock.methodReturn(propertyClientType.defaultValueExpression()));
 
@@ -331,11 +309,11 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                     }
                 });
 
-                if(!property.getIsReadOnly() && !(settings.isRequiredFieldsAsConstructorArgs() && property.isRequired()) && methodVisibility == JavaVisibility.Public) {
+                if (!property.getIsReadOnly() && !(settings.isRequiredFieldsAsConstructorArgs() && property.isRequired()) && methodVisibility == JavaVisibility.Public) {
                     generateSetterJavadoc(classBlock, model, property);
                     TemplateUtil.addJsonSetter(classBlock, settings, property.getSerializedName());
                     classBlock.method(methodVisibility, null, String.format("%s %s(%s %s)",
-                        model.getName(), property.getSetterName(), propertyClientType, property.getName()),
+                            model.getName(), property.getSetterName(), propertyClientType, property.getName()),
                         (methodBlock) -> {
                             String expression;
                             if (propertyClientType.equals(ArrayType.ByteArray)) {
@@ -345,18 +323,13 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                             }
                             if (propertyClientType != propertyType) {
                                 methodBlock.ifBlock(String.format("%s == null", property.getName()),
-                                    (ifBlock) -> ifBlock.line("this.%s = null;", property.getName()))
+                                        (ifBlock) -> ifBlock.line("this.%s = null;", property.getName()))
                                     .elseBlock((elseBlock) -> {
                                         String propertyConversion = propertyType.convertFromClientType(expression);
                                         elseBlock.line("this.%s = %s;", property.getName(), propertyConversion);
                                     });
                             } else {
-                                if (settings.shouldGenerateXmlSerialization() && property.getIsXmlWrapper()) {
-                                    methodBlock.line("this.%s = new %s(%s);", property.getName(),
-                                        propertyXmlWrapperClassName.apply(property), expression);
-                                } else {
-                                    methodBlock.line("this.%s = %s;", property.getName(), expression);
-                                }
+                                methodBlock.line("this.%s = %s;", property.getName(), expression);
                             }
                             methodBlock.methodReturn("this");
                         });
@@ -385,10 +358,10 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                                 parentProperty.getSetterName(),
                                 parentProperty.getClientType(),
                                 parentProperty.getName()),
-                                methodBlock -> {
-                                    methodBlock.line(String.format("super.%1$s(%2$s);", parentProperty.getSetterName(), parentProperty.getName()));
-                                    methodBlock.methodReturn("this");
-                                });
+                            methodBlock -> {
+                                methodBlock.line(String.format("super.%1$s(%2$s);", parentProperty.getSetterName(), parentProperty.getName()));
+                                methodBlock.methodReturn("this");
+                            });
                     }
                 }
             }
@@ -440,7 +413,7 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
         List<ClientModelProperty> constantProperties, List<ClientModelProperty> allRequiredProperties) {
 
         List<ClientModelProperty> requiredProperties =
-                allRequiredProperties.stream().filter(property -> !property.getIsConstant()).collect(Collectors.toList());
+            allRequiredProperties.stream().filter(property -> !property.getIsConstant()).collect(Collectors.toList());
         String lastParentName = model.getName();
         ClientModel parentModel = ClientModels.Instance.getModel(model.getParentModelName());
         List<ClientModelProperty> requiredParentProperties = new ArrayList<>();
@@ -487,9 +460,9 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                 comment.description(String.format("Creates an instance of %1$s class.", model.getName()));
 
                 requiredParentProperties.forEach(property -> comment
-                        .param(property.getName(), String.format("the %s value to set", property.getName())));
+                    .param(property.getName(), String.format("the %s value to set", property.getName())));
                 requiredProperties.forEach(property -> comment
-                        .param(property.getName(), String.format("the %s value to set", property.getName())));
+                    .param(property.getName(), String.format("the %s value to set", property.getName())));
             });
 
 
@@ -552,12 +525,12 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                             final String errorMessage = String.format("\"Missing required property %s in model %s\"", property.getName(), model.getName());
                             if (settings.shouldClientLogger()) {
                                 ifBlock.line(String.format(
-                                        "throw logger.logExceptionAsError(new IllegalArgumentException(%s));",
-                                        errorMessage));
+                                    "throw logger.logExceptionAsError(new IllegalArgumentException(%s));",
+                                    errorMessage));
                             } else {
                                 ifBlock.line(String.format(
-                                        "throw new IllegalArgumentException(%s);",
-                                        errorMessage));
+                                    "throw new IllegalArgumentException(%s);",
+                                    errorMessage));
                             }
                         });
                         if (validation != null) {
@@ -608,16 +581,16 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
             if (parentModel != null) {
                 if (parentModel.getProperties() != null) {
                     propertyReferences.addAll(parentModel.getProperties().stream()
-                            .filter(p -> !p.getClientFlatten() && !p.isAdditionalProperties())
-                            .map(ClientModelPropertyReference::ofParentProperty)
-                            .collect(Collectors.toList()));
+                        .filter(p -> !p.getClientFlatten() && !p.isAdditionalProperties())
+                        .map(ClientModelPropertyReference::ofParentProperty)
+                        .collect(Collectors.toList()));
                 }
 
                 if (parentModel.getPropertyReferences() != null) {
                     propertyReferences.addAll(parentModel.getPropertyReferences().stream()
-                            .filter(ClientModelPropertyReference::isFromFlattenedProperty)
-                            .map(ClientModelPropertyReference::ofParentProperty)
-                            .collect(Collectors.toList()));
+                        .filter(ClientModelPropertyReference::isFromFlattenedProperty)
+                        .map(ClientModelPropertyReference::ofParentProperty)
+                        .collect(Collectors.toList()));
                 }
             }
 

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/AppleBarrel.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/AppleBarrel.java
@@ -1,8 +1,6 @@
 package fixtures.xmlservice.models;
 
 import com.azure.core.annotation.Fluent;
-import com.fasterxml.jackson.annotation.JsonSetter;
-import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import java.util.ArrayList;
@@ -16,15 +14,13 @@ public final class AppleBarrel {
      * The GoodApples property.
      */
     @JacksonXmlElementWrapper(localName = "GoodApples")
-    @JsonSetter(nulls = Nulls.AS_EMPTY)
-    private List<String> goodApples = new ArrayList<>();
+    private List<String> goodApples;
 
     /*
      * The BadApples property.
      */
     @JacksonXmlElementWrapper(localName = "BadApples")
-    @JsonSetter(nulls = Nulls.AS_EMPTY)
-    private List<String> badApples = new ArrayList<>();
+    private List<String> badApples;
 
     /**
      * Get the goodApples property: The GoodApples property.
@@ -32,6 +28,9 @@ public final class AppleBarrel {
      * @return the goodApples value.
      */
     public List<String> getGoodApples() {
+        if (this.goodApples == null) {
+            this.goodApples = new ArrayList<String>();
+        }
         return this.goodApples;
     }
 
@@ -52,6 +51,9 @@ public final class AppleBarrel {
      * @return the badApples value.
      */
     public List<String> getBadApples() {
+        if (this.badApples == null) {
+            this.badApples = new ArrayList<String>();
+        }
         return this.badApples;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/AppleBarrel.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/AppleBarrel.java
@@ -1,9 +1,7 @@
 package fixtures.xmlservice.models;
 
 import com.azure.core.annotation.Fluent;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
@@ -12,37 +10,17 @@ import java.util.List;
 @JacksonXmlRootElement(localName = "AppleBarrel")
 @Fluent
 public final class AppleBarrel {
-    private static final class GoodApplesWrapper {
-        @JacksonXmlProperty(localName = "Apple")
-        private final List<String> items;
-
-        @JsonCreator
-        private GoodApplesWrapper(@JacksonXmlProperty(localName = "Apple") List<String> items) {
-            this.items = items;
-        }
-    }
-
     /*
      * The GoodApples property.
      */
-    @JsonProperty(value = "GoodApples")
-    private GoodApplesWrapper goodApples;
-
-    private static final class BadApplesWrapper {
-        @JacksonXmlProperty(localName = "Apple")
-        private final List<String> items;
-
-        @JsonCreator
-        private BadApplesWrapper(@JacksonXmlProperty(localName = "Apple") List<String> items) {
-            this.items = items;
-        }
-    }
+    @JacksonXmlElementWrapper(localName = "GoodApples")
+    private List<String> goodApples = new ArrayList<>();
 
     /*
      * The BadApples property.
      */
-    @JsonProperty(value = "BadApples")
-    private BadApplesWrapper badApples;
+    @JacksonXmlElementWrapper(localName = "BadApples")
+    private List<String> badApples = new ArrayList<>();
 
     /**
      * Get the goodApples property: The GoodApples property.
@@ -50,10 +28,7 @@ public final class AppleBarrel {
      * @return the goodApples value.
      */
     public List<String> getGoodApples() {
-        if (this.goodApples == null) {
-            this.goodApples = new GoodApplesWrapper(new ArrayList<String>());
-        }
-        return this.goodApples.items;
+        return this.goodApples;
     }
 
     /**
@@ -63,7 +38,7 @@ public final class AppleBarrel {
      * @return the AppleBarrel object itself.
      */
     public AppleBarrel setGoodApples(List<String> goodApples) {
-        this.goodApples = new GoodApplesWrapper(goodApples);
+        this.goodApples = goodApples;
         return this;
     }
 
@@ -73,10 +48,7 @@ public final class AppleBarrel {
      * @return the badApples value.
      */
     public List<String> getBadApples() {
-        if (this.badApples == null) {
-            this.badApples = new BadApplesWrapper(new ArrayList<String>());
-        }
-        return this.badApples.items;
+        return this.badApples;
     }
 
     /**
@@ -86,7 +58,7 @@ public final class AppleBarrel {
      * @return the AppleBarrel object itself.
      */
     public AppleBarrel setBadApples(List<String> badApples) {
-        this.badApples = new BadApplesWrapper(badApples);
+        this.badApples = badApples;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/AppleBarrel.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/AppleBarrel.java
@@ -1,6 +1,8 @@
 package fixtures.xmlservice.models;
 
 import com.azure.core.annotation.Fluent;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import java.util.ArrayList;
@@ -14,12 +16,14 @@ public final class AppleBarrel {
      * The GoodApples property.
      */
     @JacksonXmlElementWrapper(localName = "GoodApples")
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
     private List<String> goodApples = new ArrayList<>();
 
     /*
      * The BadApples property.
      */
     @JacksonXmlElementWrapper(localName = "BadApples")
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
     private List<String> badApples = new ArrayList<>();
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/ListContainersResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/ListContainersResponse.java
@@ -1,8 +1,8 @@
 package fixtures.xmlservice.models;
 
 import com.azure.core.annotation.Fluent;
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import java.util.ArrayList;
@@ -36,21 +36,11 @@ public final class ListContainersResponse {
     @JsonProperty(value = "MaxResults", required = true)
     private int maxResults;
 
-    private static final class ContainersWrapper {
-        @JacksonXmlProperty(localName = "Container")
-        private final List<Container> items;
-
-        @JsonCreator
-        private ContainersWrapper(@JacksonXmlProperty(localName = "Container") List<Container> items) {
-            this.items = items;
-        }
-    }
-
     /*
      * The Containers property.
      */
-    @JsonProperty(value = "Containers")
-    private ContainersWrapper containers;
+    @JacksonXmlElementWrapper(localName = "Containers")
+    private List<Container> containers = new ArrayList<>();
 
     /*
      * The NextMarker property.
@@ -144,10 +134,7 @@ public final class ListContainersResponse {
      * @return the containers value.
      */
     public List<Container> getContainers() {
-        if (this.containers == null) {
-            this.containers = new ContainersWrapper(new ArrayList<Container>());
-        }
-        return this.containers.items;
+        return this.containers;
     }
 
     /**
@@ -157,7 +144,7 @@ public final class ListContainersResponse {
      * @return the ListContainersResponse object itself.
      */
     public ListContainersResponse setContainers(List<Container> containers) {
-        this.containers = new ContainersWrapper(containers);
+        this.containers = containers;
         return this;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/ListContainersResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/ListContainersResponse.java
@@ -2,8 +2,6 @@ package fixtures.xmlservice.models;
 
 import com.azure.core.annotation.Fluent;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonSetter;
-import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
@@ -42,8 +40,7 @@ public final class ListContainersResponse {
      * The Containers property.
      */
     @JacksonXmlElementWrapper(localName = "Containers")
-    @JsonSetter(nulls = Nulls.AS_EMPTY)
-    private List<Container> containers = new ArrayList<>();
+    private List<Container> containers;
 
     /*
      * The NextMarker property.
@@ -137,6 +134,9 @@ public final class ListContainersResponse {
      * @return the containers value.
      */
     public List<Container> getContainers() {
+        if (this.containers == null) {
+            this.containers = new ArrayList<Container>();
+        }
         return this.containers;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/ListContainersResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/ListContainersResponse.java
@@ -2,6 +2,8 @@ package fixtures.xmlservice.models;
 
 import com.azure.core.annotation.Fluent;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
@@ -40,6 +42,7 @@ public final class ListContainersResponse {
      * The Containers property.
      */
     @JacksonXmlElementWrapper(localName = "Containers")
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
     private List<Container> containers = new ArrayList<>();
 
     /*

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/StorageServiceProperties.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/StorageServiceProperties.java
@@ -2,8 +2,6 @@ package fixtures.xmlservice.models;
 
 import com.azure.core.annotation.Fluent;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonSetter;
-import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import java.util.ArrayList;
@@ -37,8 +35,7 @@ public final class StorageServiceProperties {
      * The set of CORS rules.
      */
     @JacksonXmlElementWrapper(localName = "Cors")
-    @JsonSetter(nulls = Nulls.AS_EMPTY)
-    private List<CorsRule> cors = new ArrayList<>();
+    private List<CorsRule> cors;
 
     /*
      * The default version to use for requests to the Blob service if an
@@ -120,6 +117,9 @@ public final class StorageServiceProperties {
      * @return the cors value.
      */
     public List<CorsRule> getCors() {
+        if (this.cors == null) {
+            this.cors = new ArrayList<CorsRule>();
+        }
         return this.cors;
     }
 

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/StorageServiceProperties.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/StorageServiceProperties.java
@@ -2,6 +2,8 @@ package fixtures.xmlservice.models;
 
 import com.azure.core.annotation.Fluent;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import java.util.ArrayList;
@@ -35,6 +37,7 @@ public final class StorageServiceProperties {
      * The set of CORS rules.
      */
     @JacksonXmlElementWrapper(localName = "Cors")
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
     private List<CorsRule> cors = new ArrayList<>();
 
     /*

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/StorageServiceProperties.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/StorageServiceProperties.java
@@ -1,9 +1,8 @@
 package fixtures.xmlservice.models;
 
 import com.azure.core.annotation.Fluent;
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
@@ -32,21 +31,11 @@ public final class StorageServiceProperties {
     @JsonProperty(value = "MinuteMetrics")
     private Metrics minuteMetrics;
 
-    private static final class CorsWrapper {
-        @JacksonXmlProperty(localName = "CorsRule")
-        private final List<CorsRule> items;
-
-        @JsonCreator
-        private CorsWrapper(@JacksonXmlProperty(localName = "CorsRule") List<CorsRule> items) {
-            this.items = items;
-        }
-    }
-
     /*
      * The set of CORS rules.
      */
-    @JsonProperty(value = "Cors")
-    private CorsWrapper cors;
+    @JacksonXmlElementWrapper(localName = "Cors")
+    private List<CorsRule> cors = new ArrayList<>();
 
     /*
      * The default version to use for requests to the Blob service if an
@@ -128,10 +117,7 @@ public final class StorageServiceProperties {
      * @return the cors value.
      */
     public List<CorsRule> getCors() {
-        if (this.cors == null) {
-            this.cors = new CorsWrapper(new ArrayList<CorsRule>());
-        }
-        return this.cors.items;
+        return this.cors;
     }
 
     /**
@@ -141,7 +127,7 @@ public final class StorageServiceProperties {
      * @return the StorageServiceProperties object itself.
      */
     public StorageServiceProperties setCors(List<CorsRule> cors) {
-        this.cors = new CorsWrapper(cors);
+        this.cors = cors;
         return this;
     }
 


### PR DESCRIPTION
Fixes #934 

This PR updates XML code generation to use `JacksonXmlElementWrapper` instead of a private static inner class to maintain the wrapped element list. The change follows better Jackson XML serialization practices as it uses an annotation that Jackson leverages to provide the best serialization experience instead of the more generalized JsonProperty. It also clues Jackson in that the deserialization type is an enumeration whereas with JsonProperty this cannot be determined.