### PR TITLE
client, support immutable output

### DIFF
--- a/androidgen/src/main/java/com/azure/autorest/android/model/clientmodel/AndroidClientModel.java
+++ b/androidgen/src/main/java/com/azure/autorest/android/model/clientmodel/AndroidClientModel.java
@@ -3,6 +3,7 @@
 
 package com.azure.autorest.android.model.clientmodel;
 
+import com.azure.autorest.extension.base.model.codemodel.SchemaContext;
 import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.model.clientmodel.ClassType;
 import com.azure.autorest.model.clientmodel.ClientModel;
@@ -15,7 +16,7 @@ public class AndroidClientModel extends ClientModel {
                                  boolean isPolymorphic, String polymorphicDiscriminator, String serializedName, boolean needsFlatten,
                                  String parentModelName, java.util.List<com.azure.autorest.model.clientmodel.ClientModel> derivedModels, String xmlName, String xmlNamespace,
                                  java.util.List<com.azure.autorest.model.clientmodel.ClientModelProperty> properties, java.util.List<com.azure.autorest.model.clientmodel.ClientModelPropertyReference> propertyReferences,
-                                 IType modelType, boolean stronglyTypedHeader) {
+                                 IType modelType, boolean stronglyTypedHeader, Set<SchemaContext> usages) {
         super(packageKeyword,
                 name,
                 imports,
@@ -31,7 +32,8 @@ public class AndroidClientModel extends ClientModel {
                 properties,
                 propertyReferences,
                 modelType,
-                stronglyTypedHeader);
+                stronglyTypedHeader,
+                usages);
     }
 
     @Override
@@ -77,7 +79,8 @@ public class AndroidClientModel extends ClientModel {
                     properties,
                     propertyReferences,
                     modelType,
-                    stronglyTypedHeader);
+                    stronglyTypedHeader,
+                    usages);
         }
     }
 }

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
@@ -148,7 +148,8 @@ public class JavaSettings {
                     "http-status-code-to-exception-type-mapping"),
                 getBooleanValue(host, "partial-update", false),
                 getBooleanValue(host, "custom-strongly-typed-header-deserialization", false),
-                getBooleanValue(host, "generic-response-type", false)
+                getBooleanValue(host, "generic-response-type", false),
+                getBooleanValue(host, "model-output-immutable", false)
             );
         }
         return instance;
