### PR TITLE
mgmt, bug fix on unused Header class

### DIFF
--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentClientMethodExample.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentClientMethodExample.java
@@ -99,6 +99,8 @@ public class FluentClientMethodExample implements FluentMethodExample {
                 serviceClientReference = "subscriptionClient()";
             } else if (tag.contains("locks")) {
                 serviceClientReference = "managementLockClient()";
+            } else if (tag.contains("changes")) {
+                serviceClientReference = "resourceChangeClient()";
             }
         }
 

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMapper.java
@@ -369,6 +369,12 @@ public class ClientMapper implements IMapper<CodeModel, Client> {
     }
 
     static ObjectSchema parseHeader(Operation operation, JavaSettings settings) {
+        if (settings.isFluent()
+                && operation.getExtensions() != null && operation.getExtensions().isXmsLongRunningOperation()) {
+            // SyncPoller or PollerFlux does not contain full Response and hence does not have headers
+            return null;
+        }
+
         String name = CodeNamer.getPlural(operation.getOperationGroup().getLanguage().getJava().getName())
                 + CodeNamer.toPascalCase(operation.getLanguage().getJava().getName()) + "Headers";
         Map<String, Schema> headerMap = new HashMap<>();
@@ -417,11 +423,6 @@ public class ClientMapper implements IMapper<CodeModel, Client> {
         ClientResponse.Builder builder = new ClientResponse.Builder();
         ObjectSchema headerSchema = parseHeader(method, settings);
         if (headerSchema == null || settings.isGenericResponseTypes()) {
-            return null;
-        }
-        if (settings.isFluent()
-                && method.getExtensions() != null && method.getExtensions().isXmsLongRunningOperation()) {
-            // SyncPoller or PollerFlux does not contain full Response and hence does not have headers
             return null;
         }
 

--- a/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
@@ -234,18 +234,16 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ClientBuilder
             addGeneratedAnnotation(classBlock);
             classBlock.method(visibility, null, String.format("%1$s %2$s()", buildReturnType, buildMethodName), function ->
             {
-                List<ServiceClientProperty> allProperties = clientBuilder.getBuilderTraits()
-                        .stream()
-                        .flatMap(trait -> trait.getTraitMethods().stream())
-                        .map(ClientBuilderTraitMethod::getProperty)
-                        .filter(Objects::nonNull)
-                        .collect(Collectors.toList());
-                Set<String> propertyNames = allProperties.stream()
-                        .map(ServiceClientProperty::getName)
-                        .collect(Collectors.toSet());
-                allProperties.addAll(clientProperties.stream()
-                        .filter(p -> !propertyNames.contains(p))    // filter out properties already contained in traits
-                        .collect(Collectors.toList()));
+                List<ServiceClientProperty> allProperties = new ArrayList<>();
+                if (!settings.isAzureOrFluent()) {
+                    allProperties.addAll(clientBuilder.getBuilderTraits()
+                            .stream()
+                            .flatMap(trait -> trait.getTraitMethods().stream())
+                            .map(ClientBuilderTraitMethod::getProperty)
+                            .filter(Objects::nonNull)
+                            .collect(Collectors.toList()));
+                }
+                allProperties.addAll(clientProperties);
 
                 for (ServiceClientProperty serviceClientProperty : allProperties) {
                     if (serviceClientProperty.getDefaultValueExpression() != null) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/java",
-  "version": "4.0.55",
+  "version": "4.0.56",
   "description": "The Java extension for classic generators in AutoRest.",
   "scripts": {
     "autorest": "autorest",


### PR DESCRIPTION
2 fixes that only apply to mgmt
- ignore Header class in LRO, as LRO does not have a method with Response as return type
- management does not use Trait yet, so skip it