### PR TITLE
dpg, deduce artifactId from namespace, if not provided

### DIFF
--- a/fluentgen/src/main/java/com/azure/autorest/fluent/util/FluentUtils.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/util/FluentUtils.java
@@ -23,6 +23,7 @@ import com.azure.autorest.model.clientmodel.GenericType;
 import com.azure.autorest.model.clientmodel.IType;
 import com.azure.autorest.model.clientmodel.ListType;
 import com.azure.autorest.model.clientmodel.MapType;
+import com.azure.autorest.util.ClientModelUtil;
 import com.azure.autorest.util.CodeNamer;
 import com.azure.autorest.util.TemplateUtil;
 import com.azure.core.http.rest.PagedIterable;
@@ -131,7 +132,7 @@ public class FluentUtils {
 
     public static String getArtifactId() {
         JavaSettings settings = JavaSettings.getInstance();
-        String artifactId = settings.getArtifactId();
+        String artifactId = ClientModelUtil.getArtifactId();
         if (CoreUtils.isNullOrEmpty(artifactId)) {
             artifactId = getArtifactIdFromPackageName(settings.getPackage().toLowerCase(Locale.ROOT));
         }

--- a/javagen/src/main/java/com/azure/autorest/Javagen.java
+++ b/javagen/src/main/java/com/azure/autorest/Javagen.java
@@ -104,7 +104,7 @@ public class Javagen extends NewPlugin {
                 writeFile(textFile.getFilePath(), textFile.getContents(), null);
             }
 
-            String artifactId = settings.getArtifactId();
+            String artifactId = ClientModelUtil.getArtifactId();
             if (!CoreUtils.isNullOrEmpty(artifactId)) {
                 writeFile("src/main/resources/" + artifactId + ".properties",
                         "name=${project.artifactId}\nversion=${project" + ".version}\n", null);

--- a/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
+++ b/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
@@ -7,6 +7,7 @@ import com.azure.autorest.Javagen;
 import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.extension.base.plugin.PluginLogger;
 import com.azure.autorest.model.clientmodel.Client;
+import com.azure.autorest.util.ClientModelUtil;
 import com.azure.core.util.CoreUtils;
 import org.slf4j.Logger;
 import org.w3c.dom.Document;
@@ -28,7 +29,6 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
@@ -103,7 +103,7 @@ public class Project {
 
         this.serviceName = serviceName;
         this.namespace = JavaSettings.getInstance().getPackage();
-        this.artifactId = getArtifactIdFromNamespace();
+        this.artifactId = ClientModelUtil.getArtifactId();
 
         this.serviceDescription = String.format("This package contains Microsoft Azure %1$s client library.", serviceName);
 
@@ -360,16 +360,5 @@ public class Project {
 
     public boolean isGenerateSamples() {
         return JavaSettings.getInstance().isGenerateSamples();
-    }
-
-    private static String getArtifactIdFromNamespace() {
-        JavaSettings settings = JavaSettings.getInstance();
-        String artifactId = settings.getArtifactId();
-        if (CoreUtils.isNullOrEmpty(artifactId)) {
-            artifactId = settings.getPackage().toLowerCase(Locale.ROOT)
-                    .replace("com.", "")
-                    .replace(".", "-");
-        }
-        return artifactId;
     }
 }

--- a/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
@@ -18,9 +18,11 @@ import com.azure.autorest.model.javamodel.JavaClass;
 import com.azure.autorest.model.javamodel.JavaContext;
 import com.azure.autorest.model.javamodel.JavaFile;
 import com.azure.autorest.model.javamodel.JavaVisibility;
+import com.azure.autorest.util.ClientModelUtil;
 import com.azure.autorest.util.CodeNamer;
 import com.azure.core.annotation.Generated;
 import com.azure.core.http.HttpPipelinePosition;
+import com.azure.core.util.CoreUtils;
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
@@ -134,8 +136,9 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ClientBuilder
 
                 // properties for sdk name and version
                 String propertiesValue = "new HashMap<>()";
-                if (!settings.getArtifactId().isEmpty()) {
-                    propertiesValue = "CoreUtils.getProperties" + "(\"" + settings.getArtifactId() + ".properties\")";
+                String artifactId = ClientModelUtil.getArtifactId();
+                if (!CoreUtils.isNullOrEmpty(artifactId)) {
+                    propertiesValue = "CoreUtils.getProperties" + "(\"" + artifactId + ".properties\")";
                 }
                 addGeneratedAnnotation(classBlock);
                 classBlock.privateFinalMemberVariable("Map<String, String>", "properties", propertiesValue);

--- a/javagen/src/main/java/com/azure/autorest/util/ClientModelUtil.java
+++ b/javagen/src/main/java/com/azure/autorest/util/ClientModelUtil.java
@@ -11,8 +11,10 @@ import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.model.clientmodel.AsyncSyncClient;
 import com.azure.autorest.model.clientmodel.MethodGroupClient;
 import com.azure.autorest.model.clientmodel.ServiceClient;
+import com.azure.core.util.CoreUtils;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
@@ -249,5 +251,17 @@ public class ClientModelUtil {
                 .findFirst()
                 .orElse(null);
         return apiVersion;
+    }
+
+    public static String getArtifactId() {
+        JavaSettings settings = JavaSettings.getInstance();
+        String artifactId = settings.getArtifactId();
+        if (settings.isLowLevelClient() && CoreUtils.isNullOrEmpty(artifactId)) {
+            // convert package/namespace to artifact
+            artifactId = settings.getPackage().toLowerCase(Locale.ROOT)
+                    .replace("com.", "")
+                    .replace(".", "-");
+        }
+        return artifactId;
     }
 }

--- a/partial-update-tests/generated/src/main/java/fixtures/bodystring/AutoRestSwaggerBatServiceClientBuilder.java
+++ b/partial-update-tests/generated/src/main/java/fixtures/bodystring/AutoRestSwaggerBatServiceClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.bodystring.implementation.AutoRestSwaggerBatServiceClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -45,7 +44,7 @@ public final class AutoRestSwaggerBatServiceClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated private final Map<String, String> properties = CoreUtils.getProperties("fixtures-bodystring.properties");
 
     /** Create an instance of the AutoRestSwaggerBatServiceClientBuilder. */
     @Generated

--- a/partial-update-tests/generated/src/main/resources/fixtures-bodystring.properties
+++ b/partial-update-tests/generated/src/main/resources/fixtures-bodystring.properties
@@ -1,0 +1,2 @@
+name=${project.artifactId}
+version=${project.version}

--- a/protocol-resilience-test/llcinitial/src/main/java/fixtures/llcresi/DpgClientBuilder.java
+++ b/protocol-resilience-test/llcinitial/src/main/java/fixtures/llcresi/DpgClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.llcresi.implementation.DpgClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +36,7 @@ public final class DpgClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated private final Map<String, String> properties = CoreUtils.getProperties("fixtures-llcresi.properties");
 
     /** Create an instance of the DpgClientBuilder. */
     @Generated

--- a/protocol-resilience-test/llcinitial/src/main/resources/fixtures-llcresi.properties
+++ b/protocol-resilience-test/llcinitial/src/main/resources/fixtures-llcresi.properties
@@ -1,0 +1,2 @@
+name=${project.artifactId}
+version=${project.version}

--- a/protocol-resilience-test/llcupdate1/src/main/java/fixtures/llcresi/DpgClientBuilder.java
+++ b/protocol-resilience-test/llcupdate1/src/main/java/fixtures/llcresi/DpgClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.llcresi.implementation.DpgClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +36,7 @@ public final class DpgClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated private final Map<String, String> properties = CoreUtils.getProperties("fixtures-llcresi.properties");
 
     /** Create an instance of the DpgClientBuilder. */
     @Generated

--- a/protocol-resilience-test/llcupdate1/src/main/resources/fixtures-llcresi.properties
+++ b/protocol-resilience-test/llcupdate1/src/main/resources/fixtures-llcresi.properties
@@ -1,0 +1,2 @@
+name=${project.artifactId}
+version=${project.version}

--- a/protocol-tests/src/main/java/fixtures/bodycomplex/ArrayClientBuilder.java
+++ b/protocol-tests/src/main/java/fixtures/bodycomplex/ArrayClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.bodycomplex.implementation.AutoRestComplexTestServiceClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +36,8 @@ public final class ArrayClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated
+    private final Map<String, String> properties = CoreUtils.getProperties("fixtures-bodycomplex.properties");
 
     /** Create an instance of the ArrayClientBuilder. */
     @Generated

--- a/protocol-tests/src/main/java/fixtures/bodycomplex/BasicClientBuilder.java
+++ b/protocol-tests/src/main/java/fixtures/bodycomplex/BasicClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.bodycomplex.implementation.AutoRestComplexTestServiceClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +36,8 @@ public final class BasicClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated
+    private final Map<String, String> properties = CoreUtils.getProperties("fixtures-bodycomplex.properties");
 
     /** Create an instance of the BasicClientBuilder. */
     @Generated

--- a/protocol-tests/src/main/java/fixtures/bodycomplex/DictionaryClientBuilder.java
+++ b/protocol-tests/src/main/java/fixtures/bodycomplex/DictionaryClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.bodycomplex.implementation.AutoRestComplexTestServiceClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +36,8 @@ public final class DictionaryClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated
+    private final Map<String, String> properties = CoreUtils.getProperties("fixtures-bodycomplex.properties");
 
     /** Create an instance of the DictionaryClientBuilder. */
     @Generated

--- a/protocol-tests/src/main/java/fixtures/bodycomplex/FlattencomplexClientBuilder.java
+++ b/protocol-tests/src/main/java/fixtures/bodycomplex/FlattencomplexClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.bodycomplex.implementation.AutoRestComplexTestServiceClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +36,8 @@ public final class FlattencomplexClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated
+    private final Map<String, String> properties = CoreUtils.getProperties("fixtures-bodycomplex.properties");
 
     /** Create an instance of the FlattencomplexClientBuilder. */
     @Generated

--- a/protocol-tests/src/main/java/fixtures/bodycomplex/InheritanceClientBuilder.java
+++ b/protocol-tests/src/main/java/fixtures/bodycomplex/InheritanceClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.bodycomplex.implementation.AutoRestComplexTestServiceClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +36,8 @@ public final class InheritanceClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated
+    private final Map<String, String> properties = CoreUtils.getProperties("fixtures-bodycomplex.properties");
 
     /** Create an instance of the InheritanceClientBuilder. */
     @Generated

--- a/protocol-tests/src/main/java/fixtures/bodycomplex/PolymorphicrecursiveClientBuilder.java
+++ b/protocol-tests/src/main/java/fixtures/bodycomplex/PolymorphicrecursiveClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.bodycomplex.implementation.AutoRestComplexTestServiceClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +36,8 @@ public final class PolymorphicrecursiveClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated
+    private final Map<String, String> properties = CoreUtils.getProperties("fixtures-bodycomplex.properties");
 
     /** Create an instance of the PolymorphicrecursiveClientBuilder. */
     @Generated

--- a/protocol-tests/src/main/java/fixtures/bodycomplex/PolymorphismClientBuilder.java
+++ b/protocol-tests/src/main/java/fixtures/bodycomplex/PolymorphismClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.bodycomplex.implementation.AutoRestComplexTestServiceClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +36,8 @@ public final class PolymorphismClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated
+    private final Map<String, String> properties = CoreUtils.getProperties("fixtures-bodycomplex.properties");
 
     /** Create an instance of the PolymorphismClientBuilder. */
     @Generated

--- a/protocol-tests/src/main/java/fixtures/bodycomplex/PrimitiveClientBuilder.java
+++ b/protocol-tests/src/main/java/fixtures/bodycomplex/PrimitiveClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.bodycomplex.implementation.AutoRestComplexTestServiceClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +36,8 @@ public final class PrimitiveClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated
+    private final Map<String, String> properties = CoreUtils.getProperties("fixtures-bodycomplex.properties");
 
     /** Create an instance of the PrimitiveClientBuilder. */
     @Generated

--- a/protocol-tests/src/main/java/fixtures/bodycomplex/ReadonlypropertyClientBuilder.java
+++ b/protocol-tests/src/main/java/fixtures/bodycomplex/ReadonlypropertyClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.bodycomplex.implementation.AutoRestComplexTestServiceClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +36,8 @@ public final class ReadonlypropertyClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated
+    private final Map<String, String> properties = CoreUtils.getProperties("fixtures-bodycomplex.properties");
 
     /** Create an instance of the ReadonlypropertyClientBuilder. */
     @Generated

--- a/protocol-tests/src/main/java/fixtures/bodystring/EnumClientBuilder.java
+++ b/protocol-tests/src/main/java/fixtures/bodystring/EnumClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.bodystring.implementation.AutoRestSwaggerBatServiceClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +36,7 @@ public final class EnumClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated private final Map<String, String> properties = CoreUtils.getProperties("fixtures-bodystring.properties");
 
     /** Create an instance of the EnumClientBuilder. */
     @Generated

--- a/protocol-tests/src/main/java/fixtures/bodystring/StringOperationClientBuilder.java
+++ b/protocol-tests/src/main/java/fixtures/bodystring/StringOperationClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.bodystring.implementation.AutoRestSwaggerBatServiceClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +36,7 @@ public final class StringOperationClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated private final Map<String, String> properties = CoreUtils.getProperties("fixtures-bodystring.properties");
 
     /** Create an instance of the StringOperationClientBuilder. */
     @Generated

--- a/protocol-tests/src/main/java/fixtures/dpgcustomization/DpgClientBuilder.java
+++ b/protocol-tests/src/main/java/fixtures/dpgcustomization/DpgClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.dpgcustomization.implementation.DpgClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +36,8 @@ public final class DpgClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated
+    private final Map<String, String> properties = CoreUtils.getProperties("fixtures-dpgcustomization.properties");
 
     /** Create an instance of the DpgClientBuilder. */
     @Generated

--- a/protocol-tests/src/main/java/fixtures/header/AutoRestSwaggerBatHeaderServiceClientBuilder.java
+++ b/protocol-tests/src/main/java/fixtures/header/AutoRestSwaggerBatHeaderServiceClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.header.implementation.AutoRestSwaggerBatHeaderServiceClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -41,7 +40,7 @@ public final class AutoRestSwaggerBatHeaderServiceClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated private final Map<String, String> properties = CoreUtils.getProperties("fixtures-header.properties");
 
     /** Create an instance of the AutoRestSwaggerBatHeaderServiceClientBuilder. */
     @Generated

--- a/protocol-tests/src/main/java/fixtures/httpinfrastructure/HttpClientFailureClientBuilder.java
+++ b/protocol-tests/src/main/java/fixtures/httpinfrastructure/HttpClientFailureClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.httpinfrastructure.implementation.AutoRestHttpInfrastructureTestServiceClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +36,8 @@ public final class HttpClientFailureClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated
+    private final Map<String, String> properties = CoreUtils.getProperties("fixtures-httpinfrastructure.properties");
 
     /** Create an instance of the HttpClientFailureClientBuilder. */
     @Generated

--- a/protocol-tests/src/main/java/fixtures/httpinfrastructure/HttpFailureClientBuilder.java
+++ b/protocol-tests/src/main/java/fixtures/httpinfrastructure/HttpFailureClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.httpinfrastructure.implementation.AutoRestHttpInfrastructureTestServiceClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +36,8 @@ public final class HttpFailureClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated
+    private final Map<String, String> properties = CoreUtils.getProperties("fixtures-httpinfrastructure.properties");
 
     /** Create an instance of the HttpFailureClientBuilder. */
     @Generated

--- a/protocol-tests/src/main/java/fixtures/httpinfrastructure/HttpRedirectsClientBuilder.java
+++ b/protocol-tests/src/main/java/fixtures/httpinfrastructure/HttpRedirectsClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.httpinfrastructure.implementation.AutoRestHttpInfrastructureTestServiceClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +36,8 @@ public final class HttpRedirectsClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated
+    private final Map<String, String> properties = CoreUtils.getProperties("fixtures-httpinfrastructure.properties");
 
     /** Create an instance of the HttpRedirectsClientBuilder. */
     @Generated

--- a/protocol-tests/src/main/java/fixtures/httpinfrastructure/HttpRetryClientBuilder.java
+++ b/protocol-tests/src/main/java/fixtures/httpinfrastructure/HttpRetryClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.httpinfrastructure.implementation.AutoRestHttpInfrastructureTestServiceClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +36,8 @@ public final class HttpRetryClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated
+    private final Map<String, String> properties = CoreUtils.getProperties("fixtures-httpinfrastructure.properties");
 
     /** Create an instance of the HttpRetryClientBuilder. */
     @Generated

--- a/protocol-tests/src/main/java/fixtures/httpinfrastructure/HttpServerFailureClientBuilder.java
+++ b/protocol-tests/src/main/java/fixtures/httpinfrastructure/HttpServerFailureClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.httpinfrastructure.implementation.AutoRestHttpInfrastructureTestServiceClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +36,8 @@ public final class HttpServerFailureClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated
+    private final Map<String, String> properties = CoreUtils.getProperties("fixtures-httpinfrastructure.properties");
 
     /** Create an instance of the HttpServerFailureClientBuilder. */
     @Generated

--- a/protocol-tests/src/main/java/fixtures/httpinfrastructure/HttpSuccessClientBuilder.java
+++ b/protocol-tests/src/main/java/fixtures/httpinfrastructure/HttpSuccessClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.httpinfrastructure.implementation.AutoRestHttpInfrastructureTestServiceClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +36,8 @@ public final class HttpSuccessClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated
+    private final Map<String, String> properties = CoreUtils.getProperties("fixtures-httpinfrastructure.properties");
 
     /** Create an instance of the HttpSuccessClientBuilder. */
     @Generated

--- a/protocol-tests/src/main/java/fixtures/httpinfrastructure/MultipleResponsesClientBuilder.java
+++ b/protocol-tests/src/main/java/fixtures/httpinfrastructure/MultipleResponsesClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.httpinfrastructure.implementation.AutoRestHttpInfrastructureTestServiceClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +36,8 @@ public final class MultipleResponsesClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated
+    private final Map<String, String> properties = CoreUtils.getProperties("fixtures-httpinfrastructure.properties");
 
     /** Create an instance of the MultipleResponsesClientBuilder. */
     @Generated

--- a/protocol-tests/src/main/java/fixtures/llcinitial/DpgClientBuilder.java
+++ b/protocol-tests/src/main/java/fixtures/llcinitial/DpgClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.llcinitial.implementation.DpgClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +36,7 @@ public final class DpgClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated private final Map<String, String> properties = CoreUtils.getProperties("fixtures-llcinitial.properties");
 
     /** Create an instance of the DpgClientBuilder. */
     @Generated

--- a/protocol-tests/src/main/java/fixtures/llcupdate1/DpgClientBuilder.java
+++ b/protocol-tests/src/main/java/fixtures/llcupdate1/DpgClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.llcupdate1.implementation.DpgClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +36,7 @@ public final class DpgClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated private final Map<String, String> properties = CoreUtils.getProperties("fixtures-llcupdate1.properties");
 
     /** Create an instance of the DpgClientBuilder. */
     @Generated

--- a/protocol-tests/src/main/java/fixtures/lro/LROsClientBuilder.java
+++ b/protocol-tests/src/main/java/fixtures/lro/LROsClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.lro.implementation.AutoRestLongRunningOperationTestServiceClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +36,7 @@ public final class LROsClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated private final Map<String, String> properties = CoreUtils.getProperties("fixtures-lro.properties");
 
     /** Create an instance of the LROsClientBuilder. */
     @Generated

--- a/protocol-tests/src/main/java/fixtures/lro/LroRetrysClientBuilder.java
+++ b/protocol-tests/src/main/java/fixtures/lro/LroRetrysClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.lro.implementation.AutoRestLongRunningOperationTestServiceClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +36,7 @@ public final class LroRetrysClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated private final Map<String, String> properties = CoreUtils.getProperties("fixtures-lro.properties");
 
     /** Create an instance of the LroRetrysClientBuilder. */
     @Generated

--- a/protocol-tests/src/main/java/fixtures/lro/LrosCustomHeaderClientBuilder.java
+++ b/protocol-tests/src/main/java/fixtures/lro/LrosCustomHeaderClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.lro.implementation.AutoRestLongRunningOperationTestServiceClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +36,7 @@ public final class LrosCustomHeaderClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated private final Map<String, String> properties = CoreUtils.getProperties("fixtures-lro.properties");
 
     /** Create an instance of the LrosCustomHeaderClientBuilder. */
     @Generated

--- a/protocol-tests/src/main/java/fixtures/lro/LrosaDsClientBuilder.java
+++ b/protocol-tests/src/main/java/fixtures/lro/LrosaDsClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.lro.implementation.AutoRestLongRunningOperationTestServiceClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +36,7 @@ public final class LrosaDsClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated private final Map<String, String> properties = CoreUtils.getProperties("fixtures-lro.properties");
 
     /** Create an instance of the LrosaDsClientBuilder. */
     @Generated

--- a/protocol-tests/src/main/java/fixtures/mediatypes/MediaTypesClientBuilder.java
+++ b/protocol-tests/src/main/java/fixtures/mediatypes/MediaTypesClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.mediatypes.implementation.MediaTypesClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +36,7 @@ public final class MediaTypesClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated private final Map<String, String> properties = CoreUtils.getProperties("fixtures-mediatypes.properties");
 
     /** Create an instance of the MediaTypesClientBuilder. */
     @Generated

--- a/protocol-tests/src/main/java/fixtures/paging/AutoRestPagingTestServiceClientBuilder.java
+++ b/protocol-tests/src/main/java/fixtures/paging/AutoRestPagingTestServiceClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.paging.implementation.AutoRestPagingTestServiceClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -38,7 +37,7 @@ public final class AutoRestPagingTestServiceClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated private final Map<String, String> properties = CoreUtils.getProperties("fixtures-paging.properties");
 
     /** Create an instance of the AutoRestPagingTestServiceClientBuilder. */
     @Generated

--- a/protocol-tests/src/main/java/fixtures/url/PathItemsClientBuilder.java
+++ b/protocol-tests/src/main/java/fixtures/url/PathItemsClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.url.implementation.AutoRestUrlTestServiceClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +36,7 @@ public final class PathItemsClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated private final Map<String, String> properties = CoreUtils.getProperties("fixtures-url.properties");
 
     /** Create an instance of the PathItemsClientBuilder. */
     @Generated

--- a/protocol-tests/src/main/java/fixtures/url/PathsClientBuilder.java
+++ b/protocol-tests/src/main/java/fixtures/url/PathsClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.url.implementation.AutoRestUrlTestServiceClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +36,7 @@ public final class PathsClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated private final Map<String, String> properties = CoreUtils.getProperties("fixtures-url.properties");
 
     /** Create an instance of the PathsClientBuilder. */
     @Generated

--- a/protocol-tests/src/main/java/fixtures/url/QueriesClientBuilder.java
+++ b/protocol-tests/src/main/java/fixtures/url/QueriesClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.url.implementation.AutoRestUrlTestServiceClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +36,7 @@ public final class QueriesClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated private final Map<String, String> properties = CoreUtils.getProperties("fixtures-url.properties");
 
     /** Create an instance of the QueriesClientBuilder. */
     @Generated

--- a/protocol-tests/src/main/java/fixtures/url/multi/AutoRestUrlMutliCollectionFormatTestServiceClientBuilder.java
+++ b/protocol-tests/src/main/java/fixtures/url/multi/AutoRestUrlMutliCollectionFormatTestServiceClientBuilder.java
@@ -25,7 +25,6 @@ import com.azure.core.util.CoreUtils;
 import com.azure.core.util.serializer.JacksonAdapter;
 import fixtures.url.multi.implementation.AutoRestUrlMutliCollectionFormatTestServiceClientImpl;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -41,7 +40,7 @@ public final class AutoRestUrlMutliCollectionFormatTestServiceClientBuilder {
 
     @Generated private static final String SDK_VERSION = "version";
 
-    @Generated private final Map<String, String> properties = new HashMap<>();
+    @Generated private final Map<String, String> properties = CoreUtils.getProperties("fixtures-url-multi.properties");
 
     /** Create an instance of the AutoRestUrlMutliCollectionFormatTestServiceClientBuilder. */
     @Generated

--- a/protocol-tests/src/main/resources/fixtures-bodycomplex.properties
+++ b/protocol-tests/src/main/resources/fixtures-bodycomplex.properties
@@ -1,0 +1,2 @@
+name=${project.artifactId}
+version=${project.version}

--- a/protocol-tests/src/main/resources/fixtures-bodystring.properties
+++ b/protocol-tests/src/main/resources/fixtures-bodystring.properties
@@ -1,0 +1,2 @@
+name=${project.artifactId}
+version=${project.version}

--- a/protocol-tests/src/main/resources/fixtures-dpgcustomization.properties
+++ b/protocol-tests/src/main/resources/fixtures-dpgcustomization.properties
@@ -1,0 +1,2 @@
+name=${project.artifactId}
+version=${project.version}

--- a/protocol-tests/src/main/resources/fixtures-header.properties
+++ b/protocol-tests/src/main/resources/fixtures-header.properties
@@ -1,0 +1,2 @@
+name=${project.artifactId}
+version=${project.version}

--- a/protocol-tests/src/main/resources/fixtures-httpinfrastructure.properties
+++ b/protocol-tests/src/main/resources/fixtures-httpinfrastructure.properties
@@ -1,0 +1,2 @@
+name=${project.artifactId}
+version=${project.version}

--- a/protocol-tests/src/main/resources/fixtures-llcinitial.properties
+++ b/protocol-tests/src/main/resources/fixtures-llcinitial.properties
@@ -1,0 +1,2 @@
+name=${project.artifactId}
+version=${project.version}

--- a/protocol-tests/src/main/resources/fixtures-llcupdate1.properties
+++ b/protocol-tests/src/main/resources/fixtures-llcupdate1.properties
@@ -1,0 +1,2 @@
+name=${project.artifactId}
+version=${project.version}

--- a/protocol-tests/src/main/resources/fixtures-lro.properties
+++ b/protocol-tests/src/main/resources/fixtures-lro.properties
@@ -1,0 +1,2 @@
+name=${project.artifactId}
+version=${project.version}

--- a/protocol-tests/src/main/resources/fixtures-mediatypes.properties
+++ b/protocol-tests/src/main/resources/fixtures-mediatypes.properties
@@ -1,0 +1,2 @@
+name=${project.artifactId}
+version=${project.version}

--- a/protocol-tests/src/main/resources/fixtures-paging.properties
+++ b/protocol-tests/src/main/resources/fixtures-paging.properties
@@ -1,0 +1,2 @@
+name=${project.artifactId}
+version=${project.version}

--- a/protocol-tests/src/main/resources/fixtures-url-multi.properties
+++ b/protocol-tests/src/main/resources/fixtures-url-multi.properties
@@ -1,0 +1,2 @@
+name=${project.artifactId}
+version=${project.version}

--- a/protocol-tests/src/main/resources/fixtures-url.properties
+++ b/protocol-tests/src/main/resources/fixtures-url.properties
@@ -1,0 +1,2 @@
+name=${project.artifactId}
+version=${project.version}


### PR DESCRIPTION
package "com.azure.iot.deviceupdate" should be enough to make artifact "azure-iot-deviceupdate", without that separate `artifactId` option.

Only apply in DPG, to avoid breaking HLC.