### PR TITLE
cadl, update convenience method

### DIFF
--- a/cadl-tests/src/main/java/com/basicpolymorphicmodels/BasicPolymorphicModelsClient.java
+++ b/cadl-tests/src/main/java/com/basicpolymorphicmodels/BasicPolymorphicModelsClient.java
@@ -14,9 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.basicpolymorphicmodels.models.BaseClass;
 import com.basicpolymorphicmodels.models.ModelWithPolymorphicProperty;
 
@@ -127,31 +125,6 @@ public final class BasicPolymorphicModelsClient {
     }
 
     /**
-     * The setValue operation.
-     *
-     * @param input Example base type.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return example base type along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BaseClass> setValueWithResponse(BaseClass input, Context context) {
-        // Generated convenience method for setValueWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse =
-                setValueWithResponse(BinaryData.fromObject(input), requestOptions);
-        return new SimpleResponse<>(
-                protocolMethodResponse, protocolMethodResponse.getValue().toObject(BaseClass.class));
-    }
-
-    /**
      * The setValueWithPolymorphicProperty operation.
      *
      * @param input Illustrates case where a basic model has polymorphic properties.
@@ -171,31 +144,5 @@ public final class BasicPolymorphicModelsClient {
         return setValueWithPolymorphicPropertyWithResponse(BinaryData.fromObject(input), requestOptions)
                 .getValue()
                 .toObject(ModelWithPolymorphicProperty.class);
-    }
-
-    /**
-     * The setValueWithPolymorphicProperty operation.
-     *
-     * @param input Illustrates case where a basic model has polymorphic properties.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return illustrates case where a basic model has polymorphic properties along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<ModelWithPolymorphicProperty> setValueWithPolymorphicPropertyWithResponse(
-            ModelWithPolymorphicProperty input, Context context) {
-        // Generated convenience method for setValueWithPolymorphicPropertyWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse =
-                setValueWithPolymorphicPropertyWithResponse(BinaryData.fromObject(input), requestOptions);
-        return new SimpleResponse<>(
-                protocolMethodResponse, protocolMethodResponse.getValue().toObject(ModelWithPolymorphicProperty.class));
     }
 }

--- a/cadl-tests/src/main/java/com/cadl/auth/AuthClient.java
+++ b/cadl-tests/src/main/java/com/cadl/auth/AuthClient.java
@@ -14,9 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 
 /** Initializes a new instance of the synchronous AuthClient type. */
 @ServiceClient(builder = AuthClientBuilder.class)
@@ -71,27 +69,5 @@ public final class AuthClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions).getValue().toObject(String.class);
-    }
-
-    /**
-     * The get operation.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<String> getWithResponse(Context context) {
-        // Generated convenience method for getWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = getWithResponse(requestOptions);
-        return new SimpleResponse<>(protocolMethodResponse, protocolMethodResponse.getValue().toObject(String.class));
     }
 }

--- a/cadl-tests/src/main/java/com/cadl/builtin/BuiltinClient.java
+++ b/cadl-tests/src/main/java/com/cadl/builtin/BuiltinClient.java
@@ -14,9 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.cadl.builtin.models.Builtin;
 
 /** Initializes a new instance of the synchronous BuiltinClient type. */
@@ -95,27 +93,5 @@ public final class BuiltinClient {
         // Generated convenience method for readWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return readWithResponse(requestOptions).getValue().toObject(Builtin.class);
-    }
-
-    /**
-     * The read operation.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Builtin> readWithResponse(Context context) {
-        // Generated convenience method for readWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = readWithResponse(requestOptions);
-        return new SimpleResponse<>(protocolMethodResponse, protocolMethodResponse.getValue().toObject(Builtin.class));
     }
 }

--- a/cadl-tests/src/main/java/com/cadl/enumservice/EnumServiceClient.java
+++ b/cadl-tests/src/main/java/com/cadl/enumservice/EnumServiceClient.java
@@ -14,9 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.azure.core.util.serializer.CollectionFormat;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.cadl.enumservice.models.Color;
@@ -353,28 +351,6 @@ public final class EnumServiceClient {
     }
 
     /**
-     * The getColor operation.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Color> getColorWithResponse(Context context) {
-        // Generated convenience method for getColorWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<String> protocolMethodResponse = getColorWithResponse(requestOptions);
-        return new SimpleResponse<>(protocolMethodResponse, Color.fromString(protocolMethodResponse.getValue()));
-    }
-
-    /**
      * The getColorModel operation.
      *
      * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
@@ -390,28 +366,6 @@ public final class EnumServiceClient {
         // Generated convenience method for getColorModelWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return ColorModel.fromString(getColorModelWithResponse(requestOptions).getValue());
-    }
-
-    /**
-     * The getColorModel operation.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<ColorModel> getColorModelWithResponse(Context context) {
-        // Generated convenience method for getColorModelWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<String> protocolMethodResponse = getColorModelWithResponse(requestOptions);
-        return new SimpleResponse<>(protocolMethodResponse, ColorModel.fromString(protocolMethodResponse.getValue()));
     }
 
     /**
@@ -432,30 +386,6 @@ public final class EnumServiceClient {
         // Generated convenience method for setColorModelWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return setColorModelWithResponse(color.toString(), requestOptions).getValue().toObject(Operation.class);
-    }
-
-    /**
-     * The setColorModel operation.
-     *
-     * @param color The color parameter.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Operation> setColorModelWithResponse(ColorModel color, Context context) {
-        // Generated convenience method for setColorModelWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = setColorModelWithResponse(color.toString(), requestOptions);
-        return new SimpleResponse<>(
-                protocolMethodResponse, protocolMethodResponse.getValue().toObject(Operation.class));
     }
 
     /**
@@ -481,31 +411,6 @@ public final class EnumServiceClient {
     }
 
     /**
-     * The setPriority operation.
-     *
-     * @param priority The priority parameter.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Operation> setPriorityWithResponse(Priority priority, Context context) {
-        // Generated convenience method for setPriorityWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse =
-                setPriorityWithResponse(String.valueOf(priority.toLong()), requestOptions);
-        return new SimpleResponse<>(
-                protocolMethodResponse, protocolMethodResponse.getValue().toObject(Operation.class));
-    }
-
-    /**
      * The getRunningOperation operation.
      *
      * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
@@ -521,29 +426,6 @@ public final class EnumServiceClient {
         // Generated convenience method for getRunningOperationWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getRunningOperationWithResponse(requestOptions).getValue().toObject(Operation.class);
-    }
-
-    /**
-     * The getRunningOperation operation.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Operation> getRunningOperationWithResponse(Context context) {
-        // Generated convenience method for getRunningOperationWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = getRunningOperationWithResponse(requestOptions);
-        return new SimpleResponse<>(
-                protocolMethodResponse, protocolMethodResponse.getValue().toObject(Operation.class));
     }
 
     /**
@@ -567,27 +449,36 @@ public final class EnumServiceClient {
     }
 
     /**
-     * The getOperation operation.
+     * The setStringEnumArray operation.
      *
-     * @param state The state parameter.
-     * @param context The context to associate with this operation.
+     * @param colorArray The colorArray parameter.
+     * @param colorArrayOpt The colorArrayOpt parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
      * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
      * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link Response}.
+     * @return the response.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Operation> getOperationWithResponse(OperationStateValues state, Context context) {
-        // Generated convenience method for getOperationWithResponse
+    public String setStringEnumArray(List<ColorModel> colorArray, List<ColorModel> colorArrayOpt) {
+        // Generated convenience method for setStringEnumArrayWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = getOperationWithResponse(state.toString(), requestOptions);
-        return new SimpleResponse<>(
-                protocolMethodResponse, protocolMethodResponse.getValue().toObject(Operation.class));
+        if (colorArrayOpt != null) {
+            requestOptions.addQueryParam(
+                    "colorArrayOpt",
+                    JacksonAdapter.createDefaultSerializerAdapter()
+                            .serializeIterable(colorArrayOpt, CollectionFormat.CSV));
+        }
+        return setStringEnumArrayWithResponse(
+                        colorArray.stream()
+                                .map(paramItemValue -> Objects.toString(paramItemValue, ""))
+                                .collect(Collectors.toList()),
+                        requestOptions)
+                .getValue()
+                .toObject(String.class);
     }
 
     /**
@@ -617,39 +508,38 @@ public final class EnumServiceClient {
     }
 
     /**
-     * The setStringEnumArray operation.
+     * The setIntEnumArray operation.
      *
-     * @param colorArray The colorArray parameter.
-     * @param colorArrayOpt The colorArrayOpt parameter.
-     * @param context The context to associate with this operation.
+     * @param priorityArray The priorityArray parameter.
+     * @param priorityArrayOpt The priorityArrayOpt parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
      * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
      * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link Response}.
+     * @return the response.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<String> setStringEnumArrayWithResponse(
-            List<ColorModel> colorArray, List<ColorModel> colorArrayOpt, Context context) {
-        // Generated convenience method for setStringEnumArrayWithResponse
+    public String setIntEnumArray(List<Priority> priorityArray, List<Priority> priorityArrayOpt) {
+        // Generated convenience method for setIntEnumArrayWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        if (colorArrayOpt != null) {
+        if (priorityArrayOpt != null) {
             requestOptions.addQueryParam(
-                    "colorArrayOpt",
+                    "priorityArrayOpt",
                     JacksonAdapter.createDefaultSerializerAdapter()
-                            .serializeIterable(colorArrayOpt, CollectionFormat.CSV));
+                            .serializeIterable(priorityArrayOpt, CollectionFormat.CSV));
         }
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse =
-                setStringEnumArrayWithResponse(
-                        colorArray.stream()
-                                .map(paramItemValue -> Objects.toString(paramItemValue, ""))
+        return setIntEnumArrayWithResponse(
+                        priorityArray.stream()
+                                .map(
+                                        paramItemValue ->
+                                                paramItemValue == null ? "" : String.valueOf(paramItemValue.toLong()))
                                 .collect(Collectors.toList()),
-                        requestOptions);
-        return new SimpleResponse<>(protocolMethodResponse, protocolMethodResponse.getValue().toObject(String.class));
+                        requestOptions)
+                .getValue()
+                .toObject(String.class);
     }
 
     /**
@@ -681,41 +571,31 @@ public final class EnumServiceClient {
     }
 
     /**
-     * The setIntEnumArray operation.
+     * The setStringArray operation.
      *
-     * @param priorityArray The priorityArray parameter.
-     * @param priorityArrayOpt The priorityArrayOpt parameter.
-     * @param context The context to associate with this operation.
+     * @param stringArray The stringArray parameter.
+     * @param stringArrayOpt The stringArrayOpt parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
      * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
      * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link Response}.
+     * @return the response.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<String> setIntEnumArrayWithResponse(
-            List<Priority> priorityArray, List<Priority> priorityArrayOpt, Context context) {
-        // Generated convenience method for setIntEnumArrayWithResponse
+    public String setStringArray(List<String> stringArray, List<String> stringArrayOpt) {
+        // Generated convenience method for setStringArrayWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        if (priorityArrayOpt != null) {
+        if (stringArrayOpt != null) {
             requestOptions.addQueryParam(
-                    "priorityArrayOpt",
-                    JacksonAdapter.createDefaultSerializerAdapter()
-                            .serializeIterable(priorityArrayOpt, CollectionFormat.CSV));
+                    "stringArrayOpt",
+                    stringArrayOpt.stream()
+                            .map(paramItemValue -> Objects.toString(paramItemValue, ""))
+                            .collect(Collectors.joining(",")));
         }
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse =
-                setIntEnumArrayWithResponse(
-                        priorityArray.stream()
-                                .map(
-                                        paramItemValue ->
-                                                paramItemValue == null ? "" : String.valueOf(paramItemValue.toLong()))
-                                .collect(Collectors.toList()),
-                        requestOptions);
-        return new SimpleResponse<>(protocolMethodResponse, protocolMethodResponse.getValue().toObject(String.class));
+        return setStringArrayWithResponse(stringArray, requestOptions).getValue().toObject(String.class);
     }
 
     /**
@@ -739,35 +619,30 @@ public final class EnumServiceClient {
     }
 
     /**
-     * The setStringArray operation.
+     * The setIntArray operation.
      *
-     * @param stringArray The stringArray parameter.
-     * @param stringArrayOpt The stringArrayOpt parameter.
-     * @param context The context to associate with this operation.
+     * @param intArray The intArray parameter.
+     * @param intArrayOpt The intArrayOpt parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
      * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
      * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link Response}.
+     * @return the response.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<String> setStringArrayWithResponse(
-            List<String> stringArray, List<String> stringArrayOpt, Context context) {
-        // Generated convenience method for setStringArrayWithResponse
+    public String setIntArray(List<Long> intArray, List<Long> intArrayOpt) {
+        // Generated convenience method for setIntArrayWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        if (stringArrayOpt != null) {
+        if (intArrayOpt != null) {
             requestOptions.addQueryParam(
-                    "stringArrayOpt",
-                    stringArrayOpt.stream()
-                            .map(paramItemValue -> Objects.toString(paramItemValue, ""))
-                            .collect(Collectors.joining(",")));
+                    "intArrayOpt",
+                    JacksonAdapter.createDefaultSerializerAdapter()
+                            .serializeIterable(intArrayOpt, CollectionFormat.CSV));
         }
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = setStringArrayWithResponse(stringArray, requestOptions);
-        return new SimpleResponse<>(protocolMethodResponse, protocolMethodResponse.getValue().toObject(String.class));
+        return setIntArrayWithResponse(intArray, requestOptions).getValue().toObject(String.class);
     }
 
     /**
@@ -788,35 +663,5 @@ public final class EnumServiceClient {
         // Generated convenience method for setIntArrayWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return setIntArrayWithResponse(intArray, requestOptions).getValue().toObject(String.class);
-    }
-
-    /**
-     * The setIntArray operation.
-     *
-     * @param intArray The intArray parameter.
-     * @param intArrayOpt The intArrayOpt parameter.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<String> setIntArrayWithResponse(List<Long> intArray, List<Long> intArrayOpt, Context context) {
-        // Generated convenience method for setIntArrayWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        if (intArrayOpt != null) {
-            requestOptions.addQueryParam(
-                    "intArrayOpt",
-                    JacksonAdapter.createDefaultSerializerAdapter()
-                            .serializeIterable(intArrayOpt, CollectionFormat.CSV));
-        }
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = setIntArrayWithResponse(intArray, requestOptions);
-        return new SimpleResponse<>(protocolMethodResponse, protocolMethodResponse.getValue().toObject(String.class));
     }
 }

--- a/cadl-tests/src/main/java/com/cadl/errormodel/ErrorClient.java
+++ b/cadl-tests/src/main/java/com/cadl/errormodel/ErrorClient.java
@@ -14,9 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.cadl.errormodel.models.Diagnostic;
 
 /** Initializes a new instance of the synchronous ErrorClient type. */
