### PR TITLE
dpg, remove space in sample identifier

### DIFF
--- a/customization-base/pom.xml
+++ b/customization-base/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.2</version>
+      <version>2.13.1</version>
     </dependency>
     <dependency>
       <groupId>com.azure.tools</groupId>
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.7</version>
+      <version>1.2.10</version>
     </dependency>
     <dependency>
       <groupId>com.google.googlejavaformat</groupId>
@@ -64,19 +64,19 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.7.1</version>
+      <version>5.8.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.7.1</version>
+      <version>5.8.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
-      <version>5.7.1</version>
+      <version>5.8.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -95,7 +95,7 @@
       <plugin>
         <groupId>com.azure.tools</groupId>
         <artifactId>codesnippet-maven-plugin</artifactId>
-        <version>1.0.0-beta.2</version>
+        <version>1.0.0-beta.6</version>
         <executions>
           <execution>
             <id>update-codesnippets</id>

--- a/javagen/src/main/java/com/azure/autorest/template/ProtocolSampleBlankTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ProtocolSampleBlankTemplate.java
@@ -16,8 +16,8 @@ public class ProtocolSampleBlankTemplate implements IJavaTemplate<Void, JavaFile
 
         context.publicFinalClass("ReadmeSamples", classBlock -> {
             classBlock.publicMethod("void readmeSamples()", methodBlock -> {
-                methodBlock.line(String.format("// BEGIN: %s", snippetReference));
-                methodBlock.line(String.format("// END: %s", snippetReference));
+                methodBlock.line(String.format("// BEGIN:%s", snippetReference));
+                methodBlock.line(String.format("// END:%s", snippetReference));
             });
         });
     }

--- a/javagen/src/main/java/com/azure/autorest/template/ProtocolSampleBlankTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ProtocolSampleBlankTemplate.java
@@ -16,8 +16,8 @@ public class ProtocolSampleBlankTemplate implements IJavaTemplate<Void, JavaFile
 
         context.publicFinalClass("ReadmeSamples", classBlock -> {
             classBlock.publicMethod("void readmeSamples()", methodBlock -> {
-                methodBlock.line(String.format("// BEGIN:%s", snippetReference));
-                methodBlock.line(String.format("// END:%s", snippetReference));
+                methodBlock.line(String.format("// BEGIN: %s", snippetReference));
+                methodBlock.line(String.format("// END: %s", snippetReference));
             });
         });
     }

--- a/javagen/src/main/java/com/azure/autorest/template/ProtocolSampleTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ProtocolSampleTemplate.java
@@ -27,17 +27,18 @@ public class ProtocolSampleTemplate implements IJavaTemplate<ProtocolExample, Ja
 
         javaFile.publicClass(null, filename, classBlock -> {
             classBlock.publicStaticMethod("void main(String[] args)", methodBlock -> {
+                writer.writeClientInitialization(methodBlock);
+
                 // codesnippet begin
                 if (protocolExample.getProxyMethodExample().getCodeSnippetIdentifier() != null) {
-                    methodBlock.line(String.format("// BEGIN: %s", protocolExample.getProxyMethodExample().getCodeSnippetIdentifier()));
+                    methodBlock.line(String.format("// BEGIN:%s", protocolExample.getProxyMethodExample().getCodeSnippetIdentifier()));
                 }
 
-                writer.writeClientInitialization(methodBlock);
                 writer.writeClientMethodInvocation(methodBlock);
 
                 // codesnippet end
                 if (protocolExample.getProxyMethodExample().getCodeSnippetIdentifier() != null) {
-                    methodBlock.line(String.format("// END: %s", protocolExample.getProxyMethodExample().getCodeSnippetIdentifier()));
+                    methodBlock.line(String.format("// END:%s", protocolExample.getProxyMethodExample().getCodeSnippetIdentifier()));
                 }
             });
         });

