### PR TITLE
Fix Issues with HttpHeaders Custom Deserialization

### DIFF
--- a/androidgen/src/main/java/com/azure/autorest/android/Androidgen.java
+++ b/androidgen/src/main/java/com/azure/autorest/android/Androidgen.java
@@ -82,6 +82,7 @@ public class Androidgen extends Javagen {
             };
 
             LoaderOptions loaderOptions = new LoaderOptions();
+            loaderOptions.setCodePointLimit(50 * 1024 * 1024);
             loaderOptions.setMaxAliasesForCollections(Integer.MAX_VALUE);
             loaderOptions.setNestingDepthLimit(Integer.MAX_VALUE);
             Yaml newYaml = new Yaml(new Constructor(loaderOptions), representer, new DumperOptions(), loaderOptions);

--- a/cadl-extension/src/main/java/com/azure/cadl/Main.java
+++ b/cadl-extension/src/main/java/com/azure/cadl/Main.java
@@ -144,6 +144,7 @@ public class Main {
         representer.setPropertyUtils(new AnnotatedPropertyUtils());
         representer.getPropertyUtils().setSkipMissingProperties(true);
         LoaderOptions loaderOptions = new LoaderOptions();
+        loaderOptions.setCodePointLimit(50 * 1024 * 1024);
         loaderOptions.setMaxAliasesForCollections(Integer.MAX_VALUE);
         loaderOptions.setNestingDepthLimit(Integer.MAX_VALUE);
         Constructor constructor = new CodeModelCustomConstructor(loaderOptions);

--- a/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/NewPlugin.java
+++ b/extension-base/src/main/java/com/azure/autorest/extension/base/plugin/NewPlugin.java
@@ -199,6 +199,7 @@ public abstract class NewPlugin {
         representer.setPropertyUtils(new AnnotatedPropertyUtils());
         representer.getPropertyUtils().setSkipMissingProperties(true);
         LoaderOptions loaderOptions = new LoaderOptions();
+        loaderOptions.setCodePointLimit(50 * 1024 * 1024);
         loaderOptions.setMaxAliasesForCollections(Integer.MAX_VALUE);
         loaderOptions.setNestingDepthLimit(Integer.MAX_VALUE);
         Constructor constructor = new CodeModelCustomConstructor(loaderOptions);

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/FluentGen.java
@@ -167,6 +167,7 @@ public class FluentGen extends Javagen {
             }
         };
         LoaderOptions loaderOptions = new LoaderOptions();
+        loaderOptions.setCodePointLimit(50 * 1024 * 1024);
         loaderOptions.setMaxAliasesForCollections(Integer.MAX_VALUE);
         loaderOptions.setNestingDepthLimit(Integer.MAX_VALUE);
         Yaml newYaml = new Yaml(new Constructor(loaderOptions), representer, new DumperOptions(), loaderOptions);

--- a/fluentgen/src/test/java/com/azure/autorest/extension/base/plugin/YamlPropertyTest.java
+++ b/fluentgen/src/test/java/com/azure/autorest/extension/base/plugin/YamlPropertyTest.java
@@ -24,6 +24,7 @@ public class YamlPropertyTest {
         representer.getPropertyUtils().setSkipMissingProperties(true);
 
         LoaderOptions loaderOptions = new LoaderOptions();
+        loaderOptions.setCodePointLimit(50 * 1024 * 1024);
         loaderOptions.setMaxAliasesForCollections(Integer.MAX_VALUE);
         loaderOptions.setNestingDepthLimit(Integer.MAX_VALUE);
         Constructor constructor = new CodeModelCustomConstructor(loaderOptions);

--- a/fluentnamer/src/main/java/com/azure/autorest/fluentnamer/FluentNamer.java
+++ b/fluentnamer/src/main/java/com/azure/autorest/fluentnamer/FluentNamer.java
@@ -113,6 +113,7 @@ public class FluentNamer extends NewPlugin {
             }
         };
         LoaderOptions loaderOptions = new LoaderOptions();
+        loaderOptions.setCodePointLimit(50 * 1024 * 1024);
         loaderOptions.setMaxAliasesForCollections(Integer.MAX_VALUE);
         loaderOptions.setNestingDepthLimit(Integer.MAX_VALUE);
         return new Yaml(new Constructor(loaderOptions), representer, new DumperOptions(), loaderOptions);

--- a/javagen/src/main/java/com/azure/autorest/Javagen.java
+++ b/javagen/src/main/java/com/azure/autorest/Javagen.java
@@ -145,6 +145,7 @@ public class Javagen extends NewPlugin {
         };
 
         LoaderOptions loaderOptions = new LoaderOptions();
+        loaderOptions.setCodePointLimit(50 * 1024 * 1024);
         loaderOptions.setMaxAliasesForCollections(Integer.MAX_VALUE);
         loaderOptions.setNestingDepthLimit(Integer.MAX_VALUE);
         Yaml newYaml = new Yaml(new Constructor(loaderOptions), representer, new DumperOptions(), loaderOptions);

--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -921,7 +921,7 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
             // At this time all try-catching is for IOExceptions.
             javaBlock.decreaseIndent();
             javaBlock.line("} catch (IOException ex) {");
-            javaBlock.indent(() -> javaBlock.line("throw new UncheckedIOException(ex);"));
+            javaBlock.indent(() -> javaBlock.line("throw LOGGER.logExceptionAsError(new UncheckedIOException(ex));"));
             javaBlock.line("}");
         }
     }

