### PR TITLE
client, always have javadoc description

### DIFF
--- a/azure-tests/src/main/java/fixtures/azurespecials/models/HeadersCustomNamedRequestIdHeadResponse.java
+++ b/azure-tests/src/main/java/fixtures/azurespecials/models/HeadersCustomNamedRequestIdHeadResponse.java
@@ -29,7 +29,11 @@ public final class HeadersCustomNamedRequestIdHeadResponse
         super(request, statusCode, rawHeaders, value, headers);
     }
 
-    /** @return the deserialized response body. */
+    /**
+     * Gets the deserialized response body.
+     *
+     * @return the deserialized response body.
+     */
     @Override
     public Boolean getValue() {
         return super.getValue();

--- a/azure-tests/src/main/java/fixtures/paging/models/OperationResultStatus.java
+++ b/azure-tests/src/main/java/fixtures/paging/models/OperationResultStatus.java
@@ -54,7 +54,11 @@ public final class OperationResultStatus extends ExpandableStringEnum<OperationR
         return fromString(name, OperationResultStatus.class);
     }
 
-    /** @return known OperationResultStatus values. */
+    /**
+     * Gets known OperationResultStatus values.
+     *
+     * @return known OperationResultStatus values.
+     */
     public static Collection<OperationResultStatus> values() {
         return values(OperationResultStatus.class);
     }

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/CMYKColors.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/CMYKColors.java
@@ -33,7 +33,11 @@ public final class CMYKColors extends ExpandableStringEnum<CMYKColors> {
         return fromString(name, CMYKColors.class);
     }
 
-    /** @return known CMYKColors values. */
+    /**
+     * Gets known CMYKColors values.
+     *
+     * @return known CMYKColors values.
+     */
     public static Collection<CMYKColors> values() {
         return values(CMYKColors.class);
     }

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/GoblinSharkColor.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/GoblinSharkColor.java
@@ -36,7 +36,11 @@ public final class GoblinSharkColor extends ExpandableStringEnum<GoblinSharkColo
         return fromString(name, GoblinSharkColor.class);
     }
 
-    /** @return known GoblinSharkColor values. */
+    /**
+     * Gets known GoblinSharkColor values.
+     *
+     * @return known GoblinSharkColor values.
+     */
     public static Collection<GoblinSharkColor> values() {
         return values(GoblinSharkColor.class);
     }

--- a/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/MyKind.java
+++ b/customization-tests/src/main/java/fixtures/bodycomplex/implementation/models/MyKind.java
@@ -24,7 +24,11 @@ public final class MyKind extends ExpandableStringEnum<MyKind> {
         return fromString(name, MyKind.class);
     }
 
-    /** @return known MyKind values. */
+    /**
+     * Gets known MyKind values.
+     *
+     * @return known MyKind values.
+     */
     public static Collection<MyKind> values() {
         return values(MyKind.class);
     }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentManagerTemplate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentManagerTemplate.java