--- a/protocol-tests/src/samples/java/fixtures/bodystring/generated/EnumGetNotExpandable.java
+++ b/protocol-tests/src/samples/java/fixtures/bodystring/generated/EnumGetNotExpandable.java
@@ -11,10 +11,10 @@ import fixtures.bodystring.EnumClientBuilder;
 
 public class EnumGetNotExpandable {
     public static void main(String[] args) {
-        // BEGIN: fixtures.bodystring.generated.enumgetnotexpandable.enumgetnotexpandable
         EnumClient enumClient = new EnumClientBuilder().host("http://localhost:3000").buildClient();
+        // BEGIN:fixtures.bodystring.generated.enumgetnotexpandable.enumgetnotexpandable
         RequestOptions requestOptions = new RequestOptions();
         Response<String> response = enumClient.getNotExpandableWithResponse(requestOptions);
-        // END: fixtures.bodystring.generated.enumgetnotexpandable.enumgetnotexpandable
+        // END:fixtures.bodystring.generated.enumgetnotexpandable.enumgetnotexpandable
     }
 }

--- a/protocol-tests/src/samples/java/fixtures/bodystring/generated/EnumGetReferenced.java
+++ b/protocol-tests/src/samples/java/fixtures/bodystring/generated/EnumGetReferenced.java
@@ -11,10 +11,10 @@ import fixtures.bodystring.EnumClientBuilder;
 
 public class EnumGetReferenced {
     public static void main(String[] args) {
-        // BEGIN: fixtures.bodystring.generated.enumgetreferenced.enumgetreferenced
         EnumClient enumClient = new EnumClientBuilder().host("http://localhost:3000").buildClient();
+        // BEGIN:fixtures.bodystring.generated.enumgetreferenced.enumgetreferenced
         RequestOptions requestOptions = new RequestOptions();
         Response<String> response = enumClient.getReferencedWithResponse(requestOptions);
-        // END: fixtures.bodystring.generated.enumgetreferenced.enumgetreferenced
+        // END:fixtures.bodystring.generated.enumgetreferenced.enumgetreferenced
     }
 }

--- a/protocol-tests/src/samples/java/fixtures/bodystring/generated/EnumGetReferencedConstant.java
+++ b/protocol-tests/src/samples/java/fixtures/bodystring/generated/EnumGetReferencedConstant.java
@@ -12,10 +12,10 @@ import fixtures.bodystring.EnumClientBuilder;
 
 public class EnumGetReferencedConstant {
     public static void main(String[] args) {
-        // BEGIN: fixtures.bodystring.generated.enumgetreferencedconstant.enumgetreferencedconstant
         EnumClient enumClient = new EnumClientBuilder().host("http://localhost:3000").buildClient();
+        // BEGIN:fixtures.bodystring.generated.enumgetreferencedconstant.enumgetreferencedconstant
         RequestOptions requestOptions = new RequestOptions();
         Response<BinaryData> response = enumClient.getReferencedConstantWithResponse(requestOptions);
-        // END: fixtures.bodystring.generated.enumgetreferencedconstant.enumgetreferencedconstant
+        // END:fixtures.bodystring.generated.enumgetreferencedconstant.enumgetreferencedconstant
     }
 }

--- a/protocol-tests/src/samples/java/fixtures/bodystring/generated/EnumPutNotExpandable.java
+++ b/protocol-tests/src/samples/java/fixtures/bodystring/generated/EnumPutNotExpandable.java
@@ -12,11 +12,11 @@ import fixtures.bodystring.EnumClientBuilder;
 
 public class EnumPutNotExpandable {
     public static void main(String[] args) {
-        // BEGIN: fixtures.bodystring.generated.enumputnotexpandable.enumputnotexpandable
         EnumClient enumClient = new EnumClientBuilder().host("http://localhost:3000").buildClient();
+        // BEGIN:fixtures.bodystring.generated.enumputnotexpandable.enumputnotexpandable
         BinaryData stringBody = BinaryData.fromString("\"red color\"");
         RequestOptions requestOptions = new RequestOptions();
         Response<Void> response = enumClient.putNotExpandableWithResponse(stringBody, requestOptions);
-        // END: fixtures.bodystring.generated.enumputnotexpandable.enumputnotexpandable
+        // END:fixtures.bodystring.generated.enumputnotexpandable.enumputnotexpandable
     }
 }

