### PR TITLE
LLC, fix example generation with x-ms-client-name

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/template/ProtocolSampleTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ProtocolSampleTemplate.java
@@ -88,8 +88,8 @@ public class ProtocolSampleTemplate implements IJavaTemplate<ProtocolExample, Ja
 
         example.getParameters().forEach((parameterName, parameterValue) -> {
             boolean matchRequiredParameter = false;
-            for (int i = 0; i < numParam; i++) {
-                ProxyMethodParameter proxyMethodParameter = proxyMethodParameters.get(i);
+            for (int parameterIndex = 0; parameterIndex < numParam; parameterIndex++) {
+                ProxyMethodParameter proxyMethodParameter = proxyMethodParameters.get(parameterIndex);
                 if (proxyMethodParameter != null) {
                     if (getSerializedName(proxyMethodParameter).equalsIgnoreCase(parameterName)) {
                         // parameter in example found in method signature
@@ -100,14 +100,14 @@ public class ProtocolSampleTemplate implements IJavaTemplate<ProtocolExample, Ja
                             String exampleValue = proxyMethodParameter.getRequestParameterLocation() == RequestParameterLocation.QUERY
                                     ? parameterValue.getUnescapedQueryValue().toString()
                                     : parameterValue.getObjectValue().toString();
-                            params.set(i, proxyMethodParameter.getClientType().defaultValueExpression(exampleValue));
+                            params.set(parameterIndex, proxyMethodParameter.getClientType().defaultValueExpression(exampleValue));
                         } else {
                             // BinaryData
                             String binaryDataValue = ClassType.String.defaultValueExpression(parameterValue.getJsonString());
                             binaryDataStmt.append(
                                     String.format("BinaryData %s = BinaryData.fromString(%s);",
                                             parameterName, binaryDataValue));
-                            params.set(i, parameterName);
+                            params.set(parameterIndex, parameterName);
                         }
                         matchRequiredParameter = true;
                         break;

--- a/javagen/src/main/java/com/azure/autorest/template/ProtocolSampleTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ProtocolSampleTemplate.java
@@ -55,7 +55,7 @@ public class ProtocolSampleTemplate implements IJavaTemplate<ProtocolExample, Ja
         ServiceClient serviceClient = protocolExample.getServiceClient();
         String builderName = protocolExample.getBuilderName();
         String filename = protocolExample.getFilename();
-        ProxyMethodExample example = protocolExample.getProxyMethodExample();
+        ProxyMethodExample proxyMethodExample = protocolExample.getProxyMethodExample();
 
         // Import
         List<String> imports = new ArrayList<>();
@@ -86,7 +86,7 @@ public class ProtocolSampleTemplate implements IJavaTemplate<ProtocolExample, Ja
 
         List<ProxyMethodParameter> proxyMethodParameters = getProxyMethodParameters(method.getProxyMethod(), method.getParameters());
 
-        example.getParameters().forEach((parameterName, parameterValue) -> {
+        proxyMethodExample.getParameters().forEach((parameterName, parameterValue) -> {
             boolean matchRequiredParameter = false;
             for (int parameterIndex = 0; parameterIndex < numParam; parameterIndex++) {
                 ProxyMethodParameter proxyMethodParameter = proxyMethodParameters.get(parameterIndex);


### PR DESCRIPTION
fix https://github.com/Azure/autorest.java/issues/1313

case of the parameter not in method signature already fixed in https://github.com/Azure/autorest.java/pull/1311

this PR fix the case of the parameter in method signature (usually path parameter and body parameter).