### PR TITLE
Client, deduplicate class name, avoid Java keyword

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -21,6 +21,7 @@ import com.azure.autorest.model.clientmodel.ClientMethodParameter;
 import com.azure.autorest.model.clientmodel.ClientMethodType;
 import com.azure.autorest.model.clientmodel.ClientModel;
 import com.azure.autorest.model.clientmodel.ClientModelProperty;
+import com.azure.autorest.model.clientmodel.ClientModels;
 import com.azure.autorest.model.clientmodel.EnumType;
 import com.azure.autorest.model.clientmodel.GenericType;
 import com.azure.autorest.model.clientmodel.IType;
@@ -753,7 +754,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
             return GenericType.RestResponse(Mappers.getSchemaMapper().map(ClientMapper.parseHeader(operation, settings)),
                     syncReturnType);
         } else {
-            return ClientMapper.getClientResponseClassType(operation, settings);
+            return ClientMapper.getClientResponseClassType(operation, ClientModels.getInstance().getModels(), settings);
         }
     }
 

--- a/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ProxyMethodMapper.java
@@ -12,6 +12,7 @@ import com.azure.autorest.extension.base.model.codemodel.Response;
 import com.azure.autorest.extension.base.plugin.JavaSettings;
 import com.azure.autorest.extension.base.plugin.PluginLogger;
 import com.azure.autorest.model.clientmodel.ClassType;
+import com.azure.autorest.model.clientmodel.ClientModels;
 import com.azure.autorest.model.clientmodel.EnumType;
 import com.azure.autorest.model.clientmodel.GenericType;
 import com.azure.autorest.model.clientmodel.IType;
@@ -342,7 +343,7 @@ public class ProxyMethodMapper implements IMapper<Operation, Map<Request, List<P
                         responseBodyType);
                 return createSingleValueAsyncReturnType(genericResponseType);
             } else {
-                ClassType clientResponseClassType = ClientMapper.getClientResponseClassType(operation, settings);
+                ClassType clientResponseClassType = ClientMapper.getClientResponseClassType(operation, ClientModels.getInstance().getModels(), settings);
                 return createClientResponseAsyncReturnType(clientResponseClassType);
             }
         } else {

--- a/javagen/src/main/java/com/azure/autorest/util/CodeNamer.java
+++ b/javagen/src/main/java/com/azure/autorest/util/CodeNamer.java
@@ -209,7 +209,7 @@ public class CodeNamer {
         if (name == null || name.trim().isEmpty()) {
             return name;
         }
-        return toCamelCase(removeInvalidCharacters(getEscapedReservedName(name, "Property")));
+        return getEscapedReservedName(toCamelCase(removeInvalidCharacters(name)), "Property");
     }
 
     public static String getPlural(String name) {

--- a/preprocessor/src/main/java/com/azure/autorest/preprocessor/namer/CodeNamer.java
+++ b/preprocessor/src/main/java/com/azure/autorest/preprocessor/namer/CodeNamer.java
@@ -195,21 +195,21 @@ public class CodeNamer {
         if (name == null || name.trim().isEmpty()) {
             return name;
         }
-        return toPascalCase(removeInvalidCharacters(getEscapedReservedNameAndClasses(name, "Model")));
+        return getEscapedReservedNameAndClasses(toPascalCase(removeInvalidCharacters(name)), "Model");
     }
 
     public static String getParameterName(String name) {
         if (name == null || name.trim().isEmpty()) {
             return name;
         }
-        return toCamelCase(removeInvalidCharacters(getEscapedReservedName(name, "Parameter")));
+        return getEscapedReservedName(toCamelCase(removeInvalidCharacters(name)), "Parameter");
     }
 
     public static String getPropertyName(String name) {
         if (name == null || name.trim().isEmpty()) {
             return name;
         }
-        return toCamelCase(removeInvalidCharacters(getEscapedReservedName(name, "Property")));
+        return getEscapedReservedName(toCamelCase(removeInvalidCharacters(name)), "Property");
     }
 
     public static String getMethodGroupName(String name) {


### PR DESCRIPTION
fix https://github.com/Azure/autorest.java/issues/1707

Root cause is that the spec has "apps_list_regions_response", hence the model as "AppsListRegionsResponse".

Then there is client response "AppsListRegionsResponse" from "Apps" and "ListRegions".

In usual usage, we recommend `--generic-response-type=true` option.

---

Also fix another issue of conflict with reserved Java keyword ("private" in this case).

Escape name from keyword should happen after camel casing or pascal casing, as changing case would make non-keyword to keyword ("Private" to "private" in this case).