### PR TITLE
Remove Stale Codesnippet Configurations from Generation

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/template/PomTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/PomTemplate.java
@@ -94,10 +94,6 @@ public class PomTemplate implements IXmlTemplate<Pom, XmlFile> {
                 propertiesBlock.tag("project.build.sourceEncoding", "UTF-8");
                 // skip jacoco coverage check
                 propertiesBlock.tag("jacoco.skip", "true");
-                // use new code snippet tooling
-                propertiesBlock.tag("codesnippet.skip", "false");
-                propertiesBlock.tag("javadocDoclet", "");
-                propertiesBlock.tag("javadocDocletOptions", "");
             });
 
             if (pom.getDependencyIdentifiers() != null && pom.getDependencyIdentifiers().size() > 0) {

--- a/protocol-tests/src/main/java/fixtures/lro/LROsAsyncClient.java
+++ b/protocol-tests/src/main/java/fixtures/lro/LROsAsyncClient.java
@@ -232,6 +232,204 @@ public final class LROsAsyncClient {
     }
 
     /**
+     * Long running patch request, service returns a 201 to the initial request with async header.
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     id: String
+     *     type: String
+     *     tags: {
+     *         String: String
+     *     }
+     *     location: String
+     *     name: String
+     *     properties: {
+     *         provisioningState: String
+     *         provisioningStateValues: String(Succeeded/Failed/canceled/Accepted/Creating/Created/Updating/Updated/Deleting/Deleted/OK)
+     *     }
+     * }
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     id: String
+     *     type: String
+     *     tags: {
+     *         String: String
+     *     }
+     *     location: String
+     *     name: String
+     *     properties: {
+     *         provisioningState: String
+     *         provisioningStateValues: String(Succeeded/Failed/canceled/Accepted/Creating/Created/Updating/Updated/Deleting/Deleted/OK)
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @return the response.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BinaryData>> patch201RetryWithAsyncHeaderWithResponse(RequestOptions requestOptions) {
+        return this.serviceClient.patch201RetryWithAsyncHeaderWithResponseAsync(requestOptions);
+    }
+
+    /**
+     * Long running patch request, service returns a 201 to the initial request with async header.
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     id: String
+     *     type: String
+     *     tags: {
+     *         String: String
+     *     }
+     *     location: String
+     *     name: String
+     *     properties: {
+     *         provisioningState: String
+     *         provisioningStateValues: String(Succeeded/Failed/canceled/Accepted/Creating/Created/Updating/Updated/Deleting/Deleted/OK)
+     *     }
+     * }
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     id: String
+     *     type: String
+     *     tags: {
+     *         String: String
+     *     }
+     *     location: String
+     *     name: String
+     *     properties: {
+     *         provisioningState: String
+     *         provisioningStateValues: String(Succeeded/Failed/canceled/Accepted/Creating/Created/Updating/Updated/Deleting/Deleted/OK)
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @return the response.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
+    public PollerFlux<BinaryData, BinaryData> beginPatch201RetryWithAsyncHeader(RequestOptions requestOptions) {
+        return this.serviceClient.beginPatch201RetryWithAsyncHeaderAsync(requestOptions);
+    }
+
+    /**
+     * Long running patch request, service returns a 202 to the initial request with async and location header.
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     id: String
+     *     type: String
+     *     tags: {
+     *         String: String
+     *     }
+     *     location: String
+     *     name: String
+     *     properties: {
+     *         provisioningState: String
+     *         provisioningStateValues: String(Succeeded/Failed/canceled/Accepted/Creating/Created/Updating/Updated/Deleting/Deleted/OK)
+     *     }
+     * }
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     id: String
+     *     type: String
+     *     tags: {
+     *         String: String
+     *     }
+     *     location: String
+     *     name: String
+     *     properties: {
+     *         provisioningState: String
+     *         provisioningStateValues: String(Succeeded/Failed/canceled/Accepted/Creating/Created/Updating/Updated/Deleting/Deleted/OK)
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @return the response.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BinaryData>> patch202RetryWithAsyncAndLocationHeaderWithResponse(
+            RequestOptions requestOptions) {
+        return this.serviceClient.patch202RetryWithAsyncAndLocationHeaderWithResponseAsync(requestOptions);
+    }
+
+    /**
+     * Long running patch request, service returns a 202 to the initial request with async and location header.
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     id: String
+     *     type: String
+     *     tags: {
+     *         String: String
+     *     }
+     *     location: String
+     *     name: String
+     *     properties: {
+     *         provisioningState: String
+     *         provisioningStateValues: String(Succeeded/Failed/canceled/Accepted/Creating/Created/Updating/Updated/Deleting/Deleted/OK)
+     *     }
+     * }
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     id: String
+     *     type: String
+     *     tags: {
+     *         String: String
+     *     }
+     *     location: String
+     *     name: String
+     *     properties: {
+     *         provisioningState: String
+     *         provisioningStateValues: String(Succeeded/Failed/canceled/Accepted/Creating/Created/Updating/Updated/Deleting/Deleted/OK)
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @return the response.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
+    public PollerFlux<BinaryData, BinaryData> beginPatch202RetryWithAsyncAndLocationHeader(
+            RequestOptions requestOptions) {
+        return this.serviceClient.beginPatch202RetryWithAsyncAndLocationHeaderAsync(requestOptions);
+    }
+
+    /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains
      * ProvisioningState=’Succeeded’.
      *

--- a/protocol-tests/src/main/java/fixtures/lro/LROsClient.java
+++ b/protocol-tests/src/main/java/fixtures/lro/LROsClient.java
@@ -130,6 +130,105 @@ public final class LROsClient {
     }
 
     /**
+     * Long running patch request, service returns a 201 to the initial request with async header.
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     id: String
+     *     type: String
+     *     tags: {
+     *         String: String
+     *     }
+     *     location: String
+     *     name: String
+     *     properties: {
+     *         provisioningState: String
+     *         provisioningStateValues: String(Succeeded/Failed/canceled/Accepted/Creating/Created/Updating/Updated/Deleting/Deleted/OK)
+     *     }
+     * }
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     id: String
+     *     type: String
+     *     tags: {
+     *         String: String
+     *     }
+     *     location: String
+     *     name: String
+     *     properties: {
+     *         provisioningState: String
+     *         provisioningStateValues: String(Succeeded/Failed/canceled/Accepted/Creating/Created/Updating/Updated/Deleting/Deleted/OK)
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @return the response.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
+    public SyncPoller<BinaryData, BinaryData> beginPatch201RetryWithAsyncHeader(RequestOptions requestOptions) {
+        return this.serviceClient.beginPatch201RetryWithAsyncHeader(requestOptions);
+    }
+
+    /**
+     * Long running patch request, service returns a 202 to the initial request with async and location header.
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     id: String
+     *     type: String
+     *     tags: {
+     *         String: String
+     *     }
+     *     location: String
+     *     name: String
+     *     properties: {
+     *         provisioningState: String
+     *         provisioningStateValues: String(Succeeded/Failed/canceled/Accepted/Creating/Created/Updating/Updated/Deleting/Deleted/OK)
+     *     }
+     * }
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     id: String
+     *     type: String
+     *     tags: {
+     *         String: String
+     *     }
+     *     location: String
+     *     name: String
+     *     properties: {
+     *         provisioningState: String
+     *         provisioningStateValues: String(Succeeded/Failed/canceled/Accepted/Creating/Created/Updating/Updated/Deleting/Deleted/OK)
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @return the response.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
+    public SyncPoller<BinaryData, BinaryData> beginPatch202RetryWithAsyncAndLocationHeader(
+            RequestOptions requestOptions) {
+        return this.serviceClient.beginPatch202RetryWithAsyncAndLocationHeader(requestOptions);
+    }
+
+    /**
      * Long running put request, service returns a 201 to the initial request, with an entity that contains
      * ProvisioningState=’Succeeded’.
      *

--- a/protocol-tests/src/main/java/fixtures/lro/implementation/LROsImpl.java
+++ b/protocol-tests/src/main/java/fixtures/lro/implementation/LROsImpl.java
@@ -63,6 +63,16 @@ public final class LROsImpl {
         Mono<Response<BinaryData>> patch200SucceededIgnoreHeaders(
                 @HostParam("$host") String host, RequestOptions requestOptions, Context context);
 
+        @Patch("/lro/patch/201/retry/onlyAsyncHeader")
+        @ExpectedResponses({200, 201})
+        Mono<Response<BinaryData>> patch201RetryWithAsyncHeader(
+                @HostParam("$host") String host, RequestOptions requestOptions, Context context);
+
+        @Patch("/lro/patch/202/retry/asyncAndLocationHeader")
+        @ExpectedResponses({200, 202})
+        Mono<Response<BinaryData>> patch202RetryWithAsyncAndLocationHeader(
+                @HostParam("$host") String host, RequestOptions requestOptions, Context context);
+
         @Put("/lro/put/201/succeeded")
         @ExpectedResponses({201})
         Mono<Response<BinaryData>> put201Succeeded(
@@ -780,6 +790,521 @@ public final class LROsImpl {
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
     public SyncPoller<BinaryData, BinaryData> beginPatch200SucceededIgnoreHeaders(RequestOptions requestOptions) {
         return this.beginPatch200SucceededIgnoreHeadersAsync(requestOptions).getSyncPoller();
+    }
+
+    /**
+     * Long running patch request, service returns a 201 to the initial request with async header.
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     id: String
+     *     type: String
+     *     tags: {
+     *         String: String
+     *     }
+     *     location: String
+     *     name: String
+     *     properties: {
+     *         provisioningState: String
+     *         provisioningStateValues: String(Succeeded/Failed/canceled/Accepted/Creating/Created/Updating/Updated/Deleting/Deleted/OK)
+     *     }
+     * }
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     id: String
+     *     type: String
+     *     tags: {
+     *         String: String
+     *     }
+     *     location: String
+     *     name: String
+     *     properties: {
+     *         provisioningState: String
+     *         provisioningStateValues: String(Succeeded/Failed/canceled/Accepted/Creating/Created/Updating/Updated/Deleting/Deleted/OK)
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BinaryData>> patch201RetryWithAsyncHeaderWithResponseAsync(RequestOptions requestOptions) {
+        return FluxUtil.withContext(
+                context -> service.patch201RetryWithAsyncHeader(this.client.getHost(), requestOptions, context));
+    }
+
+    /**
+     * Long running patch request, service returns a 201 to the initial request with async header.
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     id: String
+     *     type: String
+     *     tags: {
+     *         String: String
+     *     }
+     *     location: String
+     *     name: String
+     *     properties: {
+     *         provisioningState: String
+     *         provisioningStateValues: String(Succeeded/Failed/canceled/Accepted/Creating/Created/Updating/Updated/Deleting/Deleted/OK)
+     *     }
+     * }
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     id: String
+     *     type: String
+     *     tags: {
+     *         String: String
+     *     }
+     *     location: String
+     *     name: String
+     *     properties: {
+     *         provisioningState: String
+     *         provisioningStateValues: String(Succeeded/Failed/canceled/Accepted/Creating/Created/Updating/Updated/Deleting/Deleted/OK)
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @param context The context to associate with this operation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BinaryData>> patch201RetryWithAsyncHeaderWithResponseAsync(
+            RequestOptions requestOptions, Context context) {
+        return service.patch201RetryWithAsyncHeader(this.client.getHost(), requestOptions, context);
+    }
+
+    /**
+     * Long running patch request, service returns a 201 to the initial request with async header.
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     id: String
+     *     type: String
+     *     tags: {
+     *         String: String
+     *     }
+     *     location: String
+     *     name: String
+     *     properties: {
+     *         provisioningState: String
+     *         provisioningStateValues: String(Succeeded/Failed/canceled/Accepted/Creating/Created/Updating/Updated/Deleting/Deleted/OK)
+     *     }
+     * }
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     id: String
+     *     type: String
+     *     tags: {
+     *         String: String
+     *     }
+     *     location: String
+     *     name: String
+     *     properties: {
+     *         provisioningState: String
+     *         provisioningStateValues: String(Succeeded/Failed/canceled/Accepted/Creating/Created/Updating/Updated/Deleting/Deleted/OK)
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
+    public PollerFlux<BinaryData, BinaryData> beginPatch201RetryWithAsyncHeaderAsync(RequestOptions requestOptions) {
+        return PollerFlux.create(
+                Duration.ofSeconds(1),
+                () -> this.patch201RetryWithAsyncHeaderWithResponseAsync(requestOptions),
+                new DefaultPollingStrategy<>(this.client.getHttpPipeline()),
+                new TypeReferenceBinaryData(),
+                new TypeReferenceBinaryData());
+    }
+
+    /**
+     * Long running patch request, service returns a 201 to the initial request with async header.
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     id: String
+     *     type: String
+     *     tags: {
+     *         String: String
+     *     }
+     *     location: String
+     *     name: String
+     *     properties: {
+     *         provisioningState: String
+     *         provisioningStateValues: String(Succeeded/Failed/canceled/Accepted/Creating/Created/Updating/Updated/Deleting/Deleted/OK)
+     *     }
+     * }
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     id: String
+     *     type: String
+     *     tags: {
+     *         String: String
+     *     }
+     *     location: String
+     *     name: String
+     *     properties: {
+     *         provisioningState: String
+     *         provisioningStateValues: String(Succeeded/Failed/canceled/Accepted/Creating/Created/Updating/Updated/Deleting/Deleted/OK)
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @param context The context to associate with this operation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
+    public PollerFlux<BinaryData, BinaryData> beginPatch201RetryWithAsyncHeaderAsync(
+            RequestOptions requestOptions, Context context) {
+        return PollerFlux.create(
+                Duration.ofSeconds(1),
+                () -> this.patch201RetryWithAsyncHeaderWithResponseAsync(requestOptions, context),
+                new DefaultPollingStrategy<>(this.client.getHttpPipeline()),
+                new TypeReferenceBinaryData(),
+                new TypeReferenceBinaryData());
+    }
+
+    /**
+     * Long running patch request, service returns a 201 to the initial request with async header.
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     id: String
+     *     type: String
+     *     tags: {
+     *         String: String
+     *     }
+     *     location: String
+     *     name: String
+     *     properties: {
+     *         provisioningState: String
+     *         provisioningStateValues: String(Succeeded/Failed/canceled/Accepted/Creating/Created/Updating/Updated/Deleting/Deleted/OK)
+     *     }
+     * }
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     id: String
+     *     type: String
+     *     tags: {
+     *         String: String
+     *     }
+     *     location: String
+     *     name: String
+     *     properties: {
+     *         provisioningState: String
+     *         provisioningStateValues: String(Succeeded/Failed/canceled/Accepted/Creating/Created/Updating/Updated/Deleting/Deleted/OK)
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
+    public SyncPoller<BinaryData, BinaryData> beginPatch201RetryWithAsyncHeader(RequestOptions requestOptions) {
+        return this.beginPatch201RetryWithAsyncHeaderAsync(requestOptions).getSyncPoller();
+    }
+
+    /**
+     * Long running patch request, service returns a 202 to the initial request with async and location header.
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     id: String
+     *     type: String
+     *     tags: {
+     *         String: String
+     *     }
+     *     location: String
+     *     name: String
+     *     properties: {
+     *         provisioningState: String
+     *         provisioningStateValues: String(Succeeded/Failed/canceled/Accepted/Creating/Created/Updating/Updated/Deleting/Deleted/OK)
+     *     }
+     * }
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     id: String
+     *     type: String
+     *     tags: {
+     *         String: String
+     *     }
+     *     location: String
+     *     name: String
+     *     properties: {
+     *         provisioningState: String
+     *         provisioningStateValues: String(Succeeded/Failed/canceled/Accepted/Creating/Created/Updating/Updated/Deleting/Deleted/OK)
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BinaryData>> patch202RetryWithAsyncAndLocationHeaderWithResponseAsync(
+            RequestOptions requestOptions) {
+        return FluxUtil.withContext(
+                context ->
+                        service.patch202RetryWithAsyncAndLocationHeader(
+                                this.client.getHost(), requestOptions, context));
+    }
+
+    /**
+     * Long running patch request, service returns a 202 to the initial request with async and location header.
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     id: String
+     *     type: String
+     *     tags: {
+     *         String: String
+     *     }
+     *     location: String
+     *     name: String
+     *     properties: {
+     *         provisioningState: String
+     *         provisioningStateValues: String(Succeeded/Failed/canceled/Accepted/Creating/Created/Updating/Updated/Deleting/Deleted/OK)
+     *     }
+     * }
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     id: String
+     *     type: String
+     *     tags: {
+     *         String: String
+     *     }
+     *     location: String
+     *     name: String
+     *     properties: {
+     *         provisioningState: String
+     *         provisioningStateValues: String(Succeeded/Failed/canceled/Accepted/Creating/Created/Updating/Updated/Deleting/Deleted/OK)
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @param context The context to associate with this operation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BinaryData>> patch202RetryWithAsyncAndLocationHeaderWithResponseAsync(
+            RequestOptions requestOptions, Context context) {
+        return service.patch202RetryWithAsyncAndLocationHeader(this.client.getHost(), requestOptions, context);
+    }
+
+    /**
+     * Long running patch request, service returns a 202 to the initial request with async and location header.
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     id: String
+     *     type: String
+     *     tags: {
+     *         String: String
+     *     }
+     *     location: String
+     *     name: String
+     *     properties: {
+     *         provisioningState: String
+     *         provisioningStateValues: String(Succeeded/Failed/canceled/Accepted/Creating/Created/Updating/Updated/Deleting/Deleted/OK)
+     *     }
+     * }
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     id: String
+     *     type: String
+     *     tags: {
+     *         String: String
+     *     }
+     *     location: String
+     *     name: String
+     *     properties: {
+     *         provisioningState: String
+     *         provisioningStateValues: String(Succeeded/Failed/canceled/Accepted/Creating/Created/Updating/Updated/Deleting/Deleted/OK)
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
+    public PollerFlux<BinaryData, BinaryData> beginPatch202RetryWithAsyncAndLocationHeaderAsync(
+            RequestOptions requestOptions) {
+        return PollerFlux.create(
+                Duration.ofSeconds(1),
+                () -> this.patch202RetryWithAsyncAndLocationHeaderWithResponseAsync(requestOptions),
+                new DefaultPollingStrategy<>(this.client.getHttpPipeline()),
+                new TypeReferenceBinaryData(),
+                new TypeReferenceBinaryData());
+    }
+
+    /**
+     * Long running patch request, service returns a 202 to the initial request with async and location header.
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     id: String
+     *     type: String
+     *     tags: {
+     *         String: String
+     *     }
+     *     location: String
+     *     name: String
+     *     properties: {
+     *         provisioningState: String
+     *         provisioningStateValues: String(Succeeded/Failed/canceled/Accepted/Creating/Created/Updating/Updated/Deleting/Deleted/OK)
+     *     }
+     * }
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     id: String
+     *     type: String
+     *     tags: {
+     *         String: String
+     *     }
+     *     location: String
+     *     name: String
+     *     properties: {
+     *         provisioningState: String
+     *         provisioningStateValues: String(Succeeded/Failed/canceled/Accepted/Creating/Created/Updating/Updated/Deleting/Deleted/OK)
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @param context The context to associate with this operation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
+    public PollerFlux<BinaryData, BinaryData> beginPatch202RetryWithAsyncAndLocationHeaderAsync(
+            RequestOptions requestOptions, Context context) {
+        return PollerFlux.create(
+                Duration.ofSeconds(1),
+                () -> this.patch202RetryWithAsyncAndLocationHeaderWithResponseAsync(requestOptions, context),
+                new DefaultPollingStrategy<>(this.client.getHttpPipeline()),
+                new TypeReferenceBinaryData(),
+                new TypeReferenceBinaryData());
+    }
+
+    /**
+     * Long running patch request, service returns a 202 to the initial request with async and location header.
+     *
+     * <p><strong>Request Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     id: String
+     *     type: String
+     *     tags: {
+     *         String: String
+     *     }
+     *     location: String
+     *     name: String
+     *     properties: {
+     *         provisioningState: String
+     *         provisioningStateValues: String(Succeeded/Failed/canceled/Accepted/Creating/Created/Updating/Updated/Deleting/Deleted/OK)
+     *     }
+     * }
+     * }</pre>
+     *
+     * <p><strong>Response Body Schema</strong>
+     *
+     * <pre>{@code
+     * {
+     *     id: String
+     *     type: String
+     *     tags: {
+     *         String: String
+     *     }
+     *     location: String
+     *     name: String
+     *     properties: {
+     *         provisioningState: String
+     *         provisioningStateValues: String(Succeeded/Failed/canceled/Accepted/Creating/Created/Updating/Updated/Deleting/Deleted/OK)
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
+    public SyncPoller<BinaryData, BinaryData> beginPatch202RetryWithAsyncAndLocationHeader(
+            RequestOptions requestOptions) {
+        return this.beginPatch202RetryWithAsyncAndLocationHeaderAsync(requestOptions).getSyncPoller();
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/lro/LROs.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/LROs.java
@@ -38,6 +38,8 @@ import fixtures.lro.models.LROsDeleteProvisioning202Accepted200SucceededResponse
 import fixtures.lro.models.LROsDeleteProvisioning202DeletingFailed200Response;
 import fixtures.lro.models.LROsDeleteProvisioning202Deletingcanceled200Response;
 import fixtures.lro.models.LROsPatch200SucceededIgnoreHeadersResponse;
+import fixtures.lro.models.LROsPatch201RetryWithAsyncHeaderResponse;
+import fixtures.lro.models.LROsPatch202RetryWithAsyncAndLocationHeaderResponse;
 import fixtures.lro.models.LROsPost202ListResponse;
 import fixtures.lro.models.LROsPost202NoRetry204Response;
 import fixtures.lro.models.LROsPost202Retry200Response;
@@ -96,6 +98,24 @@ public final class LROs {
         @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(CloudErrorException.class)
         Mono<LROsPatch200SucceededIgnoreHeadersResponse> patch200SucceededIgnoreHeaders(
+                @HostParam("$host") String host,
+                @BodyParam("application/json") Product product,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Patch("/lro/patch/201/retry/onlyAsyncHeader")
+        @ExpectedResponses({200, 201})
+        @UnexpectedResponseExceptionType(CloudErrorException.class)
+        Mono<LROsPatch201RetryWithAsyncHeaderResponse> patch201RetryWithAsyncHeader(
+                @HostParam("$host") String host,
+                @BodyParam("application/json") Product product,
+                @HeaderParam("Accept") String accept,
+                Context context);
+
+        @Patch("/lro/patch/202/retry/asyncAndLocationHeader")
+        @ExpectedResponses({200, 202})
+        @UnexpectedResponseExceptionType(CloudErrorException.class)
+        Mono<LROsPatch202RetryWithAsyncAndLocationHeaderResponse> patch202RetryWithAsyncAndLocationHeader(
                 @HostParam("$host") String host,
                 @BodyParam("application/json") Product product,
                 @HeaderParam("Accept") String accept,
@@ -538,6 +558,132 @@ public final class LROs {
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
     public SyncPoller<Product, Product> beginPatch200SucceededIgnoreHeaders(Product product) {
         return this.beginPatch200SucceededIgnoreHeadersAsync(product).getSyncPoller();
+    }
+
+    /**
+     * Long running patch request, service returns a 201 to the initial request with async header.
+     *
+     * @param product Product to patch.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws CloudErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<LROsPatch201RetryWithAsyncHeaderResponse> patch201RetryWithAsyncHeaderWithResponseAsync(
+            Product product) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (product != null) {
+            product.validate();
+        }
+        final String accept = "application/json";
+        return FluxUtil.withContext(
+                context -> service.patch201RetryWithAsyncHeader(this.client.getHost(), product, accept, context));
+    }
+
+    /**
+     * Long running patch request, service returns a 201 to the initial request with async header.
+     *
+     * @param product Product to patch.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws CloudErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
+    public PollerFlux<Product, Product> beginPatch201RetryWithAsyncHeaderAsync(Product product) {
+        return PollerFlux.create(
+                Duration.ofSeconds(1),
+                () -> this.patch201RetryWithAsyncHeaderWithResponseAsync(product),
+                new ChainedPollingStrategy<>(
+                        java.util.Arrays.asList(
+                                new OperationResourcePollingStrategy<>(
+                                        this.client.getHttpPipeline(), null, "Azure-AsyncOperation"),
+                                new LocationPollingStrategy<>(this.client.getHttpPipeline()),
+                                new StatusCheckPollingStrategy<>())),
+                new TypeReferenceProduct(),
+                new TypeReferenceProduct());
+    }
+
+    /**
+     * Long running patch request, service returns a 201 to the initial request with async header.
+     *
+     * @param product Product to patch.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws CloudErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
+    public SyncPoller<Product, Product> beginPatch201RetryWithAsyncHeader(Product product) {
+        return this.beginPatch201RetryWithAsyncHeaderAsync(product).getSyncPoller();
+    }
+
+    /**
+     * Long running patch request, service returns a 202 to the initial request with async and location header.
+     *
+     * @param product Product to patch.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws CloudErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<LROsPatch202RetryWithAsyncAndLocationHeaderResponse>
+            patch202RetryWithAsyncAndLocationHeaderWithResponseAsync(Product product) {
+        if (this.client.getHost() == null) {
+            return Mono.error(
+                    new IllegalArgumentException("Parameter this.client.getHost() is required and cannot be null."));
+        }
+        if (product != null) {
+            product.validate();
+        }
+        final String accept = "application/json";
+        return FluxUtil.withContext(
+                context ->
+                        service.patch202RetryWithAsyncAndLocationHeader(
+                                this.client.getHost(), product, accept, context));
+    }
+
+    /**
+     * Long running patch request, service returns a 202 to the initial request with async and location header.
+     *
+     * @param product Product to patch.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws CloudErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
+    public PollerFlux<Product, Product> beginPatch202RetryWithAsyncAndLocationHeaderAsync(Product product) {
+        return PollerFlux.create(
+                Duration.ofSeconds(1),
+                () -> this.patch202RetryWithAsyncAndLocationHeaderWithResponseAsync(product),
+                new ChainedPollingStrategy<>(
+                        java.util.Arrays.asList(
+                                new OperationResourcePollingStrategy<>(
+                                        this.client.getHttpPipeline(), null, "Azure-AsyncOperation"),
+                                new LocationPollingStrategy<>(this.client.getHttpPipeline()),
+                                new StatusCheckPollingStrategy<>())),
+                new TypeReferenceProduct(),
+                new TypeReferenceProduct());
+    }
+
+    /**
+     * Long running patch request, service returns a 202 to the initial request with async and location header.
+     *
+     * @param product Product to patch.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws CloudErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
+    public SyncPoller<Product, Product> beginPatch202RetryWithAsyncAndLocationHeader(Product product) {
+        return this.beginPatch202RetryWithAsyncAndLocationHeaderAsync(product).getSyncPoller();
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsPatch201RetryWithAsyncHeaderHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsPatch201RetryWithAsyncHeaderHeaders.java
@@ -1,0 +1,41 @@
+package fixtures.lro.models;
+
+import com.azure.core.annotation.Fluent;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** The LROsPatch201RetryWithAsyncHeaderHeaders model. */
+@Fluent
+public final class LROsPatch201RetryWithAsyncHeaderHeaders {
+    /*
+     * The Azure-AsyncOperation property.
+     */
+    @JsonProperty(value = "Azure-AsyncOperation")
+    private String azureAsyncOperation;
+
+    /**
+     * Get the azureAsyncOperation property: The Azure-AsyncOperation property.
+     *
+     * @return the azureAsyncOperation value.
+     */
+    public String getAzureAsyncOperation() {
+        return this.azureAsyncOperation;
+    }
+
+    /**
+     * Set the azureAsyncOperation property: The Azure-AsyncOperation property.
+     *
+     * @param azureAsyncOperation the azureAsyncOperation value to set.
+     * @return the LROsPatch201RetryWithAsyncHeaderHeaders object itself.
+     */
+    public LROsPatch201RetryWithAsyncHeaderHeaders setAzureAsyncOperation(String azureAsyncOperation) {
+        this.azureAsyncOperation = azureAsyncOperation;
+        return this;
+    }
+
+    /**
+     * Validates the instance.
+     *
+     * @throws IllegalArgumentException thrown if the instance is not valid.
+     */
+    public void validate() {}
+}

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsPatch201RetryWithAsyncHeaderResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsPatch201RetryWithAsyncHeaderResponse.java
@@ -1,0 +1,33 @@
+package fixtures.lro.models;
+
+import com.azure.core.http.HttpHeaders;
+import com.azure.core.http.HttpRequest;
+import com.azure.core.http.rest.ResponseBase;
+
+/** Contains all response data for the patch201RetryWithAsyncHeader operation. */
+public final class LROsPatch201RetryWithAsyncHeaderResponse
+        extends ResponseBase<LROsPatch201RetryWithAsyncHeaderHeaders, Product> {
+    /**
+     * Creates an instance of LROsPatch201RetryWithAsyncHeaderResponse.
+     *
+     * @param request the request which resulted in this LROsPatch201RetryWithAsyncHeaderResponse.
+     * @param statusCode the status code of the HTTP response.
+     * @param rawHeaders the raw headers of the HTTP response.
+     * @param value the deserialized value of the HTTP response.
+     * @param headers the deserialized headers of the HTTP response.
+     */
+    public LROsPatch201RetryWithAsyncHeaderResponse(
+            HttpRequest request,
+            int statusCode,
+            HttpHeaders rawHeaders,
+            Product value,
+            LROsPatch201RetryWithAsyncHeaderHeaders headers) {
+        super(request, statusCode, rawHeaders, value, headers);
+    }
+
+    /** @return the deserialized response body. */
+    @Override
+    public Product getValue() {
+        return super.getValue();
+    }
+}

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsPatch202RetryWithAsyncAndLocationHeaderHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsPatch202RetryWithAsyncAndLocationHeaderHeaders.java
@@ -1,0 +1,67 @@
+package fixtures.lro.models;
+
+import com.azure.core.annotation.Fluent;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** The LROsPatch202RetryWithAsyncAndLocationHeaderHeaders model. */
+@Fluent
+public final class LROsPatch202RetryWithAsyncAndLocationHeaderHeaders {
+    /*
+     * The Azure-AsyncOperation property.
+     */
+    @JsonProperty(value = "Azure-AsyncOperation")
+    private String azureAsyncOperation;
+
+    /*
+     * The Location property.
+     */
+    @JsonProperty(value = "Location")
+    private String location;
+
+    /**
+     * Get the azureAsyncOperation property: The Azure-AsyncOperation property.
+     *
+     * @return the azureAsyncOperation value.
+     */
+    public String getAzureAsyncOperation() {
+        return this.azureAsyncOperation;
+    }
+
+    /**
+     * Set the azureAsyncOperation property: The Azure-AsyncOperation property.
+     *
+     * @param azureAsyncOperation the azureAsyncOperation value to set.
+     * @return the LROsPatch202RetryWithAsyncAndLocationHeaderHeaders object itself.
+     */
+    public LROsPatch202RetryWithAsyncAndLocationHeaderHeaders setAzureAsyncOperation(String azureAsyncOperation) {
+        this.azureAsyncOperation = azureAsyncOperation;
+        return this;
+    }
+
+    /**
+     * Get the location property: The Location property.
+     *
+     * @return the location value.
+     */
+    public String getLocation() {
+        return this.location;
+    }
+
+    /**
+     * Set the location property: The Location property.
+     *
+     * @param location the location value to set.
+     * @return the LROsPatch202RetryWithAsyncAndLocationHeaderHeaders object itself.
+     */
+    public LROsPatch202RetryWithAsyncAndLocationHeaderHeaders setLocation(String location) {
+        this.location = location;
+        return this;
+    }
+
+    /**
+     * Validates the instance.
+     *
+     * @throws IllegalArgumentException thrown if the instance is not valid.
+     */
+    public void validate() {}
+}

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsPatch202RetryWithAsyncAndLocationHeaderResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsPatch202RetryWithAsyncAndLocationHeaderResponse.java
@@ -1,0 +1,33 @@
+package fixtures.lro.models;
+
+import com.azure.core.http.HttpHeaders;
+import com.azure.core.http.HttpRequest;
+import com.azure.core.http.rest.ResponseBase;
+
+/** Contains all response data for the patch202RetryWithAsyncAndLocationHeader operation. */
+public final class LROsPatch202RetryWithAsyncAndLocationHeaderResponse
+        extends ResponseBase<LROsPatch202RetryWithAsyncAndLocationHeaderHeaders, Product> {
+    /**
+     * Creates an instance of LROsPatch202RetryWithAsyncAndLocationHeaderResponse.
+     *
+     * @param request the request which resulted in this LROsPatch202RetryWithAsyncAndLocationHeaderResponse.
+     * @param statusCode the status code of the HTTP response.
+     * @param rawHeaders the raw headers of the HTTP response.
+     * @param value the deserialized value of the HTTP response.
+     * @param headers the deserialized headers of the HTTP response.
+     */
+    public LROsPatch202RetryWithAsyncAndLocationHeaderResponse(
+            HttpRequest request,
+            int statusCode,
+            HttpHeaders rawHeaders,
+            Product value,
+            LROsPatch202RetryWithAsyncAndLocationHeaderHeaders headers) {
+        super(request, statusCode, rawHeaders, value, headers);
+    }
+
+    /** @return the deserialized response body. */
+    @Override
+    public Product getValue() {
+        return super.getValue();
+    }
+}


### PR DESCRIPTION
This PR removes adding the codesnippet configurations to generated POM files as they are no longer used.