### PR TITLE
dpg, use require first, in swagger/readme.md

### DIFF
--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/AutorestSettings.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/AutorestSettings.java
@@ -19,6 +19,7 @@ public class AutorestSettings {
     private String securityHeaderName;
     private String javaSdksFolder;
     private final List<String> inputFiles = new ArrayList<>();
+    private final List<String> require = new ArrayList<>();
 
     public void setTag(String tag) {
         this.tag = tag;
@@ -54,6 +55,10 @@ public class AutorestSettings {
 
     public List<String> getInputFiles() {
         return inputFiles;
+    }
+
+    public List<String> getRequire() {
+        return require;
     }
 
     public Optional<String> getTitle() {

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
@@ -79,11 +79,19 @@ public class JavaSettings {
             loadStringSetting("base-folder", autorestSettings::setBaseFolder);
             loadStringSetting("output-folder", autorestSettings::setOutputFolder);
             loadStringSetting("java-sdks-folder", autorestSettings::setJavaSdksFolder);
+            // input-file
             List<Object> inputFiles = host.getValue(List.class, "input-file");
             if (inputFiles != null) {
                 autorestSettings.getInputFiles().addAll(
                     inputFiles.stream().map(Object::toString).collect(Collectors.toList()));
                 logger.debug("List of input files : {}", autorestSettings.getInputFiles());
+            }
+            // require (readme.md etc.)
+            List<Object> require = host.getValue(List.class, "require");
+            if (require != null) {
+                autorestSettings.getRequire().addAll(
+                        require.stream().map(Object::toString).collect(Collectors.toList()));
+                logger.debug("List of require : {}", autorestSettings.getRequire());
             }
 
             setHeader(getStringValue(host, "license-header"));

--- a/javagen/src/main/java/com/azure/autorest/template/SwaggerReadmeTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/SwaggerReadmeTemplate.java
@@ -3,6 +3,7 @@
 
 package com.azure.autorest.template;
 
+import com.azure.autorest.extension.base.plugin.AutorestSettings;
 import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.model.projectmodel.Project;
 import com.azure.autorest.util.TemplateUtil;
@@ -50,7 +51,7 @@ public class SwaggerReadmeTemplate {
         Yaml yaml = new Yaml(dumperOptions);
 
         Map<String, Object> objectNode = new LinkedHashMap<>();
-        objectNode.put("input-file", settings.getAutorestSettings().getInputFiles());
+        addRequireOrInputFile(objectNode, settings.getAutorestSettings());
         // settings from internal
         for (Map.Entry<String, Object> entry : OVERRIDE_OPTIONS.entrySet()) {
             if (entry.getValue() != null) {
@@ -76,6 +77,25 @@ public class SwaggerReadmeTemplate {
         line("```");
 
         return builder.toString();
+    }
+
+    private static void addRequireOrInputFile(Map<String, Object> objectNode, AutorestSettings autorestSettings) {
+        // try use "require"
+        boolean useRequire = false;
+        List<String> requireList = autorestSettings.getRequire();
+        if (!CoreUtils.isNullOrEmpty(requireList)) {
+            String require = requireList.iterator().next();
+
+            if (require.contains("data-plane")) {
+                useRequire = true;
+                objectNode.put("require", require);
+            }
+        }
+
+        if (!useRequire) {
+            // use "input-file"
+            objectNode.put("input-file", autorestSettings.getInputFiles());
+        }
     }
 
     private static Map<String, Object> removeDefaultOptions(Map<String, Object> objectNode) {


### PR DESCRIPTION
sample output (Wes/Laurent ask to use "require" instead of "input-file"):

## Generate autorest code

```yaml
require: c:/github/azure-rest-api-specs/specification/purview/data-plane/Azure.Analytics.Purview.Account/readme.md
output-folder: ../
java: true
regenerate-pom: false
title: PurviewAccountClient
data-plane: true
generate-tests: true
generate-samples: true
namespace: com.azure.analytics.purview.account
service-versions:
- 2019-11-01-preview
```
