### PR TITLE
Cadl, enable sdk-integration

### DIFF
--- a/cadl-extension/package.json
+++ b/cadl-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/cadl-java",
-  "version": "0.1.0-dev.2",
+  "version": "0.1.0-dev.3",
   "description": "Java client emitter for CADL compiler",
   "keywords": [
     "cadl"

--- a/cadl-extension/src/main/java/com/azure/autorest/CadlPlugin.java
+++ b/cadl-extension/src/main/java/com/azure/autorest/CadlPlugin.java
@@ -44,9 +44,7 @@ public class CadlPlugin extends Javagen {
         }
     }
 
-    @Override
-    public JavaPackage writeToTemplates(CodeModel codeModel, Client client, JavaSettings settings,
-                                        boolean generateSwaggerMarkdown) {
+    public JavaPackage writeToTemplates(CodeModel codeModel, Client client, JavaSettings settings) {
         return super.writeToTemplates(codeModel, client, settings, false);
     }
 

--- a/cadl-extension/src/main/java/com/azure/autorest/CadlPlugin.java
+++ b/cadl-extension/src/main/java/com/azure/autorest/CadlPlugin.java
@@ -45,8 +45,9 @@ public class CadlPlugin extends Javagen {
     }
 
     @Override
-    public JavaPackage writeToTemplates(CodeModel codeModel, Client client, JavaSettings settings) {
-        return super.writeToTemplates(codeModel, client, settings);
+    public JavaPackage writeToTemplates(CodeModel codeModel, Client client, JavaSettings settings,
+                                        boolean generateSwaggerMarkdown) {
+        return super.writeToTemplates(codeModel, client, settings, false);
     }
 
     @Override

--- a/cadl-extension/src/main/java/com/azure/autorest/CadlPlugin.java
+++ b/cadl-extension/src/main/java/com/azure/autorest/CadlPlugin.java
@@ -13,6 +13,7 @@ import com.azure.autorest.model.javamodel.JavaPackage;
 import com.azure.cadl.mapper.CadlMapperFactory;
 import com.azure.cadl.util.ModelUtil;
 import com.azure.core.util.Configuration;
+import com.azure.core.util.CoreUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,6 +28,21 @@ import java.util.Map;
 public class CadlPlugin extends Javagen {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CadlPlugin.class);
+
+    public static class Options {
+        private String namespace;
+        private String outputFolder;
+
+        public Options setNamespace(String namespace) {
+            this.namespace = namespace;
+            return this;
+        }
+
+        public Options setOutputFolder(String outputFolder) {
+            this.outputFolder = outputFolder;
+            return this;
+        }
+    }
 
     @Override
     public JavaPackage writeToTemplates(CodeModel codeModel, Client client, JavaSettings settings) {
@@ -69,7 +85,8 @@ public class CadlPlugin extends Javagen {
     static {
         SETTINGS_MAP.put("data-plane", true);
 
-//        SETTINGS_MAP.put("sdk-integration", true);
+        SETTINGS_MAP.put("sdk-integration", true);
+        SETTINGS_MAP.put("regenerate-pom", true);
 
         SETTINGS_MAP.put("license-header", "MICROSOFT_MIT_SMALL");
         SETTINGS_MAP.put("generate-client-interfaces", false);
@@ -89,7 +106,6 @@ public class CadlPlugin extends Javagen {
         SETTINGS_MAP.put("required-parameter-client-methods", true);
         SETTINGS_MAP.put("generic-response-type", true);
 
-        SETTINGS_MAP.put("regenerate-pom", true);
         SETTINGS_MAP.put("generate-models", Configuration.getGlobalConfiguration().get("GENERATE_MODELS", false));
     }
 
@@ -100,9 +116,12 @@ public class CadlPlugin extends Javagen {
         }
     }
 
-    public CadlPlugin(String namespace) {
+    public CadlPlugin(Options options) {
         super(new MockConnection(), "dummy", "dummy");
-        SETTINGS_MAP.put("namespace", namespace);
+        SETTINGS_MAP.put("namespace", options.namespace);
+        if (!CoreUtils.isNullOrEmpty(options.outputFolder)) {
+            SETTINGS_MAP.put("output-folder", options.outputFolder);
+        }
         JavaSettingsAccessor.setHost(this);
 
         Mappers.setFactory(new CadlMapperFactory());

--- a/cadl-extension/src/main/java/com/azure/cadl/Main.java
+++ b/cadl-extension/src/main/java/com/azure/cadl/Main.java
@@ -65,7 +65,10 @@ public class Main {
         LOGGER.info("Namespace: {}", namespace);
 
         // initialize plugin
-        CadlPlugin cadlPlugin = new CadlPlugin(namespace);
+        CadlPlugin cadlPlugin = new CadlPlugin(
+                new CadlPlugin.Options()
+                        .setNamespace(namespace)
+                        .setOutputFolder(outputFolderFinal));
 
         // transform code model
         codeModel = new Transformer().transform(codeModel);

--- a/cadl-extension/src/test/java/com/azure/cadl/util/ModelUtilTests.java
+++ b/cadl-extension/src/test/java/com/azure/cadl/util/ModelUtilTests.java
@@ -19,7 +19,9 @@ public class ModelUtilTests {
     // sadly ModelUtil.isGeneratingModel queries JavaSettings
     @BeforeAll
     public static void ensurePlugin() {
-        CadlPlugin plugin = new CadlPlugin("com.azure.client");
+        CadlPlugin plugin = new CadlPlugin(
+                new CadlPlugin.Options()
+                        .setNamespace("com.azure.client"));
     }
 
     @Test

--- a/cadl-tests/generate.sh
+++ b/cadl-tests/generate.sh
@@ -8,14 +8,15 @@ function generate {
         exit 1
     fi
 
+    rm cadl-output/src/main/java/module-info.java
+    rm -rf cadl-output/src/samples
     cp -rf cadl-output/src .
-    rm src/main/java/module-info.java
 
-    rm -rf cadl-output/
+    rm -rf cadl-output
 }
 
-rm -rf src/main/
-rm -rf cadl-output/
+rm -rf src/main
+rm -rf cadl-output
 
 # enable convenience methods for tests
 export GENERATE_MODELS=true

--- a/cadl-tests/package.json
+++ b/cadl-tests/package.json
@@ -14,7 +14,7 @@
     "@azure-tools/cadl-ranch-expect": "latest",
     "@azure-tools/cadl-ranch-specs": "latest",
     "@azure-tools/cadl-ranch-api": "latest",
-    "@azure-tools/cadl-java": "file:/../cadl-extension/azure-tools-cadl-java-0.1.0-dev.2.tgz"
+    "@azure-tools/cadl-java": "file:/../cadl-extension/azure-tools-cadl-java-0.1.0-dev.3.tgz"
   },
   "devDependencies": {
     "@cadl-lang/prettier-plugin-cadl": "^0.5.12",

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/JavaSettings.java
@@ -103,7 +103,7 @@ public class JavaSettings {
                 getBooleanValue(host, "sdk-integration", false),
                 getStringValue(host, "fluent"),
                 getBooleanValue(host, "regenerate-pom", false),
-                    header,
+                header,
                 120,
                 getStringValue(host, "service-name"),
                 getStringValue(host, "namespace", "").toLowerCase(),

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentPomMapper.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentPomMapper.java
@@ -5,7 +5,6 @@ package com.azure.autorest.fluent.mapper;
 
 import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.fluent.model.projectmodel.FluentProject;
-import com.azure.autorest.fluent.model.clientmodel.FluentStatic;
 import com.azure.autorest.mapper.PomMapper;
 import com.azure.autorest.model.clientmodel.Pom;
 
@@ -55,10 +54,12 @@ public class FluentPomMapper extends PomMapper {
                 .collect(Collectors.toList()));
         pom.setDependencyIdentifiers(dependencyIdentifiers);
 
-        if (FluentStatic.getFluentJavaSettings().isSdkIntegration()) {
+        if (project.isIntegratedWithSdk()) {
             pom.setParentIdentifier(CLIENT_SDK_PARENT_PREFIX + project.getPackageVersions().getAzureClientSdkParentVersion());
             pom.setParentRelativePath("../../parents/azure-client-sdk-parent");
         }
+
+        pom.setRequireCompilerPlugins(!project.isIntegratedWithSdk());
 
         return pom;
     }

--- a/javagen/src/main/java/com/azure/autorest/Javagen.java
+++ b/javagen/src/main/java/com/azure/autorest/Javagen.java
@@ -83,7 +83,7 @@ public class Javagen extends NewPlugin {
             Client client = Mappers.getClientMapper().map(codeModel);
 
             // Step 3: Write to templates
-            JavaPackage javaPackage = writeToTemplates(codeModel, client, settings);
+            JavaPackage javaPackage = writeToTemplates(codeModel, client, settings, true);
 
             //Step 4: Print to files
             Map<String, String> formattedFiles = new ConcurrentHashMap<>();
@@ -150,7 +150,8 @@ public class Javagen extends NewPlugin {
         return newYaml.loadAs(file, CodeModel.class);
     }
 
-    JavaPackage writeToTemplates(CodeModel codeModel, Client client, JavaSettings settings) {
+    JavaPackage writeToTemplates(CodeModel codeModel, Client client, JavaSettings settings,
+                                 boolean generateSwaggerMarkdown) {
         JavaPackage javaPackage = new JavaPackage(this);
         // Service client
         javaPackage
@@ -266,7 +267,9 @@ public class Javagen extends NewPlugin {
             // Readme, Changelog
             if (settings.isSdkIntegration()) {
                 javaPackage.addReadmeMarkdown(project);
-                javaPackage.addSwaggerReadmeMarkdown(project);    // use readme in spec repo instead
+                if (generateSwaggerMarkdown) {
+                    javaPackage.addSwaggerReadmeMarkdown(project);
+                }
                 javaPackage.addChangelogMarkdown(project);
 
                 // Blank readme sample

--- a/javagen/src/main/java/com/azure/autorest/mapper/PomMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/PomMapper.java
@@ -62,10 +62,12 @@ public class PomMapper implements IMapper<Project, Pom> {
                 .collect(Collectors.toList()));
         pom.setDependencyIdentifiers(dependencyIdentifiers);
 
-        if (JavaSettings.getInstance().isSdkIntegration()) {
+        if (project.isIntegratedWithSdk()) {
             pom.setParentIdentifier(CLIENT_SDK_PARENT_PREFIX + project.getPackageVersions().getAzureClientSdkParentVersion());
             pom.setParentRelativePath("../../parents/azure-client-sdk-parent");
         }
+
+        pom.setRequireCompilerPlugins(!project.isIntegratedWithSdk());
 
         return pom;
     }

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/Pom.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/Pom.java
@@ -16,6 +16,8 @@ public class Pom {
     private String serviceDescription;
     private List<String> dependencyIdentifiers;
 
+    private boolean requireCompilerPlugins = false;
+
     public List<String> getDependencyIdentifiers() {
         return dependencyIdentifiers;
     }
@@ -93,6 +95,15 @@ public class Pom {
 
     public Pom setServiceDescription(String serviceDescription) {
         this.serviceDescription = serviceDescription;
+        return this;
+    }
+
+    public boolean isRequireCompilerPlugins() {
+        return requireCompilerPlugins;
+    }
+
+    public Pom setRequireCompilerPlugins(boolean requireCompilerPlugins) {
+        this.requireCompilerPlugins = requireCompilerPlugins;
         return this;
     }
 }

--- a/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
+++ b/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
@@ -134,13 +134,19 @@ public class Project {
         if (outputFolder != null) {
             Path path = Paths.get(outputFolder).normalize();
             List<String> pathSegment = new ArrayList<>();
-            while (path != null && path.getFileName() != null) {
+            while (path != null) {
+                if (path.getFileName() != null) {
+                    // likely the case of "C:\"
+                    path = null;
+                    break;
+                }
+
                 Path childPath = path;
                 path = path.getParent();
 
                 pathSegment.add(childPath.getFileName().toString());
 
-                if ("sdk".equals(childPath.getFileName().toString())) {
+                if (isRepoSdkFolder(childPath)) {
                     // childPath = azure-sdk-for-java/sdk, path = azure-sdk-for-java
                     break;
                 }
@@ -170,11 +176,17 @@ public class Project {
             String outputFolder = settings.getAutorestSettings().getOutputFolder();
             if (outputFolder != null && Paths.get(outputFolder).isAbsolute()) {
                 Path path = Paths.get(outputFolder).normalize();
-                while (path != null && path.getFileName() != null) {
+                while (path != null) {
+                    if (path.getFileName() != null) {
+                        // likely the case of "C:\"
+                        path = null;
+                        break;
+                    }
+
                     Path childPath = path;
                     path = path.getParent();
 
-                    if ("sdk".equals(childPath.getFileName().toString())) {
+                    if (isRepoSdkFolder(childPath)) {
                         // childPath = azure-sdk-for-java/sdk, path = azure-sdk-for-java
                         break;
                     }
@@ -191,6 +203,17 @@ public class Project {
         }
 
         return sdkFolderOpt;
+    }
+
+    private static boolean isRepoSdkFolder(Path path) {
+        boolean ret = false;
+        if (path.getFileName() != null && "sdk".equals(path.getFileName().toString())) {
+            Path parentPomPath = path.resolve("parents/azure-client-sdk-parent/pom.xml");
+            if (parentPomPath.toFile().isFile()) {
+                ret = true;
+            }
+        }
+        return ret;
     }
 
     protected void findPackageVersions() {

--- a/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
+++ b/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
@@ -134,7 +134,7 @@ public class Project {
         if (outputFolder != null) {
             Path path = Paths.get(outputFolder).normalize();
             List<String> pathSegment = new ArrayList<>();
-            while (path != null) {
+            while (path != null && path.getFileName() != null) {
                 Path childPath = path;
                 path = path.getParent();
 
@@ -170,7 +170,7 @@ public class Project {
             String outputFolder = settings.getAutorestSettings().getOutputFolder();
             if (outputFolder != null && Paths.get(outputFolder).isAbsolute()) {
                 Path path = Paths.get(outputFolder).normalize();
-                while (path != null) {
+                while (path != null && path.getFileName() != null) {
                     Path childPath = path;
                     path = path.getParent();
 

--- a/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
+++ b/javagen/src/main/java/com/azure/autorest/model/projectmodel/Project.java
@@ -48,6 +48,8 @@ public class Project {
 
     private String apiVersion;
 
+    private boolean integratedWithSdk = false;
+
     public static class PackageVersions {
         private String azureClientSdkParentVersion = "1.7.0";
         private String azureJsonVersion = "1.0.0-beta.1";
@@ -135,7 +137,7 @@ public class Project {
             Path path = Paths.get(outputFolder).normalize();
             List<String> pathSegment = new ArrayList<>();
             while (path != null) {
-                if (path.getFileName() != null) {
+                if (path.getFileName() == null) {
                     // likely the case of "C:\"
                     path = null;
                     break;
@@ -177,7 +179,7 @@ public class Project {
             if (outputFolder != null && Paths.get(outputFolder).isAbsolute()) {
                 Path path = Paths.get(outputFolder).normalize();
                 while (path != null) {
-                    if (path.getFileName() != null) {
+                    if (path.getFileName() == null) {
                         // likely the case of "C:\"
                         path = null;
                         break;
@@ -218,6 +220,7 @@ public class Project {
 
     protected void findPackageVersions() {
         Optional<String> sdkFolderOpt = findSdkFolder();
+        this.integratedWithSdk = sdkFolderOpt.isPresent();
         if (!sdkFolderOpt.isPresent()) {
             return;
         }
@@ -391,6 +394,10 @@ public class Project {
 
     public Optional<String> getSdkRepositoryUri() {
         return Optional.ofNullable(sdkRepositoryUri);
+    }
+
+    public boolean isIntegratedWithSdk() {
+        return integratedWithSdk;
     }
 
     public boolean isGenerateSamples() {

--- a/javagen/src/main/java/com/azure/autorest/template/PomTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/PomTemplate.java
@@ -10,7 +10,6 @@
 
 package com.azure.autorest.template;
 
-import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.model.xmlmodel.XmlBlock;
 import com.azure.autorest.model.xmlmodel.XmlFile;
 import com.azure.autorest.model.clientmodel.Pom;
@@ -147,7 +146,7 @@ public class PomTemplate implements IXmlTemplate<Pom, XmlFile> {
      * @param pom the pom model.
      */
     protected void writeBuildBlock(XmlBlock projectBlock, Pom pom) {
-        if (!JavaSettings.getInstance().isSdkIntegration()) {
+        if (pom.isRequireCompilerPlugins()) {
             projectBlock.block("build", buildBlock -> {
                 buildBlock.block("plugins", pluginsBlock -> {
                     writeStandAlonePlugins(projectBlock);
@@ -161,7 +160,7 @@ public class PomTemplate implements IXmlTemplate<Pom, XmlFile> {
         pluginsBlock.block("plugin", pluginBlock -> {
             pluginBlock.tag("groupId", "org.apache.maven.plugins");
             pluginBlock.tag("artifactId", "maven-compiler-plugin");
-            pluginBlock.tag("version", "3.8.1");
+            pluginBlock.tag("version", "3.10.1");
             pluginBlock.block("configuration", configurationBlock -> {
                 configurationBlock.tag("release", "11");
             });

--- a/javagen/src/test/java/com/azure/autorest/JavagenUnitTests.java
+++ b/javagen/src/test/java/com/azure/autorest/JavagenUnitTests.java
@@ -40,7 +40,7 @@ public class JavagenUnitTests {
 
         CodeModel codeModel = javagen.parseCodeModel(fileName);
         Client client = Mappers.getClientMapper().map(codeModel);
-        JavaPackage javaPackage = javagen.writeToTemplates(codeModel, client, JavaSettings.getInstance());
+        JavaPackage javaPackage = javagen.writeToTemplates(codeModel, client, JavaSettings.getInstance(), true);
 
         System.out.println(javaPackage.getJavaFiles().size());
     }


### PR DESCRIPTION
for codegen to generate README.md, CHANGELOG.md, etc. in output.

also try generate the pom fitting the SDK repo, if `outputPath` can be reorganized as under `sdk`.

`outputPath` might not be the best option, we might improve later, when we have side-car.

---

```
cadl compile main.cadl --outputPath=../azure-sdk-for-java/sdk/<service>/<module>
```