@@ -250,7 +251,8 @@ public class JavaSettings {
         Map<Integer, String> httpStatusCodeToExceptionTypeMapping,
         boolean handlePartialUpdate,
         boolean customStronglyTypedHeaderDeserialization,
-        boolean genericResponseTypes) {
+        boolean genericResponseTypes,
+        boolean outputImmutable) {
 
         this.autorestSettings = autorestSettings;
         this.modelerSettings = new ModelerSettings(modelerSettings);
@@ -339,6 +341,8 @@ public class JavaSettings {
 
         this.customStronglyTypedHeaderDeserialization = customStronglyTypedHeaderDeserialization;
         this.genericResponseTypes = genericResponseTypes;
+
+        this.outputImmutable = outputImmutable;
     }
 
     private String keyCredentialHeaderName;
@@ -728,6 +732,7 @@ public class JavaSettings {
     }
 
     boolean overrideSetterFromParent;
+    boolean outputImmutable;
     boolean skipFormatting;
 
     /**
@@ -735,6 +740,13 @@ public class JavaSettings {
      */
     public boolean isOverrideSetterFromSuperclass() {
         return overrideSetterFromParent;
+    }
+
+    /**
+     * @return whether to make model immutable if only used as API output.
+     */
+    public boolean isOutputImmutable() {
+        return outputImmutable;
     }
 
     /**

--- a/generate
+++ b/generate
@@ -24,7 +24,7 @@ log_and_call_autorest autorest $VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/add
 log_and_call_autorest autorest $VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-array.json --namespace=fixtures.bodyarray
 log_and_call_autorest autorest $VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-boolean.json --namespace=fixtures.bodyboolean --context-client-method-parameter --client-logger
 log_and_call_autorest autorest $VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-boolean.quirks.json --namespace=fixtures.bodyboolean.quirks
-log_and_call_autorest autorest $VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-complex.json --namespace=fixtures.bodycomplex --required-fields-as-ctor-args --model-override-setter-from-superclass --client-logger --generate-tests
+log_and_call_autorest autorest $VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-complex.json --namespace=fixtures.bodycomplex --required-fields-as-ctor-args --model-override-setter-from-superclass --client-logger --generate-tests --model-output-immutable
 log_and_call_autorest autorest $VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-file.json --namespace=fixtures.bodyfile --context-client-method-parameter
 log_and_call_autorest autorest $VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/body-string.json --namespace=fixtures.bodystring --generate-client-interfaces
 log_and_call_autorest autorest $VANILLA_ARGUMENTS --input-file=$SWAGGER_PATH/custom-baseUrl.json --namespace=fixtures.custombaseuri

--- a/generate.bat
+++ b/generate.bat
@@ -14,7 +14,7 @@ call :log-and-call-autorest autorest %VANILLA_ARGUMENTS% --input-file=%SWAGGER_P
 call :log-and-call-autorest autorest %VANILLA_ARGUMENTS% --input-file=%SWAGGER_PATH%/body-array.json --namespace=fixtures.bodyarray
 call :log-and-call-autorest autorest %VANILLA_ARGUMENTS% --input-file=%SWAGGER_PATH%/body-boolean.json --namespace=fixtures.bodyboolean --context-client-method-parameter --client-logger
 call :log-and-call-autorest autorest %VANILLA_ARGUMENTS% --input-file=%SWAGGER_PATH%/body-boolean.quirks.json --namespace=fixtures.bodyboolean.quirks
-call :log-and-call-autorest autorest %VANILLA_ARGUMENTS% --input-file=%SWAGGER_PATH%/body-complex.json --namespace=fixtures.bodycomplex --required-fields-as-ctor-args --model-override-setter-from-superclass --client-logger --generate-tests
+call :log-and-call-autorest autorest %VANILLA_ARGUMENTS% --input-file=%SWAGGER_PATH%/body-complex.json --namespace=fixtures.bodycomplex --required-fields-as-ctor-args --model-override-setter-from-superclass --client-logger --generate-tests --model-output-immutable
 call :log-and-call-autorest autorest %VANILLA_ARGUMENTS% --input-file=%SWAGGER_PATH%/body-file.json --namespace=fixtures.bodyfile --context-client-method-parameter
 call :log-and-call-autorest autorest %VANILLA_ARGUMENTS% --input-file=%SWAGGER_PATH%/body-string.json --namespace=fixtures.bodystring --generate-client-interfaces
 call :log-and-call-autorest autorest %VANILLA_ARGUMENTS% --input-file=%SWAGGER_PATH%/custom-baseUrl.json --namespace=fixtures.custombaseuri

--- a/javagen/src/main/java/com/azure/autorest/mapper/ModelMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ModelMapper.java
@@ -10,6 +10,7 @@ import com.azure.autorest.extension.base.model.codemodel.Languages;
 import com.azure.autorest.extension.base.model.codemodel.ObjectSchema;
 import com.azure.autorest.extension.base.model.codemodel.Property;
 import com.azure.autorest.extension.base.model.codemodel.Schema;
+import com.azure.autorest.extension.base.model.codemodel.SchemaContext;
 import com.azure.autorest.extension.base.model.codemodel.XmlSerlializationFormat;
 import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.model.clientmodel.ClassType;
@@ -64,7 +65,8 @@ public class ModelMapper implements IMapper<ObjectSchema, ClientModel> {
                     .name(modelName)
                     .packageName(modelType.getPackage())
                     .type(modelType)
-                    .stronglyTypedHeader(compositeType.isStronglyTypedHeader());
+                    .stronglyTypedHeader(compositeType.isStronglyTypedHeader())
+                    .usages(compositeType.getUsage());
 
             boolean isPolymorphic = compositeType.getDiscriminator() != null || compositeType.getDiscriminatorValue() != null;
             builder.isPolymorphic(isPolymorphic);
@@ -244,6 +246,9 @@ public class ModelMapper implements IMapper<ObjectSchema, ClientModel> {
             List<ClientModelPropertyReference> propertyReferences = new ArrayList<>();
             for (Property property : compositeTypeProperties) {
                 ClientModelProperty modelProperty = Mappers.getModelPropertyMapper().map(property);
+                if (settings.isOutputImmutable() && !compositeType.getUsage().contains(SchemaContext.INPUT)) {
+                    modelProperty = modelProperty.newBuilder().isReadOnly(true).build();
+                }
                 properties.add(modelProperty);
 
                 if (modelProperty.getClientFlatten() && settings.getClientFlattenAnnotationTarget() == JavaSettings.ClientFlattenAnnotationTarget.NONE) {

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientModel.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientModel.java
@@ -3,9 +3,11 @@
 
 package com.azure.autorest.model.clientmodel;
 
+import com.azure.autorest.extension.base.model.codemodel.SchemaContext;
 import com.azure.autorest.extension.base.plugin.JavaSettings;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -78,6 +80,8 @@ public class ClientModel {
      */
     private final boolean stronglyTypedHeader;
 
+    private final Set<SchemaContext> usages;
+
     /**
      * Create a new ServiceModel with the provided properties.
      * @param name The name of this model.
@@ -99,7 +103,7 @@ public class ClientModel {
             boolean isPolymorphic, String polymorphicDiscriminator, String serializedName, boolean needsFlatten,
             String parentModelName, List<ClientModel> derivedModels, String xmlName, String xmlNamespace,
             List<ClientModelProperty> properties, List<ClientModelPropertyReference> propertyReferences,
-            IType modelType, boolean stronglyTypedHeader) {
+            IType modelType, boolean stronglyTypedHeader, Set<SchemaContext> usages) {
         packageName = packageKeyword;
         this.name = name;
         this.imports = imports;
@@ -116,6 +120,7 @@ public class ClientModel {
         this.propertyReferences = propertyReferences;
         this.modelType = modelType;
         this.stronglyTypedHeader = stronglyTypedHeader;
+        this.usages = usages;
     }
 
     public final String getPackage() {
@@ -192,6 +197,13 @@ public class ClientModel {
      */
     public boolean isStronglyTypedHeader() {
         return stronglyTypedHeader;
+    }
+
+    /**
+     * @return the usages of the model.
+     */
+    public Set<SchemaContext> getUsages() {
+        return usages;
     }
 
     /**
@@ -275,6 +287,7 @@ public class ClientModel {
         protected List<ClientModelPropertyReference> propertyReferences;
         protected IType modelType;
         protected boolean stronglyTypedHeader;
+        protected Set<SchemaContext> usages = new HashSet<>();
 
         /**
          * Sets the package that this model class belongs to.
@@ -438,6 +451,17 @@ public class ClientModel {
             return this;
         }
 
+        /**
+         * Sets the usage of the model.
+         *
+         * @param usages the usage of the model.
+         * @return the Builder itself
+         */
+        public Builder usages(Set<SchemaContext> usages) {
+            this.usages = usages;
+            return this;
+        }
+
         public ClientModel build() {
             return new ClientModel(packageName,
                     name,
@@ -454,7 +478,8 @@ public class ClientModel {
                     properties,
                     propertyReferences,
                     modelType,
-                    stronglyTypedHeader);
+                    stronglyTypedHeader,
+                    usages);
         }
     }
 }

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientModelProperty.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientModelProperty.java
@@ -145,6 +145,31 @@ public class ClientModelProperty implements ClientModelPropertyAccess {
         this.isXmlText = isXmlText;
     }
 
