### PR TITLE
Added Ability to Customize Constants and Miscellaneous Improvements

### DIFF
--- a/customization-base/src/main/java/com/azure/autorest/customization/AnnotationCustomization.java
+++ b/customization-base/src/main/java/com/azure/autorest/customization/AnnotationCustomization.java
@@ -3,7 +3,6 @@
 
 package com.azure.autorest.customization;
 
-import com.azure.autorest.customization.implementation.CodeCustomization;
 import com.azure.autorest.customization.implementation.ls.EclipseLanguageClient;
 import com.azure.autorest.customization.implementation.ls.models.SymbolInformation;
 

--- a/customization-base/src/main/java/com/azure/autorest/customization/ClassCustomization.java
+++ b/customization-base/src/main/java/com/azure/autorest/customization/ClassCustomization.java
@@ -3,7 +3,6 @@
 
 package com.azure.autorest.customization;
 
-import com.azure.autorest.customization.implementation.CodeCustomization;
 import com.azure.autorest.customization.implementation.Utils;
 import com.azure.autorest.customization.implementation.ls.EclipseLanguageClient;
 import com.azure.autorest.customization.implementation.ls.models.FileChangeType;
@@ -368,26 +367,12 @@ public final class ClassCustomization extends CodeCustomization {
      * @return The current ClassCustomization.
      */
     public ClassCustomization removeMethod(String methodNameOrSignature) {
-        // Begin by getting the method.
-        SymbolInformation methodSymbol = getMethod(methodNameOrSignature).getSymbol();
+        MethodCustomization methodCustomization = getMethod(methodNameOrSignature);
 
-        int methodSignatureLine = methodSymbol.getLocation().getRange().getStart().getLine();
+        int methodSignatureLine = methodCustomization.getSymbol().getLocation().getRange().getStart().getLine();
 
-        // Find the beginning location of the method being removed.
-        // If the method has a multi-line Javadoc walk until the start line is found.
-        // Else if the method has a single line Javadoc use the beginning of that line.
-        // Else using the beginning of the method signature.
-        Position start;
-        String lineAboveMethodSignature = editor.getFileLine(fileName, methodSignatureLine - 1);
-        if (Utils.JAVADOC_END_PATTERN.matcher(lineAboveMethodSignature).matches()) {
-            int startLine = Utils.walkUpFileUntilLineMatches(editor, fileName, methodSignatureLine - 2,
-                lineContent -> Utils.JAVADOC_START_PATTERN.matcher(lineContent).matches());
-            start = new Position(startLine, 0);
-        } else if (Utils.SINGLE_LINE_JAVADOC_PATTERN.matcher(lineAboveMethodSignature).matches()) {
-            start = new Position(methodSignatureLine - 1, 0);
-        } else {
-            start = new Position(methodSignatureLine, 0);
-        }
+        // Begin by getting the method's Javadoc to determine where to begin removal of the method.
+        Position start = methodCustomization.getJavadoc().getJavadocRange().getStart();
 
         // Find the ending location of the method being removed.
         String bodyPositionFinder = editor.getFileLine(fileName, methodSignatureLine);

--- a/customization-base/src/main/java/com/azure/autorest/customization/CodeCustomization.java
+++ b/customization-base/src/main/java/com/azure/autorest/customization/CodeCustomization.java
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-package com.azure.autorest.customization.implementation;
+package com.azure.autorest.customization;
 
-import com.azure.autorest.customization.Editor;
 import com.azure.autorest.customization.implementation.ls.EclipseLanguageClient;
 import com.azure.autorest.customization.implementation.ls.models.SymbolInformation;
 
@@ -13,13 +12,13 @@ import java.net.URI;
  * Base class for all code based customizations.
  */
 public abstract class CodeCustomization {
-    protected final Editor editor;
-    protected final EclipseLanguageClient languageClient;
-    protected final SymbolInformation symbol;
-    protected final URI fileUri;
-    protected final String fileName;
+    final Editor editor;
+    final EclipseLanguageClient languageClient;
+    final SymbolInformation symbol;
+    final URI fileUri;
+    final String fileName;
 
-    protected CodeCustomization(Editor editor, EclipseLanguageClient languageClient, SymbolInformation symbol) {
+    CodeCustomization(Editor editor, EclipseLanguageClient languageClient, SymbolInformation symbol) {
         this.editor = editor;
         this.languageClient = languageClient;
         this.symbol = symbol;
@@ -33,7 +32,7 @@ public abstract class CodeCustomization {
      *
      * @return The Editor.
      */
-    Editor getEditor() {
+    public final Editor getEditor() {
         return editor;
     }
 
@@ -42,7 +41,7 @@ public abstract class CodeCustomization {
      *
      * @return The EclipseLanguageClient.
      */
-    EclipseLanguageClient getLanguageClient() {
+    public final EclipseLanguageClient getLanguageClient() {
         return languageClient;
     }
 
@@ -51,7 +50,7 @@ public abstract class CodeCustomization {
      *
      * @return The SymbolInformation.
      */
-    SymbolInformation getSymbol() {
+    public final SymbolInformation getSymbol() {
         return symbol;
     }
 
@@ -60,7 +59,7 @@ public abstract class CodeCustomization {
      *
      * @return The URI of the file.
      */
-    URI getFileUri() {
+    public final URI getFileUri() {
         return fileUri;
     }
 
@@ -69,7 +68,7 @@ public abstract class CodeCustomization {
      *
      * @return The name of the file.
      */
-    public String getFileName() {
+    public final String getFileName() {
         return fileName;
     }
 }

--- a/customization-base/src/main/java/com/azure/autorest/customization/ConstantCustomization.java
+++ b/customization-base/src/main/java/com/azure/autorest/customization/ConstantCustomization.java
@@ -3,7 +3,6 @@
 
 package com.azure.autorest.customization;
 
-import com.azure.autorest.customization.implementation.CodeCustomization;
 import com.azure.autorest.customization.implementation.Utils;
 import com.azure.autorest.customization.implementation.ls.EclipseLanguageClient;
 import com.azure.autorest.customization.implementation.ls.models.SymbolInformation;

--- a/customization-base/src/main/java/com/azure/autorest/customization/ConstantCustomization.java
+++ b/customization-base/src/main/java/com/azure/autorest/customization/ConstantCustomization.java
@@ -1,0 +1,184 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.autorest.customization;
+
+import com.azure.autorest.customization.implementation.CodeCustomization;
+import com.azure.autorest.customization.implementation.Utils;
+import com.azure.autorest.customization.implementation.ls.EclipseLanguageClient;
+import com.azure.autorest.customization.implementation.ls.models.SymbolInformation;
+import com.azure.autorest.customization.implementation.ls.models.SymbolKind;
+import com.azure.autorest.customization.implementation.ls.models.WorkspaceEdit;
+
+import java.lang.reflect.Modifier;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+import static com.azure.autorest.customization.implementation.Utils.replaceModifier;
+
+/**
+ * Customization for an AutoRest generated constant property.
+ * <p>
+ * For instance property customizations use {@link PropertyCustomization}.
+ */
+public final class ConstantCustomization extends CodeCustomization {
+    private static final Pattern METHOD_PARAMS_CAPTURE = Pattern.compile("\\(.*\\)");
+
+    private final String packageName;
+    private final String className;
+    private final String constantName;
+
+    ConstantCustomization(Editor editor, EclipseLanguageClient languageClient, String packageName, String className,
+        SymbolInformation symbol, String constantName) {
+        super(editor, languageClient, symbol);
+
+        this.packageName = packageName;
+        this.className = className;
+        this.constantName = constantName;
+    }
+
+    /**
+     * Gets the name of the class that contains this constant.
+     *
+     * @return The name of the class that contains this constant.
+     */
+    public String getClassName() {
+        return className;
+    }
+
+    /**
+     * Gets the name of this constant.
+     *
+     * @return The name of this constant.
+     */
+    public String getConstantName() {
+        return constantName;
+    }
+
+    /**
+     * Gets the Javadoc customization for this constant.
+     *
+     * @return The Javadoc customization.
+     */
+    public JavadocCustomization getJavadoc() {
+        return new JavadocCustomization(editor, languageClient, fileUri, fileName,
+            symbol.getLocation().getRange().getStart().getLine());
+    }
+
+    /**
+     * Replace the modifier for this constant.
+     * <p>
+     * For compound modifiers such as {@code public abstract} use bitwise OR ({@code |}) of multiple Modifiers, {@code
+     * Modifier.PUBLIC | Modifier.ABSTRACT}.
+     * <p>
+     * This operation doesn't allow for the constant to lose constant status, so
+     * {@code Modifier.STATIC | Modifier.FINAL} will be added to the passed {@code modifiers}.
+     * <p>
+     * Pass {@code 0} for {@code modifiers} to indicate that the constant has no modifiers.
+     *
+     * @param modifiers The {@link Modifier Modifiers} for the constant.
+     * @return The updated ConstantCustomization object.
+     * @throws IllegalArgumentException If the {@code modifier} is less than to {@code 0} or any {@link Modifier}
+     * included in the bitwise OR isn't a valid constant {@link Modifier}.
+     */
+    public ConstantCustomization setModifier(int modifiers) {
+        replaceModifier(symbol, editor, languageClient, "(?:.+ )?(\\w+ )" + constantName + "\\(",
+            "$1" + constantName + "(", Modifier.fieldModifiers(), Modifier.STATIC | Modifier.FINAL | modifiers);
+
+        return refreshCustomization(constantName);
+    }
+
+    /**
+     * Renames the constant.
+     * <p>
+     * This operation doesn't allow for the constant to lose naming conventions of capitalized and underscore delimited
+     * words, so the {@code newName} will be capitalized.
+     * <p>
+     * This is a refactor operation, all references of the constant will be renamed and the getter method(s) for this
+     * property will be renamed accordingly as well.
+     *
+     * @param newName The new name for the constant.
+     * @return A new instance of {@link ConstantCustomization} for chaining.
+     * @throws NullPointerException If {@code newName} is null.
+     */
+    public ConstantCustomization rename(String newName) {
+        Objects.requireNonNull(newName, "'newName' cannot be null.");
+
+        String lowercaseConstantName = constantName.toLowerCase();
+        String currentCamelName = constantToMethodName(constantName);
+        String lowercaseCurrentCamelName = currentCamelName.toLowerCase();
+        String newCamelName = constantToMethodName(newName);
+
+        languageClient.listDocumentSymbols(fileUri).stream()
+            .filter(si -> {
+                String symbolName = si.getName().toLowerCase();
+                // Need to check is the symbol matches the constant name or expected method name.
+                return symbolName.contains(lowercaseConstantName)
+                    || symbolName.contains(lowercaseCurrentCamelName);
+            }).forEach(symbol -> {
+                if (symbol.getKind() == SymbolKind.CONSTANT) {
+                    WorkspaceEdit edit = languageClient.renameSymbol(fileUri, symbol.getLocation().getRange().getStart(),
+                        newName);
+                    Utils.applyWorkspaceEdit(edit, editor, languageClient);
+                } else if (symbol.getKind() == SymbolKind.METHOD) {
+                    String methodName = symbol.getName().replace(currentCamelName, newCamelName)
+                        .replace(constantName, newName);
+                    methodName = METHOD_PARAMS_CAPTURE.matcher(methodName).replaceFirst("");
+                    WorkspaceEdit edit = languageClient.renameSymbol(fileUri,
+                        symbol.getLocation().getRange().getStart(), methodName);
+                    Utils.applyWorkspaceEdit(edit, editor, languageClient);
+                }
+            });
+
+        return refreshCustomization(newName);
+    }
+
+    private static String constantToMethodName(String constantName) {
+        // Constants will be in the form A_WORD_SPLIT_BY_UNDERSCORE_AND_CAPITALIZED, which, if used as-is won't follow
+        // getter, or method, naming conventions of getAWordInCamelCase.
+        //
+        // Split the constant name on '_' and lower case all characters after the first.
+        StringBuilder camelBuilder = new StringBuilder(constantName.length());
+
+        for (String word : constantName.split("_")) {
+            if (word.length() == 0) {
+                continue;
+            }
+
+            camelBuilder.append(word.charAt(0));
+            if (word.length() > 1) {
+                camelBuilder.append(word.substring(1).toLowerCase());
+            }
+        }
+
+        return camelBuilder.toString();
+    }
+
+    /**
+     * Add an annotation to a property in the class.
+     *
+     * @param annotation the annotation to add. The leading @ can be omitted.
+     * @return A new instance of {@link ConstantCustomization} for chaining.
+     */
+    public ConstantCustomization addAnnotation(String annotation) {
+        return Utils.addAnnotation(annotation, this, () -> refreshCustomization(constantName));
+    }
+
+    /**
+     * Remove an annotation from the constant.
+     *
+     * @param annotation the annotation to remove from the constant. The leading @ can be omitted.
+     * @return A new instance of {@link ConstantCustomization} for chaining.
+     */
+    public ConstantCustomization removeAnnotation(String annotation) {
+        return Utils.removeAnnotation(this, compilationUnit -> compilationUnit.getClassByName(className).get()
+            .getFieldByName(constantName).get()
+            .getAnnotationByName(Utils.cleanAnnotationName(annotation)), () -> refreshCustomization(constantName));
+    }
+
+    private ConstantCustomization refreshCustomization(String constantName) {
+        return new PackageCustomization(editor, languageClient, packageName)
+            .getClass(className)
+            .getConstant(constantName);
+    }
+}

--- a/customization-base/src/main/java/com/azure/autorest/customization/ConstructorCustomization.java
+++ b/customization-base/src/main/java/com/azure/autorest/customization/ConstructorCustomization.java
@@ -3,7 +3,6 @@
 
 package com.azure.autorest.customization;
 
-import com.azure.autorest.customization.implementation.CodeCustomization;
 import com.azure.autorest.customization.implementation.Utils;
 import com.azure.autorest.customization.implementation.ls.EclipseLanguageClient;
 import com.azure.autorest.customization.implementation.ls.models.SymbolInformation;

--- a/customization-base/src/main/java/com/azure/autorest/customization/JavadocCustomization.java
+++ b/customization-base/src/main/java/com/azure/autorest/customization/JavadocCustomization.java
@@ -81,6 +81,10 @@ public final class JavadocCustomization {
         parseJavadoc(symbolLine);
     }
 
+    Range getJavadocRange() {
+        return javadocRange;
+    }
+
     public JavadocCustomization replace(JavadocCustomization other) {
         this.descriptionDocs = other.descriptionDocs;
 

--- a/customization-base/src/main/java/com/azure/autorest/customization/JavadocCustomization.java
+++ b/customization-base/src/main/java/com/azure/autorest/customization/JavadocCustomization.java
@@ -234,8 +234,7 @@ public final class JavadocCustomization {
      *
      * @param seeDoc the link to the extra documentation
      * @return the Javadoc customization object for chaining
-     * @see <a href=https://docs.oracle.com/javase/7/docs/technotes/tools/windows/javadoc.html#see>Oracle docs on see
-     * tag</a>
+     * @see <a href="https://docs.oracle.com/javase/7/docs/technotes/tools/windows/javadoc.html#see">Oracle docs on see tag</a>
      */
     public JavadocCustomization addSee(String seeDoc) {
         seeDocs.add(seeDoc);
@@ -396,7 +395,7 @@ public final class JavadocCustomization {
             writeLine(stringBuilder.append(indent).append(" * "), descriptionDocs);
         }
 
-        if (!paramDocs.isEmpty() || !throwsDocs.isEmpty() || returnDoc != null) {
+        if (!paramDocs.isEmpty() || !throwsDocs.isEmpty() || returnDoc != null || deprecatedDoc != null) {
             writeLine(stringBuilder.append(indent), " * ");
 
             for (Map.Entry<String, String> paramDoc : paramDocs.entrySet()) {

--- a/customization-base/src/main/java/com/azure/autorest/customization/MethodCustomization.java
+++ b/customization-base/src/main/java/com/azure/autorest/customization/MethodCustomization.java
@@ -138,8 +138,28 @@ public final class MethodCustomization extends CodeCustomization {
      * @return The updated MethodCustomization object.
      */
     public MethodCustomization replaceParameters(String newParameters) {
-        return Utils.replaceParameters(newParameters, this,
-            () -> refreshCustomization(String.format("%s(%s)", methodName, newParameters)));
+        return replaceParameters(newParameters, null);
+    }
+
+    /**
+     * Replaces the parameters of the method and adds any additional imports required by the new parameters.
+     *
+     * @param newParameters New method parameters.
+     * @param importsToAdd Any additional imports required by the method. These will be custom types or types that
+     * are ambiguous on which to use such as {@code List} or the utility class {@code Arrays}.
+     * @return A new MethodCustomization representing the updated method.
+     */
+    public MethodCustomization replaceParameters(String newParameters, List<String> importsToAdd) {
+        String newSignature = methodName + "(" + newParameters + ")";
+
+        ClassCustomization classCustomization = new PackageCustomization(editor, languageClient, packageName)
+            .getClass(className);
+
+        ClassCustomization updatedClassCustomization = Utils.addImports(importsToAdd, classCustomization,
+            classCustomization::refreshSymbol);
+
+        return Utils.replaceParameters(newParameters, updatedClassCustomization.getMethod(methodSignature),
+            () -> updatedClassCustomization.getMethod(newSignature));
     }
 
     /**
@@ -149,11 +169,30 @@ public final class MethodCustomization extends CodeCustomization {
      * @return The updated MethodCustomization object.
      */
     public MethodCustomization replaceBody(String newBody) {
-        return Utils.replaceBody(newBody, this, () -> refreshCustomization(methodSignature));
+        return replaceBody(newBody, null);
     }
 
     /**
-     * Change the return type of a method. The new return type will be automatically imported.
+     * Replaces the body of the method and adds any additional imports required by the new body.
+     *
+     * @param newBody New method body.
+     * @param importsToAdd Any additional imports required by the method. These will be custom types or types that
+     * are ambiguous on which to use such as {@code List} or the utility class {@code Arrays}.
+     * @return A new MethodCustomization representing the updated method.
+     */
+    public MethodCustomization replaceBody(String newBody, List<String> importsToAdd) {
+        ClassCustomization classCustomization = new PackageCustomization(editor, languageClient, packageName)
+            .getClass(className);
+
+        ClassCustomization updatedClassCustomization = Utils.addImports(importsToAdd, classCustomization,
+            classCustomization::refreshSymbol);
+
+        return Utils.replaceBody(newBody, updatedClassCustomization.getMethod(methodSignature),
+            () -> updatedClassCustomization.getMethod(methodSignature));
+    }
+
+    /**
+     * Change the return type of the method. The new return type will be automatically imported.
      *
      * <p>
      * The {@code returnValueFormatter} can be used to transform the return value. If the original return type is {@code
@@ -187,7 +226,8 @@ public final class MethodCustomization extends CodeCustomization {
      * parentheses, opening and closing of code blocks have to be taken care of in the {@code returnValueFormatter}.
      * @return the current method customization for chaining
      */
-    public MethodCustomization setReturnType(String newReturnType, String returnValueFormatter, boolean replaceReturnStatement) {
+    public MethodCustomization setReturnType(String newReturnType, String returnValueFormatter,
+        boolean replaceReturnStatement) {
         List<TextEdit> edits = new ArrayList<>();
 
         int line = symbol.getLocation().getRange().getStart().getLine();

--- a/customization-base/src/main/java/com/azure/autorest/customization/MethodCustomization.java
+++ b/customization-base/src/main/java/com/azure/autorest/customization/MethodCustomization.java
@@ -3,7 +3,6 @@
 
 package com.azure.autorest.customization;
 
-import com.azure.autorest.customization.implementation.CodeCustomization;
 import com.azure.autorest.customization.implementation.Utils;
 import com.azure.autorest.customization.implementation.ls.EclipseLanguageClient;
 import com.azure.autorest.customization.implementation.ls.models.FileChangeType;
@@ -38,10 +37,6 @@ public final class MethodCustomization extends CodeCustomization {
         this.className = className;
         this.methodName = methodName;
         this.methodSignature = methodSignature;
-    }
-
-    SymbolInformation getSymbol() {
-        return symbol;
     }
 
     /**

--- a/customization-base/src/main/java/com/azure/autorest/customization/PropertyCustomization.java
+++ b/customization-base/src/main/java/com/azure/autorest/customization/PropertyCustomization.java
@@ -3,7 +3,6 @@
 
 package com.azure.autorest.customization;
 
-import com.azure.autorest.customization.implementation.CodeCustomization;
 import com.azure.autorest.customization.implementation.Utils;
 import com.azure.autorest.customization.implementation.ls.EclipseLanguageClient;
 import com.azure.autorest.customization.implementation.ls.models.CodeAction;

--- a/customization-base/src/main/java/com/azure/autorest/customization/PropertyCustomization.java
+++ b/customization-base/src/main/java/com/azure/autorest/customization/PropertyCustomization.java
@@ -21,7 +21,9 @@ import java.util.stream.Collectors;
 
 
 /**
- * The Javadoc customization for an AutoRest generated classes and methods.
+ * Customization for an AutoRest generated instance property.
+ * <p>
+ * For constant property customizations use {@link ConstantCustomization}.
  */
 public final class PropertyCustomization extends CodeCustomization {
     private static final Pattern METHOD_PARAMS_CAPTURE = Pattern.compile("\\(.*\\)");

--- a/customization-base/src/main/java/com/azure/autorest/customization/implementation/Utils.java
+++ b/customization-base/src/main/java/com/azure/autorest/customization/implementation/Utils.java
@@ -4,6 +4,7 @@
 package com.azure.autorest.customization.implementation;
 
 import com.azure.autorest.customization.ClassCustomization;
+import com.azure.autorest.customization.CodeCustomization;
 import com.azure.autorest.customization.Editor;
 import com.azure.autorest.customization.implementation.ls.EclipseLanguageClient;
 import com.azure.autorest.customization.implementation.ls.models.CodeActionKind;


### PR DESCRIPTION
Fixes #1444 
Fixes #1419 

- Added `ConstantCustomization` to enable customization of static fields, such as on `ExpandableStringEnum` types.
- Added the ability to add imports to `ClassCustomization` directly rather than requiring the use of a method that takes a list of imports to add.
- Added overloads to parameter and body replacement methods in `ConstructorCustomization` and `MethodCustomization` which enable adding imports required by the code modifications.
- Fixed minor bug in `JavadocCustomization` where deprecation tag would be dropped if it was the only javadoc tag.
- Fixed a bug where removing a method without Javadocs but with annotations would leave dangling annotations.