### PR TITLE
cadl, log warning when rename templated model

### DIFF
--- a/cadl-extension/src/code-model-builder.ts
+++ b/cadl-extension/src/code-model-builder.ts
@@ -1139,7 +1139,7 @@ export class CodeModelBuilder {
           newName = target.name + "Request";
         } else {
           // hack for other cases, mostly Page<>
-          newName = (
+          newName =
             target.name +
             target
               .templateArguments!.map((it) => {
@@ -1152,8 +1152,7 @@ export class CodeModelBuilder {
                     return "";
                 }
               })
-              .join("")
-          );
+              .join("");
         }
         this.program.logger.warn(`Rename Cadl model '${cadlName}' to '${newName}'`);
         return newName;


### PR DESCRIPTION
e.g., on authoring

```
warning: Rename Cadl model 'OptionalProperties<UpdateableProperties<DefaultKeyVisibility<Project, read>>>' to 'ProjectRequest'
warning: Rename Cadl model 'Azure.Core.Foundations.CustomPage<Project, (anonymous model)>' to 'CustomPageProject'
warning: Rename Cadl model 'Azure.Core.Foundations.CustomPage<Deployment, {}>' to 'CustomPageDeployment'
```