--- a/protocol-tests/src/samples/java/fixtures/bodystring/generated/EnumPutReferenced.java
+++ b/protocol-tests/src/samples/java/fixtures/bodystring/generated/EnumPutReferenced.java
@@ -12,11 +12,11 @@ import fixtures.bodystring.EnumClientBuilder;
 
 public class EnumPutReferenced {
     public static void main(String[] args) {
-        // BEGIN: fixtures.bodystring.generated.enumputreferenced.enumputreferenced
         EnumClient enumClient = new EnumClientBuilder().host("http://localhost:3000").buildClient();
+        // BEGIN:fixtures.bodystring.generated.enumputreferenced.enumputreferenced
         BinaryData enumStringBody = BinaryData.fromString("\"red color\"");
         RequestOptions requestOptions = new RequestOptions();
         Response<Void> response = enumClient.putReferencedWithResponse(enumStringBody, requestOptions);
-        // END: fixtures.bodystring.generated.enumputreferenced.enumputreferenced
+        // END:fixtures.bodystring.generated.enumputreferenced.enumputreferenced
     }
 }

--- a/protocol-tests/src/samples/java/fixtures/bodystring/generated/EnumPutReferencedConstant.java
+++ b/protocol-tests/src/samples/java/fixtures/bodystring/generated/EnumPutReferencedConstant.java
@@ -12,11 +12,11 @@ import fixtures.bodystring.EnumClientBuilder;
 
 public class EnumPutReferencedConstant {
     public static void main(String[] args) {
-        // BEGIN: fixtures.bodystring.generated.enumputreferencedconstant.enumputreferencedconstant
         EnumClient enumClient = new EnumClientBuilder().host("http://localhost:3000").buildClient();
+        // BEGIN:fixtures.bodystring.generated.enumputreferencedconstant.enumputreferencedconstant
         BinaryData enumStringBody = BinaryData.fromString("\"green-color\"");
         RequestOptions requestOptions = new RequestOptions();
         Response<Void> response = enumClient.putReferencedConstantWithResponse(enumStringBody, requestOptions);
-        // END: fixtures.bodystring.generated.enumputreferencedconstant.enumputreferencedconstant
+        // END:fixtures.bodystring.generated.enumputreferencedconstant.enumputreferencedconstant
     }
 }

--- a/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringGetEmpty.java
+++ b/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringGetEmpty.java
@@ -12,11 +12,11 @@ import fixtures.bodystring.StringOperationClientBuilder;
 
 public class StringGetEmpty {
     public static void main(String[] args) {
-        // BEGIN: fixtures.bodystring.generated.stringgetempty.stringgetempty
         StringOperationClient stringOperationClient =
                 new StringOperationClientBuilder().host("http://localhost:3000").buildClient();
+        // BEGIN:fixtures.bodystring.generated.stringgetempty.stringgetempty
         RequestOptions requestOptions = new RequestOptions();
         Response<BinaryData> response = stringOperationClient.getEmptyWithResponse(requestOptions);
-        // END: fixtures.bodystring.generated.stringgetempty.stringgetempty
+        // END:fixtures.bodystring.generated.stringgetempty.stringgetempty
     }
 }

