### PR TITLE
DPG, refactor createClientMethods to take isProtocolMethod

### DIFF
--- a/androidgen/src/main/java/com/azure/autorest/android/mapper/AndroidClientMethodMapper.java
+++ b/androidgen/src/main/java/com/azure/autorest/android/mapper/AndroidClientMethodMapper.java
@@ -83,8 +83,8 @@ public class AndroidClientMethodMapper extends ClientMethodMapper {
     }
 
     @Override
-    protected IType createSyncReturnWithResponseType(IType syncReturnType, Operation operation, JavaSettings settings) {
-        return (GenericType.AndroidResponse(syncReturnType));
+    protected IType createSyncReturnWithResponseType(IType syncReturnType, Operation operation, boolean isSimpleMethod, JavaSettings settings) {
+        return GenericType.AndroidResponse(syncReturnType);
     }
 
     @Override

--- a/androidgen/src/main/java/com/azure/autorest/android/mapper/AndroidClientMethodMapper.java
+++ b/androidgen/src/main/java/com/azure/autorest/android/mapper/AndroidClientMethodMapper.java
@@ -98,9 +98,9 @@ public class AndroidClientMethodMapper extends ClientMethodMapper {
     }
 
     @Override
-    protected ReturnValue createSimpleAsyncRestResponseReturnValue(Operation operation, ProxyMethod proxyMethod, IType syncReturnType) {
+    protected ReturnValue createSimpleAsyncRestResponseReturnValue(Operation operation, IType asyncRestResponseReturnType, IType syncReturnType) {
         IType asyncWithResponseType = GenericType.AndroidCompletableFuture(GenericType.AndroidResponse(syncReturnType));
-        return new ReturnValue(returnTypeDescription(operation, proxyMethod.getReturnType().getClientType(), syncReturnType),
+        return new ReturnValue(returnTypeDescription(operation, asyncWithResponseType, syncReturnType),
                 asyncWithResponseType);
     }
 

--- a/androidgen/src/main/java/com/azure/autorest/android/mapper/AndroidClientMethodMapper.java
+++ b/androidgen/src/main/java/com/azure/autorest/android/mapper/AndroidClientMethodMapper.java
@@ -83,7 +83,7 @@ public class AndroidClientMethodMapper extends ClientMethodMapper {
     }
 
     @Override
-    protected IType createSyncReturnWithResponseType(IType syncReturnType, Operation operation, boolean isSimpleMethod, JavaSettings settings) {
+    protected IType createSyncReturnWithResponseType(IType syncReturnType, Operation operation, boolean isProtocolMethod, JavaSettings settings) {
         return GenericType.AndroidResponse(syncReturnType);
     }
 

--- a/androidgen/src/main/java/com/azure/autorest/android/mapper/AndroidProxyMethodMapper.java
+++ b/androidgen/src/main/java/com/azure/autorest/android/mapper/AndroidProxyMethodMapper.java
@@ -43,7 +43,7 @@ public class AndroidProxyMethodMapper extends ProxyMethodMapper {
     }
 
     @Override
-    protected IType createAsyncResponseReturnType(ClassType clientResponseClassType) {
+    protected IType createClientResponseAsyncReturnType(ClassType clientResponseClassType) {
         return PrimitiveType.Void; // return GenericType.CompletableFuture(clientResponseClassType);
     }
 

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentClientMethodMapper.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentClientMethodMapper.java
@@ -18,7 +18,7 @@ public class FluentClientMethodMapper extends ClientMethodMapper {
     }
 
     @Override
-    protected JavaVisibility methodVisibility(ClientMethodType methodType, boolean hasContextParameter) {
+    protected JavaVisibility methodVisibility(ClientMethodType methodType, boolean hasContextParameter, boolean isProtocolMethod) {
         JavaVisibility visibility;
         if (hasContextParameter) {
             switch (methodType) {
@@ -35,7 +35,7 @@ public class FluentClientMethodMapper extends ClientMethodMapper {
                     break;
 
                 default:
-                    visibility = super.methodVisibility(methodType, hasContextParameter);
+                    visibility = super.methodVisibility(methodType, hasContextParameter, isProtocolMethod);
                     break;
             }
         } else {
@@ -45,7 +45,7 @@ public class FluentClientMethodMapper extends ClientMethodMapper {
                     break;
 
                 default:
-                    visibility = super.methodVisibility(methodType, hasContextParameter);
+                    visibility = super.methodVisibility(methodType, hasContextParameter, isProtocolMethod);
                     break;
             }
         }

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -79,7 +79,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
             return clientMethods;
         }
 
-        clientMethods = createClientMethods(operation, false);
+        clientMethods = createClientMethods(operation, JavaSettings.getInstance().isDataPlaneClient());
         parsed.put(operation, clientMethods);
 
         return clientMethods;

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -89,10 +89,10 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
      * Creates the client methods for the operation.
      *
      * @param operation the operation.
-     * @param isSimpleMethod whether the client method to be simplified for resilience to API changes.
+     * @param isProtocolMethod whether the client method to be simplified for resilience to API changes.
      * @return the client methods created.
      */
-    private List<ClientMethod> createClientMethods(Operation operation, boolean isSimpleMethod) {
+    private List<ClientMethod> createClientMethods(Operation operation, boolean isProtocolMethod) {
         JavaSettings settings = JavaSettings.getInstance();
 
         Map<Request, List<ProxyMethod>> proxyMethodsMap = Mappers.getProxyMethodMapper().map(operation);
@@ -138,7 +138,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
             }
             IType listType = itemPropertyOpt.get().getWireType();
             IType elementType = ((ListType) listType).getElementType();
-            if (isSimpleMethod) {
+            if (isProtocolMethod) {
                 asyncRestResponseReturnType = createProtocolPagedRestResponseReturnType();
                 asyncReturnType = createProtocolPagedAsyncReturnType();
                 syncReturnType = createProtocolPagedSyncReturnType();
@@ -148,15 +148,17 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                 syncReturnType = createPagedSyncReturnType(elementType);
             }
         } else {
-            asyncRestResponseReturnType = proxyMethodsMap.values().iterator().next().iterator().next().getReturnType().getClientType();
             IType responseBodyType = SchemaUtil.getOperationResponseType(operation, settings);
-            if (isSimpleMethod) {
+            if (isProtocolMethod) {
                 if (responseBodyType instanceof ClassType || responseBodyType instanceof ListType || responseBodyType instanceof MapType) {
                     responseBodyType = ClassType.BinaryData;
                 } else if (responseBodyType instanceof EnumType) {
                     responseBodyType = ClassType.String;
                 }
             }
+
+            asyncRestResponseReturnType = Mappers.getProxyMethodMapper().getAsyncRestResponseReturnType(operation, responseBodyType, isProtocolMethod, settings);
+
             IType restAPIMethodReturnBodyClientType = responseBodyType.getClientType();
             if (responseBodyType.equals(ClassType.InputStream)) {
                 asyncReturnType = createAsyncBinaryReturnType();
@@ -183,12 +185,12 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
         if (syncReturnType == ClassType.InputStream) {
             syncReturnWithResponse = ClassType.StreamResponse;
         } else {
-            syncReturnWithResponse = createSyncReturnWithResponseType(syncReturnType, operation, isSimpleMethod, settings);
+            syncReturnWithResponse = createSyncReturnWithResponseType(syncReturnType, operation, isProtocolMethod, settings);
         }
 
         // DPG client only requires one request per operation
         List<Request> requests = operation.getRequests();
-        if (isSimpleMethod) {
+        if (isProtocolMethod) {
             Request selectedRequest = MethodUtil.tryMergeBinaryRequests(requests, operation);
             requests = Collections.singletonList(selectedRequest);
         }
@@ -203,7 +205,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                 List<MethodTransformationDetail> methodTransformationDetails = new ArrayList<>();
 
                 List<Parameter> codeModelParameters;
-                if (isSimpleMethod) {
+                if (isProtocolMethod) {
                     // Required path, body, header and query parameters are allowed
                     codeModelParameters = request.getParameters().stream().filter(p -> p.isRequired() &&
                                     (p.getProtocol().getHttp().getIn() == RequestParameterLocation.PATH ||
@@ -217,7 +219,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
 
                 Set<Parameter> originalParameters = new HashSet<>();
                 for (Parameter parameter : codeModelParameters) {
-                    ClientMethodParameter clientMethodParameter = Mappers.getClientParameterMapper().map(parameter, isSimpleMethod);
+                    ClientMethodParameter clientMethodParameter = Mappers.getClientParameterMapper().map(parameter, isProtocolMethod);
 
                     if (request.getProtocol() != null
                             && request.getProtocol().getHttp() != null
@@ -264,7 +266,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
 
                     // Transformations
                     if ((parameter.getOriginalParameter() != null || parameter.getGroupedBy() != null)
-                            && !(parameter.getSchema() instanceof ConstantSchema) && !isSimpleMethod) {
+                            && !(parameter.getSchema() instanceof ConstantSchema) && !isProtocolMethod) {
                         ClientMethodParameter outParameter;
                         if (parameter.getOriginalParameter() != null) {
                             originalParameters.add(parameter.getOriginalParameter());
@@ -306,7 +308,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                     methodTransformationDetails.add(new MethodTransformationDetail(outParameter, new ArrayList<>()));
                 }
 
-                if (isSimpleMethod) {
+                if (isProtocolMethod) {
                     ClientMethodParameter requestOptions = new ClientMethodParameter.Builder()
                             .description("The options to configure the HTTP request before HTTP client sends it")
                             .wireType(ClassType.RequestOptions)
@@ -359,11 +361,11 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                                     .onlyRequiredParameters(false)
                                     .type(ClientMethodType.PagingAsyncSinglePage)
                                     .isGroupedParameterRequired(false)
-                                    .methodVisibility(methodVisibility(ClientMethodType.PagingAsyncSinglePage, false))
+                                    .methodVisibility(methodVisibility(ClientMethodType.PagingAsyncSinglePage, false, isProtocolMethod))
                                     .build());
                         }
                         if (settings.isContextClientMethodParameter()) {
-                            builder.methodVisibility(methodVisibility(ClientMethodType.PagingAsyncSinglePage, true));
+                            builder.methodVisibility(methodVisibility(ClientMethodType.PagingAsyncSinglePage, true, isProtocolMethod));
                             addClientMethodWithContext(methods, builder, proxyMethod, parameters,
                                     ClientMethodType.PagingAsyncSinglePage, proxyMethod.getPagingAsyncSinglePageMethodName(),
                                     createPagingAsyncSinglePageReturnValue(operation, asyncRestResponseReturnType, syncReturnType),
@@ -378,7 +380,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                                         .onlyRequiredParameters(false)
                                         .type(ClientMethodType.PagingAsync)
                                         .isGroupedParameterRequired(false)
-                                        .methodVisibility(methodVisibility(ClientMethodType.PagingAsync, false))
+                                        .methodVisibility(methodVisibility(ClientMethodType.PagingAsync, false, isProtocolMethod))
                                         .build());
 
                                 if (generateClientMethodWithOnlyRequiredParameters) {
@@ -402,7 +404,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                                     }
 
                                     addClientMethodWithContext(methods,
-                                            builder.methodVisibility(methodVisibility(ClientMethodType.PagingAsync, true)),
+                                            builder.methodVisibility(methodVisibility(ClientMethodType.PagingAsync, true, isProtocolMethod)),
                                             proxyMethod, parameters,
                                             ClientMethodType.PagingAsync, proxyMethod.getSimpleAsyncMethodName(),
                                             createPagingAsyncReturnValue(operation, asyncReturnType, syncReturnType),
@@ -411,7 +413,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                             }
 
                             if (settings.getSyncMethods() == JavaSettings.SyncMethodsGeneration.ALL) {
-                                builder.methodVisibility(methodVisibility(ClientMethodType.PagingSync, false));
+                                builder.methodVisibility(methodVisibility(ClientMethodType.PagingSync, false, isProtocolMethod));
 
                                 builder
                                         .returnValue(createPagingSyncReturnValue(operation, syncReturnType))
@@ -433,7 +435,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                                 }
 
                                 if (settings.isContextClientMethodParameter()) {
-                                    addClientMethodWithContext(methods, builder.methodVisibility(methodVisibility(ClientMethodType.PagingSync, true)), parameters);
+                                    addClientMethodWithContext(methods, builder.methodVisibility(methodVisibility(ClientMethodType.PagingSync, true, isProtocolMethod)), parameters);
                                 }
                             }
                         }
@@ -442,9 +444,9 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                         && (settings.isFluent() || settings.getPollingConfig("default") != null)
                         && !syncReturnType.equals(ClassType.InputStream)) {         // temporary skip InputStream, no idea how to do this in PollerFlux
                     JavaVisibility simpleAsyncMethodVisibility =
-                            methodVisibility(ClientMethodType.SimpleAsyncRestResponse, false);
+                            methodVisibility(ClientMethodType.SimpleAsyncRestResponse, false, isProtocolMethod);
                     JavaVisibility simpleAsyncMethodVisibilityWithContext =
-                            methodVisibility(ClientMethodType.SimpleAsyncRestResponse, true);
+                            methodVisibility(ClientMethodType.SimpleAsyncRestResponse, true, isProtocolMethod);
                     if (settings.isDataPlaneClient()) {
                         simpleAsyncMethodVisibility = JavaVisibility.Private;
                         simpleAsyncMethodVisibilityWithContext = JavaVisibility.Private;
@@ -477,7 +479,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                                 getPollingFinalType(pollingDetails, syncReturnType),
                                 pollingDetails.getPollIntervalInSeconds());
 
-                        if (isSimpleMethod &&
+                        if (isProtocolMethod &&
                                 !(ClassType.BinaryData.equals(methodPollingDetails.getIntermediateType())
                                         && ClassType.BinaryData.equals(methodPollingDetails.getFinalType()))) {
                             // a new method to be added as implementation only (not exposed to client) for developer
@@ -494,7 +496,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                     addLroMethods(operation, builder, methods,
                             "begin" + CodeNamer.toPascalCase(proxyMethod.getSimpleAsyncMethodName()),
                             "begin" + CodeNamer.toPascalCase(proxyMethod.getName()),
-                            parameters, proxyMethod, syncReturnType, methodPollingDetails, settings);
+                            parameters, proxyMethod, syncReturnType, methodPollingDetails, isProtocolMethod, settings);
 
                     if (dpgMethodPollingDetailsWithModel != null) {
                         ImplementationDetails.Builder implDetailsBuilder = new ImplementationDetails.Builder().implementationOnly(true);
@@ -505,7 +507,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                         addLroMethods(operation, builder, methods,
                                 "begin" + CodeNamer.toPascalCase(proxyMethod.getName() + modelSuffix + "Async"),
                                 "begin" + CodeNamer.toPascalCase(proxyMethod.getName() + modelSuffix),
-                                parameters, proxyMethod, syncReturnType, dpgMethodPollingDetailsWithModel, settings);
+                                parameters, proxyMethod, syncReturnType, dpgMethodPollingDetailsWithModel, isProtocolMethod, settings);
 
                         builder = builder.implementationDetails(implDetailsBuilder.implementationOnly(false).build());
                     }
@@ -518,7 +520,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                                     .onlyRequiredParameters(false)
                                     .type(ClientMethodType.LongRunningAsync)
                                     .isGroupedParameterRequired(false)
-                                    .methodVisibility(methodVisibility(ClientMethodType.LongRunningAsync, false))
+                                    .methodVisibility(methodVisibility(ClientMethodType.LongRunningAsync, false, isProtocolMethod))
                                     .build());
 
                             if (generateClientMethodWithOnlyRequiredParameters) {
@@ -529,7 +531,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
 
                             if (settings.isContextClientMethodParameter()) {
                                 addClientMethodWithContext(methods,
-                                        builder.methodVisibility(methodVisibility(ClientMethodType.LongRunningAsync, true)),
+                                        builder.methodVisibility(methodVisibility(ClientMethodType.LongRunningAsync, true, isProtocolMethod)),
                                         parameters);
                             }
                         }
@@ -567,13 +569,13 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                                 .onlyRequiredParameters(false)
                                 .type(ClientMethodType.SimpleAsyncRestResponse)
                                 .isGroupedParameterRequired(false)
-                                .methodVisibility(methodVisibility(ClientMethodType.SimpleAsyncRestResponse, false))
+                                .methodVisibility(methodVisibility(ClientMethodType.SimpleAsyncRestResponse, false, isProtocolMethod))
                                 .build());
                     }
 
                     if (settings.isContextClientMethodParameter()) {
                         addClientMethodWithContext(methods,
-                                builder.methodVisibility(methodVisibility(ClientMethodType.SimpleAsyncRestResponse, true)),
+                                builder.methodVisibility(methodVisibility(ClientMethodType.SimpleAsyncRestResponse, true, isProtocolMethod)),
                                 proxyMethod, parameters,
                                 ClientMethodType.SimpleAsyncRestResponse, proxyMethod.getSimpleAsyncRestResponseMethodName(),
                                 createSimpleAsyncRestResponseReturnValue(operation, asyncRestResponseReturnType, syncReturnType),
@@ -587,7 +589,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                                 .onlyRequiredParameters(false)
                                 .type(ClientMethodType.SimpleAsync)
                                 .isGroupedParameterRequired(false)
-                                .methodVisibility(methodVisibility(ClientMethodType.SimpleAsync, false))
+                                .methodVisibility(methodVisibility(ClientMethodType.SimpleAsync, false, isProtocolMethod))
                                 .build());
 
                         if (generateClientMethodWithOnlyRequiredParameters) {
@@ -598,7 +600,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
 
                         if (settings.isContextClientMethodParameter()) {
                             addClientMethodWithContext(methods,
-                                    builder.methodVisibility(methodVisibility(ClientMethodType.SimpleAsync, true)),
+                                    builder.methodVisibility(methodVisibility(ClientMethodType.SimpleAsync, true, isProtocolMethod)),
                                     parameters);
                         }
                     }
@@ -610,7 +612,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                                 .onlyRequiredParameters(false)
                                 .type(ClientMethodType.SimpleSync)
                                 .isGroupedParameterRequired(false)
-                                .methodVisibility(methodVisibility(ClientMethodType.SimpleSync, false));
+                                .methodVisibility(methodVisibility(ClientMethodType.SimpleSync, false, isProtocolMethod));
 
                         if (!settings.isFluent() || !settings.isContextClientMethodParameter() || !generateClientMethodWithOnlyRequiredParameters) {
                             // if context parameter is required, that method will do the overload with max parameters
@@ -627,19 +629,19 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                             builder.type(ClientMethodType.SimpleSyncRestResponse)
                                     .onlyRequiredParameters(false)
                                     .name(proxyMethod.getSimpleRestResponseMethodName())
-                                    .methodVisibility(methodVisibility(ClientMethodType.SimpleSyncRestResponse, false));
+                                    .methodVisibility(methodVisibility(ClientMethodType.SimpleSyncRestResponse, false, isProtocolMethod));
                             if (syncReturnWithResponse instanceof GenericType) {
                                 builder.returnValue(createSimpleSyncRestResponseReturnValue(operation, syncReturnWithResponse, syncReturnType));
                             } else { // In high level client, method with schema in headers would require a ClientResponse, which is not generic
                                 builder.returnValue(createSimpleSyncRestResponseReturnValue(operation, syncReturnWithResponse, syncReturnWithResponse));
                             }
-                            if (isSimpleMethod) {
+                            if (isProtocolMethod) {
                                 // SimpleSyncRestResponse with RequestOptions but without Context
                                 methods.add(builder.build());
                             }
 
                             addClientMethodWithContext(methods,
-                                    builder.methodVisibility(methodVisibility(ClientMethodType.SimpleSyncRestResponse, true)),
+                                    builder.methodVisibility(methodVisibility(ClientMethodType.SimpleSyncRestResponse, true, isProtocolMethod)),
                                     parameters);
                         }
                     }
@@ -664,6 +666,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                                String asyncMethodName, String syncMethodName,
                                List<ClientMethodParameter> parameters, ProxyMethod proxyMethod,
                                IType syncReturnType, MethodPollingDetails methodPollingDetails,
+                               boolean isProtocolMethod,
                                JavaSettings settings) {
         builder.methodPollingDetails(methodPollingDetails);
         if (settings.getSyncMethods() != JavaSettings.SyncMethodsGeneration.NONE) {
@@ -674,12 +677,12 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                     .onlyRequiredParameters(false)
                     .type(ClientMethodType.LongRunningBeginAsync)
                     .isGroupedParameterRequired(false)
-                    .methodVisibility(methodVisibility(ClientMethodType.LongRunningBeginAsync, false))
+                    .methodVisibility(methodVisibility(ClientMethodType.LongRunningBeginAsync, false, isProtocolMethod))
                     .build());
 
             if (settings.isContextClientMethodParameter()) {
                 addClientMethodWithContext(methods,
-                        builder.methodVisibility(methodVisibility(ClientMethodType.LongRunningBeginAsync, true)),
+                        builder.methodVisibility(methodVisibility(ClientMethodType.LongRunningBeginAsync, true, isProtocolMethod)),
                         parameters);
             }
         }
@@ -692,11 +695,11 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                     .onlyRequiredParameters(false)
                     .type(ClientMethodType.LongRunningBeginSync)
                     .isGroupedParameterRequired(false)
-                    .methodVisibility(methodVisibility(ClientMethodType.LongRunningBeginSync, false))
+                    .methodVisibility(methodVisibility(ClientMethodType.LongRunningBeginSync, false, isProtocolMethod))
                     .build());
 
             if (settings.isContextClientMethodParameter()) {
-                addClientMethodWithContext(methods, builder.methodVisibility(methodVisibility(ClientMethodType.LongRunningBeginSync, true)), parameters);
+                addClientMethodWithContext(methods, builder.methodVisibility(methodVisibility(ClientMethodType.LongRunningBeginSync, true, isProtocolMethod)), parameters);
             }
         }
     }
@@ -705,13 +708,13 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
         return ClassType.Context;
     }
 
-    protected IType createSyncReturnWithResponseType(IType syncReturnType, Operation operation, boolean isSimpleMethod, JavaSettings settings) {
+    protected IType createSyncReturnWithResponseType(IType syncReturnType, Operation operation, boolean isProtocolMethod, JavaSettings settings) {
         boolean responseContainsHeaders = SchemaUtil.responseContainsHeaderSchemas(operation, settings);
 
         // If DPG is being generated or the response doesn't contain headers return Response<T>
         // If no named response types are being used return ResponseBase<H, T>
         // Else named response types are being used and return that.
-        if (isSimpleMethod || !responseContainsHeaders) {
+        if (isProtocolMethod || !responseContainsHeaders) {
             return GenericType.Response(syncReturnType);
         } else if (settings.isGenericResponseTypes()) {
             return GenericType.RestResponse(Mappers.getSchemaMapper().map(ClientMapper.parseHeader(operation, settings)),
@@ -840,24 +843,32 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
      * ClientMethodTemplate.writeMethod (and whether it is called) would also decide the visibility in generated code.
      * @param methodType the type of the client method.
      * @param hasContextParameter whether the method has Context parameter.
+     * @param isProtocolMethod whether the client method to be simplified for resilience to API changes.
      * @return method visibility, null if do not generate.
      */
-    protected JavaVisibility methodVisibility(ClientMethodType methodType, boolean hasContextParameter) {
+    protected JavaVisibility methodVisibility(ClientMethodType methodType, boolean hasContextParameter, boolean isProtocolMethod) {
         if (JavaSettings.getInstance().isDataPlaneClient()) {
-            /*
-            Rule for DPG
+            if (isProtocolMethod) {
+                /*
+                Rule for DPG protocol method
 
-            1. Only generate "WithResponse" method for simple API (hence exclude SimpleAsync and SimpleSync).
-            2. For sync method, Context is included in "RequestOptions", hence do not generate method with Context parameter.
-            3. For async method, Context is not included in method (this rule is valid for all clients).
-             */
+                1. Only generate "WithResponse" method for simple API (hence exclude SimpleAsync and SimpleSync).
+                2. For sync method, Context is included in "RequestOptions", hence do not generate method with Context parameter.
+                3. For async method, Context is not included in method (this rule is valid for all clients).
+                 */
 
-            return (methodType == ClientMethodType.SimpleAsync || methodType == ClientMethodType.SimpleSync
-                    || (methodType == ClientMethodType.PagingSync && hasContextParameter)
-                    || (methodType == ClientMethodType.LongRunningBeginSync && hasContextParameter)
-                    || (methodType == ClientMethodType.SimpleSyncRestResponse && hasContextParameter))
-                    ? NOT_GENERATE
-                    : VISIBLE;
+                return (methodType == ClientMethodType.SimpleAsync || methodType == ClientMethodType.SimpleSync
+                        || (methodType == ClientMethodType.PagingSync && hasContextParameter)
+                        || (methodType == ClientMethodType.LongRunningBeginSync && hasContextParameter)
+                        || (methodType == ClientMethodType.SimpleSyncRestResponse && hasContextParameter))
+                        ? NOT_GENERATE
+                        : VISIBLE;
+            } else {
+                // at present, only generate convenience method for simple API (no pageable, no LRO)
+                return (methodType == ClientMethodType.SimpleAsync || methodType == ClientMethodType.SimpleSync)
+                        ? VISIBLE
+                        : NOT_GENERATE;
+            }
         } else {
             return VISIBLE;
         }

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -157,7 +157,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                 }
             }
 
-            asyncRestResponseReturnType = Mappers.getProxyMethodMapper().getAsyncRestResponseReturnType(operation, responseBodyType, isProtocolMethod, settings);
+            asyncRestResponseReturnType = Mappers.getProxyMethodMapper().getAsyncRestResponseReturnType(operation, responseBodyType, isProtocolMethod, settings).getClientType();
 
             IType restAPIMethodReturnBodyClientType = responseBodyType.getClientType();
             if (responseBodyType.equals(ClassType.InputStream)) {

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -79,7 +79,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
             return clientMethods;
         }
 
-        clientMethods = createClientMethods(operation, JavaSettings.getInstance().isDataPlaneClient());
+        clientMethods = createClientMethods(operation, false);
         parsed.put(operation, clientMethods);
 
         return clientMethods;
@@ -217,7 +217,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
 
                 Set<Parameter> originalParameters = new HashSet<>();
                 for (Parameter parameter : codeModelParameters) {
-                    ClientMethodParameter clientMethodParameter = Mappers.getClientParameterMapper().map(parameter);
+                    ClientMethodParameter clientMethodParameter = Mappers.getClientParameterMapper().map(parameter, isSimpleMethod);
 
                     if (request.getProtocol() != null
                             && request.getProtocol().getHttp() != null

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientParameterMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientParameterMapper.java
@@ -31,7 +31,7 @@ public class ClientParameterMapper implements IMapper<Parameter, ClientMethodPar
         return map(parameter, JavaSettings.getInstance().isDataPlaneClient());
     }
 
-    public ClientMethodParameter map(Parameter parameter, boolean isSimpleMethod) {
+    public ClientMethodParameter map(Parameter parameter, boolean isProtocolMethod) {
         String name = parameter.getOriginalParameter() != null && parameter.getLanguage().getJava().getName().equals(parameter.getOriginalParameter().getLanguage().getJava().getName())
                 ? CodeNamer.toCamelCase(parameter.getOriginalParameter().getSchema().getLanguage().getJava().getName()) + CodeNamer.toPascalCase(parameter.getLanguage().getJava().getName())
                 : parameter.getLanguage().getJava().getName();
@@ -52,7 +52,7 @@ public class ClientParameterMapper implements IMapper<Parameter, ClientMethodPar
         }
         builder.rawType(wireType);
 
-        if (isSimpleMethod) {
+        if (isProtocolMethod) {
             wireType = SchemaUtil.removeModelFromParameter(parameter.getProtocol().getHttp().getIn(), wireType);
         }
         builder.wireType(wireType);
@@ -69,7 +69,7 @@ public class ClientParameterMapper implements IMapper<Parameter, ClientMethodPar
         }
         builder.isConstant(isConstant).defaultValue(defaultValue);
 
-        builder.description(MethodUtil.getMethodParameterDescription(parameter, name, isSimpleMethod));
+        builder.description(MethodUtil.getMethodParameterDescription(parameter, name, isProtocolMethod));
         return builder.build();
     }
 }

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientParameterMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientParameterMapper.java
@@ -28,6 +28,10 @@ public class ClientParameterMapper implements IMapper<Parameter, ClientMethodPar
 
     @Override
     public ClientMethodParameter map(Parameter parameter) {
+        return map(parameter, JavaSettings.getInstance().isDataPlaneClient());
+    }
+
+    public ClientMethodParameter map(Parameter parameter, boolean isSimpleMethod) {
         String name = parameter.getOriginalParameter() != null && parameter.getLanguage().getJava().getName().equals(parameter.getOriginalParameter().getLanguage().getJava().getName())
                 ? CodeNamer.toCamelCase(parameter.getOriginalParameter().getSchema().getLanguage().getJava().getName()) + CodeNamer.toPascalCase(parameter.getLanguage().getJava().getName())
                 : parameter.getLanguage().getJava().getName();
@@ -48,7 +52,7 @@ public class ClientParameterMapper implements IMapper<Parameter, ClientMethodPar
         }
         builder.rawType(wireType);
 
-        if (settings.isDataPlaneClient()) {
+        if (isSimpleMethod) {
             wireType = SchemaUtil.removeModelFromParameter(parameter.getProtocol().getHttp().getIn(), wireType);
         }
         builder.wireType(wireType);
@@ -65,7 +69,7 @@ public class ClientParameterMapper implements IMapper<Parameter, ClientMethodPar
         }
         builder.isConstant(isConstant).defaultValue(defaultValue);
 
-        builder.description(MethodUtil.getMethodParameterDescription(parameter, name, settings.isDataPlaneClient()));
+        builder.description(MethodUtil.getMethodParameterDescription(parameter, name, isSimpleMethod));
         return builder.build();
     }
 }

--- a/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
@@ -17,6 +17,7 @@ import com.azure.autorest.model.clientmodel.GenericType;
 import com.azure.autorest.model.clientmodel.IType;
 import com.azure.autorest.model.clientmodel.ListType;
 import com.azure.autorest.model.clientmodel.MapType;
+import com.azure.autorest.model.clientmodel.ParameterSynthesizedOrigin;
 import com.azure.autorest.model.clientmodel.PrimitiveType;
 import com.azure.autorest.model.clientmodel.ProxyMethod;
 import com.azure.autorest.model.clientmodel.ProxyMethodExample;
@@ -225,7 +226,7 @@ public class ProxyMethodMapper implements IMapper<Operation, Map<Request, List<P
                     // LLC will put required path, body, query, header parameters to method signature
                     final boolean parameterIsRequired = parameter.isRequired();
                     final boolean parameterIsClientOrApiVersion = ClientModelUtil.getClientDefaultValueOrConstantValue(parameter) != null
-                            && parameter.getLanguage().getJava().getName().equalsIgnoreCase("apiversion");
+                            && ParameterSynthesizedOrigin.fromValue(parameter.getOrigin()) == ParameterSynthesizedOrigin.API_VERSION;
                     final boolean parameterIsConstantOrFromClient = proxyMethodParameter.getIsConstant() || proxyMethodParameter.getFromClient();
                     if (parameterIsRequired
                             || parameterIsConstantOrFromClient

--- a/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
@@ -311,13 +311,13 @@ public class ProxyMethodMapper implements IMapper<Operation, Map<Request, List<P
      *
      * @param operation the operation.
      * @param responseBodyType the type of the response body.
-     * @param isSimpleMethod whether the client method to be simplified for resilience to API changes.
+     * @param isProtocolMethod whether the client method to be simplified for resilience to API changes.
      * @param settings the JavaSettings.
      * @return the type for AsyncRestResponse.
      */
-    private IType getAsyncRestResponseReturnType(Operation operation, IType responseBodyType,
-                                                 boolean isSimpleMethod, JavaSettings settings) {
-        if (isSimpleMethod) {
+    protected IType getAsyncRestResponseReturnType(Operation operation, IType responseBodyType,
+                                                   boolean isProtocolMethod, JavaSettings settings) {
+        if (isProtocolMethod) {
             IType singleValueType;
             if (responseBodyType.equals(PrimitiveType.Void)) {
                 singleValueType = GenericType.Response(ClassType.Void);

--- a/javagen/src/main/java/com/azure/autorest/mapper/ProxyParameterMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ProxyParameterMapper.java
@@ -113,7 +113,7 @@ public class ProxyParameterMapper implements IMapper<Parameter, ProxyMethodParam
             String caller = (operationGroupName == null || operationGroupName.isEmpty()) ? "this" : "this.client";
             String clientPropertyName = parameter.getLanguage().getJava().getName();
             boolean isServiceVersion = false;
-            if (settings.isDataPlaneClient() && clientPropertyName.equals("apiVersion")) {
+            if (settings.isDataPlaneClient() && ParameterSynthesizedOrigin.fromValue(parameter.getOrigin()) == ParameterSynthesizedOrigin.API_VERSION) {
                 isServiceVersion = true;
                 clientPropertyName = "serviceVersion";
             }

--- a/javagen/src/main/java/com/azure/autorest/mapper/ServiceClientMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ServiceClientMapper.java
@@ -16,6 +16,7 @@ import com.azure.autorest.model.clientmodel.ClientMethodParameter;
 import com.azure.autorest.model.clientmodel.Constructor;
 import com.azure.autorest.model.clientmodel.IType;
 import com.azure.autorest.model.clientmodel.MethodGroupClient;
+import com.azure.autorest.model.clientmodel.ParameterSynthesizedOrigin;
 import com.azure.autorest.model.clientmodel.Proxy;
 import com.azure.autorest.model.clientmodel.ProxyMethod;
 import com.azure.autorest.model.clientmodel.SecurityInfo;
@@ -141,7 +142,7 @@ public class ServiceClientMapper implements IMapper<CodeModel, ServiceClient> {
             String serviceClientPropertyDefaultValueExpression = serviceClientPropertyClientType.defaultValueExpression(ClientModelUtil.getClientDefaultValueOrConstantValue(p));
             boolean serviceClientPropertyRequired = p.isRequired();
 
-            if (settings.isDataPlaneClient() && serviceClientPropertyName.equals("apiVersion")) {
+            if (settings.isDataPlaneClient() && ParameterSynthesizedOrigin.fromValue(p.getOrigin()) == ParameterSynthesizedOrigin.API_VERSION) {
                 String enumTypeName = ClientModelUtil.getServiceVersionClassName(serviceClientInterfaceName);
                 serviceClientPropertyDescription = "Service version";
                 serviceClientPropertyClientType = new ClassType.Builder()

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ParameterSynthesizedOrigin.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ParameterSynthesizedOrigin.java
@@ -37,13 +37,13 @@ public enum ParameterSynthesizedOrigin {
         this.origin = origin;
     }
 
-    public String getOrigin() {
+    public String value() {
         return this.origin;
     }
 
     @Override
     public String toString() {
-        return this.getOrigin();
+        return this.value();
     }
 
     public static ParameterSynthesizedOrigin fromValue(String value) {
@@ -52,7 +52,7 @@ public enum ParameterSynthesizedOrigin {
         }
 
         for (ParameterSynthesizedOrigin v : values()) {
-            if (v.getOrigin().equalsIgnoreCase(value)) {
+            if (v.value().equalsIgnoreCase(value)) {
                 return v;
             }
         }

--- a/javagen/src/main/java/com/azure/autorest/util/MethodUtil.java
+++ b/javagen/src/main/java/com/azure/autorest/util/MethodUtil.java
@@ -81,10 +81,10 @@ public class MethodUtil {
      *
      * @param parameter the method parameter.
      * @param name the name of method parameter, used when no description found.
-     * @param isSimpleMethod whether the description is used for simplified method.
+     * @param isProtocolMethod whether the description is used for simplified method.
      * @return the Javadoc description for method parameter.
      */
-    public static String getMethodParameterDescription(Parameter parameter, String name, boolean isSimpleMethod) {
+    public static String getMethodParameterDescription(Parameter parameter, String name, boolean isProtocolMethod) {
         String summary = parameter.getSummary();
         String description = null;
         // parameter description
@@ -102,7 +102,7 @@ public class MethodUtil {
             description = String.format("The %s parameter", name);
         }
         // add allowed enum values
-        if (isSimpleMethod && parameter.getProtocol().getHttp().getIn() != RequestParameterLocation.BODY) {
+        if (isProtocolMethod && parameter.getProtocol().getHttp().getIn() != RequestParameterLocation.BODY) {
             description = MethodUtil.appendAllowedEnumValuesForEnumType(parameter, description);
         }
 

--- a/javagen/src/main/java/com/azure/autorest/util/MethodUtil.java
+++ b/javagen/src/main/java/com/azure/autorest/util/MethodUtil.java
@@ -81,10 +81,10 @@ public class MethodUtil {
      *
      * @param parameter the method parameter.
      * @param name the name of method parameter, used when no description found.
-     * @param isDPG whether the description is used for DPG.
+     * @param isSimpleMethod whether the description is used for simplified method.
      * @return the Javadoc description for method parameter.
      */
-    public static String getMethodParameterDescription(Parameter parameter, String name, boolean isDPG) {
+    public static String getMethodParameterDescription(Parameter parameter, String name, boolean isSimpleMethod) {
         String summary = parameter.getSummary();
         String description = null;
         // parameter description
@@ -102,7 +102,7 @@ public class MethodUtil {
             description = String.format("The %s parameter", name);
         }
         // add allowed enum values
-        if (isDPG && parameter.getProtocol().getHttp().getIn() != RequestParameterLocation.BODY) {
+        if (isSimpleMethod && parameter.getProtocol().getHttp().getIn() != RequestParameterLocation.BODY) {
             description = MethodUtil.appendAllowedEnumValuesForEnumType(parameter, description);
         }
 


### PR DESCRIPTION
PR is only refactor, for future work (so that we can create ClientMethod for DPG as both protocol method and convenience method in one pass), logic should be identical.

We had too much dependency on the `JavaSettings.isDataPlaneClient()`, should try to confine its usage, as basically it is just a global static variable.