### PR TITLE
client, avoid error when sync-method=none

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -375,7 +375,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                         MethodPageDetails details = new MethodPageDetails(
                                 CodeNamer.getPropertyName(operation.getExtensions().getXmsPageable().getNextLinkName()),
                                 pageableItemName,
-                                (nextMethods == null) ? null : nextMethods.stream().findFirst().get(),
+                                (nextMethods == null) ? null : nextMethods.stream().findFirst().orElse(null),
                                 lroIntermediateType,
                                 operation.getExtensions().getXmsPageable().getNextLinkName(),
                                 operation.getExtensions().getXmsPageable().getItemName());


### PR DESCRIPTION
fix https://github.com/Azure/autorest.java/issues/1703

the `nextMethods` is empty since the option is to generate no method at all...