+    public ClientModelProperty.Builder newBuilder() {
+        return new Builder()
+                .name(name)
+                .description(description)
+                .annotationArguments(annotationArguments)
+                .isXmlAttribute(isXmlAttribute)
+                .xmlName(xmlName)
+                .xmlNamespace(xmlNamespace)
+                .serializedName(serializedName)
+                .isXmlWrapper(isXmlWrapper)
+                .wireType(wireType)
+                .clientType(clientType)
+                .isConstant(isConstant)
+                .defaultValue(defaultValue)
+                .isReadOnly(isReadOnly)
+                .mutabilities(mutabilities)
+                .isRequired(isRequired)
+                .headerCollectionPrefix(headerCollectionPrefix)
+                .isAdditionalProperties(isAdditionalProperties)
+                .needsFlatten(needsFlatten)
+                .clientFlatten(clientFlatten)
+                .polymorphicDiscriminator(polymorphicDiscriminator)
+                .isXmlText(isXmlText);
+    }
+
     public final String getName() {
         return name;
     }

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/DotFish.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/DotFish.java
@@ -4,7 +4,7 @@
 
 package fixtures.bodycomplex.models;
 
-import com.azure.core.annotation.Fluent;
+import com.azure.core.annotation.Immutable;
 import com.azure.core.annotation.JsonFlatten;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("DotFish")
 @JsonSubTypes({@JsonSubTypes.Type(name = "DotSalmon", value = DotSalmon.class)})
 @JsonFlatten
