### PR TITLE
dpg, prepare smoke tests

### DIFF
--- a/protocol-sdk-integration-tests/data-specs.json
+++ b/protocol-sdk-integration-tests/data-specs.json
@@ -17,5 +17,46 @@
     "security": "AzureKey",
     "security-header-name": "Ocp-Apim-Subscription-Key",
     "required": true
+  },
+  "purview-metadata": {
+    "input": [
+      "https://github.com/Azure/azure-rest-api-specs/blob/main/specification/purview/data-plane/Azure.Analytics.Purview.MetadataPolicies/preview/2021-07-01-preview/purviewMetadataPolicy.json"
+    ],
+    "group": "purview",
+    "module": "azure-analytics-purview-metadata",
+    "security-scopes": "https://purview.azure.net/.default"
+  },
+  "purview-catalog": {
+    "input": [
+      "https://github.com/Azure/azure-rest-api-specs/blob/main/specification/purview/data-plane/Azure.Analytics.Purview.Catalog/preview/2021-05-01-preview/purviewcatalog.json"
+    ],
+    "group": "purview",
+    "module": "azure-analytics-purview-catalog",
+    "security-scopes": "https://purview.azure.net/.default"
+  },
+  "purview-scanning": {
+    "input": [
+      "https://github.com/Azure/azure-rest-api-specs/blob/main/specification/purview/data-plane/Azure.Analytics.Purview.Scanning/preview/2018-12-01-preview/scanningService.json"
+    ],
+    "group": "purview",
+    "module": "azure-analytics-purview-scanning",
+    "security-scopes": "https://purview.azure.net/.default"
+  },
+  "deviceupdate": {
+    "input": [
+      "https://github.com/Azure/azure-rest-api-specs/blob/main/specification/deviceupdate/data-plane/Microsoft.DeviceUpdate/preview/2021-06-01-preview/deviceupdate.json"
+    ],
+    "group": "deviceupdate",
+    "module": "azure-iot-deviceupdate",
+    "security-scopes": "https://api.adu.microsoft.com/.default"
+  },
+  "webpubsub": {
+    "input": [
+      "https://github.com/Azure/azure-rest-api-specs/blob/main/specification/webpubsub/data-plane/WebPubSub/stable/2021-10-01/webpubsub.json"
+    ],
+    "group": "webpubsub",
+    "module": "azure-messaging-webpubsub",
+    "security-scopes": "https://webpubsub.azure.com/.default",
+    "skip": true
   }
 }

--- a/protocol-sdk-integration-tests/data-specs.json
+++ b/protocol-sdk-integration-tests/data-specs.json
@@ -1,0 +1,21 @@
+{
+  "purview-account": {
+    "input": [
+      "https://github.com/Azure/azure-rest-api-specs/blob/main/specification/purview/data-plane/Azure.Analytics.Purview.Account/preview/2019-11-01-preview/account.json"
+    ],
+    "group": "purview",
+    "module": "azure-analytics-purview-account",
+    "security-scopes": "https://purview.azure.net/.default",
+    "required": true
+  },
+  "documenttranslator": {
+    "input": [
+      "https://github.com/Azure/azure-rest-api-specs/blob/main/specification/cognitiveservices/data-plane/TranslatorText/stable/v1.0/TranslatorBatch.json"
+    ],
+    "group": "translation",
+    "module": "azure-ai-documenttranslator",
+    "security": "AzureKey",
+    "security-header-name": "Ocp-Apim-Subscription-Key",
+    "required": true
+  }
+}

--- a/protocol-sdk-integration-tests/test.py
+++ b/protocol-sdk-integration-tests/test.py
@@ -5,6 +5,8 @@ import platform
 import subprocess
 import shutil
 import logging
+import json
+import argparse
 from os import path
 
 
@@ -12,7 +14,8 @@ AUTOREST_CORE_VERSION = '3.6.6'
 OS_WINDOWS = platform.system().lower() == 'windows'
 
 
