### PR TITLE
client, improve the check of whether type is client model

### DIFF
--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
@@ -339,6 +339,10 @@ public class JavaSettings {
 
         this.customStronglyTypedHeaderDeserialization = customStronglyTypedHeaderDeserialization;
         this.genericResponseTypes = genericResponseTypes;
+
+        if (packageName == null || packageName.isEmpty() || packageName.startsWith("java.")) {
+            throw new IllegalArgumentException("Package name / namespace " + packageName + " is invalid");
+        }
     }
 
     private String keyCredentialHeaderName;

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
@@ -339,10 +339,6 @@ public class JavaSettings {
 
         this.customStronglyTypedHeaderDeserialization = customStronglyTypedHeaderDeserialization;
         this.genericResponseTypes = genericResponseTypes;
-
-        if (packageName == null || packageName.isEmpty() || packageName.startsWith("java.")) {
-            throw new IllegalArgumentException("Package name / namespace " + packageName + " is invalid");
-        }
     }
 
     private String keyCredentialHeaderName;

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/ResourceParser.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/ResourceParser.java
@@ -25,8 +25,8 @@ import com.azure.autorest.fluent.util.Utils;
 import com.azure.autorest.model.clientmodel.ClassType;
 import com.azure.autorest.model.clientmodel.ClientMethodType;
 import com.azure.autorest.model.clientmodel.ClientModel;
-import com.azure.autorest.model.clientmodel.IType;
 import com.azure.autorest.template.prototype.MethodTemplate;
+import com.azure.autorest.util.ClientModelUtil;
 import com.azure.core.http.HttpMethod;
 import com.azure.core.management.Region;
 import com.azure.core.util.CoreUtils;
@@ -516,16 +516,7 @@ public class ResourceParser {
 
     private static boolean methodHasBodyParameter(FluentCollectionMethod method) {
         return method.getInnerProxyMethod().getParameters().stream()
-                .filter(p -> nonSimpleJavaType(p.getClientType()))
+                .filter(p -> ClientModelUtil.isClientModel(p.getClientType()))
                 .anyMatch(p -> p.getRequestParameterLocation() == RequestParameterLocation.BODY);
-    }
-
-    private static boolean nonSimpleJavaType(IType type) {
-        boolean ret = false;
-        if (type instanceof ClassType) {
-            ClassType classType = (ClassType) type;
-            ret = !classType.getPackage().startsWith("java");
-        }
-        return ret;
     }
 }

