### PR TITLE
Updates to Headers Deserialization

### DIFF
--- a/vanilla-tests/src/main/java/fixtures/customheaderdeserialization/models/HeadersResponseBoolHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/customheaderdeserialization/models/HeadersResponseBoolHeaders.java
@@ -25,7 +25,7 @@ public final class HeadersResponseBoolHeaders {
      */
     public HeadersResponseBoolHeaders(HttpHeaders rawHeaders) {
         if (rawHeaders.getValue("value") != null) {
-            this.value = Boolean.valueOf(rawHeaders.getValue("value"));
+            this.value = Boolean.parseBoolean(rawHeaders.getValue("value"));
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/customheaderdeserialization/models/HeadersResponseDoubleHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/customheaderdeserialization/models/HeadersResponseDoubleHeaders.java
@@ -25,7 +25,7 @@ public final class HeadersResponseDoubleHeaders {
      */
     public HeadersResponseDoubleHeaders(HttpHeaders rawHeaders) {
         if (rawHeaders.getValue("value") != null) {
-            this.value = Double.valueOf(rawHeaders.getValue("value"));
+            this.value = Double.parseDouble(rawHeaders.getValue("value"));
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/customheaderdeserialization/models/HeadersResponseFloatHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/customheaderdeserialization/models/HeadersResponseFloatHeaders.java
@@ -25,7 +25,7 @@ public final class HeadersResponseFloatHeaders {
      */
     public HeadersResponseFloatHeaders(HttpHeaders rawHeaders) {
         if (rawHeaders.getValue("value") != null) {
-            this.value = Float.valueOf(rawHeaders.getValue("value"));
+            this.value = Float.parseFloat(rawHeaders.getValue("value"));
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/customheaderdeserialization/models/HeadersResponseIntegerHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/customheaderdeserialization/models/HeadersResponseIntegerHeaders.java
@@ -25,7 +25,7 @@ public final class HeadersResponseIntegerHeaders {
      */
     public HeadersResponseIntegerHeaders(HttpHeaders rawHeaders) {
         if (rawHeaders.getValue("value") != null) {
-            this.value = Integer.valueOf(rawHeaders.getValue("value"));
+            this.value = Integer.parseInt(rawHeaders.getValue("value"));
         }
     }
 

--- a/vanilla-tests/src/main/java/fixtures/customheaderdeserialization/models/HeadersResponseLongHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/customheaderdeserialization/models/HeadersResponseLongHeaders.java
@@ -25,7 +25,7 @@ public final class HeadersResponseLongHeaders {
      */
     public HeadersResponseLongHeaders(HttpHeaders rawHeaders) {
         if (rawHeaders.getValue("value") != null) {
-            this.value = Long.valueOf(rawHeaders.getValue("value"));
+            this.value = Long.parseLong(rawHeaders.getValue("value"));
         }
     }
 


### PR DESCRIPTION
Modifies code generation when `custom-strongly-typed-header-deserialization` is set to true.

- Fixes a bug where multiple `HeaderCollections` would result in the same variable being initialized multiple times (was hardcoded to `headerCollection`).
- Improved handling nullable primitives that were null checked to use primitive parsing instead of nullable parsing to remove boxing of primitives.