### PR TITLE
bug fix, skip null check if enum value is primitive

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/template/EnumTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/EnumTemplate.java
@@ -125,7 +125,9 @@ public class EnumTemplate implements IJavaTemplate<EnumType, JavaFile> {
             }
 
             enumBlock.publicStaticMethod(String.format("%1$s %2$s(%3$s value)", enumName, converterName, typeName), function -> {
-                function.ifBlock("value == null", ifAction -> ifAction.methodReturn("null"));
+                if (elementType.isNullable()) {
+                    function.ifBlock("value == null", ifAction -> ifAction.methodReturn("null"));
+                }
                 function.line(enumName + "[] items = " + enumName + ".values();");
                 function.block("for (" + enumName + " item : items)", foreachBlock ->
                     foreachBlock.ifBlock(createEnumJsonCreatorIfCheck(enumType), ifBlock -> ifBlock.methodReturn("item")));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/java",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "The Java extension for classic generators in AutoRest.",
   "scripts": {
     "autorest": "autorest",


### PR DESCRIPTION
bug 

```java
    @JsonCreator
    public static FirewallPolicyIdpsSignatureMode fromInt(int value) {
        if (value == null) {
            return null;
        }
        FirewallPolicyIdpsSignatureMode[] items = FirewallPolicyIdpsSignatureMode.values();
        for (FirewallPolicyIdpsSignatureMode item : items) {
            if (item.toInt() == value) {
                return item;
            }
        }
        return null;
    }
```

Need to skip null-check when value is primitive.