### PR TITLE
DPG, enable CI of maven javadoc for protocol test

### DIFF
--- a/azure-tests/src/main/java/fixtures/lro/implementation/AutoRestLongRunningOperationTestServiceBuilder.java
+++ b/azure-tests/src/main/java/fixtures/lro/implementation/AutoRestLongRunningOperationTestServiceBuilder.java
@@ -7,7 +7,6 @@ package fixtures.lro.implementation;
 import com.azure.core.annotation.ServiceClientBuilder;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
-import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.management.AzureEnvironment;
@@ -51,22 +50,6 @@ public final class AutoRestLongRunningOperationTestServiceBuilder {
     }
 
     /*
-     * The default poll interval for long-running operation
-     */
-    private Duration defaultPollInterval;
-
-    /**
-     * Sets The default poll interval for long-running operation.
-     *
-     * @param defaultPollInterval the defaultPollInterval value.
-     * @return the AutoRestLongRunningOperationTestServiceBuilder.
-     */
-    public AutoRestLongRunningOperationTestServiceBuilder defaultPollInterval(Duration defaultPollInterval) {
-        this.defaultPollInterval = defaultPollInterval;
-        return this;
-    }
-
-    /*
      * The HTTP pipeline to send requests through
      */
     private HttpPipeline pipeline;
