### PR TITLE
mgmt, option to include async methods

### DIFF
--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentClientMethodMapper.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentClientMethodMapper.java
@@ -4,6 +4,7 @@
 package com.azure.autorest.fluent.mapper;
 
 import com.azure.autorest.extension.base.plugin.JavaSettings;
+import com.azure.autorest.fluent.model.clientmodel.FluentStatic;
 import com.azure.autorest.mapper.ClientMethodMapper;
 import com.azure.autorest.model.clientmodel.ClientMethodType;
 import com.azure.autorest.model.javamodel.JavaVisibility;
@@ -48,8 +49,8 @@ public class FluentClientMethodMapper extends ClientMethodMapper {
                     break;
             }
         }
-        if (JavaSettings.getInstance().isFluentLite()) {
-            // Fluent lite disable all async method
+        if (JavaSettings.getInstance().isFluentLite() && !FluentStatic.getFluentJavaSettings().isGenerateAsyncMethods()) {
+            // by default, Fluent lite disable all async method
             if (visibility == JavaVisibility.Public && methodType.name().contains("Async")) {
                 visibility = JavaVisibility.Private;
             }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentResourceCollection.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/clientmodel/FluentResourceCollection.java
@@ -15,6 +15,7 @@ import com.azure.autorest.model.clientmodel.ClassType;
 import com.azure.autorest.model.clientmodel.ClientMethod;
 import com.azure.autorest.model.clientmodel.ClientMethodType;
 import com.azure.autorest.model.clientmodel.MethodGroupClient;
+import com.azure.autorest.model.javamodel.JavaVisibility;
 import com.azure.autorest.template.prototype.MethodTemplate;
 import com.azure.autorest.util.CodeNamer;
 
@@ -76,10 +77,20 @@ public class FluentResourceCollection {
                 .collect(Collectors.toSet());
 
         this.methods.addAll(this.groupClient.getClientMethods().stream()
-                .filter(m -> m.getType() == ClientMethodType.SimpleSync
-                        || m.getType() == ClientMethodType.PagingSync
-                        || m.getType() == ClientMethodType.LongRunningSync
-                        || m.getType() == ClientMethodType.SimpleSyncRestResponse)
+                .filter(m -> !m.isImplementationOnly() && m.getMethodVisibility() == JavaVisibility.Public)
+                .filter(m -> {
+                            boolean isSyncMethod = m.getType() == ClientMethodType.SimpleSync
+                                    || m.getType() == ClientMethodType.PagingSync
+                                    || m.getType() == ClientMethodType.LongRunningSync
+                                    || m.getType() == ClientMethodType.SimpleSyncRestResponse;
+                            boolean isAsyncMethod = m.getType() == ClientMethodType.SimpleAsync
+                                    || m.getType() == ClientMethodType.PagingAsync
+                                    || m.getType() == ClientMethodType.LongRunningAsync
+                                    || m.getType() == ClientMethodType.SimpleAsyncRestResponse;
+                            // by default, only add sync methods
+                            return isSyncMethod;
+//                                    || (FluentStatic.getFluentJavaSettings().isGenerateAsyncMethods() && isAsyncMethod);
+                        })
                 .map(m -> {
                     // map "delete" in client to "deleteByResourceGroup" in collection
                     if (WellKnownMethodName.DELETE.getMethodName().equals(m.getName())

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentResourceCollectionInterfaceTemplate.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/template/FluentResourceCollectionInterfaceTemplate.java
@@ -5,7 +5,6 @@ package com.azure.autorest.fluent.template;
 
 import com.azure.autorest.fluent.model.clientmodel.FluentResourceCollection;
 import com.azure.autorest.fluent.model.clientmodel.fluentmodel.method.FluentDefineMethod;
-import com.azure.autorest.fluent.model.clientmodel.fluentmodel.method.FluentMethod;
 import com.azure.autorest.model.javamodel.JavaFile;
 import com.azure.autorest.template.ClientMethodTemplate;
 import com.azure.autorest.template.IJavaTemplate;
@@ -53,9 +52,9 @@ public class FluentResourceCollectionInterfaceTemplate implements IJavaTemplate<
             int resourceCount = collection.getResourceCreates().size();
             collection.getResourceCreates()
                     .forEach(rc -> {
-                        FluentMethod defineMethod = rc.getDefineMethod();
+                        FluentDefineMethod defineMethod = rc.getDefineMethod();
                         if (resourceCount == 1) {
-                            ((FluentDefineMethod) defineMethod).setName("define");
+                            defineMethod.setName("define");
                         }
 
                         interfaceBlock.javadocComment(defineMethod::writeJavadoc);

--- a/fluentnamer/src/main/java/com/azure/autorest/fluent/util/FluentJavaSettings.java
+++ b/fluentnamer/src/main/java/com/azure/autorest/fluent/util/FluentJavaSettings.java
@@ -68,6 +68,8 @@ public class FluentJavaSettings {
 
     private String artifactVersion;
 
+    private boolean generateAsyncMethods = false;
+
     private SampleGeneration generateSamples = SampleGeneration.NONE;
 
     private boolean sdkIntegration = false;
@@ -134,6 +136,10 @@ public class FluentJavaSettings {
         return Optional.ofNullable(artifactVersion);
     }
 
+    public boolean isGenerateAsyncMethods() {
+        return generateAsyncMethods;
+    }
+
     public boolean isGenerateSamples() {
         return generateSamples != SampleGeneration.NONE;
     }
@@ -176,6 +182,8 @@ public class FluentJavaSettings {
 
         loadStringSetting("pom-file", s -> pomFilename = s);
         loadStringSetting("package-version", s -> artifactVersion = s);
+
+        loadBooleanSetting("generate-async-methods", s -> generateAsyncMethods = s);
 
         loadBooleanSetting("generate-samples", s -> generateSamples = (s ? SampleGeneration.AGGREGATED : SampleGeneration.NONE));
 


### PR DESCRIPTION
used for https://github.com/Azure/azure-sdk-for-java/pull/29582

for now, only expose async methods in `serviceClient()`.