### PR TITLE
dpg, fix sample gen, for the List type and primitive type with no value

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/template/example/ProtocolExampleWriter.java
+++ b/javagen/src/main/java/com/azure/autorest/template/example/ProtocolExampleWriter.java
@@ -121,7 +121,7 @@ public class ProtocolExampleWriter {
                             if (elements != null) {
                                 IType elementType = ((GenericType) proxyMethodParameter.getClientType()).getTypeArguments()[0];
                                 String exampleValue = String.format(
-                                        "Arrays.asList(%s);",
+                                        "Arrays.asList(%s)",
                                         elements.stream().map(value -> elementType.defaultValueExpression(value.toString())).collect(Collectors.joining(", ")));
                                 params.set(parameterIndex, exampleValue);
                             }

--- a/javagen/src/main/java/com/azure/autorest/template/example/ProtocolExampleWriter.java
+++ b/javagen/src/main/java/com/azure/autorest/template/example/ProtocolExampleWriter.java
@@ -86,10 +86,9 @@ public class ProtocolExampleWriter {
 
         // method invocation
         // parameter values and required invocation on RequestOptions
-        int numParam = method.getParameters().size();
         List<String> params = new ArrayList<>();
-        for (int i = 0; i < numParam; i++) {
-            params.add("null");
+        for (ClientMethodParameter parameter : method.getParameters()) {
+            params.add(parameter.getClientType().defaultValueExpression());
         }
 
         StringBuilder binaryDataStmt = new StringBuilder();
@@ -100,7 +99,7 @@ public class ProtocolExampleWriter {
         Set<ServiceClientProperty> processedServiceClientProperties = new HashSet<>();
 
         List<ProxyMethodParameter> proxyMethodParameters = getProxyMethodParameters(method.getProxyMethod(), method.getParameters());
-
+        final int numParam = method.getParameters().size();
         proxyMethodExample.getParameters().forEach((parameterName, parameterValue) -> {
             boolean matchRequiredParameter = false;
             for (int parameterIndex = 0; parameterIndex < numParam; parameterIndex++) {


### PR DESCRIPTION
the `content-length` in sample is not filled correctly (and the body).

```java
        BinaryData file = BinaryData.fromString("\"examplefile.csv\"");
        RequestOptions requestOptions = new RequestOptions().addQueryParam("includeTermHierarchy", "true");
        SyncPoller<BinaryData, BinaryData> response =
                glossaryClient.beginImportGlossaryTermsViaCsvByGlossaryName("Glossary", file, 0L, requestOptions);
```