### PR TITLE
cadl, refactor code based on whether model needs to be written to class

### DIFF
--- a/cadl-extension/src/main/java/com/azure/cadl/mapper/CadlClientMapper.java
+++ b/cadl-extension/src/main/java/com/azure/cadl/mapper/CadlClientMapper.java
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cadl.mapper;
+
+import com.azure.autorest.mapper.ClientMapper;
+import com.azure.autorest.model.clientmodel.ClientModel;
+import com.azure.autorest.model.clientmodel.ClientResponse;
+import com.azure.autorest.model.clientmodel.EnumType;
+import com.azure.cadl.util.ModelUtil;
+
+import java.util.List;
+
+public class CadlClientMapper extends ClientMapper {
+
+    private static final ClientMapper INSTANCE = new CadlClientMapper();
+
+    public static ClientMapper getInstance() {
+        return INSTANCE;
+    }
+
+    protected CadlClientMapper() {
+    }
+
+    @Override
+    protected boolean hasModelsPackage(List<ClientModel> clientModels, List<EnumType> enumTypes, List<ClientResponse> responseModels) {
+
+        return clientModels.stream().anyMatch(ModelUtil::isGeneratingModel)
+                || enumTypes.stream().anyMatch(ModelUtil::isGeneratingModel)
+                || responseModels.stream().anyMatch(ModelUtil::isGeneratingModel);
+    }
+}

--- a/cadl-extension/src/main/java/com/azure/cadl/mapper/CadlMapperFactory.java
+++ b/cadl-extension/src/main/java/com/azure/cadl/mapper/CadlMapperFactory.java
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cadl.mapper;
+
+import com.azure.autorest.mapper.ClientMapper;
+import com.azure.autorest.mapper.DefaultMapperFactory;
+
+public class CadlMapperFactory extends DefaultMapperFactory {
+
+    @Override
+    public ClientMapper getClientMapper() {
+        return CadlClientMapper.getInstance();
+    }
+}

--- a/cadl-extension/src/main/java/com/azure/cadl/util/ModelUtil.java
+++ b/cadl-extension/src/main/java/com/azure/cadl/util/ModelUtil.java
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cadl.util;
+
+import com.azure.autorest.extension.base.plugin.JavaSettings;
+import com.azure.autorest.model.clientmodel.ClassType;
+import com.azure.autorest.model.clientmodel.ClientModel;
+import com.azure.autorest.model.clientmodel.ClientResponse;
+import com.azure.autorest.model.clientmodel.EnumType;
+import com.azure.autorest.model.clientmodel.IType;
+import com.azure.autorest.model.clientmodel.ImplementationDetails;
+import com.azure.autorest.util.ClientModelUtil;
+
+public class ModelUtil {
+
+    public static boolean isGeneratingModel(ClientModel model) {
+        return model.getImplementationDetails() != null
+                && (model.getImplementationDetails().isConvenienceMethod() || JavaSettings.getInstance().isGenerateModels())
+                && !(isModelUsedOnlyInException(model.getImplementationDetails()));
+    }
+
+    public static boolean isGeneratingModel(EnumType model) {
+        return model.getImplementationDetails() != null
+                && (model.getImplementationDetails().isConvenienceMethod() || JavaSettings.getInstance().isGenerateModels())
+                && !(isModelUsedOnlyInException(model.getImplementationDetails()));
+    }
+
+    public static boolean isGeneratingModel(ClientResponse response) {
+        IType bodyType = response.getBodyType();
+        boolean ret = ClientModelUtil.isClientModel(bodyType);
+        if (ret) {
+            ClassType classType = (ClassType) bodyType;
+            ClientModel model = ClientModelUtil.getClientModel(classType.getName());
+            if (model != null) {
+                ret = isGeneratingModel(model);
+            }
+        }
+        return ret;
+    }
+
+    private static boolean isModelUsedOnlyInException(ImplementationDetails implementationDetails) {
+        return (implementationDetails.isException() && !implementationDetails.isInput() && !implementationDetails.isOutput());
+    }
+}


### PR DESCRIPTION
separate logic in Javagen and Cadl.

Javagen distinguishes
1. DPG, no model
2. DPG with setting to generate models (so far not used in production)
3. Other (vanilla and fluent)

For (2) and (3), further check that there exists model as class.

---

Cadl would use the same logic as when writing class.
Basically, the class is used in convenience method, but not only in error response.