--- a/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplateBase.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplateBase.java
@@ -154,9 +154,7 @@ public abstract class ClientMethodTemplateBase implements IJavaTemplate<ClientMe
 
     private static void bodySchemaJavadoc(IType type, JavaJavadocComment commentBlock, String indent, String name, Set<IType> typesInJavadoc) {
         String nextIndent = indent + "    ";
-        if (type instanceof ClassType
-                && ((ClassType) type).getPackage().startsWith(JavaSettings.getInstance().getPackage())
-                && !typesInJavadoc.contains(type)) {
+        if (ClientModelUtil.isClientModel(type) && !typesInJavadoc.contains(type)) {
             typesInJavadoc.add(type);
             ClientModel model = ClientModelUtil.getClientModel(((ClassType) type).getName());
             if (name != null) {

--- a/javagen/src/main/java/com/azure/autorest/util/ClientModelUtil.java
+++ b/javagen/src/main/java/com/azure/autorest/util/ClientModelUtil.java
@@ -296,14 +296,34 @@ public class ClientModelUtil {
 
     private static Function<String, ClientModel> getClientModelFunction = name -> ClientModels.getInstance().getModel(name);
 
+    /**
+     * Replace the default function of getting ClientModel by name.
+     * <p>
+     * Used in Fluent for providing additional ClientModel that exists in azure-core-management,
+     * e.g. Resource, ManagementError
+     *
+     * @param function the function of getting ClientModel by name
+     */
     public static void setGetClientModelFunction(Function<String, ClientModel> function) {
         getClientModelFunction = function;
     }
 
+    /**
+     * Get ClientModel by name.
+     *
+     * @param name the name of the ClientModel (without package)
+     * @return the ClientModel instance. <code>null</code> if not found.
+     */
     public static ClientModel getClientModel(String name) {
         return getClientModelFunction.apply(name);
     }
 
+    /**
+     * Check if the type is a ClientModel.
+     *
+     * @param type the type
+     * @return whether the type is a ClientModel.
+     */
     public static boolean isClientModel(IType type) {
         if (type instanceof ClassType) {
             ClassType classType = (ClassType) type;

--- a/javagen/src/main/java/com/azure/autorest/util/ClientModelUtil.java
+++ b/javagen/src/main/java/com/azure/autorest/util/ClientModelUtil.java
@@ -9,9 +9,11 @@ import com.azure.autorest.extension.base.model.codemodel.ConstantSchema;
 import com.azure.autorest.extension.base.model.codemodel.Parameter;
 import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.model.clientmodel.AsyncSyncClient;
+import com.azure.autorest.model.clientmodel.ClassType;
 import com.azure.autorest.model.clientmodel.ClientModel;
 import com.azure.autorest.model.clientmodel.ClientModelProperty;
 import com.azure.autorest.model.clientmodel.ClientModels;
+import com.azure.autorest.model.clientmodel.IType;
 import com.azure.autorest.model.clientmodel.MethodGroupClient;
 import com.azure.autorest.model.clientmodel.ServiceClient;
 import com.azure.core.util.CoreUtils;
@@ -300,6 +302,16 @@ public class ClientModelUtil {
 
     public static ClientModel getClientModel(String name) {
         return getClientModelFunction.apply(name);
+    }
+
+    public static boolean isClientModel(IType type) {
+        if (type instanceof ClassType) {
+            ClassType classType = (ClassType) type;
+            return classType.getPackage().startsWith(JavaSettings.getInstance().getPackage())
+                    && getClientModel(classType.getName()) != null;
+        } else {
+            return false;
+        }
     }
 
     public static List<ClientModelProperty> getRequiredParentProperties(ClientModel model) {

--- a/javagen/src/test/java/com/azure/autorest/MockUnitJavagen.java
+++ b/javagen/src/test/java/com/azure/autorest/MockUnitJavagen.java
@@ -4,6 +4,7 @@
 package com.azure.autorest;
 
 import com.azure.autorest.extension.base.jsonrpc.Connection;
+import com.azure.autorest.extension.base.model.Message;
 import org.junit.Assert;
 
 import java.io.IOException;
@@ -11,8 +12,15 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 
 public class MockUnitJavagen extends Javagen {
+
+    private static final Map<String, Object> SETTINGS_MAP = new HashMap<>();
+    static {
+        SETTINGS_MAP.put("namespace", "com.azure.mock");
+    }
 
     public static class MockConnection extends Connection {
 
@@ -42,8 +50,13 @@ public class MockUnitJavagen extends Javagen {
         return sb.toString();
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public <T> T getValue(Type type, String key) {
-        return null;
+        return (T) SETTINGS_MAP.get(key);
+    }
+
+    @Override
+    public void message(Message message) {
     }
 }

--- a/preprocessor/src/test/java/com/azure/autorest/MockPreprocessor.java
+++ b/preprocessor/src/test/java/com/azure/autorest/MockPreprocessor.java
@@ -4,6 +4,7 @@
 package com.azure.autorest;
 
 import com.azure.autorest.extension.base.jsonrpc.Connection;
+import com.azure.autorest.extension.base.model.Message;
 import com.azure.autorest.extension.base.model.codemodel.CodeModel;
 import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.preprocessor.Preprocessor;
@@ -28,8 +29,10 @@ import java.util.Map;
 
 public class MockPreprocessor extends Preprocessor {
 
-
     private static final Map<String, Object> SETTINGS_MAP = new HashMap<>();
+    static {
+        SETTINGS_MAP.put("namespace", "com.azure.mock");
+    }
 
     public MockPreprocessor(Connection connection, String plugin, String sessionId) {
         super(connection, plugin, sessionId);
@@ -82,16 +85,14 @@ public class MockPreprocessor extends Preprocessor {
         return newYaml.dump(codeModel);
     }
 
-    /**
-     * override default behavior from fetching settings through json-rpc to read locally
-     * @param type
-     * @param key
-     * @param <T>
-     * @return
-     */
+    @SuppressWarnings("unchecked")
     @Override
     public <T> T getValue(Type type, String key) {
         return (T) SETTINGS_MAP.get(key);
+    }
+
+    @Override
+    public void message(Message message) {
     }
 
     @Override


### PR DESCRIPTION
There is certain code that implicitly assume certain pattern for namespace, e.g. not start with `java.lang`.
https://github.com/Azure/autorest.java/blob/main/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplateBase.java#L158

Ideally, we should throw when namespace is empty or invalid.

But autorest seems having problem when configure is `--java.namespace=<>`, preprocess cannot read it, but javagen can.