--- a/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringGetMbcs.java
+++ b/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringGetMbcs.java
@@ -12,11 +12,11 @@ import fixtures.bodystring.StringOperationClientBuilder;
 
 public class StringGetMbcs {
     public static void main(String[] args) {
-        // BEGIN: fixtures.bodystring.generated.stringgetmbcs.stringgetmbcs
         StringOperationClient stringOperationClient =
                 new StringOperationClientBuilder().host("http://localhost:3000").buildClient();
+        // BEGIN:fixtures.bodystring.generated.stringgetmbcs.stringgetmbcs
         RequestOptions requestOptions = new RequestOptions();
         Response<BinaryData> response = stringOperationClient.getMbcsWithResponse(requestOptions);
-        // END: fixtures.bodystring.generated.stringgetmbcs.stringgetmbcs
+        // END:fixtures.bodystring.generated.stringgetmbcs.stringgetmbcs
     }
 }

--- a/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringGetNotProvided.java
+++ b/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringGetNotProvided.java
@@ -12,11 +12,11 @@ import fixtures.bodystring.StringOperationClientBuilder;
 
 public class StringGetNotProvided {
     public static void main(String[] args) {
-        // BEGIN: fixtures.bodystring.generated.stringgetnotprovided.stringgetnotprovided
         StringOperationClient stringOperationClient =
                 new StringOperationClientBuilder().host("http://localhost:3000").buildClient();
+        // BEGIN:fixtures.bodystring.generated.stringgetnotprovided.stringgetnotprovided
         RequestOptions requestOptions = new RequestOptions();
         Response<BinaryData> response = stringOperationClient.getNotProvidedWithResponse(requestOptions);
-        // END: fixtures.bodystring.generated.stringgetnotprovided.stringgetnotprovided
+        // END:fixtures.bodystring.generated.stringgetnotprovided.stringgetnotprovided
     }
 }

--- a/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringGetNull.java
+++ b/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringGetNull.java
@@ -12,11 +12,11 @@ import fixtures.bodystring.StringOperationClientBuilder;
 
 public class StringGetNull {
     public static void main(String[] args) {
-        // BEGIN: fixtures.bodystring.generated.stringgetnull.stringgetnull
         StringOperationClient stringOperationClient =
                 new StringOperationClientBuilder().host("http://localhost:3000").buildClient();
+        // BEGIN:fixtures.bodystring.generated.stringgetnull.stringgetnull
         RequestOptions requestOptions = new RequestOptions();
         Response<BinaryData> response = stringOperationClient.getNullWithResponse(requestOptions);
-        // END: fixtures.bodystring.generated.stringgetnull.stringgetnull
+        // END:fixtures.bodystring.generated.stringgetnull.stringgetnull
     }
 }

--- a/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringGetWhitespace.java
+++ b/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringGetWhitespace.java
@@ -12,11 +12,11 @@ import fixtures.bodystring.StringOperationClientBuilder;
 
 public class StringGetWhitespace {
     public static void main(String[] args) {
-        // BEGIN: fixtures.bodystring.generated.stringgetwhitespace.stringgetwhitespace
         StringOperationClient stringOperationClient =
                 new StringOperationClientBuilder().host("http://localhost:3000").buildClient();
+        // BEGIN:fixtures.bodystring.generated.stringgetwhitespace.stringgetwhitespace
         RequestOptions requestOptions = new RequestOptions();
         Response<BinaryData> response = stringOperationClient.getWhitespaceWithResponse(requestOptions);
-        // END: fixtures.bodystring.generated.stringgetwhitespace.stringgetwhitespace
+        // END:fixtures.bodystring.generated.stringgetwhitespace.stringgetwhitespace
     }
 }

--- a/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringPutEmpty.java
+++ b/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringPutEmpty.java
@@ -12,12 +12,12 @@ import fixtures.bodystring.StringOperationClientBuilder;
 
 public class StringPutEmpty {
     public static void main(String[] args) {
-        // BEGIN: fixtures.bodystring.generated.stringputempty.stringputempty
         StringOperationClient stringOperationClient =
                 new StringOperationClientBuilder().host("http://localhost:3000").buildClient();
+        // BEGIN:fixtures.bodystring.generated.stringputempty.stringputempty
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.setBody(BinaryData.fromString("\"\""));
         Response<Void> response = stringOperationClient.putEmptyWithResponse(requestOptions);
-        // END: fixtures.bodystring.generated.stringputempty.stringputempty
+        // END:fixtures.bodystring.generated.stringputempty.stringputempty
     }
 }