@@ -206,6 +206,7 @@ public class FluentManagerTemplate {
 
             manager.getProperties().forEach(property -> {
                 classBlock.javadocComment(comment -> {
+                    comment.description(String.format("Gets the resource collection API of %1$s.", property.getFluentType().getName()));
                     comment.methodReturns(String.format("Resource collection API of %1$s.", property.getFluentType().getName()));
                 });
 

--- a/generate.bat
+++ b/generate.bat
@@ -5,7 +5,7 @@ set PROTOCOL_ARGUMENTS=--version=3.8.1 --java --use=. --output-folder=protocol-t
 set PROTOCOL_RESILIENCE_ARGUMENTS=--version=3.8.1 --java --use=. --data-plane
 set SWAGGER_PATH=node_modules/@microsoft.azure/autorest.testserver/swagger
 
-move /S vanilla-tests\src\main\java\fixtures\report\CoverageReporter.java vanilla-tests\swagger\CoverageReporter.java
+move /Y vanilla-tests\src\main\java\fixtures\report\CoverageReporter.java vanilla-tests\swagger\CoverageReporter.java
 rmdir /S /Q "vanilla-tests\src\main"
 call autorest %VANILLA_ARGUMENTS% --input-file=%SWAGGER_PATH%/additionalProperties.json --namespace=fixtures.additionalproperties
 call autorest %VANILLA_ARGUMENTS% --input-file=%SWAGGER_PATH%/body-array.json --namespace=fixtures.bodyarray

--- a/javagen/src/main/java/com/azure/autorest/template/EnumTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/EnumTemplate.java
@@ -64,6 +64,7 @@ public class EnumTemplate implements IJavaTemplate<EnumType, JavaFile> {
 
                 classBlock.javadocComment((comment) ->
                 {
+                    comment.description(String.format("Gets known %1$s values.", enumType.getName()));
                     comment.methodReturns(String.format("known %1$s values", enumType.getName()));
                 });
                 classBlock.publicStaticMethod(String.format("Collection<%1$s> values()", enumType.getName()), (function) ->

--- a/javagen/src/main/java/com/azure/autorest/template/ResponseTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ResponseTemplate.java
@@ -73,11 +73,16 @@ public class ResponseTemplate implements IJavaTemplate<ClientResponse, JavaFile>
 
             if (!response.getBodyType().asNullable().equals(ClassType.Void)) {
                 if (response.getBodyType().equals(GenericType.FluxByteBuffer)) {
-                    classBlock.javadocComment(javadoc -> javadoc.methodReturns("the response content stream"));
+                    classBlock.javadocComment(javadoc -> {
+                        javadoc.description("Gets the response content stream.");
+                        javadoc.methodReturns("the response content stream");
+                    });
                 } else {
-                    classBlock.javadocComment(javadoc -> javadoc.methodReturns("the deserialized response body"));
+                    classBlock.javadocComment(javadoc -> {
+                        javadoc.description("Gets the deserialized response body.");
+                        javadoc.methodReturns("the deserialized response body");
+                    });
                 }
-
 
                 classBlock.annotation("Override");
                 classBlock.publicMethod(String.format("%1$s getValue()", response.getBodyType().asNullable()),

--- a/protocol-tests/src/main/java/fixtures/dpgcustomization/implementation/models/ProductReceived.java
+++ b/protocol-tests/src/main/java/fixtures/dpgcustomization/implementation/models/ProductReceived.java
@@ -27,7 +27,11 @@ public final class ProductReceived extends ExpandableStringEnum<ProductReceived>
         return fromString(name, ProductReceived.class);
     }
 
-    /** @return known ProductReceived values. */
+    /**
+     * Gets known ProductReceived values.
+     *
+     * @return known ProductReceived values.
+     */
     public static Collection<ProductReceived> values() {
         return values(ProductReceived.class);
     }

--- a/vanilla-tests/src/main/java/fixtures/annotatedgettersandsetters/models/SkuFamily.java
+++ b/vanilla-tests/src/main/java/fixtures/annotatedgettersandsetters/models/SkuFamily.java
@@ -24,7 +24,11 @@ public final class SkuFamily extends ExpandableStringEnum<SkuFamily> {
         return fromString(name, SkuFamily.class);
     }
 
-    /** @return known SkuFamily values. */
+    /**
+     * Gets known SkuFamily values.
+     *
+     * @return known SkuFamily values.
+     */
     public static Collection<SkuFamily> values() {
         return values(SkuFamily.class);
     }

--- a/vanilla-tests/src/main/java/fixtures/bodyarray/models/Enum0.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyarray/models/Enum0.java
@@ -30,7 +30,11 @@ public final class Enum0 extends ExpandableStringEnum<Enum0> {
         return fromString(name, Enum0.class);
     }
 
-    /** @return known Enum0 values. */
+    /**
+     * Gets known Enum0 values.
+     *
+     * @return known Enum0 values.
+     */
     public static Collection<Enum0> values() {
         return values(Enum0.class);
     }

--- a/vanilla-tests/src/main/java/fixtures/bodyarray/models/Enum1.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyarray/models/Enum1.java
@@ -30,7 +30,11 @@ public final class Enum1 extends ExpandableStringEnum<Enum1> {
         return fromString(name, Enum1.class);
     }
 
-    /** @return known Enum1 values. */
+    /**
+     * Gets known Enum1 values.
+     *
+     * @return known Enum1 values.
+     */
     public static Collection<Enum1> values() {
         return values(Enum1.class);
     }

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/CMYKColors.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/CMYKColors.java
@@ -33,7 +33,11 @@ public final class CMYKColors extends ExpandableStringEnum<CMYKColors> {
         return fromString(name, CMYKColors.class);
     }
 
-    /** @return known CMYKColors values. */
+    /**
+     * Gets known CMYKColors values.
+     *
+     * @return known CMYKColors values.
+     */
     public static Collection<CMYKColors> values() {
         return values(CMYKColors.class);
     }

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/GoblinSharkColor.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/GoblinSharkColor.java
@@ -36,7 +36,11 @@ public final class GoblinSharkColor extends ExpandableStringEnum<GoblinSharkColo
         return fromString(name, GoblinSharkColor.class);
     }
 
-    /** @return known GoblinSharkColor values. */
+    /**
+     * Gets known GoblinSharkColor values.
+     *
+     * @return known GoblinSharkColor values.
+     */
     public static Collection<GoblinSharkColor> values() {
         return values(GoblinSharkColor.class);
     }

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/MyKind.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/MyKind.java
@@ -24,7 +24,11 @@ public final class MyKind extends ExpandableStringEnum<MyKind> {
         return fromString(name, MyKind.class);
     }
 
-    /** @return known MyKind values. */
+    /**
+     * Gets known MyKind values.
+     *
+     * @return known MyKind values.
+     */
     public static Collection<MyKind> values() {
         return values(MyKind.class);
     }

--- a/vanilla-tests/src/main/java/fixtures/bodyformdataurlencoded/models/PetFood.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyformdataurlencoded/models/PetFood.java
@@ -30,7 +30,11 @@ public final class PetFood extends ExpandableStringEnum<PetFood> {
         return fromString(name, PetFood.class);
     }
 
-    /** @return known PetFood values. */
+    /**
+     * Gets known PetFood values.
+     *
+     * @return known PetFood values.
+     */
     public static Collection<PetFood> values() {
         return values(PetFood.class);
     }

--- a/vanilla-tests/src/main/java/fixtures/clientdefaultvalue/models/SkuFamily.java
+++ b/vanilla-tests/src/main/java/fixtures/clientdefaultvalue/models/SkuFamily.java
@@ -24,7 +24,11 @@ public final class SkuFamily extends ExpandableStringEnum<SkuFamily> {
         return fromString(name, SkuFamily.class);
     }
 
-    /** @return known SkuFamily values. */
+    /**
+     * Gets known SkuFamily values.
+     *
+     * @return known SkuFamily values.
+     */
     public static Collection<SkuFamily> values() {
         return values(SkuFamily.class);
     }

--- a/vanilla-tests/src/main/java/fixtures/discriminatorflattening/clientflatten/models/Odatatype.java
+++ b/vanilla-tests/src/main/java/fixtures/discriminatorflattening/clientflatten/models/Odatatype.java
@@ -33,7 +33,11 @@ public final class Odatatype extends ExpandableStringEnum<Odatatype> {
         return fromString(name, Odatatype.class);
     }
 
-    /** @return known Odatatype values. */
+    /**
+     * Gets known Odatatype values.
+     *
+     * @return known Odatatype values.
+     */
     public static Collection<Odatatype> values() {
         return values(Odatatype.class);
     }

--- a/vanilla-tests/src/main/java/fixtures/discriminatorflattening/models/Odatatype.java
+++ b/vanilla-tests/src/main/java/fixtures/discriminatorflattening/models/Odatatype.java
@@ -33,7 +33,11 @@ public final class Odatatype extends ExpandableStringEnum<Odatatype> {
         return fromString(name, Odatatype.class);
     }
 
-    /** @return known Odatatype values. */
+    /**
+     * Gets known Odatatype values.
+     *
+     * @return known Odatatype values.
+     */
     public static Collection<Odatatype> values() {
         return values(Odatatype.class);
     }

--- a/vanilla-tests/src/main/java/fixtures/discriminatorflattening/noflatten/models/Odatatype.java
+++ b/vanilla-tests/src/main/java/fixtures/discriminatorflattening/noflatten/models/Odatatype.java
@@ -33,7 +33,11 @@ public final class Odatatype extends ExpandableStringEnum<Odatatype> {
         return fromString(name, Odatatype.class);
     }
 
-    /** @return known Odatatype values. */
+    /**
+     * Gets known Odatatype values.
+     *
+     * @return known Odatatype values.
+     */
     public static Collection<Odatatype> values() {
         return values(Odatatype.class);
     }

--- a/vanilla-tests/src/main/java/fixtures/discriminatorflattening/requirexmsflattened/models/Odatatype.java
+++ b/vanilla-tests/src/main/java/fixtures/discriminatorflattening/requirexmsflattened/models/Odatatype.java
@@ -33,7 +33,11 @@ public final class Odatatype extends ExpandableStringEnum<Odatatype> {
         return fromString(name, Odatatype.class);
     }
 
-    /** @return known Odatatype values. */
+    /**
+     * Gets known Odatatype values.
+     *
+     * @return known Odatatype values.
+     */
     public static Collection<Odatatype> values() {
         return values(Odatatype.class);
     }

--- a/vanilla-tests/src/main/java/fixtures/extensibleenums/models/DaysOfWeekExtensibleEnum.java
+++ b/vanilla-tests/src/main/java/fixtures/extensibleenums/models/DaysOfWeekExtensibleEnum.java
@@ -42,7 +42,11 @@ public final class DaysOfWeekExtensibleEnum extends ExpandableStringEnum<DaysOfW
         return fromString(name, DaysOfWeekExtensibleEnum.class);
     }
 
-    /** @return known DaysOfWeekExtensibleEnum values. */
+    /**
+     * Gets known DaysOfWeekExtensibleEnum values.
+     *
+     * @return known DaysOfWeekExtensibleEnum values.
+     */
     public static Collection<DaysOfWeekExtensibleEnum> values() {
         return values(DaysOfWeekExtensibleEnum.class);
     }

--- a/vanilla-tests/src/main/java/fixtures/extensibleenums/models/IntEnum.java
+++ b/vanilla-tests/src/main/java/fixtures/extensibleenums/models/IntEnum.java
@@ -30,7 +30,11 @@ public final class IntEnum extends ExpandableStringEnum<IntEnum> {
         return fromString(name, IntEnum.class);
     }
 
-    /** @return known IntEnum values. */
+    /**
+     * Gets known IntEnum values.
+     *
+     * @return known IntEnum values.
+     */
     public static Collection<IntEnum> values() {
         return values(IntEnum.class);
     }

--- a/vanilla-tests/src/main/java/fixtures/httpinfrastructure/models/HttpRedirectsGet300Response.java
+++ b/vanilla-tests/src/main/java/fixtures/httpinfrastructure/models/HttpRedirectsGet300Response.java
@@ -29,7 +29,11 @@ public final class HttpRedirectsGet300Response extends ResponseBase<HttpRedirect
         super(request, statusCode, rawHeaders, value, headers);
     }
 
-    /** @return the deserialized response body. */
+    /**
+     * Gets the deserialized response body.
+     *
+     * @return the deserialized response body.
+     */
     @Override
     public List<String> getValue() {
         return super.getValue();

--- a/vanilla-tests/src/main/java/fixtures/inheritance/donotpassdiscriminator/models/Odatatype.java
+++ b/vanilla-tests/src/main/java/fixtures/inheritance/donotpassdiscriminator/models/Odatatype.java
@@ -33,7 +33,11 @@ public final class Odatatype extends ExpandableStringEnum<Odatatype> {
         return fromString(name, Odatatype.class);
     }
 
-    /** @return known Odatatype values. */
+    /**
+     * Gets known Odatatype values.
+     *
+     * @return known Odatatype values.
+     */
     public static Collection<Odatatype> values() {
         return values(Odatatype.class);
     }

--- a/vanilla-tests/src/main/java/fixtures/inheritance/passdiscriminator/models/Odatatype.java
+++ b/vanilla-tests/src/main/java/fixtures/inheritance/passdiscriminator/models/Odatatype.java
@@ -33,7 +33,11 @@ public final class Odatatype extends ExpandableStringEnum<Odatatype> {
         return fromString(name, Odatatype.class);
     }
 
-    /** @return known Odatatype values. */
+    /**
+     * Gets known Odatatype values.
+     *
+     * @return known Odatatype values.
+     */
     public static Collection<Odatatype> values() {
         return values(Odatatype.class);
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LRORetrysDeleteProvisioning202Accepted200SucceededResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LRORetrysDeleteProvisioning202Accepted200SucceededResponse.java
@@ -29,7 +29,11 @@ public final class LRORetrysDeleteProvisioning202Accepted200SucceededResponse
         super(request, statusCode, rawHeaders, value, headers);
     }
 
-    /** @return the deserialized response body. */
+    /**
+     * Gets the deserialized response body.
+     *
+     * @return the deserialized response body.
+     */
     @Override
     public Product getValue() {
         return super.getValue();

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LRORetrysPutAsyncRelativeRetrySucceededResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LRORetrysPutAsyncRelativeRetrySucceededResponse.java
@@ -29,7 +29,11 @@ public final class LRORetrysPutAsyncRelativeRetrySucceededResponse
         super(request, statusCode, rawHeaders, value, headers);
     }
 
-    /** @return the deserialized response body. */
+    /**
+     * Gets the deserialized response body.
+     *
+     * @return the deserialized response body.
+     */
     @Override
     public Product getValue() {
         return super.getValue();

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsCustomHeadersPutAsyncRetrySucceededResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsCustomHeadersPutAsyncRetrySucceededResponse.java
@@ -29,7 +29,11 @@ public final class LROsCustomHeadersPutAsyncRetrySucceededResponse
         super(request, statusCode, rawHeaders, value, headers);
     }
 
-    /** @return the deserialized response body. */
+    /**
+     * Gets the deserialized response body.
+     *
+     * @return the deserialized response body.
+     */
     @Override
     public Product getValue() {
         return super.getValue();

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsDelete202NoRetry204Response.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsDelete202NoRetry204Response.java
@@ -28,7 +28,11 @@ public final class LROsDelete202NoRetry204Response extends ResponseBase<LROsDele
         super(request, statusCode, rawHeaders, value, headers);
     }
 
-    /** @return the deserialized response body. */
+    /**
+     * Gets the deserialized response body.
+     *
+     * @return the deserialized response body.
+     */
     @Override
     public Product getValue() {
         return super.getValue();

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsDelete202Retry200Response.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsDelete202Retry200Response.java
@@ -28,7 +28,11 @@ public final class LROsDelete202Retry200Response extends ResponseBase<LROsDelete
         super(request, statusCode, rawHeaders, value, headers);
     }
 
-    /** @return the deserialized response body. */
+    /**
+     * Gets the deserialized response body.
+     *
+     * @return the deserialized response body.
+     */
     @Override
     public Product getValue() {
         return super.getValue();

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsDeleteProvisioning202Accepted200SucceededResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsDeleteProvisioning202Accepted200SucceededResponse.java
@@ -29,7 +29,11 @@ public final class LROsDeleteProvisioning202Accepted200SucceededResponse
         super(request, statusCode, rawHeaders, value, headers);
     }
 
-    /** @return the deserialized response body. */
+    /**
+     * Gets the deserialized response body.
+     *
+     * @return the deserialized response body.
+     */
     @Override
     public Product getValue() {
         return super.getValue();

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsDeleteProvisioning202DeletingFailed200Response.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsDeleteProvisioning202DeletingFailed200Response.java
@@ -29,7 +29,11 @@ public final class LROsDeleteProvisioning202DeletingFailed200Response
         super(request, statusCode, rawHeaders, value, headers);
     }
 
-    /** @return the deserialized response body. */
+    /**
+     * Gets the deserialized response body.
+     *
+     * @return the deserialized response body.
+     */
     @Override
     public Product getValue() {
         return super.getValue();

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsDeleteProvisioning202Deletingcanceled200Response.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsDeleteProvisioning202Deletingcanceled200Response.java
@@ -29,7 +29,11 @@ public final class LROsDeleteProvisioning202Deletingcanceled200Response
         super(request, statusCode, rawHeaders, value, headers);
     }
 
-    /** @return the deserialized response body. */
+    /**
+     * Gets the deserialized response body.
+     *
+     * @return the deserialized response body.
+     */
     @Override
     public Product getValue() {
         return super.getValue();

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsPatch200SucceededIgnoreHeadersResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsPatch200SucceededIgnoreHeadersResponse.java
@@ -29,7 +29,11 @@ public final class LROsPatch200SucceededIgnoreHeadersResponse
         super(request, statusCode, rawHeaders, value, headers);
     }
 
-    /** @return the deserialized response body. */
+    /**
+     * Gets the deserialized response body.
+     *
+     * @return the deserialized response body.
+     */
     @Override
     public Product getValue() {
         return super.getValue();

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsPatch201RetryWithAsyncHeaderResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsPatch201RetryWithAsyncHeaderResponse.java
@@ -29,7 +29,11 @@ public final class LROsPatch201RetryWithAsyncHeaderResponse
         super(request, statusCode, rawHeaders, value, headers);
     }
 
-    /** @return the deserialized response body. */
+    /**
+     * Gets the deserialized response body.
+     *
+     * @return the deserialized response body.
+     */
     @Override
     public Product getValue() {
         return super.getValue();

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsPatch202RetryWithAsyncAndLocationHeaderResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsPatch202RetryWithAsyncAndLocationHeaderResponse.java
@@ -29,7 +29,11 @@ public final class LROsPatch202RetryWithAsyncAndLocationHeaderResponse
         super(request, statusCode, rawHeaders, value, headers);
     }
 
-    /** @return the deserialized response body. */
+    /**
+     * Gets the deserialized response body.
+     *
+     * @return the deserialized response body.
+     */
     @Override
     public Product getValue() {
         return super.getValue();

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsPost202ListResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsPost202ListResponse.java
@@ -29,7 +29,11 @@ public final class LROsPost202ListResponse extends ResponseBase<LROsPost202ListH
         super(request, statusCode, rawHeaders, value, headers);
     }
 
-    /** @return the deserialized response body. */
+    /**
+     * Gets the deserialized response body.
+     *
+     * @return the deserialized response body.
+     */
     @Override
     public List<Product> getValue() {
         return super.getValue();

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsPost202NoRetry204Response.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsPost202NoRetry204Response.java
@@ -28,7 +28,11 @@ public final class LROsPost202NoRetry204Response extends ResponseBase<LROsPost20
         super(request, statusCode, rawHeaders, value, headers);
     }
 
-    /** @return the deserialized response body. */
+    /**
+     * Gets the deserialized response body.
+     *
+     * @return the deserialized response body.
+     */
     @Override
     public Product getValue() {
         return super.getValue();

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsPostAsyncNoRetrySucceededResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsPostAsyncNoRetrySucceededResponse.java
@@ -29,7 +29,11 @@ public final class LROsPostAsyncNoRetrySucceededResponse
         super(request, statusCode, rawHeaders, value, headers);
     }
 
-    /** @return the deserialized response body. */
+    /**
+     * Gets the deserialized response body.
+     *
+     * @return the deserialized response body.
+     */
     @Override
     public Product getValue() {
         return super.getValue();

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsPostAsyncRetrySucceededResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsPostAsyncRetrySucceededResponse.java
@@ -29,7 +29,11 @@ public final class LROsPostAsyncRetrySucceededResponse
         super(request, statusCode, rawHeaders, value, headers);
     }
 
-    /** @return the deserialized response body. */
+    /**
+     * Gets the deserialized response body.
+     *
+     * @return the deserialized response body.
+     */
     @Override
     public Product getValue() {
         return super.getValue();

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsPutAsyncNoHeaderInRetryResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsPutAsyncNoHeaderInRetryResponse.java
@@ -29,7 +29,11 @@ public final class LROsPutAsyncNoHeaderInRetryResponse
         super(request, statusCode, rawHeaders, value, headers);
     }
 
-    /** @return the deserialized response body. */
+    /**
+     * Gets the deserialized response body.
+     *
+     * @return the deserialized response body.
+     */
     @Override
     public Product getValue() {
         return super.getValue();

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsPutAsyncNoRetrySucceededResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsPutAsyncNoRetrySucceededResponse.java
@@ -29,7 +29,11 @@ public final class LROsPutAsyncNoRetrySucceededResponse
         super(request, statusCode, rawHeaders, value, headers);
     }
 
-    /** @return the deserialized response body. */
+    /**
+     * Gets the deserialized response body.
+     *
+     * @return the deserialized response body.
+     */
     @Override
     public Product getValue() {
         return super.getValue();

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsPutAsyncNoRetrycanceledResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsPutAsyncNoRetrycanceledResponse.java
@@ -29,7 +29,11 @@ public final class LROsPutAsyncNoRetrycanceledResponse
         super(request, statusCode, rawHeaders, value, headers);
     }
 
-    /** @return the deserialized response body. */
+    /**
+     * Gets the deserialized response body.
+     *
+     * @return the deserialized response body.
+     */
     @Override
     public Product getValue() {
         return super.getValue();

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsPutAsyncRetryFailedResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsPutAsyncRetryFailedResponse.java
@@ -28,7 +28,11 @@ public final class LROsPutAsyncRetryFailedResponse extends ResponseBase<LROsPutA
         super(request, statusCode, rawHeaders, value, headers);
     }
 
-    /** @return the deserialized response body. */
+    /**
+     * Gets the deserialized response body.
+     *
+     * @return the deserialized response body.
+     */
     @Override
     public Product getValue() {
         return super.getValue();

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsPutAsyncRetrySucceededResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsPutAsyncRetrySucceededResponse.java
@@ -28,7 +28,11 @@ public final class LROsPutAsyncRetrySucceededResponse extends ResponseBase<LROsP
         super(request, statusCode, rawHeaders, value, headers);
     }
 
-    /** @return the deserialized response body. */
+    /**
+     * Gets the deserialized response body.
+     *
+     * @return the deserialized response body.
+     */
     @Override
     public Product getValue() {
         return super.getValue();

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsPutNoHeaderInRetryResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsPutNoHeaderInRetryResponse.java
@@ -28,7 +28,11 @@ public final class LROsPutNoHeaderInRetryResponse extends ResponseBase<LROsPutNo
         super(request, statusCode, rawHeaders, value, headers);
     }
 
-    /** @return the deserialized response body. */
+    /**
+     * Gets the deserialized response body.
+     *
+     * @return the deserialized response body.
+     */
     @Override
     public Product getValue() {
         return super.getValue();

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPutAsyncRelativeRetry400Response.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPutAsyncRelativeRetry400Response.java
@@ -29,7 +29,11 @@ public final class LrosaDsPutAsyncRelativeRetry400Response
         super(request, statusCode, rawHeaders, value, headers);
     }
 
-    /** @return the deserialized response body. */
+    /**
+     * Gets the deserialized response body.
+     *
+     * @return the deserialized response body.
+     */
     @Override
     public Product getValue() {
         return super.getValue();

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPutAsyncRelativeRetryInvalidHeaderResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPutAsyncRelativeRetryInvalidHeaderResponse.java
@@ -29,7 +29,11 @@ public final class LrosaDsPutAsyncRelativeRetryInvalidHeaderResponse
         super(request, statusCode, rawHeaders, value, headers);
     }
 
-    /** @return the deserialized response body. */
+    /**
+     * Gets the deserialized response body.
+     *
+     * @return the deserialized response body.
+     */
     @Override
     public Product getValue() {
         return super.getValue();

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPutAsyncRelativeRetryInvalidJsonPollingResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPutAsyncRelativeRetryInvalidJsonPollingResponse.java
@@ -29,7 +29,11 @@ public final class LrosaDsPutAsyncRelativeRetryInvalidJsonPollingResponse
         super(request, statusCode, rawHeaders, value, headers);
     }
 
-    /** @return the deserialized response body. */
+    /**
+     * Gets the deserialized response body.
+     *
+     * @return the deserialized response body.
+     */
     @Override
     public Product getValue() {
         return super.getValue();

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPutAsyncRelativeRetryNoStatusPayloadResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPutAsyncRelativeRetryNoStatusPayloadResponse.java
@@ -29,7 +29,11 @@ public final class LrosaDsPutAsyncRelativeRetryNoStatusPayloadResponse
         super(request, statusCode, rawHeaders, value, headers);
     }
 
-    /** @return the deserialized response body. */
+    /**
+     * Gets the deserialized response body.
+     *
+     * @return the deserialized response body.
+     */
     @Override
     public Product getValue() {
         return super.getValue();

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPutAsyncRelativeRetryNoStatusResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPutAsyncRelativeRetryNoStatusResponse.java
@@ -29,7 +29,11 @@ public final class LrosaDsPutAsyncRelativeRetryNoStatusResponse
         super(request, statusCode, rawHeaders, value, headers);
     }
 
-    /** @return the deserialized response body. */
+    /**
+     * Gets the deserialized response body.
+     *
+     * @return the deserialized response body.
+     */
     @Override
     public Product getValue() {
         return super.getValue();

--- a/vanilla-tests/src/main/java/fixtures/lro/models/OperationResultStatus.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/OperationResultStatus.java
@@ -54,7 +54,11 @@ public final class OperationResultStatus extends ExpandableStringEnum<OperationR
         return fromString(name, OperationResultStatus.class);
     }
 
-    /** @return known OperationResultStatus values. */
+    /**
+     * Gets known OperationResultStatus values.
+     *
+     * @return known OperationResultStatus values.
+     */
     public static Collection<OperationResultStatus> values() {
         return values(OperationResultStatus.class);
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/ProductPropertiesProvisioningStateValues.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/ProductPropertiesProvisioningStateValues.java
@@ -55,7 +55,11 @@ public final class ProductPropertiesProvisioningStateValues
         return fromString(name, ProductPropertiesProvisioningStateValues.class);
     }
 
-    /** @return known ProductPropertiesProvisioningStateValues values. */
+    /**
+     * Gets known ProductPropertiesProvisioningStateValues values.
+     *
+     * @return known ProductPropertiesProvisioningStateValues values.
+     */
     public static Collection<ProductPropertiesProvisioningStateValues> values() {
         return values(ProductPropertiesProvisioningStateValues.class);
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/SubProductPropertiesProvisioningStateValues.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/SubProductPropertiesProvisioningStateValues.java
@@ -55,7 +55,11 @@ public final class SubProductPropertiesProvisioningStateValues
         return fromString(name, SubProductPropertiesProvisioningStateValues.class);
     }
 
-    /** @return known SubProductPropertiesProvisioningStateValues values. */
+    /**
+     * Gets known SubProductPropertiesProvisioningStateValues values.
+     *
+     * @return known SubProductPropertiesProvisioningStateValues values.
+     */
     public static Collection<SubProductPropertiesProvisioningStateValues> values() {
         return values(SubProductPropertiesProvisioningStateValues.class);
     }

--- a/vanilla-tests/src/main/java/fixtures/modelflattening/models/FlattenedProductPropertiesProvisioningStateValues.java
+++ b/vanilla-tests/src/main/java/fixtures/modelflattening/models/FlattenedProductPropertiesProvisioningStateValues.java
@@ -55,7 +55,11 @@ public final class FlattenedProductPropertiesProvisioningStateValues
         return fromString(name, FlattenedProductPropertiesProvisioningStateValues.class);
     }
 
-    /** @return known FlattenedProductPropertiesProvisioningStateValues values. */
+    /**
+     * Gets known FlattenedProductPropertiesProvisioningStateValues values.
+     *
+     * @return known FlattenedProductPropertiesProvisioningStateValues values.
+     */
     public static Collection<FlattenedProductPropertiesProvisioningStateValues> values() {
         return values(FlattenedProductPropertiesProvisioningStateValues.class);
     }

--- a/vanilla-tests/src/main/java/fixtures/nonstringenum/models/FloatEnum.java
+++ b/vanilla-tests/src/main/java/fixtures/nonstringenum/models/FloatEnum.java
@@ -36,7 +36,11 @@ public final class FloatEnum extends ExpandableStringEnum<FloatEnum> {
         return fromString(String.valueOf(name), FloatEnum.class);
     }
 
-    /** @return known FloatEnum values. */
+    /**
+     * Gets known FloatEnum values.
+     *
+     * @return known FloatEnum values.
+     */
     public static Collection<FloatEnum> values() {
         return values(FloatEnum.class);
     }

--- a/vanilla-tests/src/main/java/fixtures/nonstringenum/models/IntEnum.java
+++ b/vanilla-tests/src/main/java/fixtures/nonstringenum/models/IntEnum.java
@@ -36,7 +36,11 @@ public final class IntEnum extends ExpandableStringEnum<IntEnum> {
         return fromString(String.valueOf(name), IntEnum.class);
     }
 
-    /** @return known IntEnum values. */
+    /**
+     * Gets known IntEnum values.
+     *
+     * @return known IntEnum values.
+     */
     public static Collection<IntEnum> values() {
         return values(IntEnum.class);
     }

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/AccessTier.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/AccessTier.java
@@ -51,7 +51,11 @@ public final class AccessTier extends ExpandableStringEnum<AccessTier> {
         return fromString(name, AccessTier.class);
     }
 
-    /** @return known AccessTier values. */
+    /**
+     * Gets known AccessTier values.
+     *
+     * @return known AccessTier values.
+     */
     public static Collection<AccessTier> values() {
         return values(AccessTier.class);
     }

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/ArchiveStatus.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/ArchiveStatus.java
@@ -27,7 +27,11 @@ public final class ArchiveStatus extends ExpandableStringEnum<ArchiveStatus> {
         return fromString(name, ArchiveStatus.class);
     }
 
-    /** @return known ArchiveStatus values. */
+    /**
+     * Gets known ArchiveStatus values.
+     *
+     * @return known ArchiveStatus values.
+     */
     public static Collection<ArchiveStatus> values() {
         return values(ArchiveStatus.class);
     }

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/PublicAccessType.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/PublicAccessType.java
@@ -27,7 +27,11 @@ public final class PublicAccessType extends ExpandableStringEnum<PublicAccessTyp
         return fromString(name, PublicAccessType.class);
     }
 
-    /** @return known PublicAccessType values. */
+    /**
+     * Gets known PublicAccessType values.
+     *
+     * @return known PublicAccessType values.
+     */
     public static Collection<PublicAccessType> values() {
         return values(PublicAccessType.class);
     }


### PR DESCRIPTION
Msdoc render on method of javadoc without description is not good.
https://docs.microsoft.com/en-us/java/api/com.azure.resourcemanager.mediaservices.mediaservicesmanager?view=azure-java-stable

Hence we should always add the "description" to javadoc on method. "@return" is not enough.