### PR TITLE
mgmt, support resourceGroupName() method

### DIFF
--- a/fluent-tests/src/test/java/com/azure/mgmttest/LiteCompilationTests.java
+++ b/fluent-tests/src/test/java/com/azure/mgmttest/LiteCompilationTests.java
@@ -107,6 +107,10 @@ public class LiteCompilationTests {
                 .authenticate(any(TokenCredential.class), any(AzureProfile.class));
 
         storageManager = StorageManager.authenticate(any(HttpPipeline.class), any(AzureProfile.class));
+
+        // resourceGroupName method
+        storageAccount.resourceGroupName();
+        blobContainer.resourceGroupName();
     }
 
     public void testResources() {

--- a/fluent-tests/src/test/java/com/azure/mgmttest/RuntimeTests.java
+++ b/fluent-tests/src/test/java/com/azure/mgmttest/RuntimeTests.java
@@ -203,7 +203,13 @@ public class RuntimeTests {
                     .withMinimumTlsVersion(MinimumTlsVersion.TLS1_2)
                     .create();
 
+            Assertions.assertEquals(saName, storageAccount.name());
+            Assertions.assertEquals(rgName, storageAccount.resourceGroupName());
+
             storageAccount.refresh();
+
+            Assertions.assertEquals(saName, storageAccount.name());
+            Assertions.assertEquals(rgName, storageAccount.resourceGroupName());
 
             StorageAccount storageAccount2 = storageManager.storageAccounts().getById(storageAccount.id());
             storageAccount2.update()
@@ -214,24 +220,30 @@ public class RuntimeTests {
 
             // container
             BlobContainer blobContainer = storageManager.blobContainers().define(blobContainerName)
-                    .withExistingStorageAccount(rgName, saName)
+                    .withExistingStorageAccount(storageAccount.resourceGroupName(), storageAccount.name())
                     .withPublicAccess(PublicAccess.BLOB)
                     .create(new Context("key", "value"));
 
+            Assertions.assertEquals(blobContainerName, blobContainer.name());
+            Assertions.assertEquals(rgName, blobContainer.resourceGroupName());
+
             blobContainer.refresh();
+
+            Assertions.assertEquals(blobContainerName, blobContainer.name());
+            Assertions.assertEquals(rgName, blobContainer.resourceGroupName());
 
             BlobContainer blobContainer2 = storageManager.blobContainers().getById(blobContainer.id());
             blobContainer2.update()
                     .withPublicAccess(PublicAccess.NONE)
                     .apply(new Context("key", "value"));
 
-            Assertions.assertEquals(1, storageManager.blobContainers().list(rgName, saName).stream().count());
+            Assertions.assertEquals(1, storageManager.blobContainers().list(storageAccount.resourceGroupName(), storageAccount.name()).stream().count());
 
             storageManager.blobContainers().deleteById(blobContainer.id());
 
             // container blob service properties
             BlobServiceProperties blobService = storageManager.blobServices().define()
-                    .withExistingStorageAccount(rgName, saName)
+                    .withExistingStorageAccount(storageAccount.resourceGroupName(), storageAccount.name())
                     .create();
 
             blobService.update()


### PR DESCRIPTION
Fix https://github.com/Azure/autorest.java/issues/1441

`resourceGroupName` is a very useful help method for most Azure resource. First add it to resource that feels "safe" to have it (i.e., those is based on "resourceGroup" in path/ID, and supports both create and update).