@@ -79,6 +62,22 @@ public final class AutoRestLongRunningOperationTestServiceBuilder {
      */
     public AutoRestLongRunningOperationTestServiceBuilder pipeline(HttpPipeline pipeline) {
         this.pipeline = pipeline;
+        return this;
+    }
+
+    /*
+     * The default poll interval for long-running operation
+     */
+    private Duration defaultPollInterval;
+
+    /**
+     * Sets The default poll interval for long-running operation.
+     *
+     * @param defaultPollInterval the defaultPollInterval value.
+     * @return the AutoRestLongRunningOperationTestServiceBuilder.
+     */
+    public AutoRestLongRunningOperationTestServiceBuilder defaultPollInterval(Duration defaultPollInterval) {
+        this.defaultPollInterval = defaultPollInterval;
         return this;
     }
 
@@ -110,14 +109,11 @@ public final class AutoRestLongRunningOperationTestServiceBuilder {
         if (environment == null) {
             this.environment = AzureEnvironment.AZURE;
         }
+        if (pipeline == null) {
+            this.pipeline = new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy()).build();
+        }
         if (defaultPollInterval == null) {
             this.defaultPollInterval = Duration.ofSeconds(30);
-        }
-        if (pipeline == null) {
-            this.pipeline =
-                new HttpPipelineBuilder()
-                    .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                    .build();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = SerializerFactory.createDefaultManagementSerializerAdapter();

--- a/azure-tests/src/main/java/fixtures/lro/implementation/AutoRestLongRunningOperationTestServiceImpl.java
+++ b/azure-tests/src/main/java/fixtures/lro/implementation/AutoRestLongRunningOperationTestServiceImpl.java
@@ -15,6 +15,7 @@ import com.azure.core.management.exception.ManagementException;
 import com.azure.core.management.polling.PollResult;
 import com.azure.core.management.polling.PollerFactory;
 import com.azure.core.util.Context;
+import com.azure.core.util.CoreUtils;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.core.util.polling.AsyncPollResponse;
 import com.azure.core.util.polling.LongRunningOperationStatus;
@@ -32,7 +33,6 @@ import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.Map;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -176,10 +176,7 @@ public final class AutoRestLongRunningOperationTestServiceImpl implements AutoRe
      * @return the merged context.
      */
     public Context mergeContext(Context context) {
-        for (Map.Entry<Object, Object> entry : this.getContext().getValues().entrySet()) {
-            context = context.addData(entry.getKey(), entry.getValue());
-        }
-        return context;
+        return CoreUtils.mergeContexts(this.getContext(), context);
     }
 
     /**

--- a/azure-tests/src/main/java/fixtures/lro/models/ProductPropertiesProvisioningStateValues.java
+++ b/azure-tests/src/main/java/fixtures/lro/models/ProductPropertiesProvisioningStateValues.java
@@ -55,7 +55,11 @@ public final class ProductPropertiesProvisioningStateValues
         return fromString(name, ProductPropertiesProvisioningStateValues.class);
     }
 
-    /** @return known ProductPropertiesProvisioningStateValues values. */
+    /**
+     * Gets known ProductPropertiesProvisioningStateValues values.
+     *
+     * @return known ProductPropertiesProvisioningStateValues values.
+     */
     public static Collection<ProductPropertiesProvisioningStateValues> values() {
         return values(ProductPropertiesProvisioningStateValues.class);
     }

--- a/azure-tests/src/main/java/fixtures/lro/models/SubProductPropertiesProvisioningStateValues.java
+++ b/azure-tests/src/main/java/fixtures/lro/models/SubProductPropertiesProvisioningStateValues.java
@@ -55,7 +55,11 @@ public final class SubProductPropertiesProvisioningStateValues
         return fromString(name, SubProductPropertiesProvisioningStateValues.class);
     }
 
-    /** @return known SubProductPropertiesProvisioningStateValues values. */
+    /**
+     * Gets known SubProductPropertiesProvisioningStateValues values.
+     *
+     * @return known SubProductPropertiesProvisioningStateValues values.
+     */
     public static Collection<SubProductPropertiesProvisioningStateValues> values() {
         return values(SubProductPropertiesProvisioningStateValues.class);
     }

--- a/azure-tests/src/main/java/fixtures/lroparameterizedendpoints/LroparameterizedendpointsManager.java
+++ b/azure-tests/src/main/java/fixtures/lroparameterizedendpoints/LroparameterizedendpointsManager.java
@@ -10,11 +10,13 @@ import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
 import com.azure.core.http.HttpPipelinePosition;
 import com.azure.core.http.policy.AddDatePolicy;
+import com.azure.core.http.policy.AddHeadersFromContextPolicy;
 import com.azure.core.http.policy.HttpLogOptions;
 import com.azure.core.http.policy.HttpLoggingPolicy;
 import com.azure.core.http.policy.HttpPipelinePolicy;
 import com.azure.core.http.policy.HttpPolicyProviders;
 import com.azure.core.http.policy.RequestIdPolicy;
+import com.azure.core.http.policy.RetryOptions;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.management.http.policy.ArmChallengeAuthenticationPolicy;
@@ -63,6 +65,19 @@ public final class LroparameterizedendpointsManager {
     }
 
     /**
+     * Creates an instance of lroparameterizedendpoints service API entry point.
+     *
+     * @param httpPipeline the {@link HttpPipeline} configured with Azure authentication credential.
+     * @param profile the Azure profile for client.
+     * @return the lroparameterizedendpoints service API instance.
+     */
+    public static LroparameterizedendpointsManager authenticate(HttpPipeline httpPipeline, AzureProfile profile) {
+        Objects.requireNonNull(httpPipeline, "'httpPipeline' cannot be null.");
+        Objects.requireNonNull(profile, "'profile' cannot be null.");
+        return new LroparameterizedendpointsManager(httpPipeline, profile, null);
+    }
+
+    /**
      * Gets a Configurable instance that can be used to create LroparameterizedendpointsManager with optional
      * configuration.
      *
@@ -81,6 +96,7 @@ public final class LroparameterizedendpointsManager {
         private final List<HttpPipelinePolicy> policies = new ArrayList<>();
         private final List<String> scopes = new ArrayList<>();
         private RetryPolicy retryPolicy;
+        private RetryOptions retryOptions;
         private Duration defaultPollInterval;
 
         private Configurable() {
@@ -142,6 +158,19 @@ public final class LroparameterizedendpointsManager {
         }
 
         /**
+         * Sets the retry options for the HTTP pipeline retry policy.
+         *
+         * <p>This setting has no effect, if retry policy is set via {@link #withRetryPolicy(RetryPolicy)}.
+         *
+         * @param retryOptions the retry options for the HTTP pipeline retry policy.
+         * @return the configurable object itself.
+         */
+        public Configurable withRetryOptions(RetryOptions retryOptions) {
+            this.retryOptions = Objects.requireNonNull(retryOptions, "'retryOptions' cannot be null.");
+            return this;
+        }
+
+        /**
          * Sets the default poll interval, used when service does not provide "Retry-After" header.
          *
          * @param defaultPollInterval the default poll interval.
@@ -192,10 +221,15 @@ public final class LroparameterizedendpointsManager {
                 scopes.add(profile.getEnvironment().getManagementEndpoint() + "/.default");
             }
             if (retryPolicy == null) {
-                retryPolicy = new RetryPolicy("Retry-After", ChronoUnit.SECONDS);
+                if (retryOptions != null) {
+                    retryPolicy = new RetryPolicy(retryOptions);
+                } else {
+                    retryPolicy = new RetryPolicy("Retry-After", ChronoUnit.SECONDS);
+                }
             }
             List<HttpPipelinePolicy> policies = new ArrayList<>();
             policies.add(new UserAgentPolicy(userAgentBuilder.toString()));
+            policies.add(new AddHeadersFromContextPolicy());
             policies.add(new RequestIdPolicy());
             policies
                 .addAll(
@@ -226,7 +260,11 @@ public final class LroparameterizedendpointsManager {
         }
     }
 
-    /** @return Resource collection API of ResourceProviders. */
+    /**
+     * Gets the resource collection API of ResourceProviders.
+     *
+     * @return Resource collection API of ResourceProviders.
+     */
     public ResourceProviders resourceProviders() {
         if (this.resourceProviders == null) {
             this.resourceProviders = new ResourceProvidersImpl(clientObject.getResourceProviders(), this);

--- a/azure-tests/src/main/java/fixtures/lroparameterizedendpoints/implementation/LroWithParamaterizedEndpointsBuilder.java
+++ b/azure-tests/src/main/java/fixtures/lroparameterizedendpoints/implementation/LroWithParamaterizedEndpointsBuilder.java
@@ -7,7 +7,6 @@ package fixtures.lroparameterizedendpoints.implementation;
 import com.azure.core.annotation.ServiceClientBuilder;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpPipelineBuilder;
-import com.azure.core.http.policy.CookiePolicy;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.http.policy.UserAgentPolicy;
 import com.azure.core.management.AzureEnvironment;
@@ -52,22 +51,6 @@ public final class LroWithParamaterizedEndpointsBuilder {
     }
 
     /*
-     * The default poll interval for long-running operation
-     */
-    private Duration defaultPollInterval;
-
-    /**
-     * Sets The default poll interval for long-running operation.
-     *
-     * @param defaultPollInterval the defaultPollInterval value.
-     * @return the LroWithParamaterizedEndpointsBuilder.
-     */
-    public LroWithParamaterizedEndpointsBuilder defaultPollInterval(Duration defaultPollInterval) {
-        this.defaultPollInterval = defaultPollInterval;
-        return this;
-    }
-
-    /*
      * The HTTP pipeline to send requests through
      */
     private HttpPipeline pipeline;
@@ -80,6 +63,22 @@ public final class LroWithParamaterizedEndpointsBuilder {
      */
     public LroWithParamaterizedEndpointsBuilder pipeline(HttpPipeline pipeline) {
         this.pipeline = pipeline;
+        return this;
+    }
+
+    /*
+     * The default poll interval for long-running operation
+     */
+    private Duration defaultPollInterval;
+
+    /**
+     * Sets The default poll interval for long-running operation.
+     *
+     * @param defaultPollInterval the defaultPollInterval value.
+     * @return the LroWithParamaterizedEndpointsBuilder.
+     */
+    public LroWithParamaterizedEndpointsBuilder defaultPollInterval(Duration defaultPollInterval) {
+        this.defaultPollInterval = defaultPollInterval;
         return this;
     }
 
@@ -111,14 +110,11 @@ public final class LroWithParamaterizedEndpointsBuilder {
         if (environment == null) {
             this.environment = AzureEnvironment.AZURE;
         }
+        if (pipeline == null) {
+            this.pipeline = new HttpPipelineBuilder().policies(new UserAgentPolicy(), new RetryPolicy()).build();
+        }
         if (defaultPollInterval == null) {
             this.defaultPollInterval = Duration.ofSeconds(30);
-        }
-        if (pipeline == null) {
-            this.pipeline =
-                new HttpPipelineBuilder()
-                    .policies(new UserAgentPolicy(), new RetryPolicy(), new CookiePolicy())
-                    .build();
         }
         if (serializerAdapter == null) {
             this.serializerAdapter = SerializerFactory.createDefaultManagementSerializerAdapter();

--- a/azure-tests/src/main/java/fixtures/lroparameterizedendpoints/implementation/LroWithParamaterizedEndpointsImpl.java
+++ b/azure-tests/src/main/java/fixtures/lroparameterizedendpoints/implementation/LroWithParamaterizedEndpointsImpl.java
@@ -15,6 +15,7 @@ import com.azure.core.management.exception.ManagementException;
 import com.azure.core.management.polling.PollResult;
 import com.azure.core.management.polling.PollerFactory;
 import com.azure.core.util.Context;
+import com.azure.core.util.CoreUtils;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.core.util.polling.AsyncPollResponse;
 import com.azure.core.util.polling.LongRunningOperationStatus;
@@ -29,7 +30,6 @@ import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.Map;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -135,10 +135,7 @@ public final class LroWithParamaterizedEndpointsImpl implements LroWithParamater
      * @return the merged context.
      */
     public Context mergeContext(Context context) {
-        for (Map.Entry<Object, Object> entry : this.getContext().getValues().entrySet()) {
-            context = context.addData(entry.getKey(), entry.getValue());
-        }
-        return context;
+        return CoreUtils.mergeContexts(this.getContext(), context);
     }
 
     /**

--- a/eng/pipelines/ci.yaml
+++ b/eng/pipelines/ci.yaml
@@ -126,6 +126,16 @@ jobs:
         displayName: 'Publish coverage report to storage account'
 
       - task: Maven@3
+        displayName: 'Verify Javadoc of protocol'
+        inputs:
+          mavenPomFile: protocol-tests/pom.xml
+          goals: 'javadoc:javadoc'
+          javaHomeOption: 'JDKVersion'
+          jdkVersionOption: $(JavaVersion)
+          jdkArchitectureOption: 'x64'
+          publishJUnitResults: false
+
+      - task: Maven@3
         displayName: 'Run protocol resilience tests'
         inputs:
           mavenPomFile: protocol-resilience-test/pom.xml

--- a/javagen/src/main/java/com/azure/autorest/Javagen.java
+++ b/javagen/src/main/java/com/azure/autorest/Javagen.java
@@ -253,7 +253,9 @@ public class Javagen extends NewPlugin {
         // Unit tests on client model
         if (settings.isGenerateTests() && (!settings.isDataPlaneClient() || settings.isGenerateModels())) {
             for (ClientModel model : client.getModels()) {
-                javaPackage.addModelUnitTest(model);
+                if (!(settings.isCustomStronglyTypedHeaderDeserializationUsed() && model.isStronglyTypedHeader())) {
+                    javaPackage.addModelUnitTest(model);
+                }
             }
         }
 

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -139,7 +139,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
             }
             IType restAPIMethodReturnBodyClientType = responseBodyType.getClientType();
             if (operation.getResponses().stream().anyMatch(r -> Boolean.TRUE.equals(r.getBinary()))
-                    && !settings.isDataPlaneClient() /* TODO: #1059 */) {
+                    && !settings.isDataPlaneClient()) {
                 asyncReturnType = createAsyncBinaryReturnType();
             } else if (restAPIMethodReturnBodyClientType != PrimitiveType.Void) {
                 asyncReturnType = createAsyncBodyReturnType(restAPIMethodReturnBodyClientType);
@@ -147,7 +147,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                 asyncReturnType = createAsyncVoidReturnType();
             }
             if (operation.getResponses().stream().anyMatch(r -> Boolean.TRUE.equals(r.getBinary()))
-                    && !settings.isDataPlaneClient() /* TODO: #1059 */) {
+                    && !settings.isDataPlaneClient()) {
                 syncReturnType = ClassType.InputStream;
             } else {
                 syncReturnType = responseBodyType.getClientType();
@@ -416,7 +416,6 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                         && (settings.isFluent() || settings.getPollingConfig("default") != null)
                         && !syncReturnType.equals(ClassType.InputStream)) {         // temporary skip InputStream, no idea how to do this in PollerFlux
                     // WithResponseAsync, with required and optional parameters
-                    // TODO: Build protocol LRO methods
                     methods.add(builder
                             .returnValue(createSimpleAsyncRestResponseReturnValue(operation, proxyMethod, syncReturnType))
                             .name(proxyMethod.getSimpleAsyncRestResponseMethodName())

--- a/javagen/src/main/java/com/azure/autorest/mapper/ConstantMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ConstantMapper.java
@@ -31,7 +31,6 @@ public class ConstantMapper implements IMapper<ConstantSchema, IType> {
             return constantType;
         }
 
-        //TODO: constants
         constantType = Mappers.getSchemaMapper().map(constantSchema.getValueType());
         parsed.put(constantSchema, constantType);
 

--- a/javagen/src/main/java/com/azure/autorest/util/SchemaUtil.java
+++ b/javagen/src/main/java/com/azure/autorest/util/SchemaUtil.java
@@ -32,7 +32,6 @@ public class SchemaUtil {
     private SchemaUtil() {
     }
 
-    // TODO: P3 support multiple inheritance
     public static Schema getLowestCommonParent(List<Schema> schemas) {
         if (schemas == null || schemas.isEmpty()) {
             return null;

--- a/javagen/src/main/resources/data-plane.md
+++ b/javagen/src/main/resources/data-plane.md
@@ -14,9 +14,10 @@ context-client-method-parameter: true
 sync-methods: all
 
 use-default-http-status-code-to-exception-type-mapping: true
+polling: {}
 
 models-subpackage: implementation.models
 client-logger: true
 model-override-setter-from-superclass: true
-polling: {}
+custom-strongly-typed-header-deserialization: true
 ```

--- a/preprocessor/data-plane.md
+++ b/preprocessor/data-plane.md
@@ -14,9 +14,10 @@ context-client-method-parameter: true
 sync-methods: all
 
 use-default-http-status-code-to-exception-type-mapping: true
+polling: {}
 
 models-subpackage: implementation.models
 client-logger: true
 model-override-setter-from-superclass: true
-polling: {}
+custom-strongly-typed-header-deserialization: true
 ```


### PR DESCRIPTION
with a bug fix, that we do not generate test on model if e.g.
```java
    public DocumentTranslationsGetTranslationsStatusHeaders(HttpHeaders rawHeaders) {
        if (rawHeaders.getValue("Retry-After") != null) {
            this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
        }
        this.eTag = rawHeaders.getValue("ETag");
    }
```

as,
1. in future, we might want to make it immutable, i.e., no setter, exception from ctor
2. making the HttpHeaders from headers could be complicated at this stage, and might not worth the effort