### PR TITLE
Add tests for cadl-ranch models/property-types

### DIFF
--- a/cadl-tests/src/test/java/com/models/property/types/BooleanOperationClientTest.java
+++ b/cadl-tests/src/test/java/com/models/property/types/BooleanOperationClientTest.java
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.models.property.types;
+
+import com.models.property.types.models.BooleanProperty;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class BooleanOperationClientTest {
+
+    BooleanOperationClient client = new BooleanOperationClientBuilder().buildClient();
+
+    @Test
+    void get() {
+        BooleanProperty response = client.get();
+        Assertions.assertTrue(response.isProperty());
+    }
+
+    @Test
+    void put() {
+        BooleanProperty booleanProperty = new BooleanProperty(true);
+        client.put(booleanProperty);
+    }
+}

--- a/cadl-tests/src/test/java/com/models/property/types/BytesClientTest.java
+++ b/cadl-tests/src/test/java/com/models/property/types/BytesClientTest.java
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.models.property.types;
+
+import com.models.property.types.models.BytesProperty;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class BytesClientTest {
+
+    BytesClient client = new BytesClientBuilder().buildClient();
+
+    @Test
+    void get() {
+        BytesProperty bytesProperty = client.get();
+        Assertions.assertNotNull(bytesProperty.getProperty());
+    }
+
+    @Test
+    void put() {
+        byte[] input = new byte[]{104, 101, 108, 108, 111, 44, 32, 119, 111, 114, 108, 100, 33};
+        BytesProperty bytesProperty = new BytesProperty(input);
+        client.put(bytesProperty);
+    }
+}

--- a/cadl-tests/src/test/java/com/models/property/types/CollectionsIntClientTest.java
+++ b/cadl-tests/src/test/java/com/models/property/types/CollectionsIntClientTest.java
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.models.property.types;
+
+import com.models.property.types.models.CollectionsIntProperty;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+class CollectionsIntClientTest {
+
+    CollectionsIntClient client = new CollectionsIntClientBuilder().buildClient();
+
+    @Test
+    void get() {
+        CollectionsIntProperty collectionsIntProperty = client.get();
+        List<Long> properties = collectionsIntProperty.getProperty();
+        Assertions.assertEquals(1L, properties.get(0));
+        Assertions.assertEquals(2L, properties.get(1));
+    }
+
+    @Test
+    void put() {
+        CollectionsIntProperty collectionsIntProperty = new CollectionsIntProperty(Arrays.asList(1L, 2L));
+        client.put(collectionsIntProperty);
+    }
+}

--- a/cadl-tests/src/test/java/com/models/property/types/CollectionsModelClientTest.java
+++ b/cadl-tests/src/test/java/com/models/property/types/CollectionsModelClientTest.java
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.models.property.types;
+
+import com.models.property.types.models.CollectionsModelProperty;
+import com.models.property.types.models.InnerModel;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+class CollectionsModelClientTest {
+
+    CollectionsModelClient client = new CollectionsModelClientBuilder().buildClient();
+
+    @Test
+    void get() {
+        CollectionsModelProperty collectionsModelProperty = client.get();
+        List<InnerModel> properties = collectionsModelProperty.getProperty();
+        Assertions.assertEquals("hello", properties.get(0).getProperty());
+        Assertions.assertEquals("world", properties.get(1).getProperty());
+    }
+
+    @Test
+    void put() {
+        InnerModel innerModel1 = new InnerModel("hello");
+        InnerModel innerModel2 = new InnerModel("world");
+        List<InnerModel> properties = Arrays.asList(innerModel1, innerModel2);
+        CollectionsModelProperty collectionsModelProperty = new CollectionsModelProperty(properties);
+        client.put(collectionsModelProperty);
+    }
+}

--- a/cadl-tests/src/test/java/com/models/property/types/CollectionsStringClientTest.java
+++ b/cadl-tests/src/test/java/com/models/property/types/CollectionsStringClientTest.java
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.models.property.types;
+
+import com.models.property.types.models.CollectionsStringProperty;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+class CollectionsStringClientTest {
+
+    CollectionsStringClient client = new CollectionsStringClientBuilder().buildClient();
+
+    @Test
+    void get() {
+        CollectionsStringProperty collectionsStringProperty = client.get();
+        System.out.println(collectionsStringProperty);
+        Assertions.assertEquals("hello", collectionsStringProperty.getProperty().get(0));
+        Assertions.assertEquals("world", collectionsStringProperty.getProperty().get(1));
+    }
+
+    @Test
+    void put() {
+        CollectionsStringProperty collectionsStringProperty = new CollectionsStringProperty(Arrays.asList("hello", "world"));
+        client.put(collectionsStringProperty);
+    }
+}

--- a/cadl-tests/src/test/java/com/models/property/types/DatetimeOperationClientTest.java
+++ b/cadl-tests/src/test/java/com/models/property/types/DatetimeOperationClientTest.java
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.models.property.types;
+
+import com.models.property.types.models.DatetimeProperty;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+
+class DatetimeOperationClientTest {
+
+    DatetimeOperationClient client = new DatetimeOperationClientBuilder().buildClient();
+
+    @Test
+    void get() {
+        DatetimeProperty datetimeProperty = client.get();
+        System.out.println(datetimeProperty);
+        Assertions.assertEquals("2022-08-26T18:38Z", datetimeProperty.getProperty().toString());
+    }
+
+    @Test
+    void put() {
+        OffsetDateTime offsetDateTime = OffsetDateTime.parse("2022-08-26T18:38Z");
+        DatetimeProperty datetimeProperty = new DatetimeProperty(offsetDateTime);
+        client.put(datetimeProperty);
+    }
+}