-@Fluent
+@Immutable
 public class DotFish {
     /*
      * The species property.
@@ -35,17 +35,6 @@ public class DotFish {
      */
     public String getSpecies() {
         return this.species;
-    }
-
-    /**
-     * Set the species property: The species property.
-     *
-     * @param species the species value to set.
-     * @return the DotFish object itself.
-     */
-    public DotFish setSpecies(String species) {
-        this.species = species;
-        return this;
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/DotFishMarket.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/DotFishMarket.java
@@ -4,12 +4,12 @@
 
 package fixtures.bodycomplex.models;
 
-import com.azure.core.annotation.Fluent;
+import com.azure.core.annotation.Immutable;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 /** The DotFishMarket model. */
-@Fluent
+@Immutable
 public final class DotFishMarket {
     /*
      * The sampleSalmon property.
@@ -45,34 +45,12 @@ public final class DotFishMarket {
     }
 
     /**
-     * Set the sampleSalmon property: The sampleSalmon property.
-     *
-     * @param sampleSalmon the sampleSalmon value to set.
-     * @return the DotFishMarket object itself.
-     */
-    public DotFishMarket setSampleSalmon(DotSalmon sampleSalmon) {
-        this.sampleSalmon = sampleSalmon;
-        return this;
-    }
-
-    /**
      * Get the salmons property: The salmons property.
      *
      * @return the salmons value.
      */
     public List<DotSalmon> getSalmons() {
         return this.salmons;
-    }
-
-    /**
-     * Set the salmons property: The salmons property.
-     *
-     * @param salmons the salmons value to set.
-     * @return the DotFishMarket object itself.
-     */
-    public DotFishMarket setSalmons(List<DotSalmon> salmons) {
-        this.salmons = salmons;
-        return this;
     }
 
     /**
@@ -85,34 +63,12 @@ public final class DotFishMarket {
     }
 
     /**
-     * Set the sampleFish property: The sampleFish property.
-     *
-     * @param sampleFish the sampleFish value to set.
-     * @return the DotFishMarket object itself.
-     */
-    public DotFishMarket setSampleFish(DotFish sampleFish) {
-        this.sampleFish = sampleFish;
-        return this;
-    }
-
-    /**
      * Get the fishes property: The fishes property.
      *
      * @return the fishes value.
      */
     public List<DotFish> getFishes() {
         return this.fishes;
-    }
-
-    /**
-     * Set the fishes property: The fishes property.
-     *
-     * @param fishes the fishes value to set.
-     * @return the DotFishMarket object itself.
-     */
-    public DotFishMarket setFishes(List<DotFish> fishes) {
-        this.fishes = fishes;
-        return this;
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/DotSalmon.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/DotSalmon.java
@@ -4,7 +4,7 @@
 
 package fixtures.bodycomplex.models;
 
-import com.azure.core.annotation.Fluent;
+import com.azure.core.annotation.Immutable;
 import com.azure.core.annotation.JsonFlatten;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "fish\\.type")
 @JsonTypeName("DotSalmon")
 @JsonFlatten
-@Fluent
+@Immutable
 public class DotSalmon extends DotFish {
     /*
      * The location property.
@@ -38,41 +38,12 @@ public class DotSalmon extends DotFish {
     }
 
     /**
-     * Set the location property: The location property.
-     *
-     * @param location the location value to set.
-     * @return the DotSalmon object itself.
-     */
-    public DotSalmon setLocation(String location) {
-        this.location = location;
-        return this;
-    }
-
-    /**
      * Get the iswild property: The iswild property.
      *
      * @return the iswild value.
      */
     public Boolean iswild() {
         return this.iswild;
-    }
-
-    /**
-     * Set the iswild property: The iswild property.
-     *
-     * @param iswild the iswild value to set.
-     * @return the DotSalmon object itself.
-     */
-    public DotSalmon setIswild(Boolean iswild) {
-        this.iswild = iswild;
-        return this;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public DotSalmon setSpecies(String species) {
-        super.setSpecies(species);
-        return this;
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Error.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/Error.java
@@ -4,11 +4,11 @@
 
 package fixtures.bodycomplex.models;
 
-import com.azure.core.annotation.Fluent;
+import com.azure.core.annotation.Immutable;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /** The Error model. */
-@Fluent
+@Immutable
 public final class Error {
     /*
      * The status property.
@@ -32,34 +32,12 @@ public final class Error {
     }
 
     /**
-     * Set the status property: The status property.
-     *
-     * @param status the status value to set.
-     * @return the Error object itself.
-     */
-    public Error setStatus(Integer status) {
-        this.status = status;
-        return this;
-    }
-
-    /**
      * Get the message property: The message property.
      *
      * @return the message value.
      */
     public String getMessage() {
         return this.message;
-    }
-
-    /**
-     * Set the message property: The message property.
-     *
-     * @param message the message value to set.
-     * @return the Error object itself.
-     */
-    public Error setMessage(String message) {
-        this.message = message;
-        return this;
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/MyBaseType.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/MyBaseType.java
@@ -4,7 +4,7 @@
 
 package fixtures.bodycomplex.models;
 
-import com.azure.core.annotation.Fluent;
+import com.azure.core.annotation.Immutable;
 import com.azure.core.annotation.JsonFlatten;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("MyBaseType")
 @JsonSubTypes({@JsonSubTypes.Type(name = "Kind1", value = MyDerivedType.class)})
 @JsonFlatten
-@Fluent
+@Immutable
 public class MyBaseType {
     /*
      * The propB1 property.
@@ -44,34 +44,12 @@ public class MyBaseType {
     }
 
     /**
-     * Set the propB1 property: The propB1 property.
-     *
-     * @param propB1 the propB1 value to set.
-     * @return the MyBaseType object itself.
-     */
-    public MyBaseType setPropB1(String propB1) {
-        this.propB1 = propB1;
-        return this;
-    }
-
-    /**
      * Get the propBH1 property: The propBH1 property.
      *
      * @return the propBH1 value.
      */
     public String getPropBH1() {
         return this.propBH1;
-    }
-
-    /**
-     * Set the propBH1 property: The propBH1 property.
-     *
-     * @param propBH1 the propBH1 value to set.
-     * @return the MyBaseType object itself.
-     */
-    public MyBaseType setPropBH1(String propBH1) {
-        this.propBH1 = propBH1;
-        return this;
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/bodycomplex/models/MyDerivedType.java
+++ b/vanilla-tests/src/main/java/fixtures/bodycomplex/models/MyDerivedType.java
@@ -4,7 +4,7 @@
 
 package fixtures.bodycomplex.models;
 
-import com.azure.core.annotation.Fluent;
+import com.azure.core.annotation.Immutable;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 /** The MyDerivedType model. */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
 @JsonTypeName("Kind1")
-@Fluent
+@Immutable
 public final class MyDerivedType extends MyBaseType {
     /*
      * The propD1 property.
@@ -27,31 +27,6 @@ public final class MyDerivedType extends MyBaseType {
      */
     public String getPropD1() {
         return this.propD1;
-    }
-
-    /**
-     * Set the propD1 property: The propD1 property.
-     *
-     * @param propD1 the propD1 value to set.
-     * @return the MyDerivedType object itself.
-     */
-    public MyDerivedType setPropD1(String propD1) {
-        this.propD1 = propD1;
-        return this;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public MyDerivedType setPropB1(String propB1) {
-        super.setPropB1(propB1);
-        return this;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public MyDerivedType setPropBH1(String propBH1) {
-        super.setPropBH1(propBH1);
-        return this;
     }
 
     /**

--- a/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/DotFishMarketTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/DotFishMarketTests.java
@@ -5,11 +5,7 @@
 package fixtures.bodycomplex.generated;
 
 import com.azure.core.util.BinaryData;
-import fixtures.bodycomplex.models.DotFish;
 import fixtures.bodycomplex.models.DotFishMarket;
-import fixtures.bodycomplex.models.DotSalmon;
-import java.util.Arrays;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public final class DotFishMarketTests {
@@ -19,45 +15,11 @@ public final class DotFishMarketTests {
                 BinaryData.fromString(
                                 "{\"sampleSalmon\":{\"fish.type\":\"DotSalmon\",\"location\":\"wyahuxinpmqnja\",\"iswild\":true,\"species\":\"jsprozvcpute\"},\"salmons\":[{\"fish.type\":\"DotSalmon\",\"location\":\"mfdatscmdvpj\",\"iswild\":true,\"species\":\"uuvmkjozkrwfnd\"}],\"sampleFish\":{\"fish.type\":\"DotFish\",\"species\":\"jpslwejd\"},\"fishes\":[{\"fish.type\":\"DotFish\",\"species\":\"yoqpsoaccta\"},{\"fish.type\":\"DotFish\",\"species\":\"kljla\"},{\"fish.type\":\"DotFish\",\"species\":\"cr\"}]}")
                         .toObject(DotFishMarket.class);
-        Assertions.assertEquals("jsprozvcpute", model.getSampleSalmon().getSpecies());
-        Assertions.assertEquals("wyahuxinpmqnja", model.getSampleSalmon().getLocation());
-        Assertions.assertEquals(true, model.getSampleSalmon().iswild());
-        Assertions.assertEquals("uuvmkjozkrwfnd", model.getSalmons().get(0).getSpecies());
-        Assertions.assertEquals("mfdatscmdvpj", model.getSalmons().get(0).getLocation());
-        Assertions.assertEquals(true, model.getSalmons().get(0).iswild());
-        Assertions.assertEquals("jpslwejd", model.getSampleFish().getSpecies());
-        Assertions.assertEquals("yoqpsoaccta", model.getFishes().get(0).getSpecies());
     }
 
     @Test
     public void testSerialize() {
-        DotFishMarket model =
-                new DotFishMarket()
-                        .setSampleSalmon(
-                                new DotSalmon()
-                                        .setSpecies("jsprozvcpute")
-                                        .setLocation("wyahuxinpmqnja")
-                                        .setIswild(true))
-                        .setSalmons(
-                                Arrays.asList(
-                                        new DotSalmon()
-                                                .setSpecies("uuvmkjozkrwfnd")
-                                                .setLocation("mfdatscmdvpj")
-                                                .setIswild(true)))
-                        .setSampleFish(new DotFish().setSpecies("jpslwejd"))
-                        .setFishes(
-                                Arrays.asList(
-                                        new DotFish().setSpecies("yoqpsoaccta"),
-                                        new DotFish().setSpecies("kljla"),
-                                        new DotFish().setSpecies("cr")));
+        DotFishMarket model = new DotFishMarket();
         model = BinaryData.fromObject(model).toObject(DotFishMarket.class);
-        Assertions.assertEquals("jsprozvcpute", model.getSampleSalmon().getSpecies());
-        Assertions.assertEquals("wyahuxinpmqnja", model.getSampleSalmon().getLocation());
-        Assertions.assertEquals(true, model.getSampleSalmon().iswild());
-        Assertions.assertEquals("uuvmkjozkrwfnd", model.getSalmons().get(0).getSpecies());
-        Assertions.assertEquals("mfdatscmdvpj", model.getSalmons().get(0).getLocation());
-        Assertions.assertEquals(true, model.getSalmons().get(0).iswild());
-        Assertions.assertEquals("jpslwejd", model.getSampleFish().getSpecies());
-        Assertions.assertEquals("yoqpsoaccta", model.getFishes().get(0).getSpecies());
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/DotFishTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/DotFishTests.java
@@ -6,7 +6,6 @@ package fixtures.bodycomplex.generated;
 
 import com.azure.core.util.BinaryData;
 import fixtures.bodycomplex.models.DotFish;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public final class DotFishTests {
@@ -15,13 +14,11 @@ public final class DotFishTests {
         DotFish model =
                 BinaryData.fromString("{\"fish.type\":\"DotFish\",\"species\":\"gejspodmailzyde\"}")
                         .toObject(DotFish.class);
-        Assertions.assertEquals("gejspodmailzyde", model.getSpecies());
     }
 
     @Test
     public void testSerialize() {
-        DotFish model = new DotFish().setSpecies("gejspodmailzyde");
+        DotFish model = new DotFish();
         model = BinaryData.fromObject(model).toObject(DotFish.class);
-        Assertions.assertEquals("gejspodmailzyde", model.getSpecies());
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/DotSalmonTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/DotSalmonTests.java
@@ -6,7 +6,6 @@ package fixtures.bodycomplex.generated;
 
 import com.azure.core.util.BinaryData;
 import fixtures.bodycomplex.models.DotSalmon;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public final class DotSalmonTests {
@@ -16,17 +15,11 @@ public final class DotSalmonTests {
                 BinaryData.fromString(
                                 "{\"fish.type\":\"DotSalmon\",\"location\":\"fdfdosygexpa\",\"iswild\":true,\"species\":\"hmsbzjhcrzevdp\"}")
                         .toObject(DotSalmon.class);
-        Assertions.assertEquals("hmsbzjhcrzevdp", model.getSpecies());
-        Assertions.assertEquals("fdfdosygexpa", model.getLocation());
-        Assertions.assertEquals(true, model.iswild());
     }
 
     @Test
     public void testSerialize() {
-        DotSalmon model = new DotSalmon().setSpecies("hmsbzjhcrzevdp").setLocation("fdfdosygexpa").setIswild(true);
+        DotSalmon model = new DotSalmon();
         model = BinaryData.fromObject(model).toObject(DotSalmon.class);
-        Assertions.assertEquals("hmsbzjhcrzevdp", model.getSpecies());
-        Assertions.assertEquals("fdfdosygexpa", model.getLocation());
-        Assertions.assertEquals(true, model.iswild());
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/ErrorTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/ErrorTests.java
@@ -6,7 +6,6 @@ package fixtures.bodycomplex.generated;
 
 import com.azure.core.util.BinaryData;
 import fixtures.bodycomplex.models.Error;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public final class ErrorTests {
@@ -14,15 +13,11 @@ public final class ErrorTests {
     public void testDeserialize() {
         Error model =
                 BinaryData.fromString("{\"status\":655985822,\"message\":\"bsphrupidgsybbe\"}").toObject(Error.class);
-        Assertions.assertEquals(655985822, model.getStatus());
-        Assertions.assertEquals("bsphrupidgsybbe", model.getMessage());
     }
 
     @Test
     public void testSerialize() {
-        Error model = new Error().setStatus(655985822).setMessage("bsphrupidgsybbe");
+        Error model = new Error();
         model = BinaryData.fromObject(model).toObject(Error.class);
-        Assertions.assertEquals(655985822, model.getStatus());
-        Assertions.assertEquals("bsphrupidgsybbe", model.getMessage());
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/MyBaseTypeTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/MyBaseTypeTests.java
@@ -6,7 +6,6 @@ package fixtures.bodycomplex.generated;
 
 import com.azure.core.util.BinaryData;
 import fixtures.bodycomplex.models.MyBaseType;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public final class MyBaseTypeTests {
@@ -16,15 +15,11 @@ public final class MyBaseTypeTests {
                 BinaryData.fromString(
                                 "{\"kind\":\"MyBaseType\",\"propB1\":\"jlxofpdvhpfxxyp\",\"helper\":{\"propBH1\":\"i\"}}")
                         .toObject(MyBaseType.class);
-        Assertions.assertEquals("jlxofpdvhpfxxyp", model.getPropB1());
-        Assertions.assertEquals("i", model.getPropBH1());
     }
 
     @Test
     public void testSerialize() {
-        MyBaseType model = new MyBaseType().setPropB1("jlxofpdvhpfxxyp").setPropBH1("i");
+        MyBaseType model = new MyBaseType();
         model = BinaryData.fromObject(model).toObject(MyBaseType.class);
-        Assertions.assertEquals("jlxofpdvhpfxxyp", model.getPropB1());
-        Assertions.assertEquals("i", model.getPropBH1());
     }
 }

--- a/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/MyDerivedTypeTests.java
+++ b/vanilla-tests/src/test/java/fixtures/bodycomplex/generated/MyDerivedTypeTests.java
@@ -6,7 +6,6 @@ package fixtures.bodycomplex.generated;
 
 import com.azure.core.util.BinaryData;
 import fixtures.bodycomplex.models.MyDerivedType;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public final class MyDerivedTypeTests {
@@ -16,18 +15,11 @@ public final class MyDerivedTypeTests {
                 BinaryData.fromString(
                                 "{\"kind\":\"Kind1\",\"propD1\":\"gphuticndvka\",\"propB1\":\"wyiftyhxhur\",\"helper\":{\"propBH1\":\"ftyxolniw\"}}")
                         .toObject(MyDerivedType.class);
-        Assertions.assertEquals("wyiftyhxhur", model.getPropB1());
-        Assertions.assertEquals("ftyxolniw", model.getPropBH1());
-        Assertions.assertEquals("gphuticndvka", model.getPropD1());
     }
 
     @Test
     public void testSerialize() {
-        MyDerivedType model =
-                new MyDerivedType().setPropB1("wyiftyhxhur").setPropBH1("ftyxolniw").setPropD1("gphuticndvka");
+        MyDerivedType model = new MyDerivedType();
         model = BinaryData.fromObject(model).toObject(MyDerivedType.class);
-        Assertions.assertEquals("wyiftyhxhur", model.getPropB1());
-        Assertions.assertEquals("ftyxolniw", model.getPropBH1());
-        Assertions.assertEquals("gphuticndvka", model.getPropD1());
     }
 }


### PR DESCRIPTION
fix https://github.com/Azure/autorest.java/issues/1336

Please take a quick look.

I might need to add some swagger for test, for cases e.g. superclass is input/output, subclass is output; and vise versa.
A more complex case is the subclass as output, but inherits multiple superclass, and some of them get flattened.