### PR TITLE
dpg, support sendRequest method

### DIFF
--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
@@ -137,6 +137,7 @@ public class JavaSettings {
                 }.getType(), "polling"),
                 getBooleanValue(host, "generate-samples", false),
                 getBooleanValue(host, "generate-tests", false),
+                getBooleanValue(host, "generate-send-request-method", false),
                 getBooleanValue(host, "pass-discriminator-to-child-deserialization", false),
                 getBooleanValue(host, "annotate-getters-and-setters-for-serialization", false),
                 getStringValue(host, "default-http-exception-type"),
@@ -231,6 +232,7 @@ public class JavaSettings {
         Map<String, PollingDetails> pollingConfig,
         boolean generateSamples,
         boolean generateTests,
+        boolean generateSendRequestMethod,
         boolean passDiscriminatorToChildDeserialization,
         boolean annotateGettersAndSettersForSerialization,
         String defaultHttpExceptionType,
@@ -311,6 +313,7 @@ public class JavaSettings {
         this.pollingConfig = pollingConfig;
         this.generateSamples = generateSamples;
         this.generateTests = generateTests;
+        this.generateSendRequestMethod = generateSendRequestMethod;
         this.passDiscriminatorToChildDeserialization = passDiscriminatorToChildDeserialization;
         this.annotateGettersAndSettersForSerialization = annotateGettersAndSettersForSerialization;
 
@@ -754,6 +757,12 @@ public class JavaSettings {
 
     public boolean isGenerateTests() {
         return generateTests;
+    }
+
+    private final boolean generateSendRequestMethod;
+
+    public boolean isGenerateSendRequestMethod() {
+        return generateSendRequestMethod;
     }
 
     private final boolean clientBuilderDisabled;

--- a/generate
+++ b/generate
@@ -22,7 +22,7 @@ autorest $VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/custom-baseUrl-more-optio
 autorest $VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/head.json --namespace=fixtures.head
 autorest $VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/head-exceptions.json --namespace=fixtures.headexceptions
 autorest $VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/header.json --namespace=fixtures.header --context-client-method-parameter
-autorest $VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-dictionary.json --namespace=fixtures.bodydictionary --generate-sync-async-clients --generate-send-request
+autorest $VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-dictionary.json --namespace=fixtures.bodydictionary --generate-sync-async-clients --generate-send-request-method
 autorest $VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-duration.json --namespace=fixtures.bodyduration
 autorest $VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-integer.json --namespace=fixtures.bodyinteger
 autorest $VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-number.json --namespace=fixtures.bodynumber --disable-client-builder
@@ -81,7 +81,7 @@ autorest $PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/url-multi-collectionForm
 autorest $PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/lro.json --namespace=fixtures.lro
 autorest $PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/dpg_initial.json --namespace=fixtures.llcinitial
 autorest $PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/dpg_update1.json --namespace=fixtures.llcupdate1
-autorest $PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/dpg-customization.json --namespace=fixtures.dpgcustomization --generate-send-request
+autorest $PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/dpg-customization.json --namespace=fixtures.dpgcustomization --generate-send-request-method
 # Java 8 does not support module. Remove it to pass CI.
 rm ./protocol-tests/src/main/java/module-info.java
 

--- a/generate
+++ b/generate
@@ -22,7 +22,7 @@ autorest $VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/custom-baseUrl-more-optio
 autorest $VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/head.json --namespace=fixtures.head
 autorest $VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/head-exceptions.json --namespace=fixtures.headexceptions
 autorest $VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/header.json --namespace=fixtures.header --context-client-method-parameter
-autorest $VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-dictionary.json --namespace=fixtures.bodydictionary --generate-sync-async-clients
+autorest $VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-dictionary.json --namespace=fixtures.bodydictionary --generate-sync-async-clients --generate-send-request
 autorest $VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-duration.json --namespace=fixtures.bodyduration
 autorest $VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-integer.json --namespace=fixtures.bodyinteger
 autorest $VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-number.json --namespace=fixtures.bodynumber --disable-client-builder
@@ -81,7 +81,7 @@ autorest $PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/url-multi-collectionForm
 autorest $PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/lro.json --namespace=fixtures.lro
 autorest $PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/dpg_initial.json --namespace=fixtures.llcinitial
 autorest $PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/dpg_update1.json --namespace=fixtures.llcupdate1
-autorest $PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/dpg-customization.json --namespace=fixtures.dpgcustomization
+autorest $PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/dpg-customization.json --namespace=fixtures.dpgcustomization --generate-send-request
 # Java 8 does not support module. Remove it to pass CI.
 rm ./protocol-tests/src/main/java/module-info.java
 

--- a/generate
+++ b/generate
@@ -80,7 +80,7 @@ autorest $PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/url.json --namespace=fix
 autorest $PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/url-multi-collectionFormat.json --namespace=fixtures.url.multi
 autorest $PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/lro.json --namespace=fixtures.lro
 autorest $PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/dpg_initial.json --namespace=fixtures.llcinitial
-autorest $PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/dpg_update1.json --namespace=fixtures.llcupdate1
+autorest $PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/dpg_update1.json --namespace=fixtures.llcupdate1 --generate-send-request-method
 autorest $PROTOCOL_ARGUMENTS --input-file=$SWAGGER_PATH/dpg-customization.json --namespace=fixtures.dpgcustomization --generate-send-request-method
 # Java 8 does not support module. Remove it to pass CI.
 rm ./protocol-tests/src/main/java/module-info.java

--- a/generate.bat
+++ b/generate.bat
@@ -17,7 +17,7 @@ call autorest %VANILLA_ARGUMENTS% --input-file=%SWAGGER_PATH%/custom-baseUrl-mor
 call autorest %VANILLA_ARGUMENTS% --input-file=%SWAGGER_PATH%/head.json --namespace=fixtures.head
 call autorest %VANILLA_ARGUMENTS% --input-file=%SWAGGER_PATH%/head-exceptions.json --namespace=fixtures.headexceptions
 call autorest %VANILLA_ARGUMENTS% --input-file=%SWAGGER_PATH%/header.json --namespace=fixtures.header --context-client-method-parameter
-call autorest %VANILLA_ARGUMENTS% --input-file=%SWAGGER_PATH%/body-dictionary.json --namespace=fixtures.bodydictionary --generate-sync-async-clients --generate-send-request
+call autorest %VANILLA_ARGUMENTS% --input-file=%SWAGGER_PATH%/body-dictionary.json --namespace=fixtures.bodydictionary --generate-sync-async-clients --generate-send-request-method
 call autorest %VANILLA_ARGUMENTS% --input-file=%SWAGGER_PATH%/body-duration.json --namespace=fixtures.bodyduration
 call autorest %VANILLA_ARGUMENTS% --input-file=%SWAGGER_PATH%/body-integer.json --namespace=fixtures.bodyinteger
 call autorest %VANILLA_ARGUMENTS% --input-file=%SWAGGER_PATH%/body-number.json --namespace=fixtures.bodynumber --disable-client-builder
@@ -80,7 +80,7 @@ call autorest %PROTOCOL_ARGUMENTS% --input-file=%SWAGGER_PATH%/url-multi-collect
 call autorest %PROTOCOL_ARGUMENTS% --input-file=%SWAGGER_PATH%/lro.json --namespace=fixtures.lro
 call autorest %PROTOCOL_ARGUMENTS% --input-file=%SWAGGER_PATH%/dpg_initial.json --namespace=fixtures.llcinitial
 call autorest %PROTOCOL_ARGUMENTS% --input-file=%SWAGGER_PATH%/dpg_update1.json --namespace=fixtures.llcupdate1
-call autorest %PROTOCOL_ARGUMENTS% --input-file=%SWAGGER_PATH%/dpg-customization.json --namespace=fixtures.dpgcustomization --generate-send-request
+call autorest %PROTOCOL_ARGUMENTS% --input-file=%SWAGGER_PATH%/dpg-customization.json --namespace=fixtures.dpgcustomization --generate-send-request-method
 del protocol-tests\src\main\java\module-info.java
 
 rem Protocol resilience

--- a/generate.bat
+++ b/generate.bat
@@ -17,7 +17,7 @@ call autorest %VANILLA_ARGUMENTS% --input-file=%SWAGGER_PATH%/custom-baseUrl-mor
 call autorest %VANILLA_ARGUMENTS% --input-file=%SWAGGER_PATH%/head.json --namespace=fixtures.head
 call autorest %VANILLA_ARGUMENTS% --input-file=%SWAGGER_PATH%/head-exceptions.json --namespace=fixtures.headexceptions
 call autorest %VANILLA_ARGUMENTS% --input-file=%SWAGGER_PATH%/header.json --namespace=fixtures.header --context-client-method-parameter
-call autorest %VANILLA_ARGUMENTS% --input-file=%SWAGGER_PATH%/body-dictionary.json --namespace=fixtures.bodydictionary --generate-sync-async-clients
+call autorest %VANILLA_ARGUMENTS% --input-file=%SWAGGER_PATH%/body-dictionary.json --namespace=fixtures.bodydictionary --generate-sync-async-clients --generate-send-request
 call autorest %VANILLA_ARGUMENTS% --input-file=%SWAGGER_PATH%/body-duration.json --namespace=fixtures.bodyduration
 call autorest %VANILLA_ARGUMENTS% --input-file=%SWAGGER_PATH%/body-integer.json --namespace=fixtures.bodyinteger
 call autorest %VANILLA_ARGUMENTS% --input-file=%SWAGGER_PATH%/body-number.json --namespace=fixtures.bodynumber --disable-client-builder
@@ -80,7 +80,7 @@ call autorest %PROTOCOL_ARGUMENTS% --input-file=%SWAGGER_PATH%/url-multi-collect
 call autorest %PROTOCOL_ARGUMENTS% --input-file=%SWAGGER_PATH%/lro.json --namespace=fixtures.lro
 call autorest %PROTOCOL_ARGUMENTS% --input-file=%SWAGGER_PATH%/dpg_initial.json --namespace=fixtures.llcinitial
 call autorest %PROTOCOL_ARGUMENTS% --input-file=%SWAGGER_PATH%/dpg_update1.json --namespace=fixtures.llcupdate1
-call autorest %PROTOCOL_ARGUMENTS% --input-file=%SWAGGER_PATH%/dpg-customization.json --namespace=fixtures.dpgcustomization
+call autorest %PROTOCOL_ARGUMENTS% --input-file=%SWAGGER_PATH%/dpg-customization.json --namespace=fixtures.dpgcustomization --generate-send-request
 del protocol-tests\src\main\java\module-info.java
 
 rem Protocol resilience

--- a/generate.bat
+++ b/generate.bat
@@ -79,7 +79,7 @@ call autorest %PROTOCOL_ARGUMENTS% --input-file=%SWAGGER_PATH%/url.json --namesp
 call autorest %PROTOCOL_ARGUMENTS% --input-file=%SWAGGER_PATH%/url-multi-collectionFormat.json --namespace=fixtures.url.multi
 call autorest %PROTOCOL_ARGUMENTS% --input-file=%SWAGGER_PATH%/lro.json --namespace=fixtures.lro
 call autorest %PROTOCOL_ARGUMENTS% --input-file=%SWAGGER_PATH%/dpg_initial.json --namespace=fixtures.llcinitial
-call autorest %PROTOCOL_ARGUMENTS% --input-file=%SWAGGER_PATH%/dpg_update1.json --namespace=fixtures.llcupdate1
+call autorest %PROTOCOL_ARGUMENTS% --input-file=%SWAGGER_PATH%/dpg_update1.json --namespace=fixtures.llcupdate1 --generate-send-request-method
 call autorest %PROTOCOL_ARGUMENTS% --input-file=%SWAGGER_PATH%/dpg-customization.json --namespace=fixtures.dpgcustomization --generate-send-request-method
 del protocol-tests\src\main\java\module-info.java
 

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -762,18 +762,6 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
         }
     }
 
-    private static final ClientMethodParameter CONTEXT_PARAM = new ClientMethodParameter.Builder()
-            .description("The context to associate with this operation.")
-            .wireType(ClassType.Context)
-            .name("context")
-            .annotations(new ArrayList<>())
-            .isConstant(false)
-            .defaultValue(null)
-            .fromClient(false)
-            .isFinal(false)
-            .isRequired(false)
-            .build();
-
     private void addClientMethodWithContext(List<ClientMethod> methods, Builder builder, ProxyMethod proxyMethod,
         List<ClientMethodParameter> parameters, ClientMethodType clientMethodType, String proxyMethodName,
         ReturnValue returnValue, MethodPageDetails details) {
@@ -794,7 +782,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
     }
 
     protected ClientMethodParameter getContextParameter() {
-        return CONTEXT_PARAM;
+        return ClientMethodParameter.CONTEXT_PARAMETER;
     }
 
     private void addClientMethodWithContext(List<ClientMethod> methods, Builder builder,

--- a/javagen/src/main/java/com/azure/autorest/mapper/MethodGroupMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/MethodGroupMapper.java
@@ -119,6 +119,12 @@ public class MethodGroupMapper implements IMapper<OperationGroup, MethodGroupCli
         for (Operation operation : methodGroup.getOperations()) {
             clientMethods.addAll(Mappers.getClientMethodMapper().map(operation));
         }
+        if (settings.isGenerateSendRequestMethod()) {
+            clientMethods.add(ClientMethod.getAsyncSendRequestClientMethod(true));
+            if (settings.getSyncMethods() != JavaSettings.SyncMethodsGeneration.NONE) {
+                clientMethods.add(ClientMethod.getSyncSendRequestClientMethod(true));
+            }
+        }
         builder.clientMethods(clientMethods);
         builder.supportedInterfaces(supportedInterfaces(methodGroup, clientMethods));
 

--- a/javagen/src/main/java/com/azure/autorest/mapper/ServiceClientMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ServiceClientMapper.java
@@ -92,9 +92,9 @@ public class ServiceClientMapper implements IMapper<CodeModel, ServiceClient> {
                     .flatMap(m -> Mappers.getClientMethodMapper().map(m).stream())
                     .collect(Collectors.toList());
             if (settings.isGenerateSendRequestMethod()) {
-                clientMethods.add(ClientMethod.getAsyncSendRequestClientMethod(true));
+                clientMethods.add(ClientMethod.getAsyncSendRequestClientMethod(false));
                 if (settings.getSyncMethods() != JavaSettings.SyncMethodsGeneration.NONE) {
-                    clientMethods.add(ClientMethod.getSyncSendRequestClientMethod(true));
+                    clientMethods.add(ClientMethod.getSyncSendRequestClientMethod(false));
                 }
             }
             builder.clientMethods(clientMethods);

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClassType.java
@@ -6,6 +6,7 @@ package com.azure.autorest.model.clientmodel;
 
 import com.azure.autorest.extension.base.model.extensionmodel.XmsExtensions;
 import com.azure.autorest.extension.base.plugin.JavaSettings;
+import com.azure.core.http.HttpRequest;
 
 import java.util.Arrays;
 import java.util.List;
@@ -74,6 +75,7 @@ public class ClassType implements IType {
     public static final ClassType BinaryData = new ClassType.Builder().knownClass(com.azure.core.util.BinaryData.class).defaultValueExpressionConverter((String defaultValueExpression) -> java.lang.String.format("BinaryData.fromObject(\"%s\")", defaultValueExpression)).build();
     public static final ClassType RequestOptions = new Builder().packageName("com.azure.core.http.rest").name("RequestOptions").build();
     public static final ClassType ClientOptions = new Builder().knownClass(com.azure.core.util.ClientOptions.class).build();
+    public static final ClassType HttpRequest = new Builder().knownClass(com.azure.core.http.HttpRequest.class).build();
 
     // Java exception types
     public static final ClassType HttpResponseException = new Builder().knownClass(com.azure.core.exception.HttpResponseException.class).build();

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientMethod.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientMethod.java
@@ -387,7 +387,8 @@ public class ClientMethod {
             }
         }
 
-        if (type == ClientMethodType.SendRequestAsync || type == ClientMethodType.SendRequestSync) {
+        if (includeImplementationImports
+                && (type == ClientMethodType.SendRequestAsync || type == ClientMethodType.SendRequestSync)) {
             imports.add(SimpleResponse.class.getName());
             ClassType.BinaryData.addImportsTo(imports, false);
         }

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientMethod.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientMethod.java
@@ -397,7 +397,7 @@ public class ClientMethod {
     public static ClientMethod getAsyncSendRequestClientMethod(boolean isInMethodGroup) {
         return new Builder()
                 .name("sendRequestAsync")
-                .description("Wraps the {@code request} in a context and sends it through client.")
+                .description("Sends the {@code httpRequest}.")
                 .clientReference(isInMethodGroup ? "this.client" : "this")
                 .methodVisibility(JavaVisibility.Public)
                 .onlyRequiredParameters(false)
@@ -411,7 +411,7 @@ public class ClientMethod {
     public static ClientMethod getSyncSendRequestClientMethod(boolean isInMethodGroup) {
         return new Builder()
                 .name("sendRequest")
-                .description("Wraps the {@code request} in a context and sends it through client.")
+                .description("Sends the {@code httpRequest}.")
                 .clientReference(isInMethodGroup ? "this.client" : "this")
                 .methodVisibility(JavaVisibility.Public)
                 .onlyRequiredParameters(false)

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientMethodParameter.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientMethodParameter.java
@@ -5,7 +5,7 @@ package com.azure.autorest.model.clientmodel;
 
 import com.azure.autorest.extension.base.model.codemodel.RequestParameterLocation;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -19,7 +19,7 @@ public class ClientMethodParameter {
             .description("The context to associate with this operation.")
             .wireType(ClassType.Context)
             .name("context")
-            .annotations(new ArrayList<>())
+            .annotations(Collections.emptyList())
             .isConstant(false)
             .defaultValue(null)
             .fromClient(false)
@@ -31,7 +31,7 @@ public class ClientMethodParameter {
             .description("The HTTP request to send.")
             .wireType(ClassType.HttpRequest)
             .name("httpRequest")
-            .annotations(new ArrayList<>())
+            .annotations(Collections.emptyList())
             .isConstant(false)
             .defaultValue(null)
             .fromClient(false)

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientMethodParameter.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientMethodParameter.java
@@ -5,6 +5,7 @@ package com.azure.autorest.model.clientmodel;
 
 import com.azure.autorest.extension.base.model.codemodel.RequestParameterLocation;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -13,6 +14,31 @@ import java.util.stream.Collectors;
  * A parameter for a method.
  */
 public class ClientMethodParameter {
+
+    public static final ClientMethodParameter CONTEXT_PARAMETER = new ClientMethodParameter.Builder()
+            .description("The context to associate with this operation.")
+            .wireType(ClassType.Context)
+            .name("context")
+            .annotations(new ArrayList<>())
+            .isConstant(false)
+            .defaultValue(null)
+            .fromClient(false)
+            .isFinal(false)
+            .isRequired(false)
+            .build();
+
+    public static final ClientMethodParameter HTTP_REQUEST_PARAMETER = new ClientMethodParameter.Builder()
+            .description("The HTTP request to send.")
+            .wireType(ClassType.HttpRequest)
+            .name("httpRequest")
+            .annotations(new ArrayList<>())
+            .isConstant(false)
+            .defaultValue(null)
+            .fromClient(false)
+            .isFinal(false)
+            .isRequired(true)
+            .build();
+
     /**
      * The description of this parameter.
      */

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientMethodType.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientMethodType.java
@@ -24,7 +24,10 @@ public enum ClientMethodType {
     SimpleAsyncRestResponse(11),
     SimpleSyncRestResponse(12),
 
-    Resumable(13);
+    Resumable(13),
+
+    SendRequestSync(14),
+    SendRequestAsync(15);
 
     private static java.util.HashMap<Integer, ClientMethodType> mappings;
     private int intValue;

--- a/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
@@ -790,6 +790,7 @@ public class ClientMethodTemplate extends ClientMethodTemplateBase {
     }
 
     protected void generateSendRequestSync(ClientMethod clientMethod, JavaType typeBlock, JavaSettings settings) {
+        typeBlock.annotation("ServiceMethod(returns = ReturnType.SINGLE)");
         writeMethod(typeBlock, clientMethod.getMethodVisibility(), clientMethod.getDeclaration(), function -> {
             function.methodReturn("this.sendRequestAsync(httpRequest).contextWrite(c -> c.putAll(FluxUtil.toReactorContext(context).readOnly())).block()");
         });

--- a/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplateBase.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplateBase.java
@@ -36,42 +36,46 @@ public abstract class ClientMethodTemplateBase implements IJavaTemplate<ClientMe
     protected static void generateProtocolMethodJavadoc(ClientMethod clientMethod, JavaJavadocComment commentBlock) {
         commentBlock.description(clientMethod.getDescription());
 
-        List<ProxyMethodParameter> queryParameters = clientMethod.getProxyMethod().getAllParameters()
-                .stream().filter(p -> RequestParameterLocation.QUERY.equals(p.getRequestParameterLocation()))
-                .collect(Collectors.toList());
-        if (!queryParameters.isEmpty()) {
-            optionalParametersJavadoc("Query Parameters", queryParameters, commentBlock);
-        }
+        if (clientMethod.getProxyMethod() != null) {
+            List<ProxyMethodParameter> queryParameters = clientMethod.getProxyMethod().getAllParameters()
+                    .stream().filter(p -> RequestParameterLocation.QUERY.equals(p.getRequestParameterLocation()))
+                    .collect(Collectors.toList());
+            if (!queryParameters.isEmpty()) {
+                optionalParametersJavadoc("Query Parameters", queryParameters, commentBlock);
+            }
 
-        List<ProxyMethodParameter> headerParameters = clientMethod.getProxyMethod().getAllParameters()
-                .stream().filter(p -> !p.getName().equals("accept") && RequestParameterLocation.HEADER.equals(p.getRequestParameterLocation()))
-                .collect(Collectors.toList());
-        if (!headerParameters.isEmpty()) {
-            optionalParametersJavadoc("Header Parameters", headerParameters, commentBlock);
-        }
+            List<ProxyMethodParameter> headerParameters = clientMethod.getProxyMethod().getAllParameters()
+                    .stream().filter(p -> !p.getName().equals("accept") && RequestParameterLocation.HEADER.equals(p.getRequestParameterLocation()))
+                    .collect(Collectors.toList());
+            if (!headerParameters.isEmpty()) {
+                optionalParametersJavadoc("Header Parameters", headerParameters, commentBlock);
+            }
 
-        // Request body
-        Set<IType> typesInJavadoc = new HashSet<>();
+            // Request body
+            Set<IType> typesInJavadoc = new HashSet<>();
 
-        clientMethod.getProxyMethod().getAllParameters()
-                .stream().filter(p -> RequestParameterLocation.BODY.equals(p.getRequestParameterLocation()))
-                .map(ProxyMethodParameter::getRawType)
-                .findFirst()
-                .ifPresent(type -> requestBodySchemaJavadoc(type, commentBlock, typesInJavadoc));
+            clientMethod.getProxyMethod().getAllParameters()
+                    .stream().filter(p -> RequestParameterLocation.BODY.equals(p.getRequestParameterLocation()))
+                    .map(ProxyMethodParameter::getRawType)
+                    .findFirst()
+                    .ifPresent(type -> requestBodySchemaJavadoc(type, commentBlock, typesInJavadoc));
 
-        // Response body
-        IType responseBodyType;
-        if (JavaSettings.getInstance().isLowLevelClient()) {
-            responseBodyType = clientMethod.getProxyMethod().getRawResponseBodyType();
-        } else {
-            responseBodyType = clientMethod.getProxyMethod().getResponseBodyType();
-        }
-        if (responseBodyType != null && !responseBodyType.equals(PrimitiveType.Void)) {
-            responseBodySchemaJavadoc(responseBodyType, commentBlock, typesInJavadoc);
+            // Response body
+            IType responseBodyType;
+            if (JavaSettings.getInstance().isLowLevelClient()) {
+                responseBodyType = clientMethod.getProxyMethod().getRawResponseBodyType();
+            } else {
+                responseBodyType = clientMethod.getProxyMethod().getResponseBodyType();
+            }
+            if (responseBodyType != null && !responseBodyType.equals(PrimitiveType.Void)) {
+                responseBodySchemaJavadoc(responseBodyType, commentBlock, typesInJavadoc);
+            }
         }
 
         clientMethod.getParameters().forEach(p -> commentBlock.param(p.getName(), methodParameterDescriptionOrDefault(p)));
-        generateJavadocExceptions(clientMethod, commentBlock, false);
+        if (clientMethod.getProxyMethod() != null) {
+            generateJavadocExceptions(clientMethod, commentBlock, false);
+        }
         commentBlock.methodReturns(clientMethod.getReturnValue().getDescription());
     }
 

--- a/javagen/src/main/java/com/azure/autorest/template/WrapperClientMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/WrapperClientMethodTemplate.java
@@ -91,11 +91,13 @@ public class WrapperClientMethodTemplate extends ClientMethodTemplateBase {
             if (clientMethod.getParametersDeclaration() != null && !clientMethod.getParametersDeclaration().isEmpty()) {
                 comment.methodThrows("IllegalArgumentException", "thrown if parameters fail the validation");
             }
-            if (restAPIMethod.getUnexpectedResponseExceptionType() != null) {
-                comment.methodThrows(restAPIMethod.getUnexpectedResponseExceptionType().toString(),
-                        "thrown if the request is rejected by server");
+            if (restAPIMethod != null) {
+                if (restAPIMethod.getUnexpectedResponseExceptionType() != null) {
+                    comment.methodThrows(restAPIMethod.getUnexpectedResponseExceptionType().toString(),
+                            "thrown if the request is rejected by server");
+                }
+                comment.methodThrows("RuntimeException", "all other wrapped checked exceptions if the request fails to be sent");
             }
-            comment.methodThrows("RuntimeException", "all other wrapped checked exceptions if the request fails to be sent");
             comment.methodReturns(clientMethod.getReturnValue().getDescription());
         });
     }

--- a/protocol-tests/src/main/java/fixtures/dpgcustomization/DpgAsyncClient.java
+++ b/protocol-tests/src/main/java/fixtures/dpgcustomization/DpgAsyncClient.java
@@ -9,6 +9,7 @@ import com.azure.core.annotation.ReturnType;
 import com.azure.core.annotation.ServiceClient;
 import com.azure.core.annotation.ServiceMethod;
 import com.azure.core.exception.HttpResponseException;
+import com.azure.core.http.HttpRequest;
 import com.azure.core.http.rest.PagedFlux;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
@@ -167,5 +168,17 @@ public final class DpgAsyncClient {
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
     public PollerFlux<BinaryData, BinaryData> beginLro(String mode, RequestOptions requestOptions) {
         return this.serviceClient.beginLroAsync(mode, requestOptions);
+    }
+
+    /**
+     * Wraps the {@code request} in a context and sends it through client.
+     *
+     * @param httpRequest The HTTP request to send.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BinaryData>> sendRequest(HttpRequest httpRequest) {
+        return this.serviceClient.sendRequestAsync(httpRequest);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/dpgcustomization/DpgAsyncClient.java
+++ b/protocol-tests/src/main/java/fixtures/dpgcustomization/DpgAsyncClient.java
@@ -171,7 +171,7 @@ public final class DpgAsyncClient {
     }
 
     /**
-     * Wraps the {@code request} in a context and sends it through client.
+     * Sends the {@code httpRequest}.
      *
      * @param httpRequest The HTTP request to send.
      * @return the response body on successful completion of {@link Mono}.

--- a/protocol-tests/src/main/java/fixtures/dpgcustomization/DpgClient.java
+++ b/protocol-tests/src/main/java/fixtures/dpgcustomization/DpgClient.java
@@ -145,7 +145,7 @@ public final class DpgClient {
     }
 
     /**
-     * Wraps the {@code request} in a context and sends it through client.
+     * Sends the {@code httpRequest}.
      *
      * @param httpRequest The HTTP request to send.
      * @param context The context to associate with this operation.

--- a/protocol-tests/src/main/java/fixtures/dpgcustomization/DpgClient.java
+++ b/protocol-tests/src/main/java/fixtures/dpgcustomization/DpgClient.java
@@ -9,10 +9,12 @@ import com.azure.core.annotation.ReturnType;
 import com.azure.core.annotation.ServiceClient;
 import com.azure.core.annotation.ServiceMethod;
 import com.azure.core.exception.HttpResponseException;
+import com.azure.core.http.HttpRequest;
 import com.azure.core.http.rest.PagedIterable;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.Context;
 import com.azure.core.util.polling.SyncPoller;
 import fixtures.dpgcustomization.implementation.DpgClientImpl;
 
@@ -140,5 +142,18 @@ public final class DpgClient {
     @ServiceMethod(returns = ReturnType.LONG_RUNNING_OPERATION)
     public SyncPoller<BinaryData, BinaryData> beginLro(String mode, RequestOptions requestOptions) {
         return this.serviceClient.beginLro(mode, requestOptions);
+    }
+
+    /**
+     * Wraps the {@code request} in a context and sends it through client.
+     *
+     * @param httpRequest The HTTP request to send.
+     * @param context The context to associate with this operation.
+     * @return the response body along with {@link Response}.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<BinaryData> sendRequest(HttpRequest httpRequest, Context context) {
+        return this.serviceClient.sendRequest(httpRequest, context);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/dpgcustomization/implementation/DpgClientImpl.java
+++ b/protocol-tests/src/main/java/fixtures/dpgcustomization/implementation/DpgClientImpl.java
@@ -712,7 +712,7 @@ public final class DpgClientImpl {
     }
 
     /**
-     * Wraps the {@code request} in a context and sends it through client.
+     * Sends the {@code httpRequest}.
      *
      * @param httpRequest The HTTP request to send.
      * @return the response body on successful completion of {@link Mono}.
@@ -734,7 +734,7 @@ public final class DpgClientImpl {
     }
 
     /**
-     * Wraps the {@code request} in a context and sends it through client.
+     * Sends the {@code httpRequest}.
      *
      * @param httpRequest The HTTP request to send.
      * @param context The context to associate with this operation.

--- a/protocol-tests/src/main/java/fixtures/dpgcustomization/implementation/DpgClientImpl.java
+++ b/protocol-tests/src/main/java/fixtures/dpgcustomization/implementation/DpgClientImpl.java
@@ -742,6 +742,7 @@ public final class DpgClientImpl {
      * @param context The context to associate with this operation.
      * @return the response body along with {@link Response}.
      */
+    @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<BinaryData> sendRequest(HttpRequest httpRequest, Context context) {
         return this.sendRequestAsync(httpRequest)
                 .contextWrite(c -> c.putAll(FluxUtil.toReactorContext(context).readOnly()))

--- a/protocol-tests/src/main/java/fixtures/llcupdate1/DpgAsyncClient.java
+++ b/protocol-tests/src/main/java/fixtures/llcupdate1/DpgAsyncClient.java
@@ -9,6 +9,7 @@ import com.azure.core.annotation.ReturnType;
 import com.azure.core.annotation.ServiceClient;
 import com.azure.core.annotation.ServiceMethod;
 import com.azure.core.exception.HttpResponseException;
+import com.azure.core.http.HttpRequest;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
@@ -207,5 +208,17 @@ public final class DpgAsyncClient {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<BinaryData>> getNewOperationWithResponse(RequestOptions requestOptions) {
         return this.serviceClient.getNewOperationWithResponseAsync(requestOptions);
+    }
+
+    /**
+     * Wraps the {@code request} in a context and sends it through client.
+     *
+     * @param httpRequest The HTTP request to send.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BinaryData>> sendRequest(HttpRequest httpRequest) {
+        return this.serviceClient.sendRequestAsync(httpRequest);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/llcupdate1/DpgAsyncClient.java
+++ b/protocol-tests/src/main/java/fixtures/llcupdate1/DpgAsyncClient.java
@@ -211,7 +211,7 @@ public final class DpgAsyncClient {
     }
 
     /**
-     * Wraps the {@code request} in a context and sends it through client.
+     * Sends the {@code httpRequest}.
      *
      * @param httpRequest The HTTP request to send.
      * @return the response body on successful completion of {@link Mono}.

--- a/protocol-tests/src/main/java/fixtures/llcupdate1/DpgClient.java
+++ b/protocol-tests/src/main/java/fixtures/llcupdate1/DpgClient.java
@@ -9,9 +9,11 @@ import com.azure.core.annotation.ReturnType;
 import com.azure.core.annotation.ServiceClient;
 import com.azure.core.annotation.ServiceMethod;
 import com.azure.core.exception.HttpResponseException;
+import com.azure.core.http.HttpRequest;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.Context;
 import fixtures.llcupdate1.implementation.ParamsImpl;
 
 /** Initializes a new instance of the synchronous DpgClient type. */
@@ -206,5 +208,18 @@ public final class DpgClient {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<BinaryData> getNewOperationWithResponse(RequestOptions requestOptions) {
         return this.serviceClient.getNewOperationWithResponse(requestOptions);
+    }
+
+    /**
+     * Wraps the {@code request} in a context and sends it through client.
+     *
+     * @param httpRequest The HTTP request to send.
+     * @param context The context to associate with this operation.
+     * @return the response body along with {@link Response}.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<BinaryData> sendRequest(HttpRequest httpRequest, Context context) {
+        return this.serviceClient.sendRequest(httpRequest, context);
     }
 }

--- a/protocol-tests/src/main/java/fixtures/llcupdate1/DpgClient.java
+++ b/protocol-tests/src/main/java/fixtures/llcupdate1/DpgClient.java
@@ -211,7 +211,7 @@ public final class DpgClient {
     }
 
     /**
-     * Wraps the {@code request} in a context and sends it through client.
+     * Sends the {@code httpRequest}.
      *
      * @param httpRequest The HTTP request to send.
      * @param context The context to associate with this operation.

--- a/protocol-tests/src/main/java/fixtures/llcupdate1/implementation/ParamsImpl.java
+++ b/protocol-tests/src/main/java/fixtures/llcupdate1/implementation/ParamsImpl.java
@@ -628,19 +628,21 @@ public final class ParamsImpl {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Response<BinaryData>> sendRequestAsync(HttpRequest httpRequest) {
-        return this.client
-                .getHttpPipeline()
-                .send(httpRequest)
-                .flatMap(
-                        response ->
-                                BinaryData.fromFlux(response.getBody())
-                                        .map(
-                                                body ->
-                                                        new SimpleResponse<>(
-                                                                response.getRequest(),
-                                                                response.getStatusCode(),
-                                                                response.getHeaders(),
-                                                                body)));
+        return FluxUtil.withContext(
+                context ->
+                        this.client
+                                .getHttpPipeline()
+                                .send(httpRequest, context)
+                                .flatMap(
+                                        response ->
+                                                BinaryData.fromFlux(response.getBody())
+                                                        .map(
+                                                                body ->
+                                                                        new SimpleResponse<>(
+                                                                                response.getRequest(),
+                                                                                response.getStatusCode(),
+                                                                                response.getHeaders(),
+                                                                                body))));
     }
 
     /**
@@ -651,19 +653,8 @@ public final class ParamsImpl {
      * @return the response body along with {@link Response}.
      */
     public Response<BinaryData> sendRequest(HttpRequest httpRequest, Context context) {
-        return this.client
-                .getHttpPipeline()
-                .send(httpRequest, context)
-                .flatMap(
-                        response ->
-                                BinaryData.fromFlux(response.getBody())
-                                        .map(
-                                                body ->
-                                                        new SimpleResponse<>(
-                                                                response.getRequest(),
-                                                                response.getStatusCode(),
-                                                                response.getHeaders(),
-                                                                body)))
+        return this.sendRequestAsync(httpRequest)
+                .contextWrite(c -> c.putAll(FluxUtil.toReactorContext(context).readOnly()))
                 .block();
     }
 }

--- a/protocol-tests/src/main/java/fixtures/llcupdate1/implementation/ParamsImpl.java
+++ b/protocol-tests/src/main/java/fixtures/llcupdate1/implementation/ParamsImpl.java
@@ -621,7 +621,7 @@ public final class ParamsImpl {
     }
 
     /**
-     * Wraps the {@code request} in a context and sends it through client.
+     * Sends the {@code httpRequest}.
      *
      * @param httpRequest The HTTP request to send.
      * @return the response body on successful completion of {@link Mono}.
@@ -644,7 +644,7 @@ public final class ParamsImpl {
     }
 
     /**
-     * Wraps the {@code request} in a context and sends it through client.
+     * Sends the {@code httpRequest}.
      *
      * @param httpRequest The HTTP request to send.
      * @param context The context to associate with this operation.

--- a/protocol-tests/src/main/java/fixtures/llcupdate1/implementation/ParamsImpl.java
+++ b/protocol-tests/src/main/java/fixtures/llcupdate1/implementation/ParamsImpl.java
@@ -17,9 +17,11 @@ import com.azure.core.annotation.ReturnType;
 import com.azure.core.annotation.ServiceInterface;
 import com.azure.core.annotation.ServiceMethod;
 import com.azure.core.exception.HttpResponseException;
+import com.azure.core.http.HttpRequest;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.http.rest.RestProxy;
+import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
 import com.azure.core.util.Context;
 import com.azure.core.util.FluxUtil;
@@ -616,5 +618,52 @@ public final class ParamsImpl {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<BinaryData> getNewOperationWithResponse(RequestOptions requestOptions) {
         return getNewOperationWithResponseAsync(requestOptions).block();
+    }
+
+    /**
+     * Wraps the {@code request} in a context and sends it through client.
+     *
+     * @param httpRequest The HTTP request to send.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BinaryData>> sendRequestAsync(HttpRequest httpRequest) {
+        return this.client
+                .getHttpPipeline()
+                .send(httpRequest)
+                .flatMap(
+                        response ->
+                                BinaryData.fromFlux(response.getBody())
+                                        .map(
+                                                body ->
+                                                        new SimpleResponse<>(
+                                                                response.getRequest(),
+                                                                response.getStatusCode(),
+                                                                response.getHeaders(),
+                                                                body)));
+    }
+
+    /**
+     * Wraps the {@code request} in a context and sends it through client.
+     *
+     * @param httpRequest The HTTP request to send.
+     * @param context The context to associate with this operation.
+     * @return the response body along with {@link Response}.
+     */
+    public Response<BinaryData> sendRequest(HttpRequest httpRequest, Context context) {
+        return this.client
+                .getHttpPipeline()
+                .send(httpRequest, context)
+                .flatMap(
+                        response ->
+                                BinaryData.fromFlux(response.getBody())
+                                        .map(
+                                                body ->
+                                                        new SimpleResponse<>(
+                                                                response.getRequest(),
+                                                                response.getStatusCode(),
+                                                                response.getHeaders(),
+                                                                body)))
+                .block();
     }
 }

--- a/protocol-tests/src/main/java/fixtures/llcupdate1/implementation/ParamsImpl.java
+++ b/protocol-tests/src/main/java/fixtures/llcupdate1/implementation/ParamsImpl.java
@@ -652,6 +652,7 @@ public final class ParamsImpl {
      * @param context The context to associate with this operation.
      * @return the response body along with {@link Response}.
      */
+    @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<BinaryData> sendRequest(HttpRequest httpRequest, Context context) {
         return this.sendRequestAsync(httpRequest)
                 .contextWrite(c -> c.putAll(FluxUtil.toReactorContext(context).readOnly()))

--- a/protocol-tests/src/test/java/fixtures/dpgcustomization/DpgCustomizationTests.java
+++ b/protocol-tests/src/test/java/fixtures/dpgcustomization/DpgCustomizationTests.java
@@ -3,9 +3,12 @@
 
 package fixtures.dpgcustomization;
 
+import com.azure.core.http.HttpMethod;
+import com.azure.core.http.HttpRequest;
 import com.azure.core.http.rest.PagedIterable;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.Context;
 import com.azure.core.util.polling.LongRunningOperationStatus;
 import com.azure.core.util.polling.PollResponse;
 import com.azure.core.util.polling.SyncPoller;
@@ -25,10 +28,12 @@ import java.util.stream.Collectors;
 public class DpgCustomizationTests {
 
     private static DpgClient client;
+    private static DpgAsyncClient asyncClient;
 
     @BeforeAll
     public static void setup() {
         client = new DpgClientBuilder().buildClient();
+        asyncClient = new DpgClientBuilder().buildAsyncClient();
     }
 
     @Test
@@ -138,5 +143,21 @@ public class DpgCustomizationTests {
         public void cancelOperation() {
             poller.cancelOperation();
         }
+    }
+
+    @Test
+    public void testSendRequestMethod() {
+        HttpRequest request = new HttpRequest(HttpMethod.GET, "http://localhost:3000/customization/model/raw");
+        Response<BinaryData> response = client.sendRequest(request, Context.NONE);
+        Assertions.assertEquals(200, response.getStatusCode());
+        Map<String, String> rawModel = (Map<String, String>) response.getValue().toObject(Object.class);
+        Assertions.assertTrue(rawModel.containsKey("received"));
+        Assertions.assertEquals("raw", rawModel.get("received"));
+
+        response = asyncClient.sendRequest(request).block();
+        Assertions.assertEquals(200, response.getStatusCode());
+        rawModel = (Map<String, String>) response.getValue().toObject(Object.class);
+        Assertions.assertTrue(rawModel.containsKey("received"));
+        Assertions.assertEquals("raw", rawModel.get("received"));
     }
 }

--- a/protocol-tests/src/test/java/fixtures/dpgcustomization/DpgSendRequestTests.java
+++ b/protocol-tests/src/test/java/fixtures/dpgcustomization/DpgSendRequestTests.java
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package fixtures.dpgcustomization;
+
+import com.azure.core.http.HttpHeaders;
+import com.azure.core.http.HttpMethod;
+import com.azure.core.http.HttpRequest;
+import com.azure.core.http.policy.AddHeadersFromContextPolicy;
+import com.azure.core.http.rest.Response;
+import com.azure.core.util.BinaryData;
+import com.azure.core.util.Context;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.UUID;
+
+public class DpgSendRequestTests {
+
+    private static DpgClient client;
+    private static DpgAsyncClient asyncClient;
+
+    @BeforeAll
+    public static void setup() {
+        client = new DpgClientBuilder()
+                .addPolicy(new AddHeadersFromContextPolicy())
+                .buildClient();
+        asyncClient = new DpgClientBuilder()
+                .addPolicy(new AddHeadersFromContextPolicy())
+                .buildAsyncClient();
+    }
+
+    @Test
+    public void testSendRequestMethodWithContext() {
+        String requestIdKey = "x-ms-client-request-id";
+        String requestIdValue = UUID.randomUUID().toString();
+        HttpHeaders requestHeaders = new HttpHeaders().set(requestIdKey, requestIdValue);
+
+        HttpRequest request = new HttpRequest(HttpMethod.GET, "https://httpbin.org/headers");
+        Response<BinaryData> response = client.sendRequest(request,
+                new Context(AddHeadersFromContextPolicy.AZURE_REQUEST_HTTP_HEADERS_KEY, requestHeaders));
+        Assertions.assertEquals(200, response.getStatusCode());
+        Map<String, Object> responseJson = (Map<String, Object>) response.getValue().toObject(Object.class);
+        Map<String, String> headersJson = (Map<String, String>) responseJson.get("headers");
+        String requestIdKeyInResponse = headersJson.keySet().stream()
+                .filter(requestIdKey::equalsIgnoreCase)
+                .findFirst().get();
+        Assertions.assertEquals(requestIdValue, headersJson.get(requestIdKeyInResponse));
+
+        response = asyncClient.sendRequest(request)
+                .contextWrite(context -> context.put(AddHeadersFromContextPolicy.AZURE_REQUEST_HTTP_HEADERS_KEY, requestHeaders)).block();
+        Assertions.assertEquals(200, response.getStatusCode());
+        responseJson = (Map<String, Object>) response.getValue().toObject(Object.class);
+        headersJson = (Map<String, String>) responseJson.get("headers");
+        Assertions.assertEquals(requestIdValue, headersJson.get(requestIdKeyInResponse));
+    }
+}

--- a/protocol-tests/src/test/java/fixtures/dpgupdate/DpgUpdateTests.java
+++ b/protocol-tests/src/test/java/fixtures/dpgupdate/DpgUpdateTests.java
@@ -1,8 +1,11 @@
 package fixtures.dpgupdate;
 
+import com.azure.core.http.HttpMethod;
+import com.azure.core.http.HttpRequest;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.Context;
 import fixtures.llcinitial.DpgAsyncClient;
 import fixtures.llcinitial.DpgClient;
 import fixtures.llcinitial.DpgClientBuilder;
@@ -10,6 +13,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+
+import java.util.Map;
 
 public class DpgUpdateTests {
     private static DpgAsyncClient asyncClient;
@@ -113,5 +118,18 @@ public class DpgUpdateTests {
 
         Response<BinaryData> response = client2.getNewOperationWithResponse(requestOptions);
         Assertions.assertEquals(200, response.getStatusCode());
+    }
+
+
+    @Test
+    public void testSendRequestMethod() {
+        HttpRequest request = new HttpRequest(HttpMethod.DELETE, "http://localhost:3000/serviceDriven/parameters");
+        Response<BinaryData> response = client2.sendRequest(request, Context.NONE);
+        Assertions.assertEquals(204, response.getStatusCode());
+        Assertions.assertEquals(0, response.getValue().getLength());
+
+        response = asyncClient2.sendRequest(request).block();
+        Assertions.assertEquals(204, response.getStatusCode());
+        Assertions.assertEquals(0, response.getValue().getLength());
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodydictionary/AutoRestSwaggerBATDictionaryServiceAsyncClient.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydictionary/AutoRestSwaggerBATDictionaryServiceAsyncClient.java
@@ -1902,7 +1902,7 @@ public final class AutoRestSwaggerBATDictionaryServiceAsyncClient {
     }
 
     /**
-     * Wraps the {@code request} in a context and sends it through client.
+     * Sends the {@code httpRequest}.
      *
      * @param httpRequest The HTTP request to send.
      * @throws IllegalArgumentException thrown if parameters fail the validation.

--- a/vanilla-tests/src/main/java/fixtures/bodydictionary/AutoRestSwaggerBATDictionaryServiceAsyncClient.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydictionary/AutoRestSwaggerBATDictionaryServiceAsyncClient.java
@@ -8,7 +8,9 @@ import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.ReturnType;
 import com.azure.core.annotation.ServiceClient;
 import com.azure.core.annotation.ServiceMethod;
+import com.azure.core.http.HttpRequest;
 import com.azure.core.http.rest.Response;
+import com.azure.core.util.BinaryData;
 import fixtures.bodydictionary.implementation.DictionariesImpl;
 import fixtures.bodydictionary.models.ErrorException;
 import fixtures.bodydictionary.models.Widget;
@@ -1897,5 +1899,18 @@ public final class AutoRestSwaggerBATDictionaryServiceAsyncClient {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Void> putDictionaryValid(Map<String, Map<String, String>> arrayBody) {
         return this.serviceClient.putDictionaryValidAsync(arrayBody);
+    }
+
+    /**
+     * Wraps the {@code request} in a context and sends it through client.
+     *
+     * @param httpRequest The HTTP request to send.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BinaryData>> sendRequest(HttpRequest httpRequest) {
+        return this.serviceClient.sendRequestAsync(httpRequest);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodydictionary/AutoRestSwaggerBATDictionaryServiceClient.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydictionary/AutoRestSwaggerBATDictionaryServiceClient.java
@@ -8,6 +8,10 @@ import com.azure.core.annotation.Generated;
 import com.azure.core.annotation.ReturnType;
 import com.azure.core.annotation.ServiceClient;
 import com.azure.core.annotation.ServiceMethod;
+import com.azure.core.http.HttpRequest;
+import com.azure.core.http.rest.Response;
+import com.azure.core.util.BinaryData;
+import com.azure.core.util.Context;
 import fixtures.bodydictionary.implementation.DictionariesImpl;
 import fixtures.bodydictionary.models.ErrorException;
 import fixtures.bodydictionary.models.Widget;
@@ -921,5 +925,19 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDictionaryValid(Map<String, Map<String, String>> arrayBody) {
         this.serviceClient.putDictionaryValid(arrayBody);
+    }
+
+    /**
+     * Wraps the {@code request} in a context and sends it through client.
+     *
+     * @param httpRequest The HTTP request to send.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @return the response body along with {@link Response}.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<BinaryData> sendRequest(HttpRequest httpRequest, Context context) {
+        return this.serviceClient.sendRequest(httpRequest, context);
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodydictionary/AutoRestSwaggerBATDictionaryServiceClient.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydictionary/AutoRestSwaggerBATDictionaryServiceClient.java
@@ -928,7 +928,7 @@ public final class AutoRestSwaggerBATDictionaryServiceClient {
     }
 
     /**
-     * Wraps the {@code request} in a context and sends it through client.
+     * Sends the {@code httpRequest}.
      *
      * @param httpRequest The HTTP request to send.
      * @param context The context to associate with this operation.

--- a/vanilla-tests/src/main/java/fixtures/bodydictionary/implementation/DictionariesImpl.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydictionary/implementation/DictionariesImpl.java
@@ -16,9 +16,12 @@ import com.azure.core.annotation.ReturnValueWireType;
 import com.azure.core.annotation.ServiceInterface;
 import com.azure.core.annotation.ServiceMethod;
 import com.azure.core.annotation.UnexpectedResponseExceptionType;
+import com.azure.core.http.HttpRequest;
 import com.azure.core.http.rest.Response;
 import com.azure.core.http.rest.RestProxy;
+import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.Base64Url;
+import com.azure.core.util.BinaryData;
 import com.azure.core.util.Context;
 import com.azure.core.util.DateTimeRfc1123;
 import com.azure.core.util.FluxUtil;
@@ -3852,5 +3855,54 @@ public final class DictionariesImpl {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void putDictionaryValid(Map<String, Map<String, String>> arrayBody) {
         putDictionaryValidAsync(arrayBody).block();
+    }
+
+    /**
+     * Wraps the {@code request} in a context and sends it through client.
+     *
+     * @param httpRequest The HTTP request to send.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BinaryData>> sendRequestAsync(HttpRequest httpRequest) {
+        return this.client
+                .getHttpPipeline()
+                .send(httpRequest)
+                .flatMap(
+                        response ->
+                                BinaryData.fromFlux(response.getBody())
+                                        .map(
+                                                body ->
+                                                        new SimpleResponse<>(
+                                                                response.getRequest(),
+                                                                response.getStatusCode(),
+                                                                response.getHeaders(),
+                                                                body)));
+    }
+
+    /**
+     * Wraps the {@code request} in a context and sends it through client.
+     *
+     * @param httpRequest The HTTP request to send.
+     * @param context The context to associate with this operation.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body along with {@link Response}.
+     */
+    public Response<BinaryData> sendRequest(HttpRequest httpRequest, Context context) {
+        return this.client
+                .getHttpPipeline()
+                .send(httpRequest, context)
+                .flatMap(
+                        response ->
+                                BinaryData.fromFlux(response.getBody())
+                                        .map(
+                                                body ->
+                                                        new SimpleResponse<>(
+                                                                response.getRequest(),
+                                                                response.getStatusCode(),
+                                                                response.getHeaders(),
+                                                                body)))
+                .block();
     }
 }

--- a/vanilla-tests/src/main/java/fixtures/bodydictionary/implementation/DictionariesImpl.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydictionary/implementation/DictionariesImpl.java
@@ -3858,7 +3858,7 @@ public final class DictionariesImpl {
     }
 
     /**
-     * Wraps the {@code request} in a context and sends it through client.
+     * Sends the {@code httpRequest}.
      *
      * @param httpRequest The HTTP request to send.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -3882,7 +3882,7 @@ public final class DictionariesImpl {
     }
 
     /**
-     * Wraps the {@code request} in a context and sends it through client.
+     * Sends the {@code httpRequest}.
      *
      * @param httpRequest The HTTP request to send.
      * @param context The context to associate with this operation.

--- a/vanilla-tests/src/main/java/fixtures/bodydictionary/implementation/DictionariesImpl.java
+++ b/vanilla-tests/src/main/java/fixtures/bodydictionary/implementation/DictionariesImpl.java
@@ -3891,6 +3891,7 @@ public final class DictionariesImpl {
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link Response}.
      */
+    @ServiceMethod(returns = ReturnType.SINGLE)
     public Response<BinaryData> sendRequest(HttpRequest httpRequest, Context context) {
         return this.sendRequestAsync(httpRequest)
                 .contextWrite(c -> c.putAll(FluxUtil.toReactorContext(context).readOnly()))


### PR DESCRIPTION
Fix https://github.com/Azure/autorest.java/issues/1356

- code https://github.com/Azure/autorest.java/commit/f036597657d52ba9a7177afb409538c2f22faa11
- example https://github.com/Azure/autorest.java/pull/1363/commits/54d095e4695f2ff86bb930c56f58c9e026d2d12f
- test https://github.com/Azure/autorest.java/commit/f68d6d4fcf2adbbb00ca76eb321f2a811bc838e0

Client
```java
    /**
     * Sends the {@code httpRequest}.
     *
     * @param httpRequest The HTTP request to send.
     * @param context The context to associate with this operation.
     * @return the response body along with {@link Response}.
     */
    @Generated
    @ServiceMethod(returns = ReturnType.SINGLE)
    public Response<BinaryData> sendRequest(HttpRequest httpRequest, Context context) {
        return this.serviceClient.sendRequest(httpRequest, context);
    }
```

Implementation
```java
    /**
     * Sends the {@code httpRequest}.
     *
     * @param httpRequest The HTTP request to send.
     * @return the response body on successful completion of {@link Mono}.
     */
    @ServiceMethod(returns = ReturnType.SINGLE)
    public Mono<Response<BinaryData>> sendRequestAsync(HttpRequest httpRequest) {
        return FluxUtil.withContext(
                context ->
                        this.getHttpPipeline()
                                .send(httpRequest, context)
                                .flatMap(
                                        response ->
                                                BinaryData.fromFlux(response.getBody())
                                                        .map(
                                                                body ->
                                                                        new SimpleResponse<>(
                                                                                response.getRequest(),
                                                                                response.getStatusCode(),
                                                                                response.getHeaders(),
                                                                                body))));
    }

    /**
     * Sends the {@code httpRequest}.
     *
     * @param httpRequest The HTTP request to send.
     * @param context The context to associate with this operation.
     * @return the response body along with {@link Response}.
     */
    @ServiceMethod(returns = ReturnType.SINGLE)
    public Response<BinaryData> sendRequest(HttpRequest httpRequest, Context context) {
        return this.sendRequestAsync(httpRequest)
                .contextWrite(c -> c.putAll(FluxUtil.toReactorContext(context).readOnly()))
                .block();
    }
```