### PR TITLE
dpg, improve javadoc

### DIFF
--- a/androidgen/src/main/java/com/azure/autorest/android/model/clientmodel/AndroidProxyMethodParameter.java
+++ b/androidgen/src/main/java/com/azure/autorest/android/model/clientmodel/AndroidProxyMethodParameter.java
@@ -6,6 +6,7 @@ package com.azure.autorest.android.model.clientmodel;
 import com.azure.autorest.extension.base.model.codemodel.RequestParameterLocation;
 import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.model.clientmodel.IType;
+import com.azure.autorest.model.clientmodel.ParameterSynthesizedOrigin;
 import com.azure.autorest.model.clientmodel.ProxyMethodParameter;
 import com.azure.autorest.util.CodeNamer;
 import com.azure.core.util.serializer.CollectionFormat;
@@ -64,7 +65,8 @@ public class AndroidProxyMethodParameter extends ProxyMethodParameter {
                 parameterReference,
                 defaultValue,
                 collectionFormat,
-                explode);
+                explode,
+                ParameterSynthesizedOrigin.NONE);
     }
 
     @Override

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/CodeModelCustomConstructor.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/CodeModelCustomConstructor.java
@@ -59,6 +59,8 @@ public class CodeModelCustomConstructor extends Constructor {
                 return TestScenarioStepType.fromValue(((ScalarNode) node).getValue());
             } else if (type.equals(ScenarioTestScope.class)) {
                 return ScenarioTestScope.fromValue(((ScalarNode) node).getValue());
+            } else if (type.equals(SchemaContext.class)) {
+                return SchemaContext.fromValue(((ScalarNode) node).getValue());
             } else {
                 // create JavaBean
                 return super.construct(node);

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Schema.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/Schema.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class Schema extends Metadata {
     /**
@@ -30,11 +31,16 @@ public class Schema extends Metadata {
      * 
      */
     private Object defaultValue;
+    // serialization and usage in SchemaUsage
     /**
      * custom extensible metadata for individual serialization formats
      * 
      */
     private SerializationFormats serialization;
+    /**
+     * Usage of the schema.
+     */
+    private Set<SchemaContext> usage;
     /**
      * 
      * (Required)
@@ -251,6 +257,14 @@ public class Schema extends Metadata {
      */
     public void setExternalDocs(ExternalDocumentation externalDocs) {
         this.externalDocs = externalDocs;
+    }
+
+    public Set<SchemaContext> getUsage() {
+        return usage;
+    }
+
+    public void setUsage(Set<SchemaContext> usage) {
+        this.usage = usage;
     }
 
     public enum AllSchemaTypes {

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/SchemaContext.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/SchemaContext.java
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.autorest.extension.base.model.codemodel;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum SchemaContext {
+
+    INPUT("input"),
+
+    OUTPUT("output"),
+
+    EXCEPTION("exception");
+
+    private final String value;
+    private final static Map<String, SchemaContext> CONSTANTS = new HashMap<>();
+
+    static {
+        for (SchemaContext c: values()) {
+            CONSTANTS.put(c.value, c);
+        }
+    }
+
+    SchemaContext(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return this.value;
+    }
+
+    public String value() {
+        return this.value;
+    }
+
+    public static SchemaContext fromValue(String value) {
+        SchemaContext constant = CONSTANTS.get(value);
+        if (constant == null) {
+            throw new IllegalArgumentException(value);
+        } else {
+            return constant;
+        }
+    }
+}

--- a/javagen/src/main/java/com/azure/autorest/mapper/ProxyParameterMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ProxyParameterMapper.java
@@ -12,6 +12,7 @@ import com.azure.autorest.model.clientmodel.ArrayType;
 import com.azure.autorest.model.clientmodel.ClassType;
 import com.azure.autorest.model.clientmodel.IType;
 import com.azure.autorest.model.clientmodel.ListType;
+import com.azure.autorest.model.clientmodel.ParameterSynthesizedOrigin;
 import com.azure.autorest.model.clientmodel.PrimitiveType;
 import com.azure.autorest.model.clientmodel.ProxyMethodParameter;
 import com.azure.autorest.model.clientmodel.ProxyMethodParameter.Builder;
@@ -38,7 +39,8 @@ public class ProxyParameterMapper implements IMapper<Parameter, ProxyMethodParam
                 .requestParameterName(parameter.getLanguage().getDefault().getSerializedName())
                 .name(name)
                 .isRequired(parameter.isRequired())
-                .isNullable(parameter.isNullable());
+                .isNullable(parameter.isNullable())
+                .origin(ParameterSynthesizedOrigin.fromValue(parameter.getOrigin()));
 
         String headerCollectionPrefix = null;
         if (parameter.getExtensions() != null && parameter.getExtensions().getXmsHeaderCollectionPrefix() != null) {

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ParameterSynthesizedOrigin.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ParameterSynthesizedOrigin.java
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.autorest.model.clientmodel;
+
+public enum ParameterSynthesizedOrigin {
+
+    /**
+     * host url parameter
+     */
+    HOST("modelerfour:synthesized/host"),
+
+    /**
+     * accept header
+     */
+    ACCEPT("modelerfour:synthesized/accept"),
+
+    /**
+     * content-type header
+     */
+    CONTENT_TYPE("modelerfour:synthesized/content-type"),
+
+    /**
+     * api-version (usually) query parameter
+     */
+    API_VERSION("modelerfour:synthesized/api-version"),
+
+    /**
+     * The parameter is not synthesized.
+     */
+    NONE("none");   // NONE is not defined as m4 output
+
+
+    private final String origin;
+
+    ParameterSynthesizedOrigin(String origin) {
+        this.origin = origin;
+    }
+
+    public String getOrigin() {
+        return this.origin;
+    }
+
+    @Override
+    public String toString() {
+        return this.getOrigin();
+    }
+
+    public static ParameterSynthesizedOrigin fromValue(String value) {
+        if (value == null) {
+            return NONE;
+        }
+
+        for (ParameterSynthesizedOrigin v : values()) {
+            if (v.getOrigin().equalsIgnoreCase(value)) {
+                return v;
+            }
+        }
+        return NONE;
+    }
+}

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethodParameter.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethodParameter.java
@@ -83,6 +83,8 @@ public class ProxyMethodParameter {
      */
     private boolean explode;
 
+    private ParameterSynthesizedOrigin origin;
+
     /**
      * Create a new RestAPIParameter based on the provided properties.
      * @param description The description of this parameter.
@@ -103,7 +105,12 @@ public class ProxyMethodParameter {
      * @param collectionFormat The collection format if the parameter is a list type.
      * @param explode Whether arrays and objects should generate separate parameters for each array item or object property.
      */
-    protected ProxyMethodParameter(String description, IType rawType, IType wireType, IType clientType, String name, com.azure.autorest.extension.base.model.codemodel.RequestParameterLocation requestParameterLocation, String requestParameterName, boolean alreadyEncoded, boolean isConstant, boolean isRequired, boolean isNullable, boolean fromClient, String headerCollectionPrefix, String parameterReference, String defaultValue, CollectionFormat collectionFormat, boolean explode) {
+    protected ProxyMethodParameter(String description, IType rawType, IType wireType, IType clientType, String name,
+                                   com.azure.autorest.extension.base.model.codemodel.RequestParameterLocation requestParameterLocation,
+                                   String requestParameterName, boolean alreadyEncoded, boolean isConstant,
+                                   boolean isRequired, boolean isNullable, boolean fromClient,
+                                   String headerCollectionPrefix, String parameterReference, String defaultValue,
+                                   CollectionFormat collectionFormat, boolean explode, ParameterSynthesizedOrigin origin) {
         this.description = description;
         this.rawType = rawType;
         this.wireType = wireType;
@@ -121,6 +128,7 @@ public class ProxyMethodParameter {
         this.collectionFormat = collectionFormat;
         this.explode = explode;
         this.defaultValue = defaultValue;
+        this.origin = origin;
     }
 
     public final String getDefaultValue() {
@@ -195,6 +203,10 @@ public class ProxyMethodParameter {
         return explode;
     }
 
+    public ParameterSynthesizedOrigin getOrigin() {
+        return origin;
+    }
+
     public final String convertFromClientType(String source, String target, boolean alwaysNull) {
         return convertFromClientType(source, target, alwaysNull, false);
     }
@@ -265,6 +277,7 @@ public class ProxyMethodParameter {
         protected String defaultValue;
         protected CollectionFormat collectionFormat;
         protected boolean explode;
+        protected ParameterSynthesizedOrigin origin;
 
         /**
          * Sets the description of this parameter.
@@ -436,6 +449,17 @@ public class ProxyMethodParameter {
             return this;
         }
 
+        /**
+         * Sets origin of the parameter.
+         *
+         * @param origin the origin of the parameter.
+         * @return the Builder itself
+         */
+        public Builder origin(ParameterSynthesizedOrigin origin) {
+            this.origin = origin;
+            return this;
+        }
+
         public ProxyMethodParameter build() {
             return new ProxyMethodParameter(description,
                     rawType,
@@ -453,7 +477,8 @@ public class ProxyMethodParameter {
                     parameterReference,
                     defaultValue,
                     collectionFormat,
-                    explode);
+                    explode,
+                    origin);
         }
     }
 }

--- a/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplateBase.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplateBase.java
@@ -15,6 +15,7 @@ import com.azure.autorest.model.clientmodel.EnumType;
 import com.azure.autorest.model.clientmodel.IType;
 import com.azure.autorest.model.clientmodel.ListType;
 import com.azure.autorest.model.clientmodel.MapType;
+import com.azure.autorest.model.clientmodel.ParameterSynthesizedOrigin;
 import com.azure.autorest.model.clientmodel.PrimitiveType;
 import com.azure.autorest.model.clientmodel.ProxyMethod;
 import com.azure.autorest.model.clientmodel.ProxyMethodParameter;
@@ -37,15 +38,24 @@ public abstract class ClientMethodTemplateBase implements IJavaTemplate<ClientMe
         commentBlock.description(clientMethod.getDescription());
 
         if (clientMethod.getProxyMethod() != null) {
-            List<ProxyMethodParameter> queryParameters = clientMethod.getProxyMethod().getAllParameters()
-                    .stream().filter(p -> RequestParameterLocation.QUERY.equals(p.getRequestParameterLocation()))
+            List<ProxyMethodParameter> queryParameters = clientMethod.getProxyMethod().getAllParameters().stream()
+                    .filter(p -> RequestParameterLocation.QUERY.equals(p.getRequestParameterLocation()))
+                    // ignore if synthesized by modelerfour, i.e. api-version
+                    .filter(p -> p.getOrigin() == ParameterSynthesizedOrigin.NONE)
+                    // ignore if the query parameter is provided by client property or is constant
+                    // currently, RequestOptions.addQueryParam cannot change a query parameter
+                    // we can remove this filter after RequestOptions add feature to replace a query parameter
+                    .filter(p -> !p.getFromClient() && !p.getIsConstant())
                     .collect(Collectors.toList());
             if (!queryParameters.isEmpty()) {
                 optionalParametersJavadoc("Query Parameters", queryParameters, commentBlock);
             }
 
-            List<ProxyMethodParameter> headerParameters = clientMethod.getProxyMethod().getAllParameters()
-                    .stream().filter(p -> !p.getName().equals("accept") && RequestParameterLocation.HEADER.equals(p.getRequestParameterLocation()))
+            List<ProxyMethodParameter> headerParameters = clientMethod.getProxyMethod().getAllParameters().stream()
+                    .filter(p -> RequestParameterLocation.HEADER.equals(p.getRequestParameterLocation()))
+                    // ignore if synthesized by modelerfour and is constant
+                    // we would want user to provide a correct "content-type" if it is not a constant
+                    .filter(p -> p.getOrigin() == ParameterSynthesizedOrigin.NONE || !p.getIsConstant())
                     .collect(Collectors.toList());
             if (!headerParameters.isEmpty()) {
                 optionalParametersJavadoc("Header Parameters", headerParameters, commentBlock);


### PR DESCRIPTION
At present, `RequestOptions` cannot update a query parameter.

Hence for query parameter that already either set by client, or by constant, we do not put it in Javadoc. (as user cannot do anything about it)


PS: also add `usage` from m4, which would help https://github.com/Azure/autorest.java/issues/1336 (though we likely having a flag for that feature, as remove unused setter could be breaking changes)
https://github.com/Azure/autorest.java/commit/9c6c281546a0322cba16456befebd2cac9a45a11