--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -28,11 +28,15 @@ import com.azure.autorest.util.ClientModelUtil;
 import com.azure.autorest.util.TemplateUtil;
 import com.azure.core.http.HttpHeader;
 import com.azure.core.util.CoreUtils;
+import com.azure.core.util.logging.ClientLogger;
 import com.azure.core.util.serializer.JacksonAdapter;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonSetter;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
@@ -40,6 +44,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.regex.Pattern;
@@ -236,7 +241,7 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
 
             addPropertyValidations(classBlock, model, settings);
 
-            if (settings.shouldClientSideValidations() && settings.shouldClientLogger()) {
+            if ((settings.shouldClientSideValidations() && settings.shouldClientLogger()) || model.isStronglyTypedHeader()) {
                 TemplateUtil.addClientLogger(classBlock, model.getName(), javaFile.getContents());
             }
 
@@ -266,6 +271,11 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
             imports.add(Base64.class.getName());
             imports.add(HashMap.class.getName());
             imports.add(HttpHeader.class.getName());
+            imports.add(UUID.class.getName());
+            imports.add(URL.class.getName());
+            imports.add(IOException.class.getName());
+            imports.add(UncheckedIOException.class.getName());
+            imports.add(ClientLogger.class.getName());
 
             // JacksonAdapter will be removed in the future once model types are converted to using stream-style
             // serialization. For now, it's needed to handle the rare scenario where the strong type is a non-Java
@@ -855,6 +865,7 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
             rawHeaderAccess = property.getName();
         }
 
+        boolean needsTryCatch = false;
         String setter;
         if (wireType == PrimitiveType.Boolean || wireType == ClassType.Boolean) {
             setter = String.format("Boolean.parseBoolean(%s)", rawHeaderAccess);
@@ -878,13 +889,24 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
             setter = String.format("LocalDate.parse(%s)", rawHeaderAccess);
         } else if (wireType == ClassType.Duration) {
             setter = String.format("Duration.parse(%s)", rawHeaderAccess);
+        } else if (wireType == ClassType.UUID) {
+            setter = "UUID.fromString(" + rawHeaderAccess + ")";
+        } else if (wireType == ClassType.URL) {
+            needsTryCatch = true;
+            setter = "new URL(" + rawHeaderAccess + ")";
         } else if (wireType instanceof EnumType) {
             EnumType enumType = (EnumType) wireType;
             setter = String.format("%s.%s(%s)", enumType.getName(), enumType.getFromJsonMethodName(), rawHeaderAccess);
         } else {
             // TODO (alzimmer): Check if the wire type is a Swagger type that could use stream-style serialization.
+            needsTryCatch = true;
             setter = String.format("JacksonAdapter.createDefaultSerializerAdapter().deserializeHeader(rawHeaders.get(\"%s\"), %s)",
                 property.getSerializedName(), getWireTypeJavaType(wireType));
+        }
+
+        if (needsTryCatch) {
+            javaBlock.line("try {");
+            javaBlock.increaseIndent();
         }
 
         // String is special as the setter is null safe for it, unlike other nullable types.
