### PR TITLE
mgmt, choose parent with polymorphic

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/mapper/ModelMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ModelMapper.java
@@ -308,8 +308,8 @@ public class ModelMapper implements IMapper<ObjectSchema, ClientModel> {
     /**
      * Separate all immediate parents into: one to keep, and the rest to flatten.
      * <p>
-     * If schema is not polymorphic, the first parent of type ObjectSchema is taken.
-     * If schema is polymorphic (but not the supertype), take the parent in polymorphic hierarchy.
+     * If schema is not polymorphic, keep the first parent of type ObjectSchema.
+     * If schema is polymorphic (but not the supertype), keep the parent in polymorphic hierarchy.
      *
      * @param compositeType the object schema
      * @return the info on parent schema.


### PR DESCRIPTION
Case: https://github.com/Azure/azure-rest-api-specs/blob/main/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2022-02-01-preview/mfe.json#L8604-L8624
1st allOf is not polymorphic.
2nd allOf `AutoMLVertical` is polymorphic.

Existing code takes first parent to keep, and flatten the rest.
It would fail the polymorphic hierarchy if that polymorphic chain is not via first parent.

Fix: for polymorphic, takes the one in hierarchy as parent to keep.