### PR TITLE
Fix Incorrect Element Wrapper Element XML Node Names

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -236,31 +236,20 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                     // Property is an XML wrapper, or simply put a node that contains a list of XML nodes.
                     // Use JacksonXmlElementWrapper to indicate to Jackson that the current node contains a list
                     // of values to be used as the property value.
-                    if (!CoreUtils.isNullOrEmpty(property.getXmlNamespace())) {
-                        classBlock.annotation(String.format("JacksonXmlElementWrapper(localName = \"%1$s\", namespace = \"%2$s\")",
-                            property.getXmlName(), property.getXmlNamespace()));
-                    } else {
-                        classBlock.annotation(String.format("JacksonXmlElementWrapper(localName = \"%1$s\")",
-                            property.getXmlName()));
-                    }
-
+                    //
                     // JacksonXmlElementWrapper will also implicitly use the property name as the XML node name for
                     // each element it is wrapping, it doesn't infer this from the type, so an additional
                     // JacksonXmlProperty needs to be added as an annotation.
-
-                    // Get the ClientModel representing the enumeration type.
-                    // Anything using JacksonXmlElementWrapper will be either an Iterable or List type, so it will be
-                    // a GenericType with one type argument, that is a class, that represents the element type.
-                    IType enumerationType = ((GenericType) property.getWireType()).getTypeArguments()[0];
-                    ClientModel elementModel = ClientModels.Instance.getModel(((ClassType) enumerationType).getName());
-
-                    // Use the class-level JacksonXmlRootElement XML name as the property local name.
-                    if (!CoreUtils.isNullOrEmpty(elementModel.getXmlNamespace())) {
+                    if (!CoreUtils.isNullOrEmpty(property.getXmlNamespace())) {
+                        classBlock.annotation(String.format("JacksonXmlElementWrapper(localName = \"%1$s\", namespace = \"%2$s\")",
+                            property.getXmlName(), property.getXmlNamespace()));
                         classBlock.annotation(String.format("JacksonXmlProperty(localName = \"%1$s\", namespace = \"%2$s\")",
-                            elementModel.getXmlName(), elementModel.getXmlNamespace()));
+                            property.getXmlListElementName(), property.getXmlNamespace()));
                     } else {
+                        classBlock.annotation(String.format("JacksonXmlElementWrapper(localName = \"%1$s\")",
+                            property.getXmlName()));
                         classBlock.annotation(String.format("JacksonXmlProperty(localName = \"%1$s\")",
-                            elementModel.getXmlName()));
+                            property.getXmlListElementName()));
                     }
                 } else if (settings.shouldGenerateXmlSerialization() && property.getWireType() instanceof ListType) {
                     // The property is a list, but it isn't an XML wrapper. Use the XML node with no special

--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -236,7 +236,32 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                     // Property is an XML wrapper, or simply put a node that contains a list of XML nodes.
                     // Use JacksonXmlElementWrapper to indicate to Jackson that the current node contains a list
                     // of values to be used as the property value.
-                    classBlock.annotation(String.format("JacksonXmlElementWrapper(localName = \"%1$s\")", property.getXmlName()));
+                    if (!CoreUtils.isNullOrEmpty(property.getXmlNamespace())) {
+                        classBlock.annotation(String.format("JacksonXmlElementWrapper(localName = \"%1$s\", namespace = \"%2$s\")",
+                            property.getXmlName(), property.getXmlNamespace()));
+                    } else {
+                        classBlock.annotation(String.format("JacksonXmlElementWrapper(localName = \"%1$s\")",
+                            property.getXmlName()));
+                    }
+
+                    // JacksonXmlElementWrapper will also implicitly use the property name as the XML node name for
+                    // each element it is wrapping, it doesn't infer this from the type, so an additional
+                    // JacksonXmlProperty needs to be added as an annotation.
+
+                    // Get the ClientModel representing the enumeration type.
+                    // Anything using JacksonXmlElementWrapper will be either an Iterable or List type, so it will be
+                    // a GenericType with one type argument, that is a class, that represents the element type.
+                    IType enumerationType = ((GenericType) property.getWireType()).getTypeArguments()[0];
+                    ClientModel elementModel = ClientModels.Instance.getModel(((ClassType) enumerationType).getName());
+
+                    // Use the class-level JacksonXmlRootElement XML name as the property local name.
+                    if (!CoreUtils.isNullOrEmpty(elementModel.getXmlNamespace())) {
+                        classBlock.annotation(String.format("JacksonXmlProperty(localName = \"%1$s\", namespace = \"%2$s\")",
+                            elementModel.getXmlName(), elementModel.getXmlNamespace()));
+                    } else {
+                        classBlock.annotation(String.format("JacksonXmlProperty(localName = \"%1$s\")",
+                            elementModel.getXmlName()));
+                    }
                 } else if (settings.shouldGenerateXmlSerialization() && property.getWireType() instanceof ListType) {
                     // The property is a list, but it isn't an XML wrapper. Use the XML node with no special
                     // handling.

--- a/protocol-tests/src/main/java/fixtures/mediatypes/MediaTypesAsyncClient.java
+++ b/protocol-tests/src/main/java/fixtures/mediatypes/MediaTypesAsyncClient.java
@@ -93,7 +93,7 @@ public final class MediaTypesAsyncClient {
     }
 
     /**
-     * Pass in contentType 'text/plain; encoding=UTF-8' to pass test. Value for input does not matter.
+     * Pass in contentType 'text/plain; charset=UTF-8' to pass test. Value for input does not matter.
      *
      * <p><strong>Request Body Schema</strong>
      *

--- a/protocol-tests/src/main/java/fixtures/mediatypes/MediaTypesClient.java
+++ b/protocol-tests/src/main/java/fixtures/mediatypes/MediaTypesClient.java
@@ -92,7 +92,7 @@ public final class MediaTypesClient {
     }
 
     /**
-     * Pass in contentType 'text/plain; encoding=UTF-8' to pass test. Value for input does not matter.
+     * Pass in contentType 'text/plain; charset=UTF-8' to pass test. Value for input does not matter.
      *
      * <p><strong>Request Body Schema</strong>
      *

--- a/protocol-tests/src/main/java/fixtures/mediatypes/implementation/MediaTypesClientImpl.java
+++ b/protocol-tests/src/main/java/fixtures/mediatypes/implementation/MediaTypesClientImpl.java
@@ -339,7 +339,7 @@ public final class MediaTypesClientImpl {
     }
 
     /**
-     * Pass in contentType 'text/plain; encoding=UTF-8' to pass test. Value for input does not matter.
+     * Pass in contentType 'text/plain; charset=UTF-8' to pass test. Value for input does not matter.
      *
      * <p><strong>Request Body Schema</strong>
      *
@@ -364,7 +364,7 @@ public final class MediaTypesClientImpl {
     }
 
     /**
-     * Pass in contentType 'text/plain; encoding=UTF-8' to pass test. Value for input does not matter.
+     * Pass in contentType 'text/plain; charset=UTF-8' to pass test. Value for input does not matter.
      *
      * <p><strong>Request Body Schema</strong>
      *
@@ -390,7 +390,7 @@ public final class MediaTypesClientImpl {
     }
 
     /**
-     * Pass in contentType 'text/plain; encoding=UTF-8' to pass test. Value for input does not matter.
+     * Pass in contentType 'text/plain; charset=UTF-8' to pass test. Value for input does not matter.
      *
      * <p><strong>Request Body Schema</strong>
      *

--- a/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClient.java
+++ b/vanilla-tests/src/main/java/fixtures/mediatypes/MediaTypesClient.java
@@ -25,9 +25,10 @@ import com.azure.core.util.serializer.SerializerAdapter;
 import fixtures.mediatypes.models.ContentType;
 import fixtures.mediatypes.models.ContentType1;
 import fixtures.mediatypes.models.SourcePath;
-import java.nio.ByteBuffer;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import java.nio.ByteBuffer;
 
 /** Initializes a new instance of the MediaTypesClient type. */
 public final class MediaTypesClient {
@@ -156,7 +157,7 @@ public final class MediaTypesClient {
         @UnexpectedResponseExceptionType(HttpResponseException.class)
         Mono<Response<String>> contentTypeWithEncoding(
                 @HostParam("$host") String host,
-                @BodyParam("text/plain") String input,
+                @BodyParam("text/plain; charset=UTF-8") String input,
                 @HeaderParam("Accept") String accept,
                 Context context);
 
@@ -575,7 +576,7 @@ public final class MediaTypesClient {
     }
 
     /**
-     * Pass in contentType 'text/plain; encoding=UTF-8' to pass test. Value for input does not matter.
+     * Pass in contentType 'text/plain; charset=UTF-8' to pass test. Value for input does not matter.
      *
      * @param input Input parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
@@ -593,7 +594,7 @@ public final class MediaTypesClient {
     }
 
     /**
-     * Pass in contentType 'text/plain; encoding=UTF-8' to pass test. Value for input does not matter.
+     * Pass in contentType 'text/plain; charset=UTF-8' to pass test. Value for input does not matter.
      *
      * @param input Input parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
@@ -615,7 +616,7 @@ public final class MediaTypesClient {
     }
 
     /**
-     * Pass in contentType 'text/plain; encoding=UTF-8' to pass test. Value for input does not matter.
+     * Pass in contentType 'text/plain; charset=UTF-8' to pass test. Value for input does not matter.
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -636,7 +637,7 @@ public final class MediaTypesClient {
     }
 
     /**
-     * Pass in contentType 'text/plain; encoding=UTF-8' to pass test. Value for input does not matter.
+     * Pass in contentType 'text/plain; charset=UTF-8' to pass test. Value for input does not matter.
      *
      * @param input Input parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
@@ -650,7 +651,7 @@ public final class MediaTypesClient {
     }
 
     /**
-     * Pass in contentType 'text/plain; encoding=UTF-8' to pass test. Value for input does not matter.
+     * Pass in contentType 'text/plain; charset=UTF-8' to pass test. Value for input does not matter.
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/AppleBarrel.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/AppleBarrel.java
@@ -2,6 +2,7 @@ package fixtures.xmlservice.models;
 
 import com.azure.core.annotation.Fluent;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
@@ -14,12 +15,14 @@ public final class AppleBarrel {
      * The GoodApples property.
      */
     @JacksonXmlElementWrapper(localName = "GoodApples")
+    @JacksonXmlProperty(localName = "Apple")
     private List<String> goodApples;
 
     /*
      * The BadApples property.
      */
     @JacksonXmlElementWrapper(localName = "BadApples")
+    @JacksonXmlProperty(localName = "Apple")
     private List<String> badApples;
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/ListContainersResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/ListContainersResponse.java
@@ -40,6 +40,7 @@ public final class ListContainersResponse {
      * The Containers property.
      */
     @JacksonXmlElementWrapper(localName = "Containers")
+    @JacksonXmlProperty(localName = "Container")
     private List<Container> containers;
 
     /*

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/StorageServiceProperties.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/StorageServiceProperties.java
@@ -3,6 +3,7 @@ package fixtures.xmlservice.models;
 import com.azure.core.annotation.Fluent;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
@@ -35,6 +36,7 @@ public final class StorageServiceProperties {
      * The set of CORS rules.
      */
     @JacksonXmlElementWrapper(localName = "Cors")
+    @JacksonXmlProperty(localName = "CorsRule")
     private List<CorsRule> cors;
 
     /*


### PR DESCRIPTION
This PR resolves an unexpected behavior when using `JacksonXmlElementWrapper` where, by default, if it isn't accompanied by a `JacksonXmlProperty` with a local name value it uses the name of the property as the element XML node name. For example,

```java
@JacksonXmlRootWrapper(localName = "null")
class TestWrapper {
  @JacksonXmlElementWrapper(localName = "tests")
  private List<Test> myTests;
}

@JacksonXmlRootWrapper(localName = "test")
class Test {
  @JacksonXmlProperty(localName = "grade")
  private int grade;
}
```

Will produce XML

```xml
<tests>
  <myTests>
    <grade>95</grade>
  </myTests>
<tests>
```

But if the `JacksonXmlElementWrapper` annotated method also include `JacksonXmlProperty` with the same local name as the wrapped type it will produce element XML nodes with that local name.

```java
@JacksonXmlRootWrapper(localName = "null")
class TestWrapper {
  @JacksonXmlElementWrapper(localName = "tests")
  @JacksonXmlProperty(localName = "test")
  private List<Test> myTests;
}

@JacksonXmlRootWrapper(localName = "test")
class Test {
  @JacksonXmlProperty(localName = "grade")
  private int grade;
}
```

```xml
<tests>
  <test>
    <grade>95</grade>
  </test>
<tests>
```

Ideally, Jackson would use the root wrapper local name of the wrapped type but this isn't the case, so this change is needed.

Also, this PR makes it so usages of `JacksonXmlElementWrapper` pickup the namespace of the property.