-def run(script_path: str, output_folder: str, json_path: str, namespace: str, security_scopes: str = None):
+def run(script_path: str, output_folder: str, json_path: str, namespace: str,
+        security: str, security_scopes: str = None, security_header_name: str = None):
     logging.info(f'SDK for {json_path}')
 
     package_relative_path = namespace.replace('.', '/')
@@ -22,11 +25,12 @@ def run(script_path: str, output_folder: str, json_path: str, namespace: str, se
     logging.info(f'delete {output_folder}')
 
     # generate code
-    security = 'AADToken'
-    security_scopes_str = f'--security={security}'
+    security_str = f'--security={security}'
     if security_scopes:
-        security_scopes_str += f' --security-scopes={security_scopes}'
-    cmd = f'autorest --input-file={json_path} --version={AUTOREST_CORE_VERSION} --use=../ --java --low-level-client --output-folder={output_folder} --namespace={namespace} {security_scopes_str} --sdk-integration --generate-samples --generate-tests'.split(' ')
+        security_str += f' --security-scopes={security_scopes}'
+    if security_header_name:
+        security_str += f' --security-header-name={security_header_name}'
+    cmd = f'autorest --input-file={json_path} --version={AUTOREST_CORE_VERSION} --use=../ --java --low-level-client --output-folder={output_folder} --namespace={namespace} {security_str} --sdk-integration --generate-samples --generate-tests'.split(' ')
     cmd[0] += ('.cmd' if OS_WINDOWS else '')
     logging.info(' '.join(cmd))
     subprocess.check_call(cmd, cwd=script_path)
@@ -45,6 +49,7 @@ def run(script_path: str, output_folder: str, json_path: str, namespace: str, se
 
     logging.info('pass maven package')
 
+    # verify
     assert path.exists(path.join(output_folder, 'README.md'))
     logging.info('pass README.md')
 
@@ -64,15 +69,25 @@ def run(script_path: str, output_folder: str, json_path: str, namespace: str, se
 def main():
     script_path = path.abspath(path.dirname(sys.argv[0]))
 
-    purview_json_path = 'https://github.com/Azure/azure-rest-api-specs/blob/main/specification/purview/data-plane/Azure.Analytics.Purview.Account/preview/2019-11-01-preview/account.json'
-    purview_output_path = path.join(script_path, 'sdk/purview/azure-analytics-purview-account')
+    with open(path.join(script_path, 'data-specs.json'), 'r', encoding='utf-8') as f_in:
+        data_specs = json.load(f_in)
 
-    run(script_path, purview_output_path, purview_json_path, 'com.azure.analytics.purview.account', 'https://purview.azure.net/.default')
+    for key, spec in data_specs.items():
+        json_path = spec['input'][0]
+        group = spec['group']
+        module = spec['module']
+        security = spec['security'] if 'security' in spec else 'AADToken'
+        security_scopes = spec['security-scopes'] if 'security-scopes' in spec else None
+        security_header_name = spec['security-header-name'] if 'security-header-name' in spec else None
 
-    translator_json_path = 'https://github.com/Azure/azure-rest-api-specs/blob/main/specification/cognitiveservices/data-plane/TranslatorText/stable/v1.0/TranslatorBatch.json'
-    translator_output_path = path.join(script_path, 'sdk/ai/azure-ai-translator')
+        required = spec['required']
 
-    run(script_path, translator_output_path, translator_json_path, 'com.azure.ai.translator', 'https://noop.azure.net/.default')
+        output_path = path.join(script_path, 'sdk', group, module)
+        namespace = 'com.' + module.replace('-', '.')
+
+        logging.info(f'case {key}')
+        run(script_path, output_path, json_path, namespace,
+            security, security_scopes, security_header_name)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Include all released data-plane SDK in smoke test.

At present, the whole list need to be triggered manually via `python protocol-sdk-integration-tests/test.py --all`

CI only test first 2, which cover AADToken and AzureKey, also include samples/tests.

webpubsub is skipped as it does not contain x-ms-examples.