### PR TITLE
client, use java-sdks-folder for consistency

### DIFF
--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/AutorestSettings.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/AutorestSettings.java
@@ -17,7 +17,7 @@ public class AutorestSettings {
     private List<String> security = new ArrayList<>();
     private List<String> securityScopes = new ArrayList<>();
     private String securityHeaderName;
-    private String azureLibrariesForJavaFolder;
+    private String javaSdksFolder;
     private final List<String> inputFiles = new ArrayList<>();
 
     public void setTag(String tag) {
@@ -32,8 +32,8 @@ public class AutorestSettings {
         this.outputFolder = outputFolder;
     }
 
-    public void setAzureLibrariesForJavaFolder(String azureLibrariesForJavaFolder) {
-        this.azureLibrariesForJavaFolder = azureLibrariesForJavaFolder;
+    public void setJavaSdksFolder(String javaSdksFolder) {
+        this.javaSdksFolder = javaSdksFolder;
     }
 
     public String getTag() {
@@ -48,8 +48,8 @@ public class AutorestSettings {
         return outputFolder;
     }
 
-    public Optional<String> getAzureLibrariesForJavaFolder() {
-        return Optional.ofNullable(azureLibrariesForJavaFolder);
+    public Optional<String> getJavaSdksFolder() {
+        return Optional.ofNullable(javaSdksFolder);
     }
 
     public List<String> getInputFiles() {

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
@@ -74,7 +74,11 @@ public class JavaSettings {
             loadStringSetting("tag", autorestSettings::setTag);
             loadStringSetting("base-folder", autorestSettings::setBaseFolder);
             loadStringSetting("output-folder", autorestSettings::setOutputFolder);
-            loadStringSetting("azure-libraries-for-java-folder", autorestSettings::setAzureLibrariesForJavaFolder);
+            loadStringSetting("java-sdks-folder", autorestSettings::setJavaSdksFolder);
+            if (!autorestSettings.getJavaSdksFolder().isPresent() || autorestSettings.getJavaSdksFolder().get().isEmpty()) {
+                // TODO remove after script updated
+                loadStringSetting("azure-libraries-for-java-folder", autorestSettings::setJavaSdksFolder);
+            }
             List<Object> inputFiles = host.getValue(List.class, "input-file");
             if (inputFiles != null) {
                 autorestSettings.getInputFiles().addAll(

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
@@ -76,7 +76,7 @@ public class JavaSettings {
             loadStringSetting("output-folder", autorestSettings::setOutputFolder);
             loadStringSetting("java-sdks-folder", autorestSettings::setJavaSdksFolder);
             if (!autorestSettings.getJavaSdksFolder().isPresent() || autorestSettings.getJavaSdksFolder().get().isEmpty()) {
-                // TODO remove after script updated
+                // TODO(weidxu): remove after script updated
                 loadStringSetting("azure-libraries-for-java-folder", autorestSettings::setJavaSdksFolder);
             }
             List<Object> inputFiles = host.getValue(List.class, "input-file");

--- a/fluentnamer/src/main/java/com/azure/autorest/fluent/util/FluentJavaSettings.java
+++ b/fluentnamer/src/main/java/com/azure/autorest/fluent/util/FluentJavaSettings.java
@@ -150,7 +150,7 @@ public class FluentJavaSettings {
             loadStringSetting("output-folder", autorestSettings::setOutputFolder);
             loadStringSetting("java-sdks-folder", autorestSettings::setJavaSdksFolder);
             if (!autorestSettings.getJavaSdksFolder().isPresent() || autorestSettings.getJavaSdksFolder().get().isEmpty()) {
-                // TODO remove after script updated
+                // TODO (weidxu): remove after script updated
                 loadStringSetting("azure-libraries-for-java-folder", autorestSettings::setJavaSdksFolder);
             }
 

--- a/fluentnamer/src/main/java/com/azure/autorest/fluent/util/FluentJavaSettings.java
+++ b/fluentnamer/src/main/java/com/azure/autorest/fluent/util/FluentJavaSettings.java
@@ -148,7 +148,11 @@ public class FluentJavaSettings {
 
             loadStringSetting("base-folder", autorestSettings::setBaseFolder);
             loadStringSetting("output-folder", autorestSettings::setOutputFolder);
-            loadStringSetting("azure-libraries-for-java-folder", autorestSettings::setAzureLibrariesForJavaFolder);
+            loadStringSetting("java-sdks-folder", autorestSettings::setJavaSdksFolder);
+            if (!autorestSettings.getJavaSdksFolder().isPresent() || autorestSettings.getJavaSdksFolder().get().isEmpty()) {
+                // TODO remove after script updated
+                loadStringSetting("azure-libraries-for-java-folder", autorestSettings::setJavaSdksFolder);
+            }
 
             List<Object> inputFiles = host.getValue(List.class, "input-file");
             if (inputFiles != null) {

--- a/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
+++ b/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
@@ -150,12 +150,12 @@ public class Project {
 
     private Optional<String> findSdkFolder() {
         JavaSettings settings = JavaSettings.getInstance();
-        Optional<String> sdkFolderOpt = settings.getAutorestSettings().getAzureLibrariesForJavaFolder();
+        Optional<String> sdkFolderOpt = settings.getAutorestSettings().getJavaSdksFolder();
         if (!sdkFolderOpt.isPresent()) {
-            logger.info("'azure-libraries-for-java-folder' parameter not available");
+            logger.info("'java-sdks-folder' parameter not available");
         } else {
             if (!Paths.get(sdkFolderOpt.get()).isAbsolute()) {
-                logger.info("'azure-libraries-for-java-folder' parameter is not an absolute path");
+                logger.info("'java-sdks-folder' parameter is not an absolute path");
                 sdkFolderOpt = Optional.empty();
             }
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/java",
-  "version": "4.0.52",
+  "version": "4.0.53",
   "description": "The Java extension for classic generators in AutoRest.",
   "scripts": {
     "autorest": "autorest",


### PR DESCRIPTION
mgmt does not use the readme, so there is not effect.

But DPG is going to rely on readme.java.md in spec repo. And its `output-folder` is better to be consistent as e.g. `$(java-sdks-folder)/sdk/foo/bar` for consistency with other languages.