### PR TITLE
log autorest options

### DIFF
--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
@@ -5,6 +5,7 @@ package com.azure.autorest.extension.base.plugin;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
+import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,6 +31,8 @@ public class JavaSettings {
     private static String header;
 
     private static final Map<String, Object> SIMPLE_JAVA_SETTINGS = new HashMap<>();
+
+    private static Logger logger;
 
     static void setHeader(String value) {
         if ("MICROSOFT_MIT".equals(value)) {
@@ -57,6 +60,7 @@ public class JavaSettings {
 
     static void setHost(NewPlugin host) {
         JavaSettings.host = host;
+        logger = new PluginLogger(host, JavaSettings.class);
     }
 
     public static void clear() {
@@ -79,6 +83,7 @@ public class JavaSettings {
             if (inputFiles != null) {
                 autorestSettings.getInputFiles().addAll(
                     inputFiles.stream().map(Object::toString).collect(Collectors.toList()));
+                logger.info("List of input files : {}", autorestSettings.getInputFiles());
             }
 
             setHeader(getStringValue(host, "license-header"));
@@ -972,6 +977,7 @@ public class JavaSettings {
 
     private static void loadStringSetting(String settingName, Consumer<String> action) {
         String settingValue = host.getStringValue(settingName);
+        logger.info("Option, string, {} : {}", settingName, settingValue);
         if (settingValue != null) {
             action.accept(settingValue);
         }
@@ -980,6 +986,7 @@ public class JavaSettings {
     private static String getStringValue(NewPlugin host, String settingName) {
         String value = host.getStringValue(settingName);
         if (value != null) {
+            logger.info("Option, string, {} : {}", settingName, value);
             SIMPLE_JAVA_SETTINGS.put(settingName, value);
         }
         return value;
@@ -990,6 +997,7 @@ public class JavaSettings {
         if (ret == null) {
             return defaultValue;
         } else {
+            logger.info("Option, string, {} : {}", settingName, ret);
             SIMPLE_JAVA_SETTINGS.put(settingName, ret);
             return ret;
         }
@@ -1000,6 +1008,7 @@ public class JavaSettings {
         if (ret == null) {
             return defaultValue;
         } else {
+            logger.info("Option, boolean, {} : {}", settingName, ret);
             SIMPLE_JAVA_SETTINGS.put(settingName, ret);
             return ret;
         }
@@ -1010,9 +1019,11 @@ public class JavaSettings {
         List<String> settingValues = new ArrayList<>();
         Object settingValue = host.getValue(Object.class, settingName);
         if (settingValue instanceof String) {
+            logger.info("Option, string, {} : {}", settingName, settingValue);
             settingValues.add(settingValue.toString());
         } else if (settingValue instanceof List) {
             List<String> settingValueList = (List<String>) settingValue;
+            logger.info("Option, array, {} : {}", settingName, settingValueList);
             settingValues.addAll(settingValueList);
         }
         if (!settingValues.isEmpty()) {

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
@@ -83,7 +83,7 @@ public class JavaSettings {
             if (inputFiles != null) {
                 autorestSettings.getInputFiles().addAll(
                     inputFiles.stream().map(Object::toString).collect(Collectors.toList()));
-                logger.info("List of input files : {}", autorestSettings.getInputFiles());
+                logger.debug("List of input files : {}", autorestSettings.getInputFiles());
             }
 
             setHeader(getStringValue(host, "license-header"));
@@ -977,8 +977,8 @@ public class JavaSettings {
 
     private static void loadStringSetting(String settingName, Consumer<String> action) {
         String settingValue = host.getStringValue(settingName);
-        logger.info("Option, string, {} : {}", settingName, settingValue);
         if (settingValue != null) {
+            logger.debug("Option, string, {} : {}", settingName, settingValue);
             action.accept(settingValue);
         }
     }
@@ -986,7 +986,7 @@ public class JavaSettings {
     private static String getStringValue(NewPlugin host, String settingName) {
         String value = host.getStringValue(settingName);
         if (value != null) {
-            logger.info("Option, string, {} : {}", settingName, value);
+            logger.debug("Option, string, {} : {}", settingName, value);
             SIMPLE_JAVA_SETTINGS.put(settingName, value);
         }
         return value;
@@ -997,7 +997,7 @@ public class JavaSettings {
         if (ret == null) {
             return defaultValue;
         } else {
-            logger.info("Option, string, {} : {}", settingName, ret);
+            logger.debug("Option, string, {} : {}", settingName, ret);
             SIMPLE_JAVA_SETTINGS.put(settingName, ret);
             return ret;
         }
@@ -1008,7 +1008,7 @@ public class JavaSettings {
         if (ret == null) {
             return defaultValue;
         } else {
-            logger.info("Option, boolean, {} : {}", settingName, ret);
+            logger.debug("Option, boolean, {} : {}", settingName, ret);
             SIMPLE_JAVA_SETTINGS.put(settingName, ret);
             return ret;
         }
@@ -1019,11 +1019,11 @@ public class JavaSettings {
         List<String> settingValues = new ArrayList<>();
         Object settingValue = host.getValue(Object.class, settingName);
         if (settingValue instanceof String) {
-            logger.info("Option, string, {} : {}", settingName, settingValue);
+            logger.debug("Option, string, {} : {}", settingName, settingValue);
             settingValues.add(settingValue.toString());
         } else if (settingValue instanceof List) {
             List<String> settingValueList = (List<String>) settingValue;
-            logger.info("Option, array, {} : {}", settingName, settingValueList);
+            logger.debug("Option, array, {} : {}", settingName, settingValueList);
             settingValues.addAll(settingValueList);
         }
         if (!settingValues.isEmpty()) {

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentClientMethodExample.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/examplemodel/FluentClientMethodExample.java
@@ -5,7 +5,6 @@ package com.azure.autorest.fluent.model.clientmodel.examplemodel;
 
 import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.fluent.model.FluentType;
-import com.azure.autorest.fluent.model.clientmodel.FluentStatic;
 import com.azure.autorest.fluent.model.clientmodel.ModelNaming;
 import com.azure.autorest.model.clientmodel.ClassType;
 import com.azure.autorest.model.clientmodel.ClientMethod;
@@ -77,7 +76,9 @@ public class FluentClientMethodExample implements FluentMethodExample {
 
     @Override
     public String getMethodReference() {
-        String namespace = JavaSettings.getInstance().getPackage();
+        JavaSettings settings = JavaSettings.getInstance();
+
+        String namespace = settings.getPackage();
         String[] identifiers = namespace.split(Pattern.quote("."));
         String lastIdentifier = identifiers[identifiers.length - 1];
 
@@ -90,7 +91,7 @@ public class FluentClientMethodExample implements FluentMethodExample {
         if ("authorization".equals(lastIdentifier)) {
             serviceClientReference = "roleServiceClient()";
         } else if ("resources".equals(lastIdentifier)) {
-            String tag = FluentStatic.getFluentJavaSettings().getAutorestSettings().getTag();
+            String tag = settings.getAutorestSettings().getTag();
             if (tag.contains("feature")) {
                 serviceClientReference = "featureClient()";
             } else if (tag.contains("policy")) {

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/projectmodel/FluentProject.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/projectmodel/FluentProject.java
@@ -61,15 +61,13 @@ public class FluentProject extends Project {
     }
 
     protected FluentProject(String serviceName, String clientDescription) {
-        FluentJavaSettings settings = FluentStatic.getFluentJavaSettings();
-
         this.groupId = "com.azure.resourcemanager";
 
         this.serviceName = serviceName;
         this.namespace = JavaSettings.getInstance().getPackage();
         this.artifactId = FluentUtils.getArtifactId();
 
-        settings.getArtifactVersion().ifPresent(version -> this.version = version);
+        FluentStatic.getFluentJavaSettings().getArtifactVersion().ifPresent(version -> this.version = version);
 
         if (clientDescription == null) {
             clientDescription = "";
@@ -83,7 +81,7 @@ public class FluentProject extends Project {
 
         this.serviceDescription.simpleDescription = String.format(simpleDescriptionTemplate, serviceName);
         this.serviceDescription.clientDescription = clientDescription;
-        this.serviceDescription.tagDescription = String.format(tagDescriptionTemplate, settings.getAutorestSettings().getTag());
+        this.serviceDescription.tagDescription = String.format(tagDescriptionTemplate, JavaSettings.getInstance().getAutorestSettings().getTag());
 
         this.changelog = new Changelog(this);
     }
@@ -104,8 +102,7 @@ public class FluentProject extends Project {
     }
 
     private void updateChangelog() {
-        FluentJavaSettings settings = FluentStatic.getFluentJavaSettings();
-        String outputFolder = settings.getAutorestSettings().getOutputFolder();
+        String outputFolder = JavaSettings.getInstance().getAutorestSettings().getOutputFolder();
         if (outputFolder != null && Paths.get(outputFolder).isAbsolute()) {
             Path changelogPath = Paths.get(outputFolder, "CHANGELOG.md");
 
@@ -126,8 +123,7 @@ public class FluentProject extends Project {
     }
 
     private void findCodeSamples() {
-        FluentJavaSettings settings = FluentStatic.getFluentJavaSettings();
-        String outputFolder = settings.getAutorestSettings().getOutputFolder();
+        String outputFolder = JavaSettings.getInstance().getAutorestSettings().getOutputFolder();
         if (outputFolder != null && Paths.get(outputFolder).isAbsolute()) {
             Path srcTestJavaPath = Paths.get(outputFolder).resolve(Paths.get("src", "test", "java"));
             if (Files.isDirectory(srcTestJavaPath)) {

--- a/fluentnamer/src/main/java/com/azure/autorest/fluent/util/FluentJavaSettings.java
+++ b/fluentnamer/src/main/java/com/azure/autorest/fluent/util/FluentJavaSettings.java
@@ -3,7 +3,6 @@
 
 package com.azure.autorest.fluent.util;
 
-import com.azure.autorest.extension.base.plugin.AutorestSettings;
 import com.azure.autorest.extension.base.plugin.NewPlugin;
 import com.azure.autorest.extension.base.plugin.PluginLogger;
 import com.azure.core.util.CoreUtils;
@@ -13,7 +12,6 @@ import org.slf4j.Logger;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -73,8 +71,6 @@ public class FluentJavaSettings {
     private SampleGeneration generateSamples = SampleGeneration.NONE;
 
     private boolean sdkIntegration = false;
-
-    private AutorestSettings autorestSettings;
 
     private enum SampleGeneration {
         NONE,
@@ -146,26 +142,6 @@ public class FluentJavaSettings {
         return sdkIntegration;
     }
 
-    public AutorestSettings getAutorestSettings() {
-        if (autorestSettings == null) {
-            autorestSettings = new AutorestSettings();
-
-            loadStringSetting("tag", autorestSettings::setTag);
-
-            loadStringSetting("base-folder", autorestSettings::setBaseFolder);
-            loadStringSetting("output-folder", autorestSettings::setOutputFolder);
-            loadStringSetting("java-sdks-folder", autorestSettings::setJavaSdksFolder);
-
-            List<Object> inputFiles = host.getValue(List.class, "input-file");
-            if (inputFiles != null) {
-                autorestSettings.getInputFiles().addAll(inputFiles.stream().map(Object::toString).collect(Collectors.toList()));
-                logger.info("List of input files : {}", autorestSettings.getInputFiles());
-            }
-        }
-
-        return autorestSettings;
-    }
-
     private void loadSettings() {
         loadStringSetting("add-inner", s -> splitStringToSet(s, javaNamesForAddInner));
 
@@ -222,16 +198,16 @@ public class FluentJavaSettings {
 
     private void loadBooleanSetting(String settingName, Consumer<Boolean> action) {
         Boolean settingValue = host.getBooleanValue(settingName);
-        logger.info("Option, boolean, {} : {}", settingName, settingValue);
         if (settingValue != null) {
+            logger.debug("Option, boolean, {} : {}", settingName, settingValue);
             action.accept(settingValue);
         }
     }
 
     private void loadStringSetting(String settingName, Consumer<String> action) {
         String settingValue = host.getStringValue(settingName);
-        logger.info("Option, string, {} : {}", settingName, settingValue);
         if (settingValue != null) {
+            logger.debug("Option, string, {} : {}", settingName, settingValue);
             action.accept(settingValue);
         }
     }


### PR DESCRIPTION
Let me know if anyone has concerns over it.
It is not a change that must get in. But it makes dev easier to see which autorest flag takes affect.

---

sample output
```
info    | JavaSettings | Option, string, title : Azure Communication Services
info    | JavaSettings | Option, string, security : AADToken
info    | JavaSettings | Option, string, security-scopes : https://communication.azure.com//.default
info    | JavaSettings | Option, string, security-header-name : null
info    | JavaSettings | Option, string, tag : package-phonenumber-2021-03-07
info    | JavaSettings | Option, string, base-folder : .
info    | JavaSettings | Option, string, output-folder : C:/github/azure-sdk-for-java//sdk/communication/azure-communication-phonenumbersdemo
info    | JavaSettings | Option, string, java-sdks-folder : C:/github/azure-sdk-for-java/
info    | JavaSettings | List of input files : [stable/2021-03-07/phonenumbers.json]
info    | JavaSettings | Option, string, license-header : MICROSOFTMITSMALL
info    | JavaSettings | Option, boolean, azure-arm : false
info    | JavaSettings | Option, string, service-name : PhoneNumbers
info    | JavaSettings | Option, string, namespace : com.azure.communication.phonenumbersdemo
info    | JavaSettings | Option, boolean, generate-client-interfaces : false
info    | JavaSettings | Option, boolean, generate-client-as-impl : true
info    | JavaSettings | Option, string, models-subpackage : implementation.models
info    | JavaSettings | Option, boolean, add-context-parameter : true
info    | JavaSettings | Option, boolean, context-client-method-parameter : true
info    | JavaSettings | Option, boolean, generate-sync-async-clients : true
info    | JavaSettings | Option, boolean, generate-builder-per-client : true
info    | JavaSettings | Option, string, sync-methods : all
info    | JavaSettings | Option, boolean, client-logger : true
info    | JavaSettings | Option, boolean, model-override-setter-from-superclass : true
info    | JavaSettings | Option, boolean, data-plane : true
info    | JavaSettings | Option, boolean, generate-samples : true
info    | JavaSettings | Option, boolean, generate-tests : true
info    | JavaSettings | Option, boolean, use-default-http-status-code-to-exception-type-mapping : true
info    | JavaSettings | Option, boolean, partial-update : true
```

however it will print 3 times, as we had preprocess and javagen and postprocess.