### PR TITLE
Remove JNA and Fix Potential Race Condition

### DIFF
--- a/customization-base/pom.xml
+++ b/customization-base/pom.xml
@@ -6,6 +6,18 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>9</source>
+          <target>9</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
   <parent>
     <artifactId>azure-autorest-parent</artifactId>
@@ -48,11 +60,6 @@
       <groupId>com.google.googlejavaformat</groupId>
       <artifactId>google-java-format</artifactId>
       <version>1.0.0-beta.1</version>
-    </dependency>
-    <dependency>
-      <groupId>net.java.dev.jna</groupId>
-      <artifactId>jna-platform</artifactId>
-      <version>5.8.0</version>
     </dependency>
     <dependency>
       <groupId>com.github.javaparser</groupId>

--- a/customization-base/src/main/java/com/azure/autorest/customization/implementation/ls/EclipseLanguageServerFacade.java
+++ b/customization-base/src/main/java/com/azure/autorest/customization/implementation/ls/EclipseLanguageServerFacade.java
@@ -3,8 +3,6 @@
 
 package com.azure.autorest.customization.implementation.ls;
 
-import com.sun.jna.Platform;
-
 import java.io.InputStream;
 import java.nio.file.Paths;
 
@@ -26,9 +24,11 @@ public class EclipseLanguageServerFacade {
             if (version >= 9) {
                 command += "--add-modules=ALL-SYSTEM --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED ";
             }
-            if (Platform.isWindows()) {
+
+            String osName = System.getProperty("os.name");
+            if (osName.startsWith("Windows")) {
                 command += "-configuration ./config_win";
-            } else if (Platform.isMac()) {
+            } else if (osName.startsWith("Mac") || osName.startsWith("Darwin")) {
                 command += "-configuration ./config_mac";
             } else {
                 command += "-configuration ./config_linux";

--- a/postprocessor/pom.xml
+++ b/postprocessor/pom.xml
@@ -24,11 +24,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.13.2.2</version>
-    </dependency>
-    <dependency>
       <groupId>com.azure.tools</groupId>
       <artifactId>azure-autorest-extension</artifactId>
       <version>1.0.0-beta.2</version>


### PR DESCRIPTION
Removes JNA as a dependency for code customizations and removes a timed `Thread.join` with an untimed `Thread.join` to prevent a race condition with the server starting up.