### PR TITLE
CADL, specify the version for cadl-lang packages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,7 @@
 
 # protocol
 /protocol*                  @weidongxu-microsoft @haolingdong-msft @XiaofeiCao @srnagar
+/partial-update-tests       @weidongxu-microsoft @haolingdong-msft @XiaofeiCao @srnagar
 
 # cadl
 /cadl-extension             @srnagar @weidongxu-microsoft @haolingdong-msft @XiaofeiCao

--- a/cadl-extension/package.json
+++ b/cadl-extension/package.json
@@ -33,18 +33,15 @@
     "target/azure-cadl-extension-jar-with-dependencies.jar"
   ],
   "peerDependencies": {
-    "@cadl-lang/compiler": "latest",
-    "@cadl-lang/rest": "latest",
-    "@cadl-lang/versioning": "latest"
+    "@cadl-lang/compiler": "^0.34.0",
+    "@cadl-lang/rest": "^0.16.0",
+    "@cadl-lang/versioning": "^0.7.0"
   },
   "dependencies": {
     "@autorest/codemodel": "~4.18.2",
     "js-yaml": "~4.1.0"
   },
   "devDependencies": {
-    "@cadl-lang/compiler": "latest",
-    "@cadl-lang/rest": "latest",
-    "@cadl-lang/versioning": "latest",
     "@types/js-yaml": "~4.0.1",
     "@types/mocha": "~9.1.0",
     "@types/node": "~14.0.27",

--- a/cadl-tests/cadl-project.yaml
+++ b/cadl-tests/cadl-project.yaml
@@ -1,4 +1,2 @@
 emitters:
-  # '@azure-tools/cadl-autorest': true
-  '@cadl-lang/openapi3': true
   '@azure-tools/cadl-java': true

--- a/cadl-tests/package.json
+++ b/cadl-tests/package.json
@@ -2,16 +2,14 @@
   "name": "cadl-tests",
   "type": "module",
   "dependencies": {
-    "@cadl-lang/compiler": "latest",
-    "@cadl-lang/rest": "latest",
-    "@cadl-lang/openapi3": "latest",
-    "@azure-tools/cadl-autorest": "latest",
-    "@azure-tools/cadl-azure-core": "latest",
-    "@azure-tools/cadl-java": "file:/../cadl-extension/azure-tools-cadl-java-0.1.0-dev.2.tgz",
+    "@cadl-lang/compiler": "^0.34.0",
+    "@cadl-lang/rest": "^0.16.0",
+    "@azure-tools/cadl-azure-core": "^0.6.0",
     "@azure-tools/cadl-ranch": "latest",
     "@azure-tools/cadl-ranch-expect": "latest",
     "@azure-tools/cadl-ranch-specs": "latest",
-    "@azure-tools/cadl-ranch-api": "latest"
+    "@azure-tools/cadl-ranch-api": "latest",
+    "@azure-tools/cadl-java": "file:/../cadl-extension/azure-tools-cadl-java-0.1.0-dev.2.tgz"
   },
   "private": true
 }


### PR DESCRIPTION
currently these version are the latest.

also removed a few not required dependency in cadl-tests (which was used to generate openapi spec for reference).