--- a/cadl-tests/src/test/java/com/models/property/types/DurationOperationClientTest.java
+++ b/cadl-tests/src/test/java/com/models/property/types/DurationOperationClientTest.java
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.models.property.types;
+
+import com.models.property.types.models.DurationProperty;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+class DurationOperationClientTest {
+
+    DurationOperationClient client = new DurationOperationClientBuilder().buildClient();
+
+    @Disabled("cadl-ranch definition error")
+    @Test
+    void get() {
+        DurationProperty durationProperty = client.get();
+    }
+
+    @Disabled("cadl-ranch definition error")
+    @Test
+    void put() {
+    }
+}

--- a/cadl-tests/src/test/java/com/models/property/types/EnumClientTest.java
+++ b/cadl-tests/src/test/java/com/models/property/types/EnumClientTest.java
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.models.property.types;
+
+import com.models.property.types.models.EnumProperty;
+import com.models.property.types.models.InnerEnum;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EnumClientTest {
+
+    EnumClient client = new EnumClientBuilder().buildClient();
+
+    @Test
+    void get() {
+        EnumProperty enumProperty = client.get();
+        InnerEnum innerEnum = enumProperty.getProperty();
+        Assertions.assertEquals("ValueOne", innerEnum.toString());
+    }
+
+    @Test
+    void put() {
+        InnerEnum innerEnum = InnerEnum.VALUE_ONE;
+        EnumProperty enumProperty = new EnumProperty(innerEnum);
+        client.put(enumProperty);
+    }
+}

--- a/cadl-tests/src/test/java/com/models/property/types/ExtensibleEnumClientTest.java
+++ b/cadl-tests/src/test/java/com/models/property/types/ExtensibleEnumClientTest.java
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.models.property.types;
+
+import com.models.property.types.models.ExtensibleEnumProperty;
+import com.models.property.types.models.InnerExtensibleEnum;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ExtensibleEnumClientTest {
+
+    ExtensibleEnumClient client = new ExtensibleEnumClientBuilder().buildClient();
+
+    @Test
+    void get() {
+        ExtensibleEnumProperty extensibleEnumProperty = client.get();
+        InnerExtensibleEnum innerExtensibleEnum = extensibleEnumProperty.getProperty();
+        Assertions.assertEquals("UnknownValue", innerExtensibleEnum.toString());
+    }
+
+    @Test
+    void put() {
+        ExtensibleEnumProperty extensibleEnumProperty = new ExtensibleEnumProperty(InnerExtensibleEnum.fromString("UnknownValue"));
+        client.put(extensibleEnumProperty);
+    }
+}

--- a/cadl-tests/src/test/java/com/models/property/types/FloatOperationClientTest.java
+++ b/cadl-tests/src/test/java/com/models/property/types/FloatOperationClientTest.java
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.models.property.types;
+
+import com.models.property.types.models.FloatProperty;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class FloatOperationClientTest {
+
+    FloatOperationClient client = new FloatOperationClientBuilder().buildClient();
+
+    @Test
+    void get() {
+        FloatProperty floatProperty = client.get();
+        Assertions.assertEquals(42.42, floatProperty.getProperty());
+    }
+
+    @Test
+    void put() {
+        FloatProperty floatProperty = new FloatProperty(42.42);
+        client.put(floatProperty);
+    }
+}

--- a/cadl-tests/src/test/java/com/models/property/types/IntClientTest.java
+++ b/cadl-tests/src/test/java/com/models/property/types/IntClientTest.java
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.models.property.types;
+
+import com.models.property.types.models.IntProperty;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class IntClientTest {
+
+    IntClient client = new IntClientBuilder().buildClient();
+
+    @Test
+    void get() {
+        IntProperty intProperty = client.get();
+        Assertions.assertEquals(42, intProperty.getProperty());
+    }
+
+    @Test
+    void put() {
+        IntProperty intProperty = new IntProperty(42);
+        client.put(intProperty);
+    }
+}

--- a/cadl-tests/src/test/java/com/models/property/types/ModelClientTest.java
+++ b/cadl-tests/src/test/java/com/models/property/types/ModelClientTest.java
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.models.property.types;
+
+import com.models.property.types.models.InnerModel;
+import com.models.property.types.models.ModelProperty;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ModelClientTest {
+
+    ModelClient client = new ModelClientBuilder().buildClient();
+
+    @Test
+    void get() {
+        ModelProperty modelProperty = client.get();
+        Assertions.assertEquals("hello", modelProperty.getProperty().getProperty());
+    }
+
+    @Test
+    void put() {
+        InnerModel innerModel = new InnerModel("hello");
+        ModelProperty modelProperty = new ModelProperty(innerModel);
+        client.put(modelProperty);
+    }
+}

--- a/cadl-tests/src/test/java/com/models/property/types/StringOperationClientTest.java
+++ b/cadl-tests/src/test/java/com/models/property/types/StringOperationClientTest.java
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.models.property.types;
+
+import com.models.property.types.models.StringProperty;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class StringOperationClientTest {
+
+    StringOperationClient client = new StringOperationClientBuilder().buildClient();
+
+    @Test
+    void get() {
+        StringProperty stringProperty = client.get();
+        Assertions.assertEquals("hello", stringProperty.getProperty());
+    }
+
+    @Test
+    void put() {
+        StringProperty stringProperty = new StringProperty("hello");
+        client.put(stringProperty);
+    }
+}


### PR DESCRIPTION
cadl-ranch has mock api for models/property/types. I added the corresponding tests in our autorest.java.