### PR TITLE
mgmt, auto rename for unnamed array>object

### DIFF
--- a/fluentgen/src/main/java/com/azure/autorest/fluent/util/FluentUtils.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/util/FluentUtils.java
@@ -196,19 +196,7 @@ public class FluentUtils {
     }
 
     public static String getSingular(String name) {
-        if (name == null) {
-            return null;
-        }
-
-        if (name.endsWith("ies")) {
-            return name.substring(0, name.length() - 3) + 'y';
-        } else if (name.endsWith("sses")) {
-            return name.substring(0, name.length() - 2);
-        } else if (name.endsWith("s") && !name.endsWith("ss")) {
-            return name.substring(0, name.length() - 1);
-        } else {
-            return name;
-        }
+        return Utils.getSingular(name);
     }
 
     public static boolean isContextParameter(ClientMethodParameter parameter) {

--- a/fluentnamer/src/main/java/com/azure/autorest/fluent/transformer/SchemaNameNormalization.java
+++ b/fluentnamer/src/main/java/com/azure/autorest/fluent/transformer/SchemaNameNormalization.java
@@ -62,12 +62,29 @@ public class SchemaNameNormalization {
         Set<String> names = new HashSet<>();
         codeModel = normalizeUnnamedAdditionalProperties(codeModel, names);
         codeModel = normalizeUnnamedBaseType(codeModel, names);
-        codeModel = normalizeUnnamedChoiceSchema(codeModel, names);
+        codeModel = normalizeUnnamedObjectTypeInArray(codeModel, names);    // after normalizeUnnamedBaseType
+        codeModel = normalizeUnnamedChoiceType(codeModel, names);
         codeModel = normalizeUnnamedRequestBody(codeModel, names);
         return codeModel;
     }
 
-    protected CodeModel normalizeUnnamedChoiceSchema(CodeModel codeModel, Set<String> names) {
+    protected CodeModel normalizeUnnamedObjectTypeInArray(CodeModel codeModel, Set<String> names) {
+        final String prefix = "Components";
+        final String postfix = "Items";
+
+        List<ObjectSchema> unnamedObjectSchemas = codeModel.getSchemas().getObjects().stream()
+                .filter(s -> {
+                    String name = Utils.getDefaultName(s);
+                    return name.startsWith(prefix) && name.endsWith(postfix);
+                })
+                .collect(Collectors.toList());
+        if (!unnamedObjectSchemas.isEmpty()) {
+            unnamedObjectSchemas.forEach(s -> renameSchema(codeModel, s, names));
+        }
+        return codeModel;
+    }
+
+    protected CodeModel normalizeUnnamedChoiceType(CodeModel codeModel, Set<String> names) {
         List<ChoiceSchema> unnamedChoiceSchemas = codeModel.getSchemas().getChoices().stream()
                 .filter(s -> isUnnamedChoice(Utils.getDefaultName(s)))
                 .collect(Collectors.toList());
@@ -113,7 +130,24 @@ public class SchemaNameNormalization {
             if (property.isPresent()) {
                 String newName = Utils.getDefaultName(compositeType) + CodeNamer.toPascalCase(property.get().getSerializedName());
                 newName = rename(newName, names, deduplicate);
-                LOGGER.warn("Rename schema from '{}' to '{}', based on parent schema '{}'", Utils.getDefaultName(schema), newName, Utils.getDefaultName(compositeType));
+                LOGGER.warn("Rename schema from '{}' to '{}', based on parent schema '{}' and property '{}'",
+                        Utils.getDefaultName(schema), newName, Utils.getDefaultName(compositeType), property.get().getSerializedName());
+                schema.getLanguage().getDefault().setName(newName);
+                return;
+            }
+        }
+
+        // rename based for object in array
+        for (ObjectSchema compositeType : codeModel.getSchemas().getObjects()) {
+            Optional<Property> arrayProperty = compositeType.getProperties().stream()
+                    .filter(p -> p.getSchema() instanceof ArraySchema)
+                    .filter(p -> ((ArraySchema) p.getSchema()).getElementType() == schema)
+                    .findFirst();
+            if (arrayProperty.isPresent()) {
+                String newName = Utils.getDefaultName(compositeType) + CodeNamer.toPascalCase(getSingular(arrayProperty.get().getSerializedName()));
+                newName = rename(newName, names, deduplicate);
+                LOGGER.warn("Rename schema from '{}' to '{}', based on parent schema '{}' and property '{}'",
+                        Utils.getDefaultName(schema), newName, Utils.getDefaultName(compositeType), arrayProperty.get().getSerializedName());
                 schema.getLanguage().getDefault().setName(newName);
                 return;
             }
@@ -355,5 +389,22 @@ public class SchemaNameNormalization {
     private static boolean isSameCase(char c1, char c2) {
         return (Character.isUpperCase(c1) && Character.isUpperCase(c2))
                 || (Character.isLowerCase(c1) && Character.isLowerCase(c2));
+    }
+
+    // duplication of FluentUtils.getSingular
+    private static String getSingular(String name) {
+        if (name == null) {
+            return null;
+        }
+
+        if (name.endsWith("ies")) {
+            return name.substring(0, name.length() - 3) + 'y';
+        } else if (name.endsWith("sses")) {
+            return name.substring(0, name.length() - 2);
+        } else if (name.endsWith("s") && !name.endsWith("ss")) {
+            return name.substring(0, name.length() - 1);
+        } else {
+            return name;
+        }
     }
 }

--- a/fluentnamer/src/main/java/com/azure/autorest/fluent/transformer/SchemaNameNormalization.java
+++ b/fluentnamer/src/main/java/com/azure/autorest/fluent/transformer/SchemaNameNormalization.java
@@ -144,7 +144,7 @@ public class SchemaNameNormalization {
                     .filter(p -> ((ArraySchema) p.getSchema()).getElementType() == schema)
                     .findFirst();
             if (arrayProperty.isPresent()) {
-                String newName = Utils.getDefaultName(compositeType) + CodeNamer.toPascalCase(getSingular(arrayProperty.get().getSerializedName()));
+                String newName = Utils.getDefaultName(compositeType) + CodeNamer.toPascalCase(Utils.getSingular(arrayProperty.get().getSerializedName()));
                 newName = rename(newName, names, deduplicate);
                 LOGGER.warn("Rename schema from '{}' to '{}', based on parent schema '{}' and property '{}'",
                         Utils.getDefaultName(schema), newName, Utils.getDefaultName(compositeType), arrayProperty.get().getSerializedName());
@@ -389,22 +389,5 @@ public class SchemaNameNormalization {
     private static boolean isSameCase(char c1, char c2) {
         return (Character.isUpperCase(c1) && Character.isUpperCase(c2))
                 || (Character.isLowerCase(c1) && Character.isLowerCase(c2));
-    }
-
-    // duplication of FluentUtils.getSingular
-    private static String getSingular(String name) {
-        if (name == null) {
-            return null;
-        }
-
-        if (name.endsWith("ies")) {
-            return name.substring(0, name.length() - 3) + 'y';
-        } else if (name.endsWith("sses")) {
-            return name.substring(0, name.length() - 2);
-        } else if (name.endsWith("s") && !name.endsWith("ss")) {
-            return name.substring(0, name.length() - 1);
-        } else {
-            return name;
-        }
     }
 }

--- a/fluentnamer/src/main/java/com/azure/autorest/fluent/util/Utils.java
+++ b/fluentnamer/src/main/java/com/azure/autorest/fluent/util/Utils.java
@@ -79,4 +79,21 @@ public class Utils {
         }
         return nameForUngroupOperations;
     }
+
+
+    public static String getSingular(String name) {
+        if (name == null) {
+            return null;
+        }
+
+        if (name.endsWith("ies")) {
+            return name.substring(0, name.length() - 3) + 'y';
+        } else if (name.endsWith("sses")) {
+            return name.substring(0, name.length() - 2);
+        } else if (name.endsWith("s") && !name.endsWith("ss")) {
+            return name.substring(0, name.length() - 1);
+        } else {
+            return name;
+        }
+    }
 }


### PR DESCRIPTION
It is named as "name of parent object" + "singular of property name" (as that property is an array)

PR in https://github.com/Azure/azure-sdk-for-java/pull/30480

source of the problem https://github.com/Azure/azure-rest-api-specs/blob/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2022-05-15/managedCassandra.json#L1010
Since "dataCenters" and "items" is also unnamed, the final name is now `CassandraClusterPublicStatusDataCentersItemNode` = "CassandraClusterPublicStatus" + "DataCenters" + "Item" (up to this is done by m4) + "Node".