### PR TITLE
mgmt, fix extract example from test

### DIFF
--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/projectmodel/CodeSample.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/projectmodel/CodeSample.java
@@ -32,6 +32,7 @@ public class CodeSample {
 
     public static CodeSample fromTestFile(Path testFilePath) {
         // the assumption is there is a embedme block in a @Test method
+        // for now, only extract first block
 
         CodeSample codeSample = new CodeSample();
 
@@ -58,7 +59,7 @@ public class CodeSample {
                         // method ends without embedme block
 
                         testMethodBegin = false;
-                        break;
+                        // continue
                     } else if (line.trim().equals(EMBEDME_START_COMMENT)) {
                         // next get inside embedme block, similar to https://github.com/zakhenry/embedme/issues/48
 
@@ -74,6 +75,7 @@ public class CodeSample {
 
                         embedmeBlockBegin = false;
                         break;
+                        // for now, only extract one block
                     } else {
                         // extract the code line (except Assertions)
 


### PR DESCRIPTION
Previously it only work for first `@Test`.

Seems nothing would block it from trying to read from next test method.