@@ -75,28 +73,5 @@ public final class ErrorClient {
         // Generated convenience method for readWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return readWithResponse(requestOptions).getValue().toObject(Diagnostic.class);
-    }
-
-    /**
-     * The read operation.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Diagnostic> readWithResponse(Context context) {
-        // Generated convenience method for readWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = readWithResponse(requestOptions);
-        return new SimpleResponse<>(
-                protocolMethodResponse, protocolMethodResponse.getValue().toObject(Diagnostic.class));
     }
 }

--- a/cadl-tests/src/main/java/com/cadl/longrunning/LongRunningClient.java
+++ b/cadl-tests/src/main/java/com/cadl/longrunning/LongRunningClient.java
@@ -14,9 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.azure.core.util.polling.SyncPoller;
 import com.cadl.longrunning.models.Resource;
 
@@ -163,28 +161,5 @@ public final class LongRunningClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(name, requestOptions).getValue().toObject(Resource.class);
-    }
-
-    /**
-     * Get a Resource.
-     *
-     * @param name The name parameter.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return a Resource along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Resource> getWithResponse(String name, Context context) {
-        // Generated convenience method for getWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = getWithResponse(name, requestOptions);
-        return new SimpleResponse<>(protocolMethodResponse, protocolMethodResponse.getValue().toObject(Resource.class));
     }
 }

--- a/cadl-tests/src/main/java/com/cadl/naming/NamingClient.java
+++ b/cadl-tests/src/main/java/com/cadl/naming/NamingClient.java
@@ -14,9 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.cadl.naming.models.DataResponse;
 
 /** Initializes a new instance of the synchronous NamingClient type. */
