### PR TITLE
Change lowlevelclient to dataplaneclient

### DIFF
--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
@@ -230,7 +230,7 @@ public class JavaSettings {
         String customizationClass,
         boolean overrideSetterFromSuperclass,
         boolean optionalConstantAsEnum,
-        boolean lowLevelClient,
+        boolean dataPlaneClient,
         boolean useIterable,
         List<String> serviceVersions,
         boolean requireXMsFlattenedToFlatten,
@@ -285,7 +285,7 @@ public class JavaSettings {
         this.artifactId = artifactId;
         this.overrideSetterFromParent = overrideSetterFromSuperclass;
         this.optionalConstantAsEnum = optionalConstantAsEnum;
-        this.lowLevelClient = lowLevelClient;
+        this.dataPlaneClient = dataPlaneClient;
         this.useIterable = useIterable;
         this.serviceVersions = serviceVersions;
         this.requireXMsFlattenedToFlatten = requireXMsFlattenedToFlatten;
@@ -750,10 +750,10 @@ public class JavaSettings {
         return optionalConstantAsEnum;
     }
 
-    private final boolean lowLevelClient;
+    private final boolean dataPlaneClient;
 
-    public boolean isLowLevelClient() {
-        return lowLevelClient;
+    public boolean isDataPlaneClient() {
+        return dataPlaneClient;
     }
 
     private final boolean useIterable;

--- a/javagen/src/main/java/com/azure/autorest/Javagen.java
+++ b/javagen/src/main/java/com/azure/autorest/Javagen.java
@@ -159,7 +159,7 @@ public class Javagen extends NewPlugin {
         for (AsyncSyncClient syncClient : client.getSyncClients()) {
             boolean syncClientWrapAsync = settings.isSyncClientWrapAsyncClient()
                     // HLC could have sync method that is harder to convert, e.g. Flux<ByteBuffer> -> InputStream
-                    && settings.isLowLevelClient()
+                    && settings.isDataPlaneClient()
                     // 1-1 match of SyncClient and AsyncClient
                     && client.getAsyncClients().size() == client.getSyncClients().size();
             javaPackage.addSyncServiceClient(syncClient.getPackageName(), syncClient, syncClientWrapAsync);
@@ -179,14 +179,14 @@ public class Javagen extends NewPlugin {
         }
 
         // Sample
-        if (settings.isLowLevelClient() && settings.isGenerateSamples()) {
+        if (settings.isDataPlaneClient() && settings.isGenerateSamples()) {
             for (ProtocolExample protocolExample : client.getProtocolExamples()) {
                 javaPackage.addProtocolExamples(protocolExample);
             }
         }
 
         // Test
-        if (settings.isLowLevelClient() && settings.isGenerateTests()) {
+        if (settings.isDataPlaneClient() && settings.isGenerateTests()) {
             if (!client.getSyncClients().isEmpty() && client.getSyncClients().iterator().next().getClientBuilder() != null) {
                 TestContext testContext = new TestContext(client.getServiceClient(), client.getSyncClients());
 
@@ -201,7 +201,7 @@ public class Javagen extends NewPlugin {
         }
 
         // Service version
-        if (settings.isLowLevelClient()) {
+        if (settings.isDataPlaneClient()) {
             List<String> serviceVersions = settings.getServiceVersions();
             if (serviceVersions == null) {
                 String apiVersion = ClientModelUtil.getFirstApiVersion(codeModel);
@@ -222,7 +222,7 @@ public class Javagen extends NewPlugin {
             javaPackage.addServiceVersion(packageName, new ServiceVersion(className, serviceName, serviceVersions));
         }
 
-        if (!settings.isLowLevelClient() || settings.isGenerateModels()) {
+        if (!settings.isDataPlaneClient() || settings.isGenerateModels()) {
             // Response
             for (ClientResponse response : client.getResponseModels()) {
                 javaPackage.addClientResponse(response.getPackage(), response.getName(), response);
@@ -251,7 +251,7 @@ public class Javagen extends NewPlugin {
         }
 
         // Unit tests on client model
-        if (settings.isGenerateTests() && (!settings.isLowLevelClient() || settings.isGenerateModels())) {
+        if (settings.isGenerateTests() && (!settings.isDataPlaneClient() || settings.isGenerateModels())) {
             for (ClientModel model : client.getModels()) {
                 javaPackage.addModelUnitTest(model);
             }
@@ -262,7 +262,7 @@ public class Javagen extends NewPlugin {
             javaPackage.addPackageInfo(packageInfo.getPackage(), "package-info", packageInfo);
         }
 
-        if (settings.isLowLevelClient()) {
+        if (settings.isDataPlaneClient()) {
             Project project = new Project(client, ClientModelUtil.getFirstApiVersion(codeModel));
             if (settings.isSdkIntegration()) {
                 project.integrateWithSdk();

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMapper.java
@@ -148,7 +148,7 @@ public class ClientMapper implements IMapper<CodeModel, Client> {
         Map<String, PackageInfo> packageInfos = new HashMap<>();
         if (settings.shouldGenerateClientInterfaces() || !settings.shouldGenerateClientAsImpl()
                 || settings.getImplementationSubpackage() == null || settings.getImplementationSubpackage().isEmpty()
-                || settings.isFluent() || settings.shouldGenerateSyncAsyncClients() || settings.isLowLevelClient()) {
+                || settings.isFluent() || settings.shouldGenerateSyncAsyncClients() || settings.isDataPlaneClient()) {
             packageInfos.put(settings.getPackage(), new PackageInfo(
                 settings.getPackage(),
                 String.format("Package containing the classes for %s.\n%s", serviceClientName,
@@ -193,7 +193,7 @@ public class ClientMapper implements IMapper<CodeModel, Client> {
                 }
             }
         }
-        if (!settings.isLowLevelClient() || settings.isGenerateModels()) {
+        if (!settings.isDataPlaneClient() || settings.isGenerateModels()) {
             if (settings.getModelsSubpackage() != null && !settings.getModelsSubpackage().isEmpty()
                     && !settings.getModelsSubpackage().equals(settings.getImplementationSubpackage())
                     // add package-info models package only if the models package is not empty
@@ -276,7 +276,7 @@ public class ClientMapper implements IMapper<CodeModel, Client> {
         }
 
         // example/test
-        if (settings.isLowLevelClient() && (settings.isGenerateSamples() || settings.isGenerateTests())) {
+        if (settings.isDataPlaneClient() && (settings.isGenerateSamples() || settings.isGenerateTests())) {
             List<ProtocolExample> protocolExamples = new ArrayList<>();
             Set<String> protocolExampleNameSet = new HashSet<>();
 

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -116,7 +116,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
             }
             IType listType = itemPropertyOpt.get().getWireType();
             IType elementType = ((ListType) listType).getElementType();
-            if (settings.isLowLevelClient()) {
+            if (settings.isDataPlaneClient()) {
                 asyncRestResponseReturnType = createProtocolPagedRestResponseReturnType();
                 asyncReturnType = createProtocolPagedAsyncReturnType();
                 syncReturnType = createProtocolPagedSyncReturnType();
@@ -128,7 +128,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
         } else {
             asyncRestResponseReturnType = null;
             IType responseBodyType = SchemaUtil.getOperationResponseType(operation);
-            if (settings.isLowLevelClient()) {
+            if (settings.isDataPlaneClient()) {
                 if (responseBodyType instanceof ClassType || responseBodyType instanceof ListType || responseBodyType instanceof MapType) {
                     responseBodyType = ClassType.BinaryData;
                 } else if (responseBodyType instanceof EnumType) {
@@ -137,7 +137,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
             }
             IType restAPIMethodReturnBodyClientType = responseBodyType.getClientType();
             if (operation.getResponses().stream().anyMatch(r -> Boolean.TRUE.equals(r.getBinary()))
-                && !settings.isLowLevelClient() /* TODO: #1059 */) {
+                && !settings.isDataPlaneClient() /* TODO: #1059 */) {
                 asyncReturnType = createAsyncBinaryReturnType();
             } else if (restAPIMethodReturnBodyClientType != PrimitiveType.Void) {
                 asyncReturnType = createAsyncBodyReturnType(restAPIMethodReturnBodyClientType);
@@ -145,7 +145,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                 asyncReturnType = createAsyncVoidReturnType();
             }
             if (operation.getResponses().stream().anyMatch(r -> Boolean.TRUE.equals(r.getBinary()))
-                && !settings.isLowLevelClient() /* TODO: #1059 */) {
+                && !settings.isDataPlaneClient() /* TODO: #1059 */) {
                 syncReturnType = ClassType.InputStream;
             } else {
                 syncReturnType = responseBodyType.getClientType();
@@ -160,7 +160,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
 
         // Low-level client only requires one request per operation
         List<Request> requests = operation.getRequests();
-        if (settings.isLowLevelClient()) {
+        if (settings.isDataPlaneClient()) {
             requests = Collections.singletonList(requests.get(0));
         }
 
@@ -174,7 +174,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
             List<MethodTransformationDetail> methodTransformationDetails = new ArrayList<>();
 
             List<Parameter> codeModelParameters;
-            if (settings.isLowLevelClient()) {
+            if (settings.isDataPlaneClient()) {
                 // Required path and body parameters are allowed
                 codeModelParameters = request.getParameters().stream().filter(p -> p.isRequired() &&
                         (p.getProtocol().getHttp().getIn() == RequestParameterLocation.PATH ||
@@ -227,7 +227,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
 
                 // Transformations
                 if ((parameter.getOriginalParameter() != null || parameter.getGroupedBy() != null)
-                    && !(parameter.getSchema() instanceof ConstantSchema) && !settings.isLowLevelClient()) {
+                    && !(parameter.getSchema() instanceof ConstantSchema) && !settings.isDataPlaneClient()) {
                     ClientMethodParameter outParameter;
                     if (parameter.getOriginalParameter() != null) {
                         originalParameters.add(parameter.getOriginalParameter());
@@ -269,7 +269,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                 methodTransformationDetails.add(new MethodTransformationDetail(outParameter, new ArrayList<>()));
             }
 
-            if (settings.isLowLevelClient()) {
+            if (settings.isDataPlaneClient()) {
                 ClientMethodParameter requestOptions = new ClientMethodParameter.Builder()
                     .description("The options to configure the HTTP request before HTTP client sends it")
                     .wireType(ClassType.RequestOptions)
@@ -432,7 +432,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                         getPollingFinalType(pollingDetails, syncReturnType),
                         pollingDetails.getPollIntervalInSeconds());
 
-                    if (settings.isLowLevelClient() &&
+                    if (settings.isDataPlaneClient() &&
                             !(ClassType.BinaryData.equals(methodPollingDetails.getIntermediateType())
                                     && ClassType.BinaryData.equals(methodPollingDetails.getFinalType()))) {
                         // a new method to be added as implementation only (not exposed to client) for developer
@@ -586,7 +586,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                         } else { // In high level client, method with schema in headers would require a ClientResponse, which is not generic
                             builder.returnValue(createSimpleSyncRestResponseReturnValue(operation, syncReturnWithResponse, syncReturnWithResponse));
                         }
-                        if (settings.isLowLevelClient()) {
+                        if (settings.isDataPlaneClient()) {
                             // SimpleSyncRestResponse with RequestOptions but without Context
                             methods.add(builder.build());
                         }
@@ -654,7 +654,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
         // If LLC is being generated or the response doesn't contain headers return Response<T>
         // If no named response types are being used return ResponseBase<H, T>
         // Else named response types are being used and return that.
-        if (settings.isLowLevelClient() || !responseContainsHeaders) {
+        if (settings.isDataPlaneClient() || !responseContainsHeaders) {
             return GenericType.Response(syncReturnType);
         } else if (settings.isGenericResponseTypes()) {
             return GenericType.RestResponse(Mappers.getSchemaMapper().map(ClientMapper.parseHeader(operation, settings)),
@@ -787,7 +787,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
      * @return method visibility, null if do not generate.
      */
     protected JavaVisibility methodVisibility(ClientMethodType methodType, boolean hasContextParameter) {
-        if (JavaSettings.getInstance().isLowLevelClient()) {
+        if (JavaSettings.getInstance().isDataPlaneClient()) {
             /*
             Rule for LLC
 

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientParameterMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientParameterMapper.java
@@ -47,7 +47,7 @@ public class ClientParameterMapper implements IMapper<Parameter, ClientMethodPar
             wireType = wireType.asNullable();
         }
         builder.rawType(wireType);
-        if (settings.isLowLevelClient() && !(wireType instanceof PrimitiveType)) {
+        if (settings.isDataPlaneClient() && !(wireType instanceof PrimitiveType)) {
             if (parameter.getProtocol().getHttp().getIn() == RequestParameterLocation.BODY) {
                 wireType = ClassType.BinaryData;
             } else {

--- a/javagen/src/main/java/com/azure/autorest/mapper/CustomProxyParameterMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/CustomProxyParameterMapper.java
@@ -90,7 +90,7 @@ public class CustomProxyParameterMapper implements IMapper<Parameter, ProxyMetho
             } else {
                 wireType = ClassType.String;
             }
-        } else if (settings.isLowLevelClient() && !(wireType instanceof PrimitiveType)) {
+        } else if (settings.isDataPlaneClient() && !(wireType instanceof PrimitiveType)) {
             wireType = ClassType.String;
         }
         if (parameter.getProtocol().getHttp().getExplode()) {

--- a/javagen/src/main/java/com/azure/autorest/mapper/PrimitiveMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/PrimitiveMapper.java
@@ -37,7 +37,7 @@ public class PrimitiveMapper implements IMapper<PrimitiveSchema, IType> {
     }
 
     private IType createPrimitiveType(PrimitiveSchema primaryType) {
-        boolean isLowLevelClient = JavaSettings.getInstance().isLowLevelClient();
+        boolean isLowLevelClient = JavaSettings.getInstance().isDataPlaneClient();
         switch (primaryType.getType()) {
 //            case null:
 //                iType = PrimitiveType.Void;

--- a/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
@@ -99,7 +99,7 @@ public class ProxyMethodMapper implements IMapper<Operation, Map<Request, ProxyM
         builder.responseExpectedStatusCodes(expectedStatusCodes);
 
         IType responseBodyType = SchemaUtil.getOperationResponseType(operation);
-        if (settings.isLowLevelClient()) {
+        if (settings.isDataPlaneClient()) {
             builder.rawResponseBodyType(responseBodyType);
             if (responseBodyType instanceof ClassType || responseBodyType instanceof ListType || responseBodyType instanceof MapType) {
                 responseBodyType = ClassType.BinaryData;
@@ -109,7 +109,7 @@ public class ProxyMethodMapper implements IMapper<Operation, Map<Request, ProxyM
         }
         builder.responseBodyType(responseBodyType);
 
-        if (settings.isLowLevelClient()) {
+        if (settings.isDataPlaneClient()) {
             IType singleValueType;
             if (responseBodyType.equals(PrimitiveType.Void)) {
                 singleValueType = GenericType.Response(ClassType.Void);
@@ -170,7 +170,7 @@ public class ProxyMethodMapper implements IMapper<Operation, Map<Request, ProxyM
 
         // Low-level client only requires one request per operation
         List<Request> requests = operation.getRequests();
-        if (settings.isLowLevelClient()) {
+        if (settings.isDataPlaneClient()) {
             requests = Collections.singletonList(requests.get(0));
         }
 
@@ -210,7 +210,7 @@ public class ProxyMethodMapper implements IMapper<Operation, Map<Request, ProxyM
                     proxyMethodParameter = CustomProxyParameterMapper.getInstance().map(parameter);
                 }
                 allParameters.add(proxyMethodParameter);
-                if (!settings.isLowLevelClient()) {
+                if (!settings.isDataPlaneClient()) {
                     parameters.add(proxyMethodParameter);
                 } else {
                     // LLC move most query and header parameters to RequestOptions
@@ -225,7 +225,7 @@ public class ProxyMethodMapper implements IMapper<Operation, Map<Request, ProxyM
                 }
             }
             List<ProxyMethodParameter> specialParameters = getSpecialParameters(operation);
-            if (!settings.isLowLevelClient()) {
+            if (!settings.isDataPlaneClient()) {
                 parameters.addAll(specialParameters);
             }
             allParameters.addAll(specialParameters);
@@ -234,7 +234,7 @@ public class ProxyMethodMapper implements IMapper<Operation, Map<Request, ProxyM
             builder.name(name);
 
             // RequestOptions
-            if (settings.isLowLevelClient()) {
+            if (settings.isDataPlaneClient()) {
                 ProxyMethodParameter requestOptions = new ProxyMethodParameter.Builder()
                         .description("The options to configure the HTTP request before HTTP client sends it")
                         .wireType(ClassType.RequestOptions)
@@ -392,7 +392,7 @@ public class ProxyMethodMapper implements IMapper<Operation, Map<Request, ProxyM
         ClassType swaggerDefaultExceptionType = null;
         Map<Integer, ClassType> swaggerExceptionTypeMap = new HashMap<>();
 
-        if (settings.isLowLevelClient()) {
+        if (settings.isDataPlaneClient()) {
             // LLC does not use model, hence exception from swagger
             swaggerDefaultExceptionType = ClassType.HttpResponseException;
             exceptionDefinitions.defaultExceptionType = swaggerDefaultExceptionType;

--- a/javagen/src/main/java/com/azure/autorest/mapper/ProxyParameterMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ProxyParameterMapper.java
@@ -62,7 +62,7 @@ public class ProxyParameterMapper implements IMapper<Parameter, ProxyMethodParam
         builder.rawType(wireType);
 
         IType clientType = wireType.getClientType();
-        if (settings.isLowLevelClient() && !(clientType instanceof PrimitiveType)) {
+        if (settings.isDataPlaneClient() && !(clientType instanceof PrimitiveType)) {
             if (parameterRequestLocation == RequestParameterLocation.BODY /*&& parameterRequestLocation != RequestParameterLocation.FormData*/) {
                 clientType = ClassType.BinaryData;
             } else {
@@ -90,7 +90,7 @@ public class ProxyParameterMapper implements IMapper<Parameter, ProxyMethodParam
             } else {
                 wireType = ClassType.String;
             }
-        } else if (settings.isLowLevelClient() && !(wireType instanceof PrimitiveType)) {
+        } else if (settings.isDataPlaneClient() && !(wireType instanceof PrimitiveType)) {
             if (parameterRequestLocation == RequestParameterLocation.BODY /*&& parameterRequestLocation != RequestParameterLocation.FormData*/) {
                 wireType = ClassType.BinaryData;
             } else {
@@ -133,7 +133,7 @@ public class ProxyParameterMapper implements IMapper<Parameter, ProxyMethodParam
             String caller = (operationGroupName == null || operationGroupName.isEmpty()) ? "this" : "this.client";
             String clientPropertyName = parameter.getLanguage().getJava().getName();
             boolean isServiceVersion = false;
-            if (settings.isLowLevelClient() && clientPropertyName.equals("apiVersion")) {
+            if (settings.isDataPlaneClient() && clientPropertyName.equals("apiVersion")) {
                 isServiceVersion = true;
                 clientPropertyName = "serviceVersion";
             }

--- a/javagen/src/main/java/com/azure/autorest/mapper/ServiceClientMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ServiceClientMapper.java
@@ -140,7 +140,7 @@ public class ServiceClientMapper implements IMapper<CodeModel, ServiceClient> {
             String serviceClientPropertyDefaultValueExpression = serviceClientPropertyClientType.defaultValueExpression(ClientModelUtil.getClientDefaultValueOrConstantValue(p));
             boolean serviceClientPropertyRequired = p.isRequired();
 
-            if (settings.isLowLevelClient() && serviceClientPropertyName.equals("apiVersion")) {
+            if (settings.isDataPlaneClient() && serviceClientPropertyName.equals("apiVersion")) {
                 String enumTypeName = ClientModelUtil.getServiceVersionClassName(serviceClientInterfaceName);
                 serviceClientPropertyDescription = "Service version";
                 serviceClientPropertyClientType = new ClassType.Builder()

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientMethod.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientMethod.java
@@ -317,7 +317,7 @@ public class ClientMethod {
 
         getReturnValue().addImportsTo(imports, includeImplementationImports);
 
-        if (settings.isLowLevelClient()) {
+        if (settings.isDataPlaneClient()) {
             imports.add("com.azure.core.http.HttpMethod");
             imports.add("com.azure.core.http.rest.Response");
             imports.add("com.azure.core.http.rest.RequestOptions");

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethodParameter.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ProxyMethodParameter.java
@@ -245,7 +245,7 @@ public class ProxyMethodParameter {
                 imports.add("com.azure.core.util.Base64Util");
             } else if (getClientType() instanceof ListType && !getExplode()) {
                 imports.add("com.azure.core.util.serializer.CollectionFormat");
-                if (!settings.isLowLevelClient()) {
+                if (!settings.isDataPlaneClient()) {
                     imports.add("com.azure.core.util.serializer.JacksonAdapter");
                 }
             } else if (getClientType() instanceof ListType && getExplode()) {

--- a/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
@@ -467,21 +467,21 @@ public class ClientMethodTemplate extends ClientMethodTemplateBase {
 
         switch (clientMethod.getType()) {
             case PagingSync:
-                if (settings.isLowLevelClient()) {
+                if (settings.isDataPlaneClient()) {
                     generateProtocolPagingSync(clientMethod, typeBlock, restAPIMethod, settings);
                 } else {
                     generatePagingSync(clientMethod, typeBlock, restAPIMethod, settings);
                 }
                 break;
             case PagingAsync:
-                if (settings.isLowLevelClient()) {
+                if (settings.isDataPlaneClient()) {
                     generateProtocolPagingAsync(clientMethod, typeBlock, restAPIMethod, settings);
                 } else {
                     generatePagingAsync(clientMethod, typeBlock, restAPIMethod, settings);
                 }
                 break;
             case PagingAsyncSinglePage:
-                if (settings.isLowLevelClient()) {
+                if (settings.isDataPlaneClient()) {
                     generateProtocolPagingAsyncSinglePage(clientMethod, typeBlock, restAPIMethod, settings);
                 } else {
                     generatePagedAsyncSinglePage(clientMethod, typeBlock, restAPIMethod, settings);
@@ -530,7 +530,7 @@ public class ClientMethodTemplate extends ClientMethodTemplateBase {
                 break;
 
             case LongRunningBeginAsync:
-                if (settings.isLowLevelClient()) {
+                if (settings.isDataPlaneClient()) {
                     generateProtocolLongRunningBeginAsync(clientMethod, typeBlock);
                 } else {
                     generateLongRunningBeginAsync(clientMethod, typeBlock, restAPIMethod, settings);
@@ -596,7 +596,7 @@ public class ClientMethodTemplate extends ClientMethodTemplateBase {
         if (clientMethod.getMethodPageDetails().nonNullNextLink()) {
             writeMethod(typeBlock, clientMethod.getMethodVisibility(), clientMethod.getDeclaration(), function -> {
                 addOptionalVariables(function, clientMethod, restAPIMethod.getParameters(), settings);
-                if (settings.isLowLevelClient()) {
+                if (settings.isDataPlaneClient()) {
                     function.line("RequestOptions requestOptionsForNextPage = new RequestOptions();");
                     function.line("requestOptionsForNextPage.setContext(requestOptions != null && requestOptions.getContext() != null ? requestOptions.getContext() : Context.NONE);");
                 }
@@ -703,7 +703,7 @@ public class ClientMethodTemplate extends ClientMethodTemplateBase {
     public static void generateJavadoc(ClientMethod clientMethod, JavaType typeBlock, ProxyMethod restAPIMethod, boolean useFullClassName) {
         // interface need a fully-qualified exception class name, since exception is usually only included in ProxyMethod
         typeBlock.javadocComment(comment -> {
-            if (JavaSettings.getInstance().isLowLevelClient()) {
+            if (JavaSettings.getInstance().isDataPlaneClient()) {
                 generateProtocolMethodJavadoc(clientMethod, comment);
             } else {
                 generateJavadoc(clientMethod, comment, restAPIMethod, useFullClassName);
@@ -751,7 +751,7 @@ public class ClientMethodTemplate extends ClientMethodTemplateBase {
             convertClientTypesToWireTypes(function, clientMethod, restAPIMethod.getParameters(), clientMethod.getClientReference(), settings);
 
             boolean requestOptionsLocal = false;
-            if (settings.isLowLevelClient()) {
+            if (settings.isDataPlaneClient()) {
                 requestOptionsLocal = addSpecialHeadersToRequestOptions(function, clientMethod);
             } else {
                 addSpecialHeadersToLocalVariables(function, clientMethod);
@@ -775,13 +775,13 @@ public class ClientMethodTemplate extends ClientMethodTemplateBase {
                     function.line("res.getRequest(),");
                     function.line("res.getStatusCode(),");
                     function.line("res.getHeaders(),");
-                    if (settings.isLowLevelClient()) {
+                    if (settings.isDataPlaneClient()) {
                         function.line("getValues(res.getValue(), \"%s\"),", clientMethod.getMethodPageDetails().getRawItemName());
                     } else {
                         function.line("res.getValue().%s(),", CodeNamer.getModelNamer().modelPropertyGetterName(clientMethod.getMethodPageDetails().getItemName()));
                     }
                     if (clientMethod.getMethodPageDetails().nonNullNextLink()) {
-                        if (settings.isLowLevelClient()) {
+                        if (settings.isDataPlaneClient()) {
                             function.line("getNextLink(res.getValue(), \"%s\"),", clientMethod.getMethodPageDetails().getRawNextLinkName());
                         } else {
                             function.line("res.getValue().%s(),", CodeNamer.getModelNamer().modelPropertyGetterName(clientMethod.getMethodPageDetails().getNextLinkName()));
@@ -849,7 +849,7 @@ public class ClientMethodTemplate extends ClientMethodTemplateBase {
             convertClientTypesToWireTypes(function, clientMethod, restAPIMethod.getParameters(), clientMethod.getClientReference(), settings);
 
             boolean requestOptionsLocal = false;
-            if (settings.isLowLevelClient()) {
+            if (settings.isDataPlaneClient()) {
                 requestOptionsLocal = addSpecialHeadersToRequestOptions(function, clientMethod);
             } else {
                 addSpecialHeadersToLocalVariables(function, clientMethod);

--- a/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplateBase.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplateBase.java
@@ -68,7 +68,7 @@ public abstract class ClientMethodTemplateBase implements IJavaTemplate<ClientMe
 
             // Response body
             IType responseBodyType;
-            if (JavaSettings.getInstance().isLowLevelClient()) {
+            if (JavaSettings.getInstance().isDataPlaneClient()) {
                 responseBodyType = clientMethod.getProxyMethod().getRawResponseBodyType();
             } else {
                 responseBodyType = clientMethod.getProxyMethod().getResponseBodyType();

--- a/javagen/src/main/java/com/azure/autorest/template/ProxyTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ProxyTemplate.java
@@ -65,14 +65,14 @@ public class ProxyTemplate implements IJavaTemplate<Proxy, JavaClass> {
                         interfaceBlock.annotation(String.format("ExpectedResponses({%1$s})", restAPIMethod.getResponseExpectedStatusCodes().stream().map(String::valueOf).collect(Collectors.joining(", "))));
                     }
 
-                    if (!settings.isLowLevelClient()) {
+                    if (!settings.isDataPlaneClient()) {
                         if (restAPIMethod.getReturnValueWireType() != null) {
                             interfaceBlock.annotation(String.format("ReturnValueWireType(%1$s.class)",
                                     restAPIMethod.getReturnValueWireType()));
                         }
                     }
 
-                    if (!settings.isLowLevelClient() || isExceptionCustomized()) {
+                    if (!settings.isDataPlaneClient() || isExceptionCustomized()) {
                         // write @UnexpectedResponseExceptionType
 
                         if (restAPIMethod.getUnexpectedResponseExceptionTypes() != null) {

--- a/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ServiceClientBuilderTemplate.java
@@ -271,7 +271,7 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ClientBuilder
                 }
 
                 final String serializerExpression;
-                if (settings.isLowLevelClient()) {
+                if (settings.isDataPlaneClient()) {
                     serializerExpression = JACKSON_SERIALIZER;
                 } else {
                     serializerExpression = getSerializerMemberName();
@@ -379,7 +379,7 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ClientBuilder
                                               String buildMethodName, boolean wrapServiceClient) {
         JavaSettings settings = JavaSettings.getInstance();
         boolean syncClientWrapAsync = settings.isSyncClientWrapAsyncClient()
-                && settings.isLowLevelClient()
+                && settings.isDataPlaneClient()
                 && asyncClient != null;
         if (syncClientWrapAsync) {
             writeSyncClientBuildMethodFromAsyncClient(syncClient, asyncClient, function, buildMethodName, wrapServiceClient);
@@ -531,7 +531,7 @@ public class ServiceClientBuilderTemplate implements IJavaTemplate<ClientBuilder
         }
 
         // Low-level client does not need serializer. It returns BinaryData.
-        if (!settings.isLowLevelClient()) {
+        if (!settings.isDataPlaneClient()) {
             commonProperties.add(new ServiceClientProperty("The serializer to serialize an object into a string",
                     ClassType.SerializerAdapter, getSerializerMemberName(), false,
                     settings.isFluent() ? "SerializerFactory.createDefaultManagementSerializerAdapter()" : JACKSON_SERIALIZER));

--- a/javagen/src/main/java/com/azure/autorest/template/WrapperClientMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/WrapperClientMethodTemplate.java
@@ -39,7 +39,7 @@ public class WrapperClientMethodTemplate extends ClientMethodTemplateBase {
         if (clientMethod.getType() == ClientMethodType.PagingAsyncSinglePage) return;
 
         ProxyMethod restAPIMethod = clientMethod.getProxyMethod();
-        if (settings.isLowLevelClient()) {
+        if (settings.isDataPlaneClient()) {
             typeBlock.javadocComment(comment -> generateProtocolMethodJavadoc(clientMethod, comment));
         } else {
             generateJavadoc(clientMethod, typeBlock, restAPIMethod);

--- a/javagen/src/main/java/com/azure/autorest/util/ClientModelUtil.java
+++ b/javagen/src/main/java/com/azure/autorest/util/ClientModelUtil.java
@@ -105,7 +105,7 @@ public class ClientModelUtil {
         JavaSettings settings = JavaSettings.getInstance();
         String serviceClientInterfaceName = (settings.getClientTypePrefix() == null ? "" : settings.getClientTypePrefix())
                 + codeModel.getLanguage().getJava().getName();
-        if (settings.isLowLevelClient()) {
+        if (settings.isDataPlaneClient()) {
             // mandate ending Client for LLC
             if (!serviceClientInterfaceName.endsWith("Client")) {
                 String serviceName = settings.getServiceName();
@@ -175,7 +175,7 @@ public class ClientModelUtil {
         if (!settings.isFluent()
                 && settings.shouldGenerateClientAsImpl()
                 && !settings.shouldGenerateSyncAsyncClients()
-                && !settings.isLowLevelClient()) {
+                && !settings.isDataPlaneClient()) {
             builderSuffix.append("Impl");
         }
         builderSuffix.append("Builder");
@@ -185,7 +185,7 @@ public class ClientModelUtil {
     public static String getServiceClientBuilderPackageName(ServiceClient serviceClient) {
         JavaSettings settings = JavaSettings.getInstance();
         String builderPackage = serviceClient.getPackage();
-        if ((settings.shouldGenerateSyncAsyncClients() || settings.isLowLevelClient()) && !settings.isFluent()) {
+        if ((settings.shouldGenerateSyncAsyncClients() || settings.isDataPlaneClient()) && !settings.isFluent()) {
             builderPackage = settings.getPackage();
         } else if (settings.isFluent()) {
             builderPackage = settings.getPackage(settings.getImplementationSubpackage());
@@ -256,7 +256,7 @@ public class ClientModelUtil {
     public static String getArtifactId() {
         JavaSettings settings = JavaSettings.getInstance();
         String artifactId = settings.getArtifactId();
-        if (settings.isLowLevelClient() && CoreUtils.isNullOrEmpty(artifactId)) {
+        if (settings.isDataPlaneClient() && CoreUtils.isNullOrEmpty(artifactId)) {
             // convert package/namespace to artifact
             artifactId = settings.getPackage().toLowerCase(Locale.ROOT)
                     .replace("com.", "")

--- a/javagen/src/main/java/com/azure/autorest/util/TemplateUtil.java
+++ b/javagen/src/main/java/com/azure/autorest/util/TemplateUtil.java
@@ -115,7 +115,7 @@ public class TemplateUtil {
         }
 
         // helper methods for LLC
-        if (settings.isLowLevelClient() &&
+        if (settings.isDataPlaneClient() &&
                 clientMethods.stream().anyMatch(m -> m.getMethodPageDetails() != null)) {
             writePagingHelperMethods(classBlock);
         }


### PR DESCRIPTION
This PR changes the `lowLevelClient` term to `dataPlaneClient` to match the JavaSettings name. Also, the term `lowLevelClient` is not longer used.