### PR TITLE
mgmt, enable generate-tests for fluent lite

### DIFF
--- a/fluent-tests/prepare-tests.bat
+++ b/fluent-tests/prepare-tests.bat
@@ -15,7 +15,7 @@ SET AUTOREST_CORE_VERSION=3.8.4
 SET MODELERFOUR_ARGUMENTS=--modelerfour.additional-checks=false --modelerfour.lenient-model-deduplication=true
 SET COMMON_ARGUMENTS=--java --use=../ --java.output-folder=./ %MODELERFOUR_ARGUMENTS% --azure-arm --java.license-header=MICROSOFT_MIT_SMALL
 SET FLUENT_ARGUMENTS=%COMMON_ARGUMENTS% --fluent
-SET FLUENTLITE_ARGUMENTS=%COMMON_ARGUMENTS% --fluent=lite --generate-samples
+SET FLUENTLITE_ARGUMENTS=%COMMON_ARGUMENTS% --fluent=lite --generate-samples --generate-tests
 
 REM fluent premium
 CALL autorest --version=%AUTOREST_CORE_VERSION% %FLUENT_ARGUMENTS% --input-file=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/resources/resource-manager/Microsoft.Resources/stable/2019-08-01/resources.json --namespace=com.azure.mgmttest.resources

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
@@ -278,7 +278,9 @@ public class FluentGen extends Javagen {
         if (javaSettings.isGenerateTests()) {
             // Unit tests for models
             for (ClientModel model : client.getModels()) {
-                javaPackage.addModelUnitTest(model);
+                if (!model.isStronglyTypedHeader()) {
+                    javaPackage.addModelUnitTest(model);
+                }
             }
         }
 

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/UnitTestParser.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/UnitTestParser.java
@@ -20,6 +20,7 @@ import com.azure.autorest.model.clientmodel.ProxyMethodExample;
 import com.azure.autorest.model.clientmodel.examplemodel.ExampleNode;
 import com.azure.autorest.util.ModelExampleUtil;
 import com.azure.autorest.util.ModelTestCaseUtil;
+import com.azure.core.http.HttpMethod;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -169,7 +170,10 @@ public class UnitTestParser extends ExampleParser {
         if (clientMethod.getType() == ClientMethodType.SimpleSync
                 || clientMethod.getType() == ClientMethodType.PagingSync
                 // limit the scope of LRO to status code of 200
-                || (clientMethod.getType() == ClientMethodType.LongRunningSync && clientMethod.getProxyMethod().getResponseExpectedStatusCodes().contains(200))) {
+                || (clientMethod.getType() == ClientMethodType.LongRunningSync
+                && clientMethod.getProxyMethod().getResponseExpectedStatusCodes().contains(200)
+                // also azure-core-management does not support LRO from GET
+                && clientMethod.getProxyMethod().getHttpMethod() != HttpMethod.GET)) {
             // generate example for the method with full parameters
             return clientMethod.getParameters().stream().anyMatch(p -> ClassType.Context.equals(p.getClientType()));
         }


### PR DESCRIPTION
bug fix
- no UT for Headers models (too much trouble about `HttpHeaders` in ctor)
- no UT for GET LRO (not supported in core-management)