### PR TITLE
client, dedpulicate proxy method parameter item

### DIFF
--- a/preprocessor/src/main/java/com/azure/autorest/preprocessor/tranformer/Transformer.java
+++ b/preprocessor/src/main/java/com/azure/autorest/preprocessor/tranformer/Transformer.java
@@ -116,7 +116,7 @@ public class Transformer {
               contentType.get().getLanguage().getDefault().setSerializedName("Content-Type");
             }
           }
-          deduplicateParameterNames(request.getParameters());
+          deduplicateParameterNames(request);
         }
 
         if (operation.getExtensions() != null && operation.getExtensions().getXmsPageable() != null) {
@@ -401,7 +401,22 @@ public class Transformer {
     return contentType;
   }
 
-  private static void deduplicateParameterNames(List<Parameter> parameters) {
+  private static void deduplicateParameterNames(Request request) {
+    if (request == null || request.getParameters() == null || request.getParameters().isEmpty()) {
+      return;
+    }
+
+    List<Parameter> parameters = request.getParameters();
+    // remove duplicate item
+    List<Parameter> deduplicatedParameters = parameters.stream()
+        .distinct()
+        .collect(Collectors.toList());
+    if (deduplicatedParameters.size() != parameters.size()) {
+      parameters = deduplicatedParameters;
+      request.setParameters(parameters);
+    }
+
+    // rename if name conflict
     Set<String> parameterNames = new HashSet<>();
     ListIterator<Parameter> iter = parameters.listIterator();
     while (iter.hasNext()) {


### PR DESCRIPTION
This case is more likely a bug in swagger definition. E.g. define 2 `api-version` parameter in one operation https://github.com/Azure/azure-rest-api-specs-pr/pull/5597#discussion_r761717461

m4 output will be:
```
  - $key: Operations
    operations:
      - apiVersions:
          - version: 2021-08-11-preview
        parameters:
          - *ref_114
          - *ref_116
          - *ref_115
          - *ref_155
          - *ref_116
```

I am not sure whether I should throw Exception and abort, or just silently deduplicate as done in this PR.

However I would want to either stop it here, or fix it here, instead of let it get to later stages, which causes non-compliable code, or other obscure error message during codegen.

Do let me know if we have validate case to have 2 same parameter reference in the operation (I think no, but not 100% sure).