### PR TITLE
mgmt, remove duplicate property init code

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientBuilderTrait.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientBuilderTrait.java
@@ -105,7 +105,7 @@ public class ClientBuilderTrait {
         ServiceClientProperty pipelineProperty = new ServiceClientProperty("The HTTP pipeline to send requests " +
                 "through.", ClassType.HttpPipeline, "pipeline", false,
                 JavaSettings.getInstance().isAzureOrFluent()
-                        ? "new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build()"
+                        ? "new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy()).build()"
                         : "createHttpPipeline()");
         Consumer<JavaBlock> pipelineMethodImpl = function -> {
             function.line(String.format("this.%1$s = %2$s;", "pipeline", "pipeline"));

--- a/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
@@ -241,7 +241,7 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ClientBuilder
                         .collect(Collectors.toList());
                 Set<String> propertyNames = allProperties.stream()
                         .map(ServiceClientProperty::getName)
-                        .collect(Collectors.toSet());;
+                        .collect(Collectors.toSet());
                 allProperties.addAll(clientProperties.stream()
                         .filter(p -> !propertyNames.contains(p))    // filter out properties already contained in traits
                         .collect(Collectors.toList()));

--- a/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
@@ -232,20 +232,23 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ClientBuilder
                 comment.methodReturns(String.format("an instance of %1$s", buildReturnType));
             });
             addGeneratedAnnotation(classBlock);
-            classBlock.method(visibility, null, String.format("%1$s %2$s()", buildReturnType, buildMethodName), function ->
-            {
+            classBlock.method(visibility, null, String.format("%1$s %2$s()", buildReturnType, buildMethodName), function -> {
                 List<ServiceClientProperty> allProperties = clientBuilder.getBuilderTraits()
                         .stream()
                         .flatMap(trait -> trait.getTraitMethods().stream())
                         .map(ClientBuilderTraitMethod::getProperty)
                         .filter(Objects::nonNull)
                         .collect(Collectors.toList());
-                allProperties.addAll(clientProperties);
+                Set<String> propertyNames = allProperties.stream()
+                        .map(ServiceClientProperty::getName)
+                        .collect(Collectors.toSet());;
+                allProperties.addAll(clientProperties.stream()
+                        .filter(p -> !propertyNames.contains(p))    // filter out properties already contained in traits
+                        .collect(Collectors.toList()));
 
                 for (ServiceClientProperty serviceClientProperty : allProperties) {
                     if (serviceClientProperty.getDefaultValueExpression() != null) {
-                        function.ifBlock(String.format("%1$s == null", serviceClientProperty.getName()), ifBlock ->
-                        {
+                        function.ifBlock(String.format("%1$s == null", serviceClientProperty.getName()), ifBlock -> {
                             function.line(String.format("this.%1$s = %2$s;", serviceClientProperty.getName(), serviceClientProperty.getDefaultValueExpression()));
                         });
                     }
@@ -514,7 +517,7 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ClientBuilder
         if (settings.isAzureOrFluent()) {
             commonProperties.add(new ServiceClientProperty("The environment to connect to", ClassType.AzureEnvironment, "environment", false, "AzureEnvironment.AZURE"));
             commonProperties.add(new ServiceClientProperty("The HTTP pipeline to send requests through", ClassType.HttpPipeline, "pipeline", false,
-                            "new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy()).build()"));
+                            "new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy()).build()"));
         }
         if (settings.isFluent()) {
             commonProperties.add(new ServiceClientProperty("The default poll interval for long-running operation", ClassType.Duration, "defaultPollInterval", false, "Duration.ofSeconds(30)"));

--- a/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
@@ -232,7 +232,8 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ClientBuilder
                 comment.methodReturns(String.format("an instance of %1$s", buildReturnType));
             });
             addGeneratedAnnotation(classBlock);
-            classBlock.method(visibility, null, String.format("%1$s %2$s()", buildReturnType, buildMethodName), function -> {
+            classBlock.method(visibility, null, String.format("%1$s %2$s()", buildReturnType, buildMethodName), function ->
+            {
                 List<ServiceClientProperty> allProperties = clientBuilder.getBuilderTraits()
                         .stream()
                         .flatMap(trait -> trait.getTraitMethods().stream())
@@ -248,7 +249,8 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ClientBuilder
 
                 for (ServiceClientProperty serviceClientProperty : allProperties) {
                     if (serviceClientProperty.getDefaultValueExpression() != null) {
-                        function.ifBlock(String.format("%1$s == null", serviceClientProperty.getName()), ifBlock -> {
+                        function.ifBlock(String.format("%1$s == null", serviceClientProperty.getName()), ifBlock ->
+                        {
                             function.line(String.format("this.%1$s = %2$s;", serviceClientProperty.getName(), serviceClientProperty.getDefaultValueExpression()));
                         });
                     }


### PR DESCRIPTION
Avoid 2 `httpPipeline` null check and init code in Builder for mgmt.

Previously the httpPipeline in trait will generate some code in `buildClient`, then the one in serviceClient will also generate code.