### PR TITLE
cadl, load "java.json" and read namespace (temporary solution)

### DIFF
--- a/cadl-extension/src/main/java/com/azure/cadl/Main.java
+++ b/cadl-extension/src/main/java/com/azure/cadl/Main.java
@@ -61,7 +61,13 @@ public class Main {
         if (codeModel.getLanguage().getJava() != null && !CoreUtils.isNullOrEmpty(codeModel.getLanguage().getJava().getNamespace())) {
             namespace = codeModel.getLanguage().getJava().getNamespace();
         }
+
+        // TODO (weidxu): side-car
         namespace = Configuration.getGlobalConfiguration().get("NAMESPACE", namespace);
+        if (codeModel.getConfiguration() != null && codeModel.getConfiguration() instanceof Map) {
+            namespace = (String) ((Map<String, Object>) codeModel.getConfiguration()).get("namespace");
+        }
+
         LOGGER.info("Namespace: {}", namespace);
 
         // initialize plugin

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/CodeModel.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/model/codemodel/CodeModel.java
@@ -145,4 +145,13 @@ public class CodeModel extends Metadata {
     public void setTestModel(TestModel testModel) {
         this.testModel = testModel;
     }
+
+    // TODO (weidxu): side-car
+    private Object configuration;
+    public Object getConfiguration() {
+        return configuration;
+    }
+    public void setConfiguration(Object configuration) {
+        this.configuration = configuration;
+    }
 }


### PR DESCRIPTION
temporary solution (before side-car is ready)

java.json as
```json
{
  "namespace": "com.azure.storage"
}
```

gets to code-model.yaml
```yaml
...
configuration:
  namespace: com.azure.storage
```