### PR TITLE
Cadl/DPG, bug fix on content-type and header model

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMapper.java
@@ -15,6 +15,7 @@ import com.azure.autorest.extension.base.model.codemodel.Operation;
 import com.azure.autorest.extension.base.model.codemodel.Property;
 import com.azure.autorest.extension.base.model.codemodel.Response;
 import com.azure.autorest.extension.base.model.codemodel.Schema;
+import com.azure.autorest.extension.base.model.codemodel.SchemaContext;
 import com.azure.autorest.extension.base.model.codemodel.Scheme;
 import com.azure.autorest.extension.base.model.codemodel.SealedChoiceSchema;
 import com.azure.autorest.extension.base.model.extensionmodel.XmsExtensions;
@@ -390,6 +391,10 @@ public class ClientMapper implements IMapper<CodeModel, Client> {
         headerSchema.getLanguage().getJava().setName(name);
         headerSchema.setProperties(new ArrayList<>());
         headerSchema.setStronglyTypedHeader(true);
+        headerSchema.setUsage(new HashSet<>(Collections.singletonList(SchemaContext.OUTPUT)));
+        if (operation.getExtensions() != null && operation.getExtensions().isConvenienceMethod()) {
+            headerSchema.getUsage().add(SchemaContext.CONVENIENCE_METHOD);
+        }
         for (Map.Entry<String, Schema> header : headerMap.entrySet()) {
             Property property = new Property();
             property.setSerializedName(header.getKey());

--- a/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
@@ -167,9 +167,11 @@ public class ProxyMethodMapper implements IMapper<Operation, Map<Request, List<P
             List<ProxyMethodParameter> allParameters = new ArrayList<>();
             List<ProxyMethod> proxyMethods = new ArrayList<>();
             // add content-type parameter to allParameters when body is optional and there is single content type
-            if (settings.isDataPlaneClient()) {
+            if (settings.isDataPlaneClient()
+                    // only if "content-type" is not already defined in parameters
+                    && request.getParameters().stream().noneMatch(p -> p.getProtocol() != null && p.getProtocol().getHttp() != null && p.getProtocol().getHttp().getIn() == RequestParameterLocation.HEADER && "content-type".equalsIgnoreCase(p.getLanguage().getDefault().getSerializedName()))) {
                 boolean isBodyParamRequired = request.getParameters()
-                        .stream().filter(p -> p.getProtocol() != null && p.getProtocol().getHttp() != null ? p.getProtocol().getHttp().getIn() == RequestParameterLocation.BODY : false)
+                        .stream().filter(p -> p.getProtocol() != null && p.getProtocol().getHttp() != null && p.getProtocol().getHttp().getIn() == RequestParameterLocation.BODY)
                         .map(Parameter::isRequired).findFirst().orElse(false);
                 if (MethodUtil.getContentTypeCount(operation.getRequests()) == 1 && !isBodyParamRequired) {
                     Parameter contentTypeParameter = MethodUtil.createContentTypeParameter(request, operation);


### PR DESCRIPTION
1. 1st commit on bug of duplicate `content-type`, one generated by codegen for optional Body, another included in cadl parameter definition
2. 2nd commit on bug of model generation of Header model in convenience method `ResponseBase<ProjectsCreateOrUpdateHeaders, Project> createOrUpdateWithResponse(...)`