@@ -86,6 +84,34 @@ public final class NamingClient {
      *
      * @param name summary of name query parameter
      *     <p>description of name query parameter.
+     * @param etag summary of etag header parameter
+     *     <p>description of etag header parameter.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
+     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
+     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
+     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return summary of Response.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public DataResponse post(String name, String etag) {
+        // Generated convenience method for postWithResponse
+        RequestOptions requestOptions = new RequestOptions();
+        if (etag != null) {
+            requestOptions.setHeader("etag", etag);
+        }
+        return postWithResponse(name, requestOptions).getValue().toObject(DataResponse.class);
+    }
+
+    /**
+     * summary of POST op
+     *
+     * <p>description of POST op.
+     *
+     * @param name summary of name query parameter
+     *     <p>description of name query parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -100,37 +126,5 @@ public final class NamingClient {
         // Generated convenience method for postWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return postWithResponse(name, requestOptions).getValue().toObject(DataResponse.class);
-    }
-
-    /**
-     * summary of POST op
-     *
-     * <p>description of POST op.
-     *
-     * @param name summary of name query parameter
-     *     <p>description of name query parameter.
-     * @param etag summary of etag header parameter
-     *     <p>description of etag header parameter.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return summary of Response along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<DataResponse> postWithResponse(String name, String etag, Context context) {
-        // Generated convenience method for postWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        if (etag != null) {
-            requestOptions.setHeader("etag", etag);
-        }
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = postWithResponse(name, requestOptions);
-        return new SimpleResponse<>(
-                protocolMethodResponse, protocolMethodResponse.getValue().toObject(DataResponse.class));
     }
 }

--- a/cadl-tests/src/main/java/com/cadl/optional/OptionalClient.java
+++ b/cadl-tests/src/main/java/com/cadl/optional/OptionalClient.java
@@ -14,12 +14,9 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.ResponseBase;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.cadl.optional.models.AllPropertiesOptional;
 import com.cadl.optional.models.Optional;
-import com.cadl.optional.models.OptionalOpsPutHeaders;
 
 /** Initializes a new instance of the synchronous OptionalClient type. */
 @ServiceClient(builder = OptionalClientBuilder.class)
@@ -157,6 +154,68 @@ public final class OptionalClient {
      * @param booleanRequiredNullable The booleanRequiredNullable parameter.
      * @param stringRequired The stringRequired parameter.
      * @param stringRequiredNullable The stringRequiredNullable parameter.
+     * @param requestHeaderOptional The requestHeaderOptional parameter.
+     * @param booleanNullable The booleanNullable parameter.
+     * @param string The string parameter.
+     * @param stringNullable The stringNullable parameter.
+     * @param optional The optional parameter.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
+     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
+     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
+     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public AllPropertiesOptional put(
+            String requestHeaderRequired,
+            boolean booleanRequired,
+            Boolean booleanRequiredNullable,
+            String stringRequired,
+            String stringRequiredNullable,
+            String requestHeaderOptional,
+            Boolean booleanNullable,
+            String string,
+            String stringNullable,
+            Optional optional) {
+        // Generated convenience method for putWithResponse
+        RequestOptions requestOptions = new RequestOptions();
+        if (requestHeaderOptional != null) {
+            requestOptions.setHeader("request-header-optional", requestHeaderOptional);
+        }
+        if (booleanNullable != null) {
+            requestOptions.addQueryParam("booleanNullable", String.valueOf(booleanNullable));
+        }
+        if (string != null) {
+            requestOptions.addQueryParam("string", string);
+        }
+        if (stringNullable != null) {
+            requestOptions.addQueryParam("stringNullable", stringNullable);
+        }
+        if (optional != null) {
+            requestOptions.setBody(BinaryData.fromObject(optional));
+        }
+        return putWithResponse(
+                        requestHeaderRequired,
+                        booleanRequired,
+                        booleanRequiredNullable,
+                        stringRequired,
+                        stringRequiredNullable,
+                        requestOptions)
+                .getValue()
+                .toObject(AllPropertiesOptional.class);
+    }
+
+    /**
+     * The put operation.
+     *
+     * @param requestHeaderRequired The requestHeaderRequired parameter.
+     * @param booleanRequired The booleanRequired parameter.
+     * @param booleanRequiredNullable The booleanRequiredNullable parameter.
+     * @param stringRequired The stringRequired parameter.
+     * @param stringRequiredNullable The stringRequiredNullable parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
@@ -184,75 +243,5 @@ public final class OptionalClient {
                         requestOptions)
                 .getValue()
                 .toObject(AllPropertiesOptional.class);
-    }
-
-    /**
-     * The put operation.
-     *
-     * @param requestHeaderRequired The requestHeaderRequired parameter.
-     * @param booleanRequired The booleanRequired parameter.
-     * @param booleanRequiredNullable The booleanRequiredNullable parameter.
-     * @param stringRequired The stringRequired parameter.
-     * @param stringRequiredNullable The stringRequiredNullable parameter.
-     * @param requestHeaderOptional The requestHeaderOptional parameter.
-     * @param booleanNullable The booleanNullable parameter.
-     * @param string The string parameter.
-     * @param stringNullable The stringNullable parameter.
-     * @param optional The optional parameter.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link ResponseBase}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public ResponseBase<OptionalOpsPutHeaders, AllPropertiesOptional> putWithResponse(
-            String requestHeaderRequired,
-            boolean booleanRequired,
-            Boolean booleanRequiredNullable,
-            String stringRequired,
-            String stringRequiredNullable,
-            String requestHeaderOptional,
-            Boolean booleanNullable,
-            String string,
-            String stringNullable,
-            Optional optional,
-            Context context) {
-        // Generated convenience method for putWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        if (requestHeaderOptional != null) {
-            requestOptions.setHeader("request-header-optional", requestHeaderOptional);
-        }
-        if (booleanNullable != null) {
-            requestOptions.addQueryParam("booleanNullable", String.valueOf(booleanNullable));
-        }
-        if (string != null) {
-            requestOptions.addQueryParam("string", string);
-        }
-        if (stringNullable != null) {
-            requestOptions.addQueryParam("stringNullable", stringNullable);
-        }
-        if (optional != null) {
-            requestOptions.setBody(BinaryData.fromObject(optional));
-        }
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse =
-                putWithResponse(
-                        requestHeaderRequired,
-                        booleanRequired,
-                        booleanRequiredNullable,
-                        stringRequired,
-                        stringRequiredNullable,
-                        requestOptions);
-        return new ResponseBase<>(
-                protocolMethodResponse.getRequest(),
-                protocolMethodResponse.getStatusCode(),
-                protocolMethodResponse.getHeaders(),
-                protocolMethodResponse.getValue().toObject(AllPropertiesOptional.class),
-                new OptionalOpsPutHeaders(protocolMethodResponse.getHeaders()));
     }
 }

--- a/cadl-tests/src/main/java/com/cadl/partialupdate/PartialUpdateClient.java
+++ b/cadl-tests/src/main/java/com/cadl/partialupdate/PartialUpdateClient.java
@@ -13,9 +13,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.cadl.partialupdate.models.PartialUpdateModel;
 
 /** Initializes a new instance of the synchronous PartialUpdateClient type. */
@@ -76,29 +74,6 @@ public final class PartialUpdateClient {
         // Generated convenience method for readWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return readWithResponse(requestOptions).getValue().toObject(PartialUpdateModel.class);
-    }
-
-    /**
-     * The read operation.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<PartialUpdateModel> readWithResponse(Context context) {
-        // Generated convenience method for readWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = readWithResponse(requestOptions);
-        return new SimpleResponse<>(
-                protocolMethodResponse, protocolMethodResponse.getValue().toObject(PartialUpdateModel.class));
     }
 
     public void test() {}

--- a/cadl-tests/src/main/java/com/cadl/patch/JsonMergePatchClient.java
+++ b/cadl-tests/src/main/java/com/cadl/patch/JsonMergePatchClient.java
@@ -14,9 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.cadl.patch.models.Resource;
 
 /** Initializes a new instance of the synchronous JsonMergePatchClient type. */
@@ -130,31 +128,6 @@ public final class JsonMergePatchClient {
     }
 
     /**
-     * The create operation.
-     *
-     * @param name The name parameter.
-     * @param body The body parameter.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Resource> createWithResponse(String name, Resource body, Context context) {
-        // Generated convenience method for createWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse =
-                createWithResponse(name, BinaryData.fromObject(body), requestOptions);
-        return new SimpleResponse<>(protocolMethodResponse, protocolMethodResponse.getValue().toObject(Resource.class));
-    }
-
-    /**
      * The update operation.
      *
      * @param name The name parameter.
@@ -175,30 +148,5 @@ public final class JsonMergePatchClient {
         return updateWithResponse(name, BinaryData.fromObject(body), requestOptions)
                 .getValue()
                 .toObject(Resource.class);
-    }
-
-    /**
-     * The update operation.
-     *
-     * @param name The name parameter.
-     * @param body The body parameter.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Resource> updateWithResponse(String name, Resource body, Context context) {
-        // Generated convenience method for updateWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse =
-                updateWithResponse(name, BinaryData.fromObject(body), requestOptions);
-        return new SimpleResponse<>(protocolMethodResponse, protocolMethodResponse.getValue().toObject(Resource.class));
     }
 }

--- a/cadl-tests/src/main/java/com/cadl/polymorphism/PolymorphismClient.java
+++ b/cadl-tests/src/main/java/com/cadl/polymorphism/PolymorphismClient.java
@@ -14,9 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.cadl.polymorphism.models.BaseType;
 import com.cadl.polymorphism.models.Pet;
 import com.cadl.polymorphism.models.Task;
@@ -144,28 +142,6 @@ public final class PolymorphismClient {
     }
 
     /**
-     * The read operation.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Pet> readWithResponse(Context context) {
-        // Generated convenience method for readWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = readWithResponse(requestOptions);
-        return new SimpleResponse<>(protocolMethodResponse, protocolMethodResponse.getValue().toObject(Pet.class));
-    }
-
-    /**
      * The write operation.
      *
      * @param body The body parameter.
@@ -186,29 +162,6 @@ public final class PolymorphismClient {
     }
 
     /**
-     * The write operation.
-     *
-     * @param body The body parameter.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BaseType> writeWithResponse(BaseType body, Context context) {
-        // Generated convenience method for writeWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = writeWithResponse(BinaryData.fromObject(body), requestOptions);
-        return new SimpleResponse<>(protocolMethodResponse, protocolMethodResponse.getValue().toObject(BaseType.class));
-    }
-
-    /**
      * The task operation.
      *
      * @param body The body parameter.
@@ -226,28 +179,5 @@ public final class PolymorphismClient {
         // Generated convenience method for taskWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return taskWithResponse(BinaryData.fromObject(body), requestOptions).getValue().toObject(Task.class);
-    }
-
-    /**
-     * The task operation.
-     *
-     * @param body The body parameter.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Task> taskWithResponse(Task body, Context context) {
-        // Generated convenience method for taskWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = taskWithResponse(BinaryData.fromObject(body), requestOptions);
-        return new SimpleResponse<>(protocolMethodResponse, protocolMethodResponse.getValue().toObject(Task.class));
     }
 }

--- a/cadl-tests/src/main/java/com/cadl/response/ResponseClient.java
+++ b/cadl-tests/src/main/java/com/cadl/response/ResponseClient.java
@@ -14,14 +14,9 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.ResponseBase;
-import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.cadl.response.models.Resource;
 import com.cadl.response.models.ResourceRequest;
-import com.cadl.response.models.ResponseOpsCreateWithHeadersHeaders;
-import com.cadl.response.models.ResponseOpsDeleteWithHeadersHeaders;
 
 /** Initializes a new instance of the synchronous ResponseClient type. */
 @ServiceClient(builder = ResponseClientBuilder.class)
@@ -158,27 +153,6 @@ public final class ResponseClient {
     }
 
     /**
-     * The getBinary operation.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BinaryData> getBinaryWithResponse(Context context) {
-        // Generated convenience method for getBinaryWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        return getBinaryWithResponse(requestOptions);
-    }
-
-    /**
      * The createWithHeaders operation.
      *
      * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
@@ -197,33 +171,6 @@ public final class ResponseClient {
     }
 
     /**
-     * The createWithHeaders operation.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link ResponseBase}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public ResponseBase<ResponseOpsCreateWithHeadersHeaders, Resource> createWithHeadersWithResponse(Context context) {
-        // Generated convenience method for createWithHeadersWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = createWithHeadersWithResponse(requestOptions);
-        return new ResponseBase<>(
-                protocolMethodResponse.getRequest(),
-                protocolMethodResponse.getStatusCode(),
-                protocolMethodResponse.getHeaders(),
-                protocolMethodResponse.getValue().toObject(Resource.class),
-                new ResponseOpsCreateWithHeadersHeaders(protocolMethodResponse.getHeaders()));
-    }
-
-    /**
      * The deleteWithHeaders operation.
      *
      * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
@@ -238,33 +185,6 @@ public final class ResponseClient {
         // Generated convenience method for deleteWithHeadersWithResponse
         RequestOptions requestOptions = new RequestOptions();
         deleteWithHeadersWithResponse(requestOptions).getValue();
-    }
-
-    /**
-     * The deleteWithHeaders operation.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the {@link ResponseBase}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public ResponseBase<ResponseOpsDeleteWithHeadersHeaders, Void> deleteWithHeadersWithResponse(Context context) {
-        // Generated convenience method for deleteWithHeadersWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<Void> protocolMethodResponse = deleteWithHeadersWithResponse(requestOptions);
-        return new ResponseBase<>(
-                protocolMethodResponse.getRequest(),
-                protocolMethodResponse.getStatusCode(),
-                protocolMethodResponse.getHeaders(),
-                null,
-                new ResponseOpsDeleteWithHeadersHeaders(protocolMethodResponse.getHeaders()));
     }
 
     /**
@@ -288,30 +208,5 @@ public final class ResponseClient {
         return createWithResponse(name, BinaryData.fromObject(updateableProperties), requestOptions)
                 .getValue()
                 .toObject(Resource.class);
-    }
-
-    /**
-     * Creates or replaces a Resource.
-     *
-     * @param name The name parameter.
-     * @param updateableProperties The template for adding updateable properties.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Resource> createWithResponse(String name, ResourceRequest updateableProperties, Context context) {
-        // Generated convenience method for createWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse =
-                createWithResponse(name, BinaryData.fromObject(updateableProperties), requestOptions);
-        return new SimpleResponse<>(protocolMethodResponse, protocolMethodResponse.getValue().toObject(Resource.class));
     }
 }

--- a/cadl-tests/src/main/java/com/cadl/server/ServerClient.java
+++ b/cadl-tests/src/main/java/com/cadl/server/ServerClient.java
@@ -14,7 +14,6 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.util.Context;
 
 /** Initializes a new instance of the synchronous ServerClient type. */
 @ServiceClient(builder = ServerClientBuilder.class)
@@ -65,27 +64,5 @@ public final class ServerClient {
         // Generated convenience method for statusWithResponse
         RequestOptions requestOptions = new RequestOptions();
         statusWithResponse(code, requestOptions).getValue();
-    }
-
-    /**
-     * The status operation.
-     *
-     * @param code The code parameter.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> statusWithResponse(long code, Context context) {
-        // Generated convenience method for statusWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        return statusWithResponse(code, requestOptions);
     }
 }

--- a/cadl-tests/src/main/java/com/cadl/testserver/servicedriven1/ResiliencyServiceDriven1Client.java
+++ b/cadl-tests/src/main/java/com/cadl/testserver/servicedriven1/ResiliencyServiceDriven1Client.java
@@ -14,9 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.cadl.testserver.servicedriven1.models.Message;
 import com.cadl.testserver.servicedriven1.models.PostInput;
 
@@ -201,28 +199,6 @@ public final class ResiliencyServiceDriven1Client {
     }
 
     /**
-     * Head request, no params. Initially has no query parameters. After evolution, a new optional query parameter is
-     * added.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> headNoParamsWithResponse(Context context) {
-        // Generated convenience method for headNoParamsWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        return headNoParamsWithResponse(requestOptions);
-    }
-
-    /**
      * Get true Boolean value on path. Initially only has one required Query Parameter. After evolution, a new optional
      * query parameter is added.
      *
@@ -244,27 +220,28 @@ public final class ResiliencyServiceDriven1Client {
     }
 
     /**
-     * Get true Boolean value on path. Initially only has one required Query Parameter. After evolution, a new optional
+     * Initially has one required query parameter and one optional query parameter. After evolution, a new optional
      * query parameter is added.
      *
-     * @param parameter I am a required parameter.
-     * @param context The context to associate with this operation.
+     * @param requiredParam I am a required parameter.
+     * @param optionalParam I am an optional parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
      * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
      * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return true Boolean value on path. Initially only has one required Query Parameter along with {@link Response}.
+     * @return the response.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Message> getRequiredWithResponse(String parameter, Context context) {
-        // Generated convenience method for getRequiredWithResponse
+    public Message putRequiredOptional(String requiredParam, String optionalParam) {
+        // Generated convenience method for putRequiredOptionalWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = getRequiredWithResponse(parameter, requestOptions);
-        return new SimpleResponse<>(protocolMethodResponse, protocolMethodResponse.getValue().toObject(Message.class));
+        if (optionalParam != null) {
+            requestOptions.addQueryParam("optionalParam", optionalParam);
+        }
+        return putRequiredOptionalWithResponse(requiredParam, requestOptions).getValue().toObject(Message.class);
     }
 
     /**
@@ -286,35 +263,6 @@ public final class ResiliencyServiceDriven1Client {
         // Generated convenience method for putRequiredOptionalWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return putRequiredOptionalWithResponse(requiredParam, requestOptions).getValue().toObject(Message.class);
-    }
-
-    /**
-     * Initially has one required query parameter and one optional query parameter. After evolution, a new optional
-     * query parameter is added.
-     *
-     * @param requiredParam I am a required parameter.
-     * @param optionalParam I am an optional parameter.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Message> putRequiredOptionalWithResponse(
-            String requiredParam, String optionalParam, Context context) {
-        // Generated convenience method for putRequiredOptionalWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        if (optionalParam != null) {
-            requestOptions.addQueryParam("optionalParam", optionalParam);
-        }
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = putRequiredOptionalWithResponse(requiredParam, requestOptions);
-        return new SimpleResponse<>(protocolMethodResponse, protocolMethodResponse.getValue().toObject(Message.class));
     }
 
     /**
@@ -340,27 +288,27 @@ public final class ResiliencyServiceDriven1Client {
     }
 
     /**
-     * POST a JSON.
+     * Get true Boolean value on path. Initially has one optional query parameter. After evolution, a new optional query
+     * parameter is added.
      *
-     * @param parameter I am a body parameter. My only valid JSON entry is { url: "http://example.org/myimage.jpeg" }.
-     * @param context The context to associate with this operation.
+     * @param optionalParam I am an optional parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
      * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
      * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link Response}.
+     * @return true Boolean value on path. Initially has one optional query parameter.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Message> postParametersWithResponse(PostInput parameter, Context context) {
-        // Generated convenience method for postParametersWithResponse
+    public Message getOptional(String optionalParam) {
+        // Generated convenience method for getOptionalWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse =
-                postParametersWithResponse(BinaryData.fromObject(parameter), requestOptions);
-        return new SimpleResponse<>(protocolMethodResponse, protocolMethodResponse.getValue().toObject(Message.class));
+        if (optionalParam != null) {
+            requestOptions.addQueryParam("optionalParam", optionalParam);
+        }
+        return getOptionalWithResponse(requestOptions).getValue().toObject(Message.class);
     }
 
     /**
@@ -380,32 +328,5 @@ public final class ResiliencyServiceDriven1Client {
         // Generated convenience method for getOptionalWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getOptionalWithResponse(requestOptions).getValue().toObject(Message.class);
-    }
-
-    /**
-     * Get true Boolean value on path. Initially has one optional query parameter. After evolution, a new optional query
-     * parameter is added.
-     *
-     * @param optionalParam I am an optional parameter.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return true Boolean value on path. Initially has one optional query parameter along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Message> getOptionalWithResponse(String optionalParam, Context context) {
-        // Generated convenience method for getOptionalWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        if (optionalParam != null) {
-            requestOptions.addQueryParam("optionalParam", optionalParam);
-        }
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = getOptionalWithResponse(requestOptions);
-        return new SimpleResponse<>(protocolMethodResponse, protocolMethodResponse.getValue().toObject(Message.class));
     }
 }

--- a/cadl-tests/src/main/java/com/cadl/testserver/servicedriven2/ResiliencyServiceDriven2Client.java
+++ b/cadl-tests/src/main/java/com/cadl/testserver/servicedriven2/ResiliencyServiceDriven2Client.java
@@ -14,9 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.cadl.testserver.servicedriven2.models.ContentTypePath;
 import com.cadl.testserver.servicedriven2.models.Message;
 import com.cadl.testserver.servicedriven2.models.PostInput;
@@ -253,6 +251,29 @@ public final class ResiliencyServiceDriven2Client {
      * Head request, no params. Initially has no query parameters. After evolution, a new optional query parameter is
      * added.
      *
+     * @param newParameter I'm a new input optional parameter.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
+     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
+     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
+     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     */
+    @Generated
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public void headNoParams(String newParameter) {
+        // Generated convenience method for headNoParamsWithResponse
+        RequestOptions requestOptions = new RequestOptions();
+        if (newParameter != null) {
+            requestOptions.addQueryParam("new_parameter", newParameter);
+        }
+        headNoParamsWithResponse(requestOptions).getValue();
+    }
+
+    /**
+     * Head request, no params. Initially has no query parameters. After evolution, a new optional query parameter is
+     * added.
+     *
      * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
      * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
@@ -268,29 +289,28 @@ public final class ResiliencyServiceDriven2Client {
     }
 
     /**
-     * Head request, no params. Initially has no query parameters. After evolution, a new optional query parameter is
-     * added.
+     * Get true Boolean value on path. Initially only has one required Query Parameter. After evolution, a new optional
+     * query parameter is added.
      *
+     * @param parameter I am a required parameter.
      * @param newParameter I'm a new input optional parameter.
-     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
      * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
      * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the {@link Response}.
+     * @return true Boolean value on path. Initially only has one required Query Parameter.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> headNoParamsWithResponse(String newParameter, Context context) {
-        // Generated convenience method for headNoParamsWithResponse
+    public Message getRequired(String parameter, String newParameter) {
+        // Generated convenience method for getRequiredWithResponse
         RequestOptions requestOptions = new RequestOptions();
         if (newParameter != null) {
             requestOptions.addQueryParam("new_parameter", newParameter);
         }
-        requestOptions.setContext(context);
-        return headNoParamsWithResponse(requestOptions);
+        return getRequiredWithResponse(parameter, requestOptions).getValue().toObject(Message.class);
     }
 
     /**
@@ -315,31 +335,32 @@ public final class ResiliencyServiceDriven2Client {
     }
 
     /**
-     * Get true Boolean value on path. Initially only has one required Query Parameter. After evolution, a new optional
+     * Initially has one required query parameter and one optional query parameter. After evolution, a new optional
      * query parameter is added.
      *
-     * @param parameter I am a required parameter.
+     * @param requiredParam I am a required parameter.
+     * @param optionalParam I am an optional parameter.
      * @param newParameter I'm a new input optional parameter.
-     * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
      * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
      * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return true Boolean value on path. Initially only has one required Query Parameter along with {@link Response}.
+     * @return the response.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Message> getRequiredWithResponse(String parameter, String newParameter, Context context) {
-        // Generated convenience method for getRequiredWithResponse
+    public Message putRequiredOptional(String requiredParam, String optionalParam, String newParameter) {
+        // Generated convenience method for putRequiredOptionalWithResponse
         RequestOptions requestOptions = new RequestOptions();
+        if (optionalParam != null) {
+            requestOptions.addQueryParam("optionalParam", optionalParam);
+        }
         if (newParameter != null) {
             requestOptions.addQueryParam("new_parameter", newParameter);
         }
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = getRequiredWithResponse(parameter, requestOptions);
-        return new SimpleResponse<>(protocolMethodResponse, protocolMethodResponse.getValue().toObject(Message.class));
+        return putRequiredOptionalWithResponse(requiredParam, requestOptions).getValue().toObject(Message.class);
     }
 
     /**
@@ -361,39 +382,6 @@ public final class ResiliencyServiceDriven2Client {
         // Generated convenience method for putRequiredOptionalWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return putRequiredOptionalWithResponse(requiredParam, requestOptions).getValue().toObject(Message.class);
-    }
-
-    /**
-     * Initially has one required query parameter and one optional query parameter. After evolution, a new optional
-     * query parameter is added.
-     *
-     * @param requiredParam I am a required parameter.
-     * @param optionalParam I am an optional parameter.
-     * @param newParameter I'm a new input optional parameter.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Message> putRequiredOptionalWithResponse(
-            String requiredParam, String optionalParam, String newParameter, Context context) {
-        // Generated convenience method for putRequiredOptionalWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        if (optionalParam != null) {
-            requestOptions.addQueryParam("optionalParam", optionalParam);
-        }
-        if (newParameter != null) {
-            requestOptions.addQueryParam("new_parameter", newParameter);
-        }
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = putRequiredOptionalWithResponse(requiredParam, requestOptions);
-        return new SimpleResponse<>(protocolMethodResponse, protocolMethodResponse.getValue().toObject(Message.class));
     }
 
     /**
@@ -420,33 +408,6 @@ public final class ResiliencyServiceDriven2Client {
     }
 
     /**
-     * POST a JSON or a JPEG.
-     *
-     * @param contentTypePath The contentTypePath parameter.
-     * @param parameter I am a body parameter. My only valid JSON entry is { url: "http://example.org/myimage.jpeg" }.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Message> postParametersWithResponse(
-            ContentTypePath contentTypePath, PostInput parameter, Context context) {
-        // Generated convenience method for postParametersWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse =
-                postParametersWithResponse(
-                        contentTypePath.toString(), BinaryData.fromObject(parameter), requestOptions);
-        return new SimpleResponse<>(protocolMethodResponse, protocolMethodResponse.getValue().toObject(Message.class));
-    }
-
-    /**
      * Delete something. Initially the path exists but there is no delete method. After evolution this is a new method
      * in a known path.
      *
@@ -465,25 +426,31 @@ public final class ResiliencyServiceDriven2Client {
     }
 
     /**
-     * Delete something. Initially the path exists but there is no delete method. After evolution this is a new method
-     * in a known path.
+     * Get true Boolean value on path. Initially has one optional query parameter. After evolution, a new optional query
+     * parameter is added.
      *
-     * @param context The context to associate with this operation.
+     * @param optionalParam I am an optional parameter.
+     * @param newParameter I'm a new input optional parameter.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
      * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
      * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
      * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the {@link Response}.
+     * @return true Boolean value on path. Initially has one optional query parameter.
      */
     @Generated
     @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> deleteParametersWithResponse(Context context) {
-        // Generated convenience method for deleteParametersWithResponse
+    public Message getOptional(String optionalParam, String newParameter) {
+        // Generated convenience method for getOptionalWithResponse
         RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        return deleteParametersWithResponse(requestOptions);
+        if (optionalParam != null) {
+            requestOptions.addQueryParam("optionalParam", optionalParam);
+        }
+        if (newParameter != null) {
+            requestOptions.addQueryParam("new_parameter", newParameter);
+        }
+        return getOptionalWithResponse(requestOptions).getValue().toObject(Message.class);
     }
 
     /**
@@ -506,37 +473,6 @@ public final class ResiliencyServiceDriven2Client {
     }
 
     /**
-     * Get true Boolean value on path. Initially has one optional query parameter. After evolution, a new optional query
-     * parameter is added.
-     *
-     * @param optionalParam I am an optional parameter.
-     * @param newParameter I'm a new input optional parameter.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return true Boolean value on path. Initially has one optional query parameter along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Message> getOptionalWithResponse(String optionalParam, String newParameter, Context context) {
-        // Generated convenience method for getOptionalWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        if (optionalParam != null) {
-            requestOptions.addQueryParam("optionalParam", optionalParam);
-        }
-        if (newParameter != null) {
-            requestOptions.addQueryParam("new_parameter", newParameter);
-        }
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = getOptionalWithResponse(requestOptions);
-        return new SimpleResponse<>(protocolMethodResponse, protocolMethodResponse.getValue().toObject(Message.class));
-    }
-
-    /**
      * I'm a new operation. Initiallty neither path or method exist for this operation. After evolution, this is a new
      * method in a new path.
      *
@@ -553,28 +489,5 @@ public final class ResiliencyServiceDriven2Client {
         // Generated convenience method for getNewOperationWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getNewOperationWithResponse(requestOptions).getValue().toObject(Message.class);
-    }
-
-    /**
-     * I'm a new operation. Initiallty neither path or method exist for this operation. After evolution, this is a new
-     * method in a new path.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Message> getNewOperationWithResponse(Context context) {
-        // Generated convenience method for getNewOperationWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = getNewOperationWithResponse(requestOptions);
-        return new SimpleResponse<>(protocolMethodResponse, protocolMethodResponse.getValue().toObject(Message.class));
     }
 }

--- a/cadl-tests/src/main/java/com/cadl/visibility/VisibilityOpClient.java
+++ b/cadl-tests/src/main/java/com/cadl/visibility/VisibilityOpClient.java
@@ -14,9 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.cadl.visibility.models.Dog;
 import com.cadl.visibility.models.ReadDog;
 import com.cadl.visibility.models.WriteDog;
@@ -153,28 +151,6 @@ public final class VisibilityOpClient {
     }
 
     /**
-     * The get operation.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Dog> getWithResponse(Context context) {
-        // Generated convenience method for getWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = getWithResponse(requestOptions);
-        return new SimpleResponse<>(protocolMethodResponse, protocolMethodResponse.getValue().toObject(Dog.class));
-    }
-
-    /**
      * The create operation.
      *
      * @param dog The dog parameter.
@@ -195,29 +171,6 @@ public final class VisibilityOpClient {
     }
 
     /**
-     * The create operation.
-     *
-     * @param dog The dog parameter.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Dog> createWithResponse(WriteDog dog, Context context) {
-        // Generated convenience method for createWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = createWithResponse(BinaryData.fromObject(dog), requestOptions);
-        return new SimpleResponse<>(protocolMethodResponse, protocolMethodResponse.getValue().toObject(Dog.class));
-    }
-
-    /**
      * The query operation.
      *
      * @param dog The dog parameter.
@@ -235,28 +188,5 @@ public final class VisibilityOpClient {
         // Generated convenience method for queryWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return queryWithResponse(BinaryData.fromObject(dog), requestOptions).getValue().toObject(Dog.class);
-    }
-
-    /**
-     * The query operation.
-     *
-     * @param dog The dog parameter.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Dog> queryWithResponse(ReadDog dog, Context context) {
-        // Generated convenience method for queryWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = queryWithResponse(BinaryData.fromObject(dog), requestOptions);
-        return new SimpleResponse<>(protocolMethodResponse, protocolMethodResponse.getValue().toObject(Dog.class));
     }
 }

--- a/cadl-tests/src/main/java/com/cadl/visibility/VisibilityReadClient.java
+++ b/cadl-tests/src/main/java/com/cadl/visibility/VisibilityReadClient.java
@@ -14,9 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.cadl.visibility.models.Dog;
 
 /** Initializes a new instance of the synchronous VisibilityClient type. */
@@ -76,27 +74,5 @@ public final class VisibilityReadClient {
         // Generated convenience method for getWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getWithResponse(requestOptions).getValue().toObject(Dog.class);
-    }
-
-    /**
-     * The get operation.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Dog> getWithResponse(Context context) {
-        // Generated convenience method for getWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = getWithResponse(requestOptions);
-        return new SimpleResponse<>(protocolMethodResponse, protocolMethodResponse.getValue().toObject(Dog.class));
     }
 }

--- a/cadl-tests/src/main/java/com/cadl/visibility/VisibilityWriteClient.java
+++ b/cadl-tests/src/main/java/com/cadl/visibility/VisibilityWriteClient.java
@@ -14,9 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.cadl.visibility.models.Dog;
 import com.cadl.visibility.models.WriteDog;
 
@@ -89,28 +87,5 @@ public final class VisibilityWriteClient {
         // Generated convenience method for createWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return createWithResponse(BinaryData.fromObject(dog), requestOptions).getValue().toObject(Dog.class);
-    }
-
-    /**
-     * The create operation.
-     *
-     * @param dog The dog parameter.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Dog> createWithResponse(WriteDog dog, Context context) {
-        // Generated convenience method for createWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = createWithResponse(BinaryData.fromObject(dog), requestOptions);
-        return new SimpleResponse<>(protocolMethodResponse, protocolMethodResponse.getValue().toObject(Dog.class));
     }
 }

--- a/cadl-tests/src/main/java/com/inputbasic/InputBasicClient.java
+++ b/cadl-tests/src/main/java/com/inputbasic/InputBasicClient.java
@@ -15,7 +15,6 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.inputbasic.models.InputModel;
 
 /** Initializes a new instance of the synchronous InputBasicClient type. */
@@ -76,27 +75,5 @@ public final class InputBasicClient {
         // Generated convenience method for getModelWithResponse
         RequestOptions requestOptions = new RequestOptions();
         getModelWithResponse(BinaryData.fromObject(input), requestOptions).getValue();
-    }
-
-    /**
-     * The getModel operation.
-     *
-     * @param input Input Model.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> getModelWithResponse(InputModel input, Context context) {
-        // Generated convenience method for getModelWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        return getModelWithResponse(BinaryData.fromObject(input), requestOptions);
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/types/BooleanOperationClient.java
+++ b/cadl-tests/src/main/java/com/models/property/types/BooleanOperationClient.java
@@ -14,9 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.models.property.types.models.BooleanProperty;
 
 /** Initializes a new instance of the synchronous ModelsPropertyTypesClient type. */
@@ -102,29 +100,6 @@ public final class BooleanOperationClient {
     }
 
     /**
-     * The get operation.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return model with a boolean property along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BooleanProperty> getWithResponse(Context context) {
-        // Generated convenience method for getWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = getWithResponse(requestOptions);
-        return new SimpleResponse<>(
-                protocolMethodResponse, protocolMethodResponse.getValue().toObject(BooleanProperty.class));
-    }
-
-    /**
      * The put operation.
      *
      * @param body Model with a boolean property.
@@ -141,27 +116,5 @@ public final class BooleanOperationClient {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
         putWithResponse(BinaryData.fromObject(body), requestOptions).getValue();
-    }
-
-    /**
-     * The put operation.
-     *
-     * @param body Model with a boolean property.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putWithResponse(BooleanProperty body, Context context) {
-        // Generated convenience method for putWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        return putWithResponse(BinaryData.fromObject(body), requestOptions);
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/types/BytesClient.java
+++ b/cadl-tests/src/main/java/com/models/property/types/BytesClient.java
@@ -14,9 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.models.property.types.models.BytesProperty;
 
 /** Initializes a new instance of the synchronous ModelsPropertyTypesClient type. */
@@ -102,29 +100,6 @@ public final class BytesClient {
     }
 
     /**
-     * The get operation.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return model with a bytes property along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<BytesProperty> getWithResponse(Context context) {
-        // Generated convenience method for getWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = getWithResponse(requestOptions);
-        return new SimpleResponse<>(
-                protocolMethodResponse, protocolMethodResponse.getValue().toObject(BytesProperty.class));
-    }
-
-    /**
      * The put operation.
      *
      * @param body Model with a bytes property.
@@ -141,27 +116,5 @@ public final class BytesClient {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
         putWithResponse(BinaryData.fromObject(body), requestOptions).getValue();
-    }
-
-    /**
-     * The put operation.
-     *
-     * @param body Model with a bytes property.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putWithResponse(BytesProperty body, Context context) {
-        // Generated convenience method for putWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        return putWithResponse(BinaryData.fromObject(body), requestOptions);
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/types/CollectionsIntClient.java
+++ b/cadl-tests/src/main/java/com/models/property/types/CollectionsIntClient.java
@@ -14,9 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.models.property.types.models.CollectionsIntProperty;
 
 /** Initializes a new instance of the synchronous ModelsPropertyTypesClient type. */
@@ -106,29 +104,6 @@ public final class CollectionsIntClient {
     }
 
     /**
-     * The get operation.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return model with collection int properties along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<CollectionsIntProperty> getWithResponse(Context context) {
-        // Generated convenience method for getWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = getWithResponse(requestOptions);
-        return new SimpleResponse<>(
-                protocolMethodResponse, protocolMethodResponse.getValue().toObject(CollectionsIntProperty.class));
-    }
-
-    /**
      * The put operation.
      *
      * @param body Model with collection int properties.
@@ -145,27 +120,5 @@ public final class CollectionsIntClient {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
         putWithResponse(BinaryData.fromObject(body), requestOptions).getValue();
-    }
-
-    /**
-     * The put operation.
-     *
-     * @param body Model with collection int properties.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putWithResponse(CollectionsIntProperty body, Context context) {
-        // Generated convenience method for putWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        return putWithResponse(BinaryData.fromObject(body), requestOptions);
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/types/CollectionsModelClient.java
+++ b/cadl-tests/src/main/java/com/models/property/types/CollectionsModelClient.java
@@ -14,9 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.models.property.types.models.CollectionsModelProperty;
 
 /** Initializes a new instance of the synchronous ModelsPropertyTypesClient type. */
@@ -110,29 +108,6 @@ public final class CollectionsModelClient {
     }
 
     /**
-     * The get operation.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return model with collection model properties along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<CollectionsModelProperty> getWithResponse(Context context) {
-        // Generated convenience method for getWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = getWithResponse(requestOptions);
-        return new SimpleResponse<>(
-                protocolMethodResponse, protocolMethodResponse.getValue().toObject(CollectionsModelProperty.class));
-    }
-
-    /**
      * The put operation.
      *
      * @param body Model with collection model properties.
@@ -149,27 +124,5 @@ public final class CollectionsModelClient {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
         putWithResponse(BinaryData.fromObject(body), requestOptions).getValue();
-    }
-
-    /**
-     * The put operation.
-     *
-     * @param body Model with collection model properties.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putWithResponse(CollectionsModelProperty body, Context context) {
-        // Generated convenience method for putWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        return putWithResponse(BinaryData.fromObject(body), requestOptions);
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/types/CollectionsStringClient.java
+++ b/cadl-tests/src/main/java/com/models/property/types/CollectionsStringClient.java
@@ -14,9 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.models.property.types.models.CollectionsStringProperty;
 
 /** Initializes a new instance of the synchronous ModelsPropertyTypesClient type. */
@@ -106,29 +104,6 @@ public final class CollectionsStringClient {
     }
 
     /**
-     * The get operation.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return model with collection string properties along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<CollectionsStringProperty> getWithResponse(Context context) {
-        // Generated convenience method for getWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = getWithResponse(requestOptions);
-        return new SimpleResponse<>(
-                protocolMethodResponse, protocolMethodResponse.getValue().toObject(CollectionsStringProperty.class));
-    }
-
-    /**
      * The put operation.
      *
      * @param body Model with collection string properties.
@@ -145,27 +120,5 @@ public final class CollectionsStringClient {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
         putWithResponse(BinaryData.fromObject(body), requestOptions).getValue();
-    }
-
-    /**
-     * The put operation.
-     *
-     * @param body Model with collection string properties.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putWithResponse(CollectionsStringProperty body, Context context) {
-        // Generated convenience method for putWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        return putWithResponse(BinaryData.fromObject(body), requestOptions);
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/types/DatetimeOperationClient.java
+++ b/cadl-tests/src/main/java/com/models/property/types/DatetimeOperationClient.java
@@ -14,9 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.models.property.types.models.DatetimeProperty;
 
 /** Initializes a new instance of the synchronous ModelsPropertyTypesClient type. */
@@ -102,29 +100,6 @@ public final class DatetimeOperationClient {
     }
 
     /**
-     * The get operation.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return model with a datetime property along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<DatetimeProperty> getWithResponse(Context context) {
-        // Generated convenience method for getWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = getWithResponse(requestOptions);
-        return new SimpleResponse<>(
-                protocolMethodResponse, protocolMethodResponse.getValue().toObject(DatetimeProperty.class));
-    }
-
-    /**
      * The put operation.
      *
      * @param body Model with a datetime property.
@@ -141,27 +116,5 @@ public final class DatetimeOperationClient {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
         putWithResponse(BinaryData.fromObject(body), requestOptions).getValue();
-    }
-
-    /**
-     * The put operation.
-     *
-     * @param body Model with a datetime property.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putWithResponse(DatetimeProperty body, Context context) {
-        // Generated convenience method for putWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        return putWithResponse(BinaryData.fromObject(body), requestOptions);
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/types/DurationOperationClient.java
+++ b/cadl-tests/src/main/java/com/models/property/types/DurationOperationClient.java
@@ -14,9 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.models.property.types.models.DurationProperty;
 
 /** Initializes a new instance of the synchronous ModelsPropertyTypesClient type. */
@@ -102,29 +100,6 @@ public final class DurationOperationClient {
     }
 
     /**
-     * The get operation.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return model with a duration property along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<DurationProperty> getWithResponse(Context context) {
-        // Generated convenience method for getWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = getWithResponse(requestOptions);
-        return new SimpleResponse<>(
-                protocolMethodResponse, protocolMethodResponse.getValue().toObject(DurationProperty.class));
-    }
-
-    /**
      * The put operation.
      *
      * @param body Model with a duration property.
@@ -141,27 +116,5 @@ public final class DurationOperationClient {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
         putWithResponse(BinaryData.fromObject(body), requestOptions).getValue();
-    }
-
-    /**
-     * The put operation.
-     *
-     * @param body Model with a duration property.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putWithResponse(DurationProperty body, Context context) {
-        // Generated convenience method for putWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        return putWithResponse(BinaryData.fromObject(body), requestOptions);
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/types/EnumClient.java
+++ b/cadl-tests/src/main/java/com/models/property/types/EnumClient.java
@@ -14,9 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.models.property.types.models.EnumProperty;
 
 /** Initializes a new instance of the synchronous ModelsPropertyTypesClient type. */
@@ -102,29 +100,6 @@ public final class EnumClient {
     }
 
     /**
-     * The get operation.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return model with enum properties along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<EnumProperty> getWithResponse(Context context) {
-        // Generated convenience method for getWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = getWithResponse(requestOptions);
-        return new SimpleResponse<>(
-                protocolMethodResponse, protocolMethodResponse.getValue().toObject(EnumProperty.class));
-    }
-
-    /**
      * The put operation.
      *
      * @param body Model with enum properties.
@@ -141,27 +116,5 @@ public final class EnumClient {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
         putWithResponse(BinaryData.fromObject(body), requestOptions).getValue();
-    }
-
-    /**
-     * The put operation.
-     *
-     * @param body Model with enum properties.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putWithResponse(EnumProperty body, Context context) {
-        // Generated convenience method for putWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        return putWithResponse(BinaryData.fromObject(body), requestOptions);
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/types/ExtensibleEnumClient.java
+++ b/cadl-tests/src/main/java/com/models/property/types/ExtensibleEnumClient.java
@@ -14,9 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.models.property.types.models.ExtensibleEnumProperty;
 
 /** Initializes a new instance of the synchronous ModelsPropertyTypesClient type. */
@@ -102,29 +100,6 @@ public final class ExtensibleEnumClient {
     }
 
     /**
-     * The get operation.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return model with extensible enum properties along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<ExtensibleEnumProperty> getWithResponse(Context context) {
-        // Generated convenience method for getWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = getWithResponse(requestOptions);
-        return new SimpleResponse<>(
-                protocolMethodResponse, protocolMethodResponse.getValue().toObject(ExtensibleEnumProperty.class));
-    }
-
-    /**
      * The put operation.
      *
      * @param body Model with extensible enum properties.
@@ -141,27 +116,5 @@ public final class ExtensibleEnumClient {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
         putWithResponse(BinaryData.fromObject(body), requestOptions).getValue();
-    }
-
-    /**
-     * The put operation.
-     *
-     * @param body Model with extensible enum properties.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putWithResponse(ExtensibleEnumProperty body, Context context) {
-        // Generated convenience method for putWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        return putWithResponse(BinaryData.fromObject(body), requestOptions);
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/types/FloatOperationClient.java
+++ b/cadl-tests/src/main/java/com/models/property/types/FloatOperationClient.java
@@ -14,9 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.models.property.types.models.FloatProperty;
 
 /** Initializes a new instance of the synchronous ModelsPropertyTypesClient type. */
@@ -102,29 +100,6 @@ public final class FloatOperationClient {
     }
 
     /**
-     * The get operation.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return model with a float property along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<FloatProperty> getWithResponse(Context context) {
-        // Generated convenience method for getWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = getWithResponse(requestOptions);
-        return new SimpleResponse<>(
-                protocolMethodResponse, protocolMethodResponse.getValue().toObject(FloatProperty.class));
-    }
-
-    /**
      * The put operation.
      *
      * @param body Model with a float property.
@@ -141,27 +116,5 @@ public final class FloatOperationClient {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
         putWithResponse(BinaryData.fromObject(body), requestOptions).getValue();
-    }
-
-    /**
-     * The put operation.
-     *
-     * @param body Model with a float property.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putWithResponse(FloatProperty body, Context context) {
-        // Generated convenience method for putWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        return putWithResponse(BinaryData.fromObject(body), requestOptions);
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/types/IntClient.java
+++ b/cadl-tests/src/main/java/com/models/property/types/IntClient.java
@@ -14,9 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.models.property.types.models.IntProperty;
 
 /** Initializes a new instance of the synchronous ModelsPropertyTypesClient type. */
@@ -102,29 +100,6 @@ public final class IntClient {
     }
 
     /**
-     * The get operation.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return model with a int property along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<IntProperty> getWithResponse(Context context) {
-        // Generated convenience method for getWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = getWithResponse(requestOptions);
-        return new SimpleResponse<>(
-                protocolMethodResponse, protocolMethodResponse.getValue().toObject(IntProperty.class));
-    }
-
-    /**
      * The put operation.
      *
      * @param body Model with a int property.
@@ -141,27 +116,5 @@ public final class IntClient {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
         putWithResponse(BinaryData.fromObject(body), requestOptions).getValue();
-    }
-
-    /**
-     * The put operation.
-     *
-     * @param body Model with a int property.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putWithResponse(IntProperty body, Context context) {
-        // Generated convenience method for putWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        return putWithResponse(BinaryData.fromObject(body), requestOptions);
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/types/ModelClient.java
+++ b/cadl-tests/src/main/java/com/models/property/types/ModelClient.java
@@ -14,9 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.models.property.types.models.ModelProperty;
 
 /** Initializes a new instance of the synchronous ModelsPropertyTypesClient type. */
@@ -106,29 +104,6 @@ public final class ModelClient {
     }
 
     /**
-     * The get operation.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return model with model properties along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<ModelProperty> getWithResponse(Context context) {
-        // Generated convenience method for getWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = getWithResponse(requestOptions);
-        return new SimpleResponse<>(
-                protocolMethodResponse, protocolMethodResponse.getValue().toObject(ModelProperty.class));
-    }
-
-    /**
      * The put operation.
      *
      * @param body Model with model properties.
@@ -145,27 +120,5 @@ public final class ModelClient {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
         putWithResponse(BinaryData.fromObject(body), requestOptions).getValue();
-    }
-
-    /**
-     * The put operation.
-     *
-     * @param body Model with model properties.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putWithResponse(ModelProperty body, Context context) {
-        // Generated convenience method for putWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        return putWithResponse(BinaryData.fromObject(body), requestOptions);
     }
 }

--- a/cadl-tests/src/main/java/com/models/property/types/StringOperationClient.java
+++ b/cadl-tests/src/main/java/com/models/property/types/StringOperationClient.java
@@ -14,9 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.models.property.types.models.StringProperty;
 
 /** Initializes a new instance of the synchronous ModelsPropertyTypesClient type. */
@@ -102,29 +100,6 @@ public final class StringOperationClient {
     }
 
     /**
-     * The get operation.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return model with a string property along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<StringProperty> getWithResponse(Context context) {
-        // Generated convenience method for getWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = getWithResponse(requestOptions);
-        return new SimpleResponse<>(
-                protocolMethodResponse, protocolMethodResponse.getValue().toObject(StringProperty.class));
-    }
-
-    /**
      * The put operation.
      *
      * @param body Model with a string property.
@@ -141,27 +116,5 @@ public final class StringOperationClient {
         // Generated convenience method for putWithResponse
         RequestOptions requestOptions = new RequestOptions();
         putWithResponse(BinaryData.fromObject(body), requestOptions).getValue();
-    }
-
-    /**
-     * The put operation.
-     *
-     * @param body Model with a string property.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> putWithResponse(StringProperty body, Context context) {
-        // Generated convenience method for putWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        return putWithResponse(BinaryData.fromObject(body), requestOptions);
     }
 }

--- a/cadl-tests/src/main/java/com/nestedmodelsbasic/NestedModelsBasicClient.java
+++ b/cadl-tests/src/main/java/com/nestedmodelsbasic/NestedModelsBasicClient.java
@@ -14,9 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.nestedmodelsbasic.models.InputModel;
 import com.nestedmodelsbasic.models.OutputModel;
 import com.nestedmodelsbasic.models.RoundTripModel;
@@ -214,28 +212,6 @@ public final class NestedModelsBasicClient {
     }
 
     /**
-     * The sendNestedModel operation.
-     *
-     * @param input Input model with nested model properties.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> sendNestedModelWithResponse(InputModel input, Context context) {
-        // Generated convenience method for sendNestedModelWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        return sendNestedModelWithResponse(BinaryData.fromObject(input), requestOptions);
-    }
-
-    /**
      * The getNestedModel operation.
      *
      * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
@@ -251,29 +227,6 @@ public final class NestedModelsBasicClient {
         // Generated convenience method for getNestedModelWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getNestedModelWithResponse(requestOptions).getValue().toObject(OutputModel.class);
-    }
-
-    /**
-     * The getNestedModel operation.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return output model with nested model properties along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<OutputModel> getNestedModelWithResponse(Context context) {
-        // Generated convenience method for getNestedModelWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = getNestedModelWithResponse(requestOptions);
-        return new SimpleResponse<>(
-                protocolMethodResponse, protocolMethodResponse.getValue().toObject(OutputModel.class));
     }
 
     /**
@@ -296,30 +249,5 @@ public final class NestedModelsBasicClient {
         return setNestedModelWithResponse(BinaryData.fromObject(input), requestOptions)
                 .getValue()
                 .toObject(RoundTripModel.class);
-    }
-
-    /**
-     * The setNestedModel operation.
-     *
-     * @param input Round-trip model with nested model properties.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return round-trip model with nested model properties along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<RoundTripModel> setNestedModelWithResponse(RoundTripModel input, Context context) {
-        // Generated convenience method for setNestedModelWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse =
-                setNestedModelWithResponse(BinaryData.fromObject(input), requestOptions);
-        return new SimpleResponse<>(
-                protocolMethodResponse, protocolMethodResponse.getValue().toObject(RoundTripModel.class));
     }
 }

--- a/cadl-tests/src/main/java/com/optionalproperties/OptionalPropertiesClient.java
+++ b/cadl-tests/src/main/java/com/optionalproperties/OptionalPropertiesClient.java
@@ -14,9 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.optionalproperties.models.InputModel;
 import com.optionalproperties.models.OutputModel;
 import com.optionalproperties.models.RoundTripModel;
@@ -166,28 +164,6 @@ public final class OptionalPropertiesClient {
     }
 
     /**
-     * The sendOptionalPropertyModel operation.
-     *
-     * @param input Input model with optional properties.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<Void> sendOptionalPropertyModelWithResponse(InputModel input, Context context) {
-        // Generated convenience method for sendOptionalPropertyModelWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        return sendOptionalPropertyModelWithResponse(BinaryData.fromObject(input), requestOptions);
-    }
-
-    /**
      * The getOptionalPropertyModel operation.
      *
      * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
@@ -203,29 +179,6 @@ public final class OptionalPropertiesClient {
         // Generated convenience method for getOptionalPropertyModelWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getOptionalPropertyModelWithResponse(requestOptions).getValue().toObject(OutputModel.class);
-    }
-
-    /**
-     * The getOptionalPropertyModel operation.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return output model with optional properties along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<OutputModel> getOptionalPropertyModelWithResponse(Context context) {
-        // Generated convenience method for getOptionalPropertyModelWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = getOptionalPropertyModelWithResponse(requestOptions);
-        return new SimpleResponse<>(
-                protocolMethodResponse, protocolMethodResponse.getValue().toObject(OutputModel.class));
     }
 
     /**
@@ -248,30 +201,5 @@ public final class OptionalPropertiesClient {
         return setOptionalPropertyModelWithResponse(BinaryData.fromObject(input), requestOptions)
                 .getValue()
                 .toObject(RoundTripModel.class);
-    }
-
-    /**
-     * The setOptionalPropertyModel operation.
-     *
-     * @param input Round-trip model with optional properties.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return round-trip model with optional properties along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<RoundTripModel> setOptionalPropertyModelWithResponse(RoundTripModel input, Context context) {
-        // Generated convenience method for setOptionalPropertyModelWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse =
-                setOptionalPropertyModelWithResponse(BinaryData.fromObject(input), requestOptions);
-        return new SimpleResponse<>(
-                protocolMethodResponse, protocolMethodResponse.getValue().toObject(RoundTripModel.class));
     }
 }

--- a/cadl-tests/src/main/java/com/outputbasic/OutputBasicClient.java
+++ b/cadl-tests/src/main/java/com/outputbasic/OutputBasicClient.java
@@ -14,9 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.outputbasic.models.OutputModel;
 
 /** Initializes a new instance of the synchronous OutputBasicClient type. */
@@ -75,28 +73,5 @@ public final class OutputBasicClient {
         // Generated convenience method for getModelWithResponse
         RequestOptions requestOptions = new RequestOptions();
         return getModelWithResponse(requestOptions).getValue().toObject(OutputModel.class);
-    }
-
-    /**
-     * The getModel operation.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return output Model along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<OutputModel> getModelWithResponse(Context context) {
-        // Generated convenience method for getModelWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = getModelWithResponse(requestOptions);
-        return new SimpleResponse<>(
-                protocolMethodResponse, protocolMethodResponse.getValue().toObject(OutputModel.class));
     }
 }

--- a/cadl-tests/src/main/java/com/readonlyproperties/ReadonlyPropertiesClient.java
+++ b/cadl-tests/src/main/java/com/readonlyproperties/ReadonlyPropertiesClient.java
@@ -14,9 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.readonlyproperties.models.OutputModel;
 import com.readonlyproperties.models.RoundTripModel;
 
@@ -168,29 +166,6 @@ public final class ReadonlyPropertiesClient {
     }
 
     /**
-     * The getOptionalPropertyModel operation.
-     *
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return output model with readonly properties along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<OutputModel> getOptionalPropertyModelWithResponse(Context context) {
-        // Generated convenience method for getOptionalPropertyModelWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse = getOptionalPropertyModelWithResponse(requestOptions);
-        return new SimpleResponse<>(
-                protocolMethodResponse, protocolMethodResponse.getValue().toObject(OutputModel.class));
-    }
-
-    /**
      * The setOptionalPropertyModel operation.
      *
      * @param input Round-trip model with readonly properties.
@@ -210,30 +185,5 @@ public final class ReadonlyPropertiesClient {
         return setOptionalPropertyModelWithResponse(BinaryData.fromObject(input), requestOptions)
                 .getValue()
                 .toObject(RoundTripModel.class);
-    }
-
-    /**
-     * The setOptionalPropertyModel operation.
-     *
-     * @param input Round-trip model with readonly properties.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return round-trip model with readonly properties along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<RoundTripModel> setOptionalPropertyModelWithResponse(RoundTripModel input, Context context) {
-        // Generated convenience method for setOptionalPropertyModelWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse =
-                setOptionalPropertyModelWithResponse(BinaryData.fromObject(input), requestOptions);
-        return new SimpleResponse<>(
-                protocolMethodResponse, protocolMethodResponse.getValue().toObject(RoundTripModel.class));
     }
 }

--- a/cadl-tests/src/main/java/com/roundtripbasic/RoundTripBasicClient.java
+++ b/cadl-tests/src/main/java/com/roundtripbasic/RoundTripBasicClient.java
@@ -14,9 +14,7 @@ import com.azure.core.exception.ResourceModifiedException;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.http.rest.Response;
-import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
 import com.roundtripbasic.models.RoundTripModel;
 
 /** Initializes a new instance of the synchronous RoundTripBasicClient type. */
@@ -89,30 +87,5 @@ public final class RoundTripBasicClient {
         return getModelWithResponse(BinaryData.fromObject(input), requestOptions)
                 .getValue()
                 .toObject(RoundTripModel.class);
-    }
-
-    /**
-     * The getModel operation.
-     *
-     * @param input Round-trip Model.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws com.azure.core.exception.HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return round-trip Model along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Response<RoundTripModel> getModelWithResponse(RoundTripModel input, Context context) {
-        // Generated convenience method for getModelWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        requestOptions.setContext(context);
-        Response<BinaryData> protocolMethodResponse =
-                getModelWithResponse(BinaryData.fromObject(input), requestOptions);
-        return new SimpleResponse<>(
-                protocolMethodResponse, protocolMethodResponse.getValue().toObject(RoundTripModel.class));
     }
 }

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -647,7 +647,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                                 .isGroupedParameterRequired(false)
                                 .methodVisibility(methodVisibility(ClientMethodType.SimpleSync, false, isProtocolMethod));
 
-                        if (!(settings.isFluent() || settings.isDataPlaneClient()) || !settings.isContextClientMethodParameter() || !generateClientMethodWithOnlyRequiredParameters) {
+                        if (!(settings.isFluent() || isProtocolMethod) || !settings.isContextClientMethodParameter() || !generateClientMethodWithOnlyRequiredParameters) {
                             // if context parameter is required, that method will do the overload with max parameters
                             methods.add(builder.build());
                         }
@@ -898,8 +898,8 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
             } else {
                 // at present, only generate convenience method for simple API (no pageable, no LRO)
                 return ((methodType == ClientMethodType.SimpleAsync && !hasContextParameter)
-                        || methodType == ClientMethodType.SimpleSync
-                        || (methodType == ClientMethodType.SimpleSyncRestResponse && hasContextParameter))
+                        || methodType == ClientMethodType.SimpleSync && !hasContextParameter)
+//                        || (methodType == ClientMethodType.SimpleSyncRestResponse && hasContextParameter))
                         ? VISIBLE
                         : NOT_GENERATE;
             }


### PR DESCRIPTION
for both sync/async

generate convenience method for
`foo(required)`

if there is optional parameters, generate
`foo(required, optional)`

at present, do not generate `WithResponse` (to be discussed later).