### PR TITLE
client, clear data in singleton at Process

### DIFF
--- a/androidgen/src/main/java/com/azure/autorest/android/Androidgen.java
+++ b/androidgen/src/main/java/com/azure/autorest/android/Androidgen.java
@@ -52,6 +52,8 @@ public class Androidgen extends Javagen {
 
     @Override
     public boolean processInternal() {
+        this.clear();
+
         JavaSettings settings = JavaSettings.getInstance();
 
         List<String> allFiles = listInputs();
@@ -186,5 +188,9 @@ public class Androidgen extends Javagen {
             return false;
         }
         return true;
+    }
+
+    private void clear() {
+        JavaSettings.clear();
     }
 }

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
@@ -64,6 +64,10 @@ public class JavaSettings {
         JavaSettings.host = host;
     }
 
+    public static void clear() {
+        _instance = null;
+    }
+
     public static JavaSettings getInstance() {
         if (_instance == null) {
             AutorestSettings autorestSettings = new AutorestSettings();

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
@@ -83,14 +83,15 @@ public class FluentGen extends Javagen {
     @Override
     public boolean processInternal() {
         this.clear();
-        JavaSettings settings = JavaSettings.getInstance();
-
-        List<String> files = listInputs().stream().filter(s -> s.contains("no-tags")).collect(Collectors.toList());
-        if (files.size() != 1) {
-            throw new RuntimeException(String.format("Generator received incorrect number of inputs: %s : %s}", files.size(), String.join(", ", files)));
-        }
 
         try {
+            JavaSettings settings = JavaSettings.getInstance();
+
+            List<String> files = listInputs().stream().filter(s -> s.contains("no-tags")).collect(Collectors.toList());
+            if (files.size() != 1) {
+                throw new RuntimeException(String.format("Generator received incorrect number of inputs: %s : %s}", files.size(), String.join(", ", files)));
+            }
+
             logger.info("Read YAML");
             String fileContent = readFile(files.get(0));
             createInputCodeModelFile(fileContent);

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
@@ -358,7 +358,7 @@ public class FluentGen extends Javagen {
         JavaSettings.clear();
         fluentJavaSettings = null;
         fluentMapper = null;
-        fluentPremiumExamples.clear();
+        fluentPremiumExamples = null;
     }
 
     private FluentJavaSettings getFluentJavaSettings() {

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
@@ -82,6 +82,7 @@ public class FluentGen extends Javagen {
 
     @Override
     public boolean processInternal() {
+        this.clear();
         JavaSettings settings = JavaSettings.getInstance();
 
         List<String> files = listInputs().stream().filter(s -> s.contains("no-tags")).collect(Collectors.toList());
@@ -350,6 +351,13 @@ public class FluentGen extends Javagen {
         }
 
         return fluentClient;
+    }
+
+    private void clear() {
+        JavaSettings.clear();
+        fluentJavaSettings = null;
+        fluentMapper = null;
+        fluentPremiumExamples.clear();
     }
 
     private FluentJavaSettings getFluentJavaSettings() {

--- a/fluentnamer/src/main/java/com/azure/autorest/fluentnamer/FluentNamer.java
+++ b/fluentnamer/src/main/java/com/azure/autorest/fluentnamer/FluentNamer.java
@@ -8,6 +8,7 @@ package com.azure.autorest.fluentnamer;
 
 import com.azure.autorest.extension.base.jsonrpc.Connection;
 import com.azure.autorest.extension.base.model.codemodel.CodeModel;
+import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.extension.base.plugin.NewPlugin;
 import com.azure.autorest.extension.base.plugin.PluginLogger;
 import com.azure.autorest.fluent.namer.FluentNamerFactory;
@@ -49,6 +50,8 @@ public class FluentNamer extends NewPlugin {
 
     @Override
     public boolean processInternal() {
+        this.clear();
+
         try {
             List<String> files = listInputs().stream().filter(s -> s.contains("no-tags")).collect(Collectors.toList());
             if (files.size() != 1) {
@@ -132,5 +135,9 @@ public class FluentNamer extends NewPlugin {
         codeModel = transformer.postTransform(codeModel);
 
         return codeModel;
+    }
+
+    private void clear() {
+        JavaSettings.clear();
     }
 }

--- a/javagen/src/main/java/com/azure/autorest/Javagen.java
+++ b/javagen/src/main/java/com/azure/autorest/Javagen.java
@@ -66,6 +66,7 @@ public class Javagen extends NewPlugin {
     @Override
     public boolean processInternal() {
         this.clear();
+
         JavaSettings settings = JavaSettings.getInstance();
 
         List<String> allFiles = listInputs();

--- a/javagen/src/main/java/com/azure/autorest/Javagen.java
+++ b/javagen/src/main/java/com/azure/autorest/Javagen.java
@@ -65,6 +65,7 @@ public class Javagen extends NewPlugin {
 
     @Override
     public boolean processInternal() {
+        this.clear();
         JavaSettings settings = JavaSettings.getInstance();
 
         List<String> allFiles = listInputs();
@@ -294,5 +295,9 @@ public class Javagen extends NewPlugin {
             }
         }
         return javaPackage;
+    }
+
+    private void clear() {
+        JavaSettings.clear();
     }
 }

--- a/postprocessor/src/main/java/com/azure/autorest/postprocessor/Postprocessor.java
+++ b/postprocessor/src/main/java/com/azure/autorest/postprocessor/Postprocessor.java
@@ -42,6 +42,8 @@ public class Postprocessor extends NewPlugin {
     @SuppressWarnings("unchecked")
     @Override
     public boolean processInternal() {
+        this.clear();
+
         List<String> files = listInputs();
         Map<String, String> fileContents = files.stream().collect(Collectors.toMap(f -> f, this::readFile));
 
@@ -269,4 +271,7 @@ public class Postprocessor extends NewPlugin {
         logger.info("Finish handle partial update.");
     }
 
+    private void clear() {
+        JavaSettings.clear();
+    }
 }

--- a/preprocessor/src/main/java/com/azure/autorest/preprocessor/Preprocessor.java
+++ b/preprocessor/src/main/java/com/azure/autorest/preprocessor/Preprocessor.java
@@ -41,6 +41,8 @@ public class Preprocessor extends NewPlugin {
 
   @Override
   public boolean processInternal() {
+    this.clear();
+
     List<String> allFiles = listInputs();
     List<String> files = allFiles.stream().filter(s -> s.contains("no-tags")).collect(Collectors.toList());
     if (files.size() != 1) {
@@ -195,5 +197,9 @@ public class Preprocessor extends NewPlugin {
     choice.setLanguage(constantSchema.getValue().getLanguage());
     sealedChoiceSchema.setChoices(Collections.singletonList(choice));
     return sealedChoiceSchema;
+  }
+
+  private void clear() {
+    JavaSettings.clear();
   }
 }


### PR DESCRIPTION
Current codegen does not work correctly in "batch" mode in autorest.
https://github.com/Azure/azure-sdk-for-java/blob/438424541172d5b19ae5c89a05817f01b5c88414/sdk/purview/azure-analytics-purview-administration/swagger/README_SPEC.md

I haven't dig deep. Quick idea: in batch mode, our module only has 1 instance overall, but autorest call multiple "Process" on our instance to process multiple inputs.

This is only part of the immediate fix. We still have quite some date cached in Mapper, which is likely not correct given different content.
E.g. (this one probably OK as it uses object as key, which is likely to cause conflict)
https://github.com/Azure/autorest.java/blob/main/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java#L59

If possible, future code should avoid singleton (at least avoid singleton with mutable data inside).