--- a/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringPutMbcs.java
+++ b/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringPutMbcs.java
@@ -12,13 +12,13 @@ import fixtures.bodystring.StringOperationClientBuilder;
 
 public class StringPutMbcs {
     public static void main(String[] args) {
-        // BEGIN: fixtures.bodystring.generated.stringputmbcs.stringputmbcs
         StringOperationClient stringOperationClient =
                 new StringOperationClientBuilder().host("http://localhost:3000").buildClient();
+        // BEGIN:fixtures.bodystring.generated.stringputmbcs.stringputmbcs
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.setBody(
                 BinaryData.fromString("\"啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€\""));
         Response<Void> response = stringOperationClient.putMbcsWithResponse(requestOptions);
-        // END: fixtures.bodystring.generated.stringputmbcs.stringputmbcs
+        // END:fixtures.bodystring.generated.stringputmbcs.stringputmbcs
     }
 }

--- a/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringPutNull.java
+++ b/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringPutNull.java
@@ -11,11 +11,11 @@ import fixtures.bodystring.StringOperationClientBuilder;
 
 public class StringPutNull {
     public static void main(String[] args) {
-        // BEGIN: fixtures.bodystring.generated.stringputnull.stringputnull
         StringOperationClient stringOperationClient =
                 new StringOperationClientBuilder().host("http://localhost:3000").buildClient();
+        // BEGIN:fixtures.bodystring.generated.stringputnull.stringputnull
         RequestOptions requestOptions = new RequestOptions();
         Response<Void> response = stringOperationClient.putNullWithResponse(requestOptions);
-        // END: fixtures.bodystring.generated.stringputnull.stringputnull
+        // END:fixtures.bodystring.generated.stringputnull.stringputnull
     }
 }

--- a/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringPutWhitespace.java
+++ b/protocol-tests/src/samples/java/fixtures/bodystring/generated/StringPutWhitespace.java
@@ -12,14 +12,14 @@ import fixtures.bodystring.StringOperationClientBuilder;
 
 public class StringPutWhitespace {
     public static void main(String[] args) {
-        // BEGIN: fixtures.bodystring.generated.stringputwhitespace.stringputwhitespace
         StringOperationClient stringOperationClient =
                 new StringOperationClientBuilder().host("http://localhost:3000").buildClient();
+        // BEGIN:fixtures.bodystring.generated.stringputwhitespace.stringputwhitespace
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.setBody(
                 BinaryData.fromString(
                         "\"<tab><space><space>Now is the time for all good men to come to the aid of their country<tab><space><space>\""));
         Response<Void> response = stringOperationClient.putWhitespaceWithResponse(requestOptions);
-        // END: fixtures.bodystring.generated.stringputwhitespace.stringputwhitespace
+        // END:fixtures.bodystring.generated.stringputwhitespace.stringputwhitespace
     }
 }

--- a/protocol-tests/src/samples/java/fixtures/url/multi/generated/QueriesArrayStringMultiEmpty.java
+++ b/protocol-tests/src/samples/java/fixtures/url/multi/generated/QueriesArrayStringMultiEmpty.java
@@ -11,15 +11,15 @@ import fixtures.url.multi.AutoRestUrlMutliCollectionFormatTestServiceClientBuild
 
 public class QueriesArrayStringMultiEmpty {
     public static void main(String[] args) {
-        // BEGIN: fixtures.url.multi.generated.queriesarraystringmultiempty.queriesarraystringmultiempty
         AutoRestUrlMutliCollectionFormatTestServiceClient autoRestUrlMutliCollectionFormatTestServiceClient =
                 new AutoRestUrlMutliCollectionFormatTestServiceClientBuilder()
                         .host("http://localhost:3000")
                         .buildClient();
+        // BEGIN:fixtures.url.multi.generated.queriesarraystringmultiempty.queriesarraystringmultiempty
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.addQueryParam("arrayQuery", "");
         Response<Void> response =
                 autoRestUrlMutliCollectionFormatTestServiceClient.arrayStringMultiEmptyWithResponse(requestOptions);
-        // END: fixtures.url.multi.generated.queriesarraystringmultiempty.queriesarraystringmultiempty
+        // END:fixtures.url.multi.generated.queriesarraystringmultiempty.queriesarraystringmultiempty
     }
 }