@@ -893,6 +915,14 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                 ifBlock -> ifBlock.line("this.%s = %s;", property.getName(), setter));
         } else {
             javaBlock.line("this.%s = %s;", property.getName(), setter);
+        }
+
+        if (needsTryCatch) {
+            // At this time all try-catching is for IOExceptions.
+            javaBlock.decreaseIndent();
+            javaBlock.line("} catch (IOException ex) {");
+            javaBlock.indent(() -> javaBlock.line("throw new UncheckedIOException(ex);"));
+            javaBlock.line("}");
         }
     }
 

--- a/javagen/src/main/java/com/azure/autorest/template/StreamSerializationModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/StreamSerializationModelTemplate.java
@@ -20,7 +20,6 @@ import com.azure.autorest.model.javamodel.JavaIfBlock;
 import com.azure.autorest.model.javamodel.JavaVisibility;
 import com.azure.autorest.util.ClientModelUtil;
 import com.azure.core.util.CoreUtils;
-import com.azure.json.DefaultJsonReader;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
 import com.azure.json.JsonToken;
@@ -63,7 +62,6 @@ public class StreamSerializationModelTemplate extends ModelTemplate {
         imports.add(JsonSerializable.class.getName());
         imports.add(JsonWriter.class.getName());
         imports.add(JsonReader.class.getName());
-        imports.add(DefaultJsonReader.class.getName());
         imports.add(JsonToken.class.getName());
 
         imports.add(CoreUtils.class.getName());

--- a/preprocessor/src/main/java/com/azure/autorest/preprocessor/Preprocessor.java
+++ b/preprocessor/src/main/java/com/azure/autorest/preprocessor/Preprocessor.java
@@ -94,6 +94,7 @@ public class Preprocessor extends NewPlugin {
       }
     };
     LoaderOptions loaderOptions = new LoaderOptions();
+    loaderOptions.setCodePointLimit(50 * 1024 * 1024);
     loaderOptions.setMaxAliasesForCollections(Integer.MAX_VALUE);
     Yaml newYaml = new Yaml(new Constructor(loaderOptions), representer, new DumperOptions(), loaderOptions);
     String output = newYaml.dump(codeModel);

--- a/preprocessor/src/test/java/com/azure/autorest/MockPreprocessor.java
+++ b/preprocessor/src/test/java/com/azure/autorest/MockPreprocessor.java
@@ -19,7 +19,6 @@ import org.yaml.snakeyaml.nodes.Tag;
 import org.yaml.snakeyaml.representer.Representer;
 
 import java.io.BufferedReader;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -87,6 +86,7 @@ public class MockPreprocessor extends Preprocessor {
             }
         };
         LoaderOptions loaderOptions = new LoaderOptions();
+        loaderOptions.setCodePointLimit(50 * 1024 * 1024);
         loaderOptions.setMaxAliasesForCollections(Integer.MAX_VALUE);
         loaderOptions.setNestingDepthLimit(Integer.MAX_VALUE);
         Yaml newYaml = new Yaml(new Constructor(loaderOptions), representer, new DumperOptions(), loaderOptions);


### PR DESCRIPTION
Fixes #1702 

Resolves a few issues when using custom strongly-typed header deserialization:

- Added direct support for `UUID` and `URL`.
- Added try-catching for `URL` and when `JacksonAdapter` is used.