--- a/protocol-tests/src/samples/java/fixtures/url/multi/generated/QueriesArrayStringMultiNull.java
+++ b/protocol-tests/src/samples/java/fixtures/url/multi/generated/QueriesArrayStringMultiNull.java
@@ -11,14 +11,14 @@ import fixtures.url.multi.AutoRestUrlMutliCollectionFormatTestServiceClientBuild
 
 public class QueriesArrayStringMultiNull {
     public static void main(String[] args) {
-        // BEGIN: fixtures.url.multi.generated.queriesarraystringmultinull.queriesarraystringmultinull
         AutoRestUrlMutliCollectionFormatTestServiceClient autoRestUrlMutliCollectionFormatTestServiceClient =
                 new AutoRestUrlMutliCollectionFormatTestServiceClientBuilder()
                         .host("http://localhost:3000")
                         .buildClient();
+        // BEGIN:fixtures.url.multi.generated.queriesarraystringmultinull.queriesarraystringmultinull
         RequestOptions requestOptions = new RequestOptions();
         Response<Void> response =
                 autoRestUrlMutliCollectionFormatTestServiceClient.arrayStringMultiNullWithResponse(requestOptions);
-        // END: fixtures.url.multi.generated.queriesarraystringmultinull.queriesarraystringmultinull
+        // END:fixtures.url.multi.generated.queriesarraystringmultinull.queriesarraystringmultinull
     }
 }

--- a/protocol-tests/src/samples/java/fixtures/url/multi/generated/QueriesArrayStringMultiValid.java
+++ b/protocol-tests/src/samples/java/fixtures/url/multi/generated/QueriesArrayStringMultiValid.java
@@ -11,15 +11,15 @@ import fixtures.url.multi.AutoRestUrlMutliCollectionFormatTestServiceClientBuild
 
 public class QueriesArrayStringMultiValid {
     public static void main(String[] args) {
-        // BEGIN: fixtures.url.multi.generated.queriesarraystringmultivalid.queriesarraystringmultivalid
         AutoRestUrlMutliCollectionFormatTestServiceClient autoRestUrlMutliCollectionFormatTestServiceClient =
                 new AutoRestUrlMutliCollectionFormatTestServiceClientBuilder()
                         .host("http://localhost:3000")
                         .buildClient();
+        // BEGIN:fixtures.url.multi.generated.queriesarraystringmultivalid.queriesarraystringmultivalid
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.addQueryParam("arrayQuery", "ArrayQuery1,begin!*'();:@ &= $,/?#[]end,,");
         Response<Void> response =
                 autoRestUrlMutliCollectionFormatTestServiceClient.arrayStringMultiValidWithResponse(requestOptions);
-        // END: fixtures.url.multi.generated.queriesarraystringmultivalid.queriesarraystringmultivalid
+        // END:fixtures.url.multi.generated.queriesarraystringmultivalid.queriesarraystringmultivalid
     }
 }


### PR DESCRIPTION
As https://github.com/Azure/azure-sdk-tools/pull/2909, space is not required in `BEGIN`, `END`, `src_embed`, `end`
Remove the space to avoid line break by formatter.

Require codesnippet-maven-plugin 1.0.0-beta.7

Fix https://github.com/Azure/autorest.java/issues/1389