### PR TITLE
StreamResponse and Miscellaneous Fixes

### DIFF
--- a/azure-tests/src/main/java/fixtures/custombaseuri/paging/Pagings.java
+++ b/azure-tests/src/main/java/fixtures/custombaseuri/paging/Pagings.java
@@ -15,6 +15,8 @@ import com.azure.core.annotation.ServiceInterface;
 import com.azure.core.annotation.ServiceMethod;
 import com.azure.core.annotation.UnexpectedResponseExceptionType;
 import com.azure.core.exception.HttpResponseException;
+import com.azure.core.http.rest.PagedFlux;
+import com.azure.core.http.rest.PagedIterable;
 import com.azure.core.http.rest.PagedResponse;
 import com.azure.core.http.rest.PagedResponseBase;
 import com.azure.core.http.rest.Response;
@@ -128,11 +130,41 @@ public final class Pagings {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> getPagesPartialUrlAsync(String accountName) {
+        return new PagedFlux<>(
+                () -> getPagesPartialUrlSinglePageAsync(accountName),
+                nextLink -> getPagesPartialUrlNextSinglePageAsync(nextLink, accountName));
+    }
+
+    /**
+     * A paging operation that combines custom url, paging and partial URL and expect to concat after host.
+     *
+     * @param accountName Account Name.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getPagesPartialUrlSinglePage(String accountName) {
         return getPagesPartialUrlSinglePageAsync(accountName).block();
+    }
+
+    /**
+     * A paging operation that combines custom url, paging and partial URL and expect to concat after host.
+     *
+     * @param accountName Account Name.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> getPagesPartialUrl(String accountName) {
+        return new PagedIterable<>(getPagesPartialUrlAsync(accountName));
     }
 
     /**
@@ -176,11 +208,41 @@ public final class Pagings {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> getPagesPartialUrlOperationAsync(String accountName) {
+        return new PagedFlux<>(
+                () -> getPagesPartialUrlOperationSinglePageAsync(accountName),
+                nextLink -> getPagesPartialUrlOperationNextSinglePageAsync(accountName, nextLink));
+    }
+
+    /**
+     * A paging operation that combines custom url, paging and partial URL with next operation.
+     *
+     * @param accountName Account Name.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getPagesPartialUrlOperationSinglePage(String accountName) {
         return getPagesPartialUrlOperationSinglePageAsync(accountName).block();
+    }
+
+    /**
+     * A paging operation that combines custom url, paging and partial URL with next operation.
+     *
+     * @param accountName Account Name.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> getPagesPartialUrlOperation(String accountName) {
+        return new PagedIterable<>(getPagesPartialUrlOperationAsync(accountName));
     }
 
     /**

--- a/azure-tests/src/main/java/fixtures/custombaseuri/paging/Pagings.java
+++ b/azure-tests/src/main/java/fixtures/custombaseuri/paging/Pagings.java
@@ -15,8 +15,6 @@ import com.azure.core.annotation.ServiceInterface;
 import com.azure.core.annotation.ServiceMethod;
 import com.azure.core.annotation.UnexpectedResponseExceptionType;
 import com.azure.core.exception.HttpResponseException;
-import com.azure.core.http.rest.PagedFlux;
-import com.azure.core.http.rest.PagedIterable;
 import com.azure.core.http.rest.PagedResponse;
 import com.azure.core.http.rest.PagedResponseBase;
 import com.azure.core.http.rest.Response;
@@ -130,41 +128,11 @@ public final class Pagings {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> getPagesPartialUrlAsync(String accountName) {
-        return new PagedFlux<>(
-                () -> getPagesPartialUrlSinglePageAsync(accountName),
-                nextLink -> getPagesPartialUrlNextSinglePageAsync(nextLink, accountName));
-    }
-
-    /**
-     * A paging operation that combines custom url, paging and partial URL and expect to concat after host.
-     *
-     * @param accountName Account Name.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getPagesPartialUrlSinglePage(String accountName) {
         return getPagesPartialUrlSinglePageAsync(accountName).block();
-    }
-
-    /**
-     * A paging operation that combines custom url, paging and partial URL and expect to concat after host.
-     *
-     * @param accountName Account Name.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> getPagesPartialUrl(String accountName) {
-        return new PagedIterable<>(getPagesPartialUrlAsync(accountName));
     }
 
     /**
@@ -208,41 +176,11 @@ public final class Pagings {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> getPagesPartialUrlOperationAsync(String accountName) {
-        return new PagedFlux<>(
-                () -> getPagesPartialUrlOperationSinglePageAsync(accountName),
-                nextLink -> getPagesPartialUrlOperationNextSinglePageAsync(accountName, nextLink));
-    }
-
-    /**
-     * A paging operation that combines custom url, paging and partial URL with next operation.
-     *
-     * @param accountName Account Name.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getPagesPartialUrlOperationSinglePage(String accountName) {
         return getPagesPartialUrlOperationSinglePageAsync(accountName).block();
-    }
-
-    /**
-     * A paging operation that combines custom url, paging and partial URL with next operation.
-     *
-     * @param accountName Account Name.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> getPagesPartialUrlOperation(String accountName) {
-        return new PagedIterable<>(getPagesPartialUrlOperationAsync(accountName));
     }
 
     /**

--- a/azure-tests/src/main/java/fixtures/paging/Pagings.java
+++ b/azure-tests/src/main/java/fixtures/paging/Pagings.java
@@ -17,8 +17,6 @@ import com.azure.core.annotation.ServiceInterface;
 import com.azure.core.annotation.ServiceMethod;
 import com.azure.core.annotation.UnexpectedResponseExceptionType;
 import com.azure.core.exception.HttpResponseException;
-import com.azure.core.http.rest.PagedFlux;
-import com.azure.core.http.rest.PagedIterable;
 import com.azure.core.http.rest.PagedResponse;
 import com.azure.core.http.rest.PagedResponseBase;
 import com.azure.core.http.rest.Response;
@@ -461,36 +459,11 @@ public final class Pagings {
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> getNoItemNamePagesAsync() {
-        return new PagedFlux<>(
-                () -> getNoItemNamePagesSinglePageAsync(), nextLink -> getNoItemNamePagesNextSinglePageAsync(nextLink));
-    }
-
-    /**
-     * A paging operation that must return result of the default 'value' node.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getNoItemNamePagesSinglePage() {
         return getNoItemNamePagesSinglePageAsync().block();
-    }
-
-    /**
-     * A paging operation that must return result of the default 'value' node.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> getNoItemNamePages() {
-        return new PagedIterable<>(getNoItemNamePagesAsync());
     }
 
     /**
@@ -524,35 +497,11 @@ public final class Pagings {
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> getNullNextLinkNamePagesAsync() {
-        return new PagedFlux<>(() -> getNullNextLinkNamePagesSinglePageAsync());
-    }
-
-    /**
-     * A paging operation that must ignore any kind of nextLink, and stop after page 1.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getNullNextLinkNamePagesSinglePage() {
         return getNullNextLinkNamePagesSinglePageAsync().block();
-    }
-
-    /**
-     * A paging operation that must ignore any kind of nextLink, and stop after page 1.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> getNullNextLinkNamePages() {
-        return new PagedIterable<>(getNullNextLinkNamePagesAsync());
     }
 
     /**
@@ -586,36 +535,11 @@ public final class Pagings {
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> getSinglePagesAsync() {
-        return new PagedFlux<>(
-                () -> getSinglePagesSinglePageAsync(), nextLink -> getSinglePagesNextSinglePageAsync(nextLink));
-    }
-
-    /**
-     * A paging operation that finishes on the first call without a nextlink.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getSinglePagesSinglePage() {
         return getSinglePagesSinglePageAsync().block();
-    }
-
-    /**
-     * A paging operation that finishes on the first call without a nextlink.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> getSinglePages() {
-        return new PagedIterable<>(getSinglePagesAsync());
     }
 
     /**
@@ -651,38 +575,11 @@ public final class Pagings {
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> firstResponseEmptyAsync() {
-        return new PagedFlux<>(
-                () -> firstResponseEmptySinglePageAsync(), nextLink -> firstResponseEmptyNextSinglePageAsync(nextLink));
-    }
-
-    /**
-     * A paging operation whose first response's items list is empty, but still returns a next link. Second (and final)
-     * call, will give you an items list of 1.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> firstResponseEmptySinglePage() {
         return firstResponseEmptySinglePageAsync().block();
-    }
-
-    /**
-     * A paging operation whose first response's items list is empty, but still returns a next link. Second (and final)
-     * call, will give you an items list of 1.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> firstResponseEmpty() {
-        return new PagedIterable<>(firstResponseEmptyAsync());
     }
 
     /**
@@ -739,78 +636,12 @@ public final class Pagings {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> getMultiplePagesAsync(
-            String clientRequestId, PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) {
-        return new PagedFlux<>(
-                () -> getMultiplePagesSinglePageAsync(clientRequestId, pagingGetMultiplePagesOptions),
-                nextLink ->
-                        getMultiplePagesNextSinglePageAsync(nextLink, clientRequestId, pagingGetMultiplePagesOptions));
-    }
-
-    /**
-     * A paging operation that includes a nextLink that has 10 pages.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> getMultiplePagesAsync() {
-        final String clientRequestId = null;
-        final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions = null;
-        return new PagedFlux<>(
-                () -> getMultiplePagesSinglePageAsync(clientRequestId, pagingGetMultiplePagesOptions),
-                nextLink ->
-                        getMultiplePagesNextSinglePageAsync(nextLink, clientRequestId, pagingGetMultiplePagesOptions));
-    }
-
-    /**
-     * A paging operation that includes a nextLink that has 10 pages.
-     *
-     * @param clientRequestId The clientRequestId parameter.
-     * @param pagingGetMultiplePagesOptions Parameter group.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getMultiplePagesSinglePage(
             String clientRequestId, PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) {
         return getMultiplePagesSinglePageAsync(clientRequestId, pagingGetMultiplePagesOptions).block();
-    }
-
-    /**
-     * A paging operation that includes a nextLink that has 10 pages.
-     *
-     * @param clientRequestId The clientRequestId parameter.
-     * @param pagingGetMultiplePagesOptions Parameter group.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> getMultiplePages(
-            String clientRequestId, PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) {
-        return new PagedIterable<>(getMultiplePagesAsync(clientRequestId, pagingGetMultiplePagesOptions));
-    }
-
-    /**
-     * A paging operation that includes a nextLink that has 10 pages.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> getMultiplePages() {
-        final String clientRequestId = null;
-        final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions = null;
-        return new PagedIterable<>(getMultiplePagesAsync(clientRequestId, pagingGetMultiplePagesOptions));
     }
 
     /**
@@ -854,43 +685,11 @@ public final class Pagings {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> getWithQueryParamsAsync(int requiredQueryParameter) {
-        return new PagedFlux<>(
-                () -> getWithQueryParamsSinglePageAsync(requiredQueryParameter),
-                nextLink -> nextOperationWithQueryParamsSinglePageAsync());
-    }
-
-    /**
-     * A paging operation that includes a next operation. It has a different query parameter from it's next operation
-     * nextOperationWithQueryParams. Returns a ProductResult.
-     *
-     * @param requiredQueryParameter A required integer query parameter. Put in value '100' to pass test.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getWithQueryParamsSinglePage(int requiredQueryParameter) {
         return getWithQueryParamsSinglePageAsync(requiredQueryParameter).block();
-    }
-
-    /**
-     * A paging operation that includes a next operation. It has a different query parameter from it's next operation
-     * nextOperationWithQueryParams. Returns a ProductResult.
-     *
-     * @param requiredQueryParameter A required integer query parameter. Put in value '100' to pass test.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> getWithQueryParams(int requiredQueryParameter) {
-        return new PagedIterable<>(getWithQueryParamsAsync(requiredQueryParameter));
     }
 
     /**
@@ -930,71 +729,11 @@ public final class Pagings {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> duplicateParamsAsync(String filter) {
-        return new PagedFlux<>(
-                () -> duplicateParamsSinglePageAsync(filter), nextLink -> duplicateParamsNextSinglePageAsync(nextLink));
-    }
-
-    /**
-     * Define `filter` as a query param for all calls. However, the returned next link will also include the `filter` as
-     * part of it. Make sure you don't end up duplicating the `filter` param in the url sent.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> duplicateParamsAsync() {
-        final String filter = null;
-        return new PagedFlux<>(
-                () -> duplicateParamsSinglePageAsync(filter), nextLink -> duplicateParamsNextSinglePageAsync(nextLink));
-    }
-
-    /**
-     * Define `filter` as a query param for all calls. However, the returned next link will also include the `filter` as
-     * part of it. Make sure you don't end up duplicating the `filter` param in the url sent.
-     *
-     * @param filter OData filter options. Pass in 'foo'.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> duplicateParamsSinglePage(String filter) {
         return duplicateParamsSinglePageAsync(filter).block();
-    }
-
-    /**
-     * Define `filter` as a query param for all calls. However, the returned next link will also include the `filter` as
-     * part of it. Make sure you don't end up duplicating the `filter` param in the url sent.
-     *
-     * @param filter OData filter options. Pass in 'foo'.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> duplicateParams(String filter) {
-        return new PagedIterable<>(duplicateParamsAsync(filter));
-    }
-
-    /**
-     * Define `filter` as a query param for all calls. However, the returned next link will also include the `filter` as
-     * part of it. Make sure you don't end up duplicating the `filter` param in the url sent.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> duplicateParams() {
-        final String filter = null;
-        return new PagedIterable<>(duplicateParamsAsync(filter));
     }
 
     /**
@@ -1030,37 +769,11 @@ public final class Pagings {
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> pageWithMaxPageSizeAsync() {
-        return new PagedFlux<>(
-                () -> pageWithMaxPageSizeSinglePageAsync(),
-                nextLink -> pageWithMaxPageSizeNextSinglePageAsync(nextLink));
-    }
-
-    /**
-     * Paging with max page size. We don't want to.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> pageWithMaxPageSizeSinglePage() {
         return pageWithMaxPageSizeSinglePageAsync().block();
-    }
-
-    /**
-     * Paging with max page size. We don't want to.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> pageWithMaxPageSize() {
-        return new PagedIterable<>(pageWithMaxPageSizeAsync());
     }
 
     /**
@@ -1159,80 +872,12 @@ public final class Pagings {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> getOdataMultiplePagesAsync(
-            String clientRequestId, PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) {
-        return new PagedFlux<>(
-                () -> getOdataMultiplePagesSinglePageAsync(clientRequestId, pagingGetOdataMultiplePagesOptions),
-                nextLink ->
-                        getOdataMultiplePagesNextSinglePageAsync(
-                                nextLink, clientRequestId, pagingGetOdataMultiplePagesOptions));
-    }
-
-    /**
-     * A paging operation that includes a nextLink in odata format that has 10 pages.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> getOdataMultiplePagesAsync() {
-        final String clientRequestId = null;
-        final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions = null;
-        return new PagedFlux<>(
-                () -> getOdataMultiplePagesSinglePageAsync(clientRequestId, pagingGetOdataMultiplePagesOptions),
-                nextLink ->
-                        getOdataMultiplePagesNextSinglePageAsync(
-                                nextLink, clientRequestId, pagingGetOdataMultiplePagesOptions));
-    }
-
-    /**
-     * A paging operation that includes a nextLink in odata format that has 10 pages.
-     *
-     * @param clientRequestId The clientRequestId parameter.
-     * @param pagingGetOdataMultiplePagesOptions Parameter group.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getOdataMultiplePagesSinglePage(
             String clientRequestId, PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) {
         return getOdataMultiplePagesSinglePageAsync(clientRequestId, pagingGetOdataMultiplePagesOptions).block();
-    }
-
-    /**
-     * A paging operation that includes a nextLink in odata format that has 10 pages.
-     *
-     * @param clientRequestId The clientRequestId parameter.
-     * @param pagingGetOdataMultiplePagesOptions Parameter group.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> getOdataMultiplePages(
-            String clientRequestId, PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) {
-        return new PagedIterable<>(getOdataMultiplePagesAsync(clientRequestId, pagingGetOdataMultiplePagesOptions));
-    }
-
-    /**
-     * A paging operation that includes a nextLink in odata format that has 10 pages.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> getOdataMultiplePages() {
-        final String clientRequestId = null;
-        final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions = null;
-        return new PagedIterable<>(getOdataMultiplePagesAsync(clientRequestId, pagingGetOdataMultiplePagesOptions));
     }
 
     /**
@@ -1292,50 +937,6 @@ public final class Pagings {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> getMultiplePagesWithOffsetAsync(
-            PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions, String clientRequestId) {
-        return new PagedFlux<>(
-                () ->
-                        getMultiplePagesWithOffsetSinglePageAsync(
-                                pagingGetMultiplePagesWithOffsetOptions, clientRequestId),
-                nextLink ->
-                        getMultiplePagesWithOffsetNextSinglePageAsync(
-                                nextLink, pagingGetMultiplePagesWithOffsetOptions, clientRequestId));
-    }
-
-    /**
-     * A paging operation that includes a nextLink that has 10 pages.
-     *
-     * @param pagingGetMultiplePagesWithOffsetOptions Parameter group.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> getMultiplePagesWithOffsetAsync(
-            PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions) {
-        final String clientRequestId = null;
-        return new PagedFlux<>(
-                () ->
-                        getMultiplePagesWithOffsetSinglePageAsync(
-                                pagingGetMultiplePagesWithOffsetOptions, clientRequestId),
-                nextLink ->
-                        getMultiplePagesWithOffsetNextSinglePageAsync(
-                                nextLink, pagingGetMultiplePagesWithOffsetOptions, clientRequestId));
-    }
-
-    /**
-     * A paging operation that includes a nextLink that has 10 pages.
-     *
-     * @param pagingGetMultiplePagesWithOffsetOptions Parameter group.
-     * @param clientRequestId The clientRequestId parameter.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
@@ -1343,40 +944,6 @@ public final class Pagings {
             PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions, String clientRequestId) {
         return getMultiplePagesWithOffsetSinglePageAsync(pagingGetMultiplePagesWithOffsetOptions, clientRequestId)
                 .block();
-    }
-
-    /**
-     * A paging operation that includes a nextLink that has 10 pages.
-     *
-     * @param pagingGetMultiplePagesWithOffsetOptions Parameter group.
-     * @param clientRequestId The clientRequestId parameter.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> getMultiplePagesWithOffset(
-            PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions, String clientRequestId) {
-        return new PagedIterable<>(
-                getMultiplePagesWithOffsetAsync(pagingGetMultiplePagesWithOffsetOptions, clientRequestId));
-    }
-
-    /**
-     * A paging operation that includes a nextLink that has 10 pages.
-     *
-     * @param pagingGetMultiplePagesWithOffsetOptions Parameter group.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> getMultiplePagesWithOffset(
-            PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions) {
-        final String clientRequestId = null;
-        return new PagedIterable<>(
-                getMultiplePagesWithOffsetAsync(pagingGetMultiplePagesWithOffsetOptions, clientRequestId));
     }
 
     /**
@@ -1413,39 +980,11 @@ public final class Pagings {
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> getMultiplePagesRetryFirstAsync() {
-        return new PagedFlux<>(
-                () -> getMultiplePagesRetryFirstSinglePageAsync(),
-                nextLink -> getMultiplePagesRetryFirstNextSinglePageAsync(nextLink));
-    }
-
-    /**
-     * A paging operation that fails on the first call with 500 and then retries and then get a response including a
-     * nextLink that has 10 pages.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getMultiplePagesRetryFirstSinglePage() {
         return getMultiplePagesRetryFirstSinglePageAsync().block();
-    }
-
-    /**
-     * A paging operation that fails on the first call with 500 and then retries and then get a response including a
-     * nextLink that has 10 pages.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> getMultiplePagesRetryFirst() {
-        return new PagedIterable<>(getMultiplePagesRetryFirstAsync());
     }
 
     /**
@@ -1482,39 +1021,11 @@ public final class Pagings {
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> getMultiplePagesRetrySecondAsync() {
-        return new PagedFlux<>(
-                () -> getMultiplePagesRetrySecondSinglePageAsync(),
-                nextLink -> getMultiplePagesRetrySecondNextSinglePageAsync(nextLink));
-    }
-
-    /**
-     * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The
-     * client should retry and finish all 10 pages eventually.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getMultiplePagesRetrySecondSinglePage() {
         return getMultiplePagesRetrySecondSinglePageAsync().block();
-    }
-
-    /**
-     * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The
-     * client should retry and finish all 10 pages eventually.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> getMultiplePagesRetrySecond() {
-        return new PagedIterable<>(getMultiplePagesRetrySecondAsync());
     }
 
     /**
@@ -1548,37 +1059,11 @@ public final class Pagings {
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> getSinglePagesFailureAsync() {
-        return new PagedFlux<>(
-                () -> getSinglePagesFailureSinglePageAsync(),
-                nextLink -> getSinglePagesFailureNextSinglePageAsync(nextLink));
-    }
-
-    /**
-     * A paging operation that receives a 400 on the first call.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getSinglePagesFailureSinglePage() {
         return getSinglePagesFailureSinglePageAsync().block();
-    }
-
-    /**
-     * A paging operation that receives a 400 on the first call.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> getSinglePagesFailure() {
-        return new PagedIterable<>(getSinglePagesFailureAsync());
     }
 
     /**
@@ -1612,37 +1097,11 @@ public final class Pagings {
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> getMultiplePagesFailureAsync() {
-        return new PagedFlux<>(
-                () -> getMultiplePagesFailureSinglePageAsync(),
-                nextLink -> getMultiplePagesFailureNextSinglePageAsync(nextLink));
-    }
-
-    /**
-     * A paging operation that receives a 400 on the second call.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getMultiplePagesFailureSinglePage() {
         return getMultiplePagesFailureSinglePageAsync().block();
-    }
-
-    /**
-     * A paging operation that receives a 400 on the second call.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> getMultiplePagesFailure() {
-        return new PagedIterable<>(getMultiplePagesFailureAsync());
     }
 
     /**
@@ -1677,37 +1136,11 @@ public final class Pagings {
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> getMultiplePagesFailureUriAsync() {
-        return new PagedFlux<>(
-                () -> getMultiplePagesFailureUriSinglePageAsync(),
-                nextLink -> getMultiplePagesFailureUriNextSinglePageAsync(nextLink));
-    }
-
-    /**
-     * A paging operation that receives an invalid nextLink.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getMultiplePagesFailureUriSinglePage() {
         return getMultiplePagesFailureUriSinglePageAsync().block();
-    }
-
-    /**
-     * A paging operation that receives an invalid nextLink.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> getMultiplePagesFailureUri() {
-        return new PagedIterable<>(getMultiplePagesFailureUriAsync());
     }
 
     /**
@@ -1757,43 +1190,11 @@ public final class Pagings {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> getMultiplePagesFragmentNextLinkAsync(String apiVersion, String tenant) {
-        return new PagedFlux<>(
-                () -> getMultiplePagesFragmentNextLinkSinglePageAsync(apiVersion, tenant),
-                nextLink -> nextFragmentSinglePageAsync(apiVersion, tenant, nextLink));
-    }
-
-    /**
-     * A paging operation that doesn't return a full URL, just a fragment.
-     *
-     * @param apiVersion Sets the api version to use.
-     * @param tenant Sets the tenant to use.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getMultiplePagesFragmentNextLinkSinglePage(String apiVersion, String tenant) {
         return getMultiplePagesFragmentNextLinkSinglePageAsync(apiVersion, tenant).block();
-    }
-
-    /**
-     * A paging operation that doesn't return a full URL, just a fragment.
-     *
-     * @param apiVersion Sets the api version to use.
-     * @param tenant Sets the tenant to use.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> getMultiplePagesFragmentNextLink(String apiVersion, String tenant) {
-        return new PagedIterable<>(getMultiplePagesFragmentNextLinkAsync(apiVersion, tenant));
     }
 
     /**
@@ -1843,44 +1244,12 @@ public final class Pagings {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> getMultiplePagesFragmentWithGroupingNextLinkAsync(
-            CustomParameterGroup customParameterGroup) {
-        return new PagedFlux<>(
-                () -> getMultiplePagesFragmentWithGroupingNextLinkSinglePageAsync(customParameterGroup),
-                nextLink -> nextFragmentWithGroupingSinglePageAsync(nextLink, customParameterGroup));
-    }
-
-    /**
-     * A paging operation that doesn't return a full URL, just a fragment with parameters grouped.
-     *
-     * @param customParameterGroup Parameter group.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getMultiplePagesFragmentWithGroupingNextLinkSinglePage(
             CustomParameterGroup customParameterGroup) {
         return getMultiplePagesFragmentWithGroupingNextLinkSinglePageAsync(customParameterGroup).block();
-    }
-
-    /**
-     * A paging operation that doesn't return a full URL, just a fragment with parameters grouped.
-     *
-     * @param customParameterGroup Parameter group.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> getMultiplePagesFragmentWithGroupingNextLink(
-            CustomParameterGroup customParameterGroup) {
-        return new PagedIterable<>(getMultiplePagesFragmentWithGroupingNextLinkAsync(customParameterGroup));
     }
 
     /**
@@ -1937,80 +1306,12 @@ public final class Pagings {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> getMultiplePagesLROAsync(
-            String clientRequestId, PagingGetMultiplePagesLroOptions pagingGetMultiplePagesLroOptions) {
-        return new PagedFlux<>(
-                () -> getMultiplePagesLROSinglePageAsync(clientRequestId, pagingGetMultiplePagesLroOptions),
-                nextLink ->
-                        getMultiplePagesLRONextSinglePageAsync(
-                                nextLink, clientRequestId, pagingGetMultiplePagesLroOptions));
-    }
-
-    /**
-     * A long-running paging operation that includes a nextLink that has 10 pages.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> getMultiplePagesLROAsync() {
-        final String clientRequestId = null;
-        final PagingGetMultiplePagesLroOptions pagingGetMultiplePagesLroOptions = null;
-        return new PagedFlux<>(
-                () -> getMultiplePagesLROSinglePageAsync(clientRequestId, pagingGetMultiplePagesLroOptions),
-                nextLink ->
-                        getMultiplePagesLRONextSinglePageAsync(
-                                nextLink, clientRequestId, pagingGetMultiplePagesLroOptions));
-    }
-
-    /**
-     * A long-running paging operation that includes a nextLink that has 10 pages.
-     *
-     * @param clientRequestId The clientRequestId parameter.
-     * @param pagingGetMultiplePagesLroOptions Parameter group.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getMultiplePagesLROSinglePage(
             String clientRequestId, PagingGetMultiplePagesLroOptions pagingGetMultiplePagesLroOptions) {
         return getMultiplePagesLROSinglePageAsync(clientRequestId, pagingGetMultiplePagesLroOptions).block();
-    }
-
-    /**
-     * A long-running paging operation that includes a nextLink that has 10 pages.
-     *
-     * @param clientRequestId The clientRequestId parameter.
-     * @param pagingGetMultiplePagesLroOptions Parameter group.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> getMultiplePagesLRO(
-            String clientRequestId, PagingGetMultiplePagesLroOptions pagingGetMultiplePagesLroOptions) {
-        return new PagedIterable<>(getMultiplePagesLROAsync(clientRequestId, pagingGetMultiplePagesLroOptions));
-    }
-
-    /**
-     * A long-running paging operation that includes a nextLink that has 10 pages.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> getMultiplePagesLRO() {
-        final String clientRequestId = null;
-        final PagingGetMultiplePagesLroOptions pagingGetMultiplePagesLroOptions = null;
-        return new PagedIterable<>(getMultiplePagesLROAsync(clientRequestId, pagingGetMultiplePagesLroOptions));
     }
 
     /**
@@ -2049,38 +1350,11 @@ public final class Pagings {
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> appendApiVersionAsync() {
-        return new PagedFlux<>(
-                () -> appendApiVersionSinglePageAsync(), nextLink -> appendApiVersionNextSinglePageAsync(nextLink));
-    }
-
-    /**
-     * A paging operation with api version. When calling the next link, you want to append your client's api version to
-     * the next link.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> appendApiVersionSinglePage() {
         return appendApiVersionSinglePageAsync().block();
-    }
-
-    /**
-     * A paging operation with api version. When calling the next link, you want to append your client's api version to
-     * the next link.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> appendApiVersion() {
-        return new PagedIterable<>(appendApiVersionAsync());
     }
 
     /**
@@ -2119,38 +1393,11 @@ public final class Pagings {
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> replaceApiVersionAsync() {
-        return new PagedFlux<>(
-                () -> replaceApiVersionSinglePageAsync(), nextLink -> replaceApiVersionNextSinglePageAsync(nextLink));
-    }
-
-    /**
-     * A paging operation with api version. When calling the next link, you want to reformat it and override the
-     * returned api version with your client's api version.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> replaceApiVersionSinglePage() {
         return replaceApiVersionSinglePageAsync().block();
-    }
-
-    /**
-     * A paging operation with api version. When calling the next link, you want to reformat it and override the
-     * returned api version with your client's api version.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> replaceApiVersion() {
-        return new PagedIterable<>(replaceApiVersionAsync());
     }
 
     /**
@@ -2305,37 +1552,11 @@ public final class Pagings {
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Product> getPagingModelWithItemNameWithXMSClientNameAsync() {
-        return new PagedFlux<>(
-                () -> getPagingModelWithItemNameWithXMSClientNameSinglePageAsync(),
-                nextLink -> getPagingModelWithItemNameWithXMSClientNameNextSinglePageAsync(nextLink));
-    }
-
-    /**
-     * A paging operation that returns a paging model whose item name is is overriden by x-ms-client-name 'indexes'.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getPagingModelWithItemNameWithXMSClientNameSinglePage() {
         return getPagingModelWithItemNameWithXMSClientNameSinglePageAsync().block();
-    }
-
-    /**
-     * A paging operation that returns a paging model whose item name is is overriden by x-ms-client-name 'indexes'.
-     *
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Product> getPagingModelWithItemNameWithXMSClientName() {
-        return new PagedIterable<>(getPagingModelWithItemNameWithXMSClientNameAsync());
     }
 
     /**

--- a/azure-tests/src/main/java/fixtures/paging/Pagings.java
+++ b/azure-tests/src/main/java/fixtures/paging/Pagings.java
@@ -17,6 +17,8 @@ import com.azure.core.annotation.ServiceInterface;
 import com.azure.core.annotation.ServiceMethod;
 import com.azure.core.annotation.UnexpectedResponseExceptionType;
 import com.azure.core.exception.HttpResponseException;
+import com.azure.core.http.rest.PagedFlux;
+import com.azure.core.http.rest.PagedIterable;
 import com.azure.core.http.rest.PagedResponse;
 import com.azure.core.http.rest.PagedResponseBase;
 import com.azure.core.http.rest.Response;
@@ -459,11 +461,36 @@ public final class Pagings {
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> getNoItemNamePagesAsync() {
+        return new PagedFlux<>(
+                () -> getNoItemNamePagesSinglePageAsync(), nextLink -> getNoItemNamePagesNextSinglePageAsync(nextLink));
+    }
+
+    /**
+     * A paging operation that must return result of the default 'value' node.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getNoItemNamePagesSinglePage() {
         return getNoItemNamePagesSinglePageAsync().block();
+    }
+
+    /**
+     * A paging operation that must return result of the default 'value' node.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> getNoItemNamePages() {
+        return new PagedIterable<>(getNoItemNamePagesAsync());
     }
 
     /**
@@ -497,11 +524,35 @@ public final class Pagings {
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> getNullNextLinkNamePagesAsync() {
+        return new PagedFlux<>(() -> getNullNextLinkNamePagesSinglePageAsync());
+    }
+
+    /**
+     * A paging operation that must ignore any kind of nextLink, and stop after page 1.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getNullNextLinkNamePagesSinglePage() {
         return getNullNextLinkNamePagesSinglePageAsync().block();
+    }
+
+    /**
+     * A paging operation that must ignore any kind of nextLink, and stop after page 1.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> getNullNextLinkNamePages() {
+        return new PagedIterable<>(getNullNextLinkNamePagesAsync());
     }
 
     /**
@@ -535,11 +586,36 @@ public final class Pagings {
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> getSinglePagesAsync() {
+        return new PagedFlux<>(
+                () -> getSinglePagesSinglePageAsync(), nextLink -> getSinglePagesNextSinglePageAsync(nextLink));
+    }
+
+    /**
+     * A paging operation that finishes on the first call without a nextlink.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getSinglePagesSinglePage() {
         return getSinglePagesSinglePageAsync().block();
+    }
+
+    /**
+     * A paging operation that finishes on the first call without a nextlink.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> getSinglePages() {
+        return new PagedIterable<>(getSinglePagesAsync());
     }
 
     /**
@@ -575,11 +651,38 @@ public final class Pagings {
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> firstResponseEmptyAsync() {
+        return new PagedFlux<>(
+                () -> firstResponseEmptySinglePageAsync(), nextLink -> firstResponseEmptyNextSinglePageAsync(nextLink));
+    }
+
+    /**
+     * A paging operation whose first response's items list is empty, but still returns a next link. Second (and final)
+     * call, will give you an items list of 1.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> firstResponseEmptySinglePage() {
         return firstResponseEmptySinglePageAsync().block();
+    }
+
+    /**
+     * A paging operation whose first response's items list is empty, but still returns a next link. Second (and final)
+     * call, will give you an items list of 1.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> firstResponseEmpty() {
+        return new PagedIterable<>(firstResponseEmptyAsync());
     }
 
     /**
@@ -636,12 +739,78 @@ public final class Pagings {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> getMultiplePagesAsync(
+            String clientRequestId, PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) {
+        return new PagedFlux<>(
+                () -> getMultiplePagesSinglePageAsync(clientRequestId, pagingGetMultiplePagesOptions),
+                nextLink ->
+                        getMultiplePagesNextSinglePageAsync(nextLink, clientRequestId, pagingGetMultiplePagesOptions));
+    }
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> getMultiplePagesAsync() {
+        final String clientRequestId = null;
+        final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions = null;
+        return new PagedFlux<>(
+                () -> getMultiplePagesSinglePageAsync(clientRequestId, pagingGetMultiplePagesOptions),
+                nextLink ->
+                        getMultiplePagesNextSinglePageAsync(nextLink, clientRequestId, pagingGetMultiplePagesOptions));
+    }
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param clientRequestId The clientRequestId parameter.
+     * @param pagingGetMultiplePagesOptions Parameter group.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getMultiplePagesSinglePage(
             String clientRequestId, PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) {
         return getMultiplePagesSinglePageAsync(clientRequestId, pagingGetMultiplePagesOptions).block();
+    }
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param clientRequestId The clientRequestId parameter.
+     * @param pagingGetMultiplePagesOptions Parameter group.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> getMultiplePages(
+            String clientRequestId, PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions) {
+        return new PagedIterable<>(getMultiplePagesAsync(clientRequestId, pagingGetMultiplePagesOptions));
+    }
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> getMultiplePages() {
+        final String clientRequestId = null;
+        final PagingGetMultiplePagesOptions pagingGetMultiplePagesOptions = null;
+        return new PagedIterable<>(getMultiplePagesAsync(clientRequestId, pagingGetMultiplePagesOptions));
     }
 
     /**
@@ -685,11 +854,43 @@ public final class Pagings {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> getWithQueryParamsAsync(int requiredQueryParameter) {
+        return new PagedFlux<>(
+                () -> getWithQueryParamsSinglePageAsync(requiredQueryParameter),
+                nextLink -> nextOperationWithQueryParamsSinglePageAsync());
+    }
+
+    /**
+     * A paging operation that includes a next operation. It has a different query parameter from it's next operation
+     * nextOperationWithQueryParams. Returns a ProductResult.
+     *
+     * @param requiredQueryParameter A required integer query parameter. Put in value '100' to pass test.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getWithQueryParamsSinglePage(int requiredQueryParameter) {
         return getWithQueryParamsSinglePageAsync(requiredQueryParameter).block();
+    }
+
+    /**
+     * A paging operation that includes a next operation. It has a different query parameter from it's next operation
+     * nextOperationWithQueryParams. Returns a ProductResult.
+     *
+     * @param requiredQueryParameter A required integer query parameter. Put in value '100' to pass test.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> getWithQueryParams(int requiredQueryParameter) {
+        return new PagedIterable<>(getWithQueryParamsAsync(requiredQueryParameter));
     }
 
     /**
@@ -729,11 +930,71 @@ public final class Pagings {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> duplicateParamsAsync(String filter) {
+        return new PagedFlux<>(
+                () -> duplicateParamsSinglePageAsync(filter), nextLink -> duplicateParamsNextSinglePageAsync(nextLink));
+    }
+
+    /**
+     * Define `filter` as a query param for all calls. However, the returned next link will also include the `filter` as
+     * part of it. Make sure you don't end up duplicating the `filter` param in the url sent.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> duplicateParamsAsync() {
+        final String filter = null;
+        return new PagedFlux<>(
+                () -> duplicateParamsSinglePageAsync(filter), nextLink -> duplicateParamsNextSinglePageAsync(nextLink));
+    }
+
+    /**
+     * Define `filter` as a query param for all calls. However, the returned next link will also include the `filter` as
+     * part of it. Make sure you don't end up duplicating the `filter` param in the url sent.
+     *
+     * @param filter OData filter options. Pass in 'foo'.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> duplicateParamsSinglePage(String filter) {
         return duplicateParamsSinglePageAsync(filter).block();
+    }
+
+    /**
+     * Define `filter` as a query param for all calls. However, the returned next link will also include the `filter` as
+     * part of it. Make sure you don't end up duplicating the `filter` param in the url sent.
+     *
+     * @param filter OData filter options. Pass in 'foo'.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> duplicateParams(String filter) {
+        return new PagedIterable<>(duplicateParamsAsync(filter));
+    }
+
+    /**
+     * Define `filter` as a query param for all calls. However, the returned next link will also include the `filter` as
+     * part of it. Make sure you don't end up duplicating the `filter` param in the url sent.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> duplicateParams() {
+        final String filter = null;
+        return new PagedIterable<>(duplicateParamsAsync(filter));
     }
 
     /**
@@ -769,11 +1030,37 @@ public final class Pagings {
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> pageWithMaxPageSizeAsync() {
+        return new PagedFlux<>(
+                () -> pageWithMaxPageSizeSinglePageAsync(),
+                nextLink -> pageWithMaxPageSizeNextSinglePageAsync(nextLink));
+    }
+
+    /**
+     * Paging with max page size. We don't want to.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> pageWithMaxPageSizeSinglePage() {
         return pageWithMaxPageSizeSinglePageAsync().block();
+    }
+
+    /**
+     * Paging with max page size. We don't want to.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> pageWithMaxPageSize() {
+        return new PagedIterable<>(pageWithMaxPageSizeAsync());
     }
 
     /**
@@ -872,12 +1159,80 @@ public final class Pagings {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> getOdataMultiplePagesAsync(
+            String clientRequestId, PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) {
+        return new PagedFlux<>(
+                () -> getOdataMultiplePagesSinglePageAsync(clientRequestId, pagingGetOdataMultiplePagesOptions),
+                nextLink ->
+                        getOdataMultiplePagesNextSinglePageAsync(
+                                nextLink, clientRequestId, pagingGetOdataMultiplePagesOptions));
+    }
+
+    /**
+     * A paging operation that includes a nextLink in odata format that has 10 pages.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> getOdataMultiplePagesAsync() {
+        final String clientRequestId = null;
+        final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions = null;
+        return new PagedFlux<>(
+                () -> getOdataMultiplePagesSinglePageAsync(clientRequestId, pagingGetOdataMultiplePagesOptions),
+                nextLink ->
+                        getOdataMultiplePagesNextSinglePageAsync(
+                                nextLink, clientRequestId, pagingGetOdataMultiplePagesOptions));
+    }
+
+    /**
+     * A paging operation that includes a nextLink in odata format that has 10 pages.
+     *
+     * @param clientRequestId The clientRequestId parameter.
+     * @param pagingGetOdataMultiplePagesOptions Parameter group.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getOdataMultiplePagesSinglePage(
             String clientRequestId, PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) {
         return getOdataMultiplePagesSinglePageAsync(clientRequestId, pagingGetOdataMultiplePagesOptions).block();
+    }
+
+    /**
+     * A paging operation that includes a nextLink in odata format that has 10 pages.
+     *
+     * @param clientRequestId The clientRequestId parameter.
+     * @param pagingGetOdataMultiplePagesOptions Parameter group.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> getOdataMultiplePages(
+            String clientRequestId, PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions) {
+        return new PagedIterable<>(getOdataMultiplePagesAsync(clientRequestId, pagingGetOdataMultiplePagesOptions));
+    }
+
+    /**
+     * A paging operation that includes a nextLink in odata format that has 10 pages.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> getOdataMultiplePages() {
+        final String clientRequestId = null;
+        final PagingGetOdataMultiplePagesOptions pagingGetOdataMultiplePagesOptions = null;
+        return new PagedIterable<>(getOdataMultiplePagesAsync(clientRequestId, pagingGetOdataMultiplePagesOptions));
     }
 
     /**
@@ -937,6 +1292,50 @@ public final class Pagings {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> getMultiplePagesWithOffsetAsync(
+            PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions, String clientRequestId) {
+        return new PagedFlux<>(
+                () ->
+                        getMultiplePagesWithOffsetSinglePageAsync(
+                                pagingGetMultiplePagesWithOffsetOptions, clientRequestId),
+                nextLink ->
+                        getMultiplePagesWithOffsetNextSinglePageAsync(
+                                nextLink, pagingGetMultiplePagesWithOffsetOptions, clientRequestId));
+    }
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param pagingGetMultiplePagesWithOffsetOptions Parameter group.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> getMultiplePagesWithOffsetAsync(
+            PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions) {
+        final String clientRequestId = null;
+        return new PagedFlux<>(
+                () ->
+                        getMultiplePagesWithOffsetSinglePageAsync(
+                                pagingGetMultiplePagesWithOffsetOptions, clientRequestId),
+                nextLink ->
+                        getMultiplePagesWithOffsetNextSinglePageAsync(
+                                nextLink, pagingGetMultiplePagesWithOffsetOptions, clientRequestId));
+    }
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param pagingGetMultiplePagesWithOffsetOptions Parameter group.
+     * @param clientRequestId The clientRequestId parameter.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
@@ -944,6 +1343,40 @@ public final class Pagings {
             PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions, String clientRequestId) {
         return getMultiplePagesWithOffsetSinglePageAsync(pagingGetMultiplePagesWithOffsetOptions, clientRequestId)
                 .block();
+    }
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param pagingGetMultiplePagesWithOffsetOptions Parameter group.
+     * @param clientRequestId The clientRequestId parameter.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> getMultiplePagesWithOffset(
+            PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions, String clientRequestId) {
+        return new PagedIterable<>(
+                getMultiplePagesWithOffsetAsync(pagingGetMultiplePagesWithOffsetOptions, clientRequestId));
+    }
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param pagingGetMultiplePagesWithOffsetOptions Parameter group.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> getMultiplePagesWithOffset(
+            PagingGetMultiplePagesWithOffsetOptions pagingGetMultiplePagesWithOffsetOptions) {
+        final String clientRequestId = null;
+        return new PagedIterable<>(
+                getMultiplePagesWithOffsetAsync(pagingGetMultiplePagesWithOffsetOptions, clientRequestId));
     }
 
     /**
@@ -980,11 +1413,39 @@ public final class Pagings {
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> getMultiplePagesRetryFirstAsync() {
+        return new PagedFlux<>(
+                () -> getMultiplePagesRetryFirstSinglePageAsync(),
+                nextLink -> getMultiplePagesRetryFirstNextSinglePageAsync(nextLink));
+    }
+
+    /**
+     * A paging operation that fails on the first call with 500 and then retries and then get a response including a
+     * nextLink that has 10 pages.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getMultiplePagesRetryFirstSinglePage() {
         return getMultiplePagesRetryFirstSinglePageAsync().block();
+    }
+
+    /**
+     * A paging operation that fails on the first call with 500 and then retries and then get a response including a
+     * nextLink that has 10 pages.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> getMultiplePagesRetryFirst() {
+        return new PagedIterable<>(getMultiplePagesRetryFirstAsync());
     }
 
     /**
@@ -1021,11 +1482,39 @@ public final class Pagings {
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> getMultiplePagesRetrySecondAsync() {
+        return new PagedFlux<>(
+                () -> getMultiplePagesRetrySecondSinglePageAsync(),
+                nextLink -> getMultiplePagesRetrySecondNextSinglePageAsync(nextLink));
+    }
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The
+     * client should retry and finish all 10 pages eventually.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getMultiplePagesRetrySecondSinglePage() {
         return getMultiplePagesRetrySecondSinglePageAsync().block();
+    }
+
+    /**
+     * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The
+     * client should retry and finish all 10 pages eventually.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> getMultiplePagesRetrySecond() {
+        return new PagedIterable<>(getMultiplePagesRetrySecondAsync());
     }
 
     /**
@@ -1059,11 +1548,37 @@ public final class Pagings {
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> getSinglePagesFailureAsync() {
+        return new PagedFlux<>(
+                () -> getSinglePagesFailureSinglePageAsync(),
+                nextLink -> getSinglePagesFailureNextSinglePageAsync(nextLink));
+    }
+
+    /**
+     * A paging operation that receives a 400 on the first call.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getSinglePagesFailureSinglePage() {
         return getSinglePagesFailureSinglePageAsync().block();
+    }
+
+    /**
+     * A paging operation that receives a 400 on the first call.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> getSinglePagesFailure() {
+        return new PagedIterable<>(getSinglePagesFailureAsync());
     }
 
     /**
@@ -1097,11 +1612,37 @@ public final class Pagings {
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> getMultiplePagesFailureAsync() {
+        return new PagedFlux<>(
+                () -> getMultiplePagesFailureSinglePageAsync(),
+                nextLink -> getMultiplePagesFailureNextSinglePageAsync(nextLink));
+    }
+
+    /**
+     * A paging operation that receives a 400 on the second call.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getMultiplePagesFailureSinglePage() {
         return getMultiplePagesFailureSinglePageAsync().block();
+    }
+
+    /**
+     * A paging operation that receives a 400 on the second call.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> getMultiplePagesFailure() {
+        return new PagedIterable<>(getMultiplePagesFailureAsync());
     }
 
     /**
@@ -1136,11 +1677,37 @@ public final class Pagings {
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> getMultiplePagesFailureUriAsync() {
+        return new PagedFlux<>(
+                () -> getMultiplePagesFailureUriSinglePageAsync(),
+                nextLink -> getMultiplePagesFailureUriNextSinglePageAsync(nextLink));
+    }
+
+    /**
+     * A paging operation that receives an invalid nextLink.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getMultiplePagesFailureUriSinglePage() {
         return getMultiplePagesFailureUriSinglePageAsync().block();
+    }
+
+    /**
+     * A paging operation that receives an invalid nextLink.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> getMultiplePagesFailureUri() {
+        return new PagedIterable<>(getMultiplePagesFailureUriAsync());
     }
 
     /**
@@ -1190,11 +1757,43 @@ public final class Pagings {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> getMultiplePagesFragmentNextLinkAsync(String apiVersion, String tenant) {
+        return new PagedFlux<>(
+                () -> getMultiplePagesFragmentNextLinkSinglePageAsync(apiVersion, tenant),
+                nextLink -> nextFragmentSinglePageAsync(apiVersion, tenant, nextLink));
+    }
+
+    /**
+     * A paging operation that doesn't return a full URL, just a fragment.
+     *
+     * @param apiVersion Sets the api version to use.
+     * @param tenant Sets the tenant to use.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getMultiplePagesFragmentNextLinkSinglePage(String apiVersion, String tenant) {
         return getMultiplePagesFragmentNextLinkSinglePageAsync(apiVersion, tenant).block();
+    }
+
+    /**
+     * A paging operation that doesn't return a full URL, just a fragment.
+     *
+     * @param apiVersion Sets the api version to use.
+     * @param tenant Sets the tenant to use.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> getMultiplePagesFragmentNextLink(String apiVersion, String tenant) {
+        return new PagedIterable<>(getMultiplePagesFragmentNextLinkAsync(apiVersion, tenant));
     }
 
     /**
@@ -1244,12 +1843,44 @@ public final class Pagings {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> getMultiplePagesFragmentWithGroupingNextLinkAsync(
+            CustomParameterGroup customParameterGroup) {
+        return new PagedFlux<>(
+                () -> getMultiplePagesFragmentWithGroupingNextLinkSinglePageAsync(customParameterGroup),
+                nextLink -> nextFragmentWithGroupingSinglePageAsync(nextLink, customParameterGroup));
+    }
+
+    /**
+     * A paging operation that doesn't return a full URL, just a fragment with parameters grouped.
+     *
+     * @param customParameterGroup Parameter group.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getMultiplePagesFragmentWithGroupingNextLinkSinglePage(
             CustomParameterGroup customParameterGroup) {
         return getMultiplePagesFragmentWithGroupingNextLinkSinglePageAsync(customParameterGroup).block();
+    }
+
+    /**
+     * A paging operation that doesn't return a full URL, just a fragment with parameters grouped.
+     *
+     * @param customParameterGroup Parameter group.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> getMultiplePagesFragmentWithGroupingNextLink(
+            CustomParameterGroup customParameterGroup) {
+        return new PagedIterable<>(getMultiplePagesFragmentWithGroupingNextLinkAsync(customParameterGroup));
     }
 
     /**
@@ -1306,12 +1937,80 @@ public final class Pagings {
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> getMultiplePagesLROAsync(
+            String clientRequestId, PagingGetMultiplePagesLroOptions pagingGetMultiplePagesLroOptions) {
+        return new PagedFlux<>(
+                () -> getMultiplePagesLROSinglePageAsync(clientRequestId, pagingGetMultiplePagesLroOptions),
+                nextLink ->
+                        getMultiplePagesLRONextSinglePageAsync(
+                                nextLink, clientRequestId, pagingGetMultiplePagesLroOptions));
+    }
+
+    /**
+     * A long-running paging operation that includes a nextLink that has 10 pages.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> getMultiplePagesLROAsync() {
+        final String clientRequestId = null;
+        final PagingGetMultiplePagesLroOptions pagingGetMultiplePagesLroOptions = null;
+        return new PagedFlux<>(
+                () -> getMultiplePagesLROSinglePageAsync(clientRequestId, pagingGetMultiplePagesLroOptions),
+                nextLink ->
+                        getMultiplePagesLRONextSinglePageAsync(
+                                nextLink, clientRequestId, pagingGetMultiplePagesLroOptions));
+    }
+
+    /**
+     * A long-running paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param clientRequestId The clientRequestId parameter.
+     * @param pagingGetMultiplePagesLroOptions Parameter group.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getMultiplePagesLROSinglePage(
             String clientRequestId, PagingGetMultiplePagesLroOptions pagingGetMultiplePagesLroOptions) {
         return getMultiplePagesLROSinglePageAsync(clientRequestId, pagingGetMultiplePagesLroOptions).block();
+    }
+
+    /**
+     * A long-running paging operation that includes a nextLink that has 10 pages.
+     *
+     * @param clientRequestId The clientRequestId parameter.
+     * @param pagingGetMultiplePagesLroOptions Parameter group.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> getMultiplePagesLRO(
+            String clientRequestId, PagingGetMultiplePagesLroOptions pagingGetMultiplePagesLroOptions) {
+        return new PagedIterable<>(getMultiplePagesLROAsync(clientRequestId, pagingGetMultiplePagesLroOptions));
+    }
+
+    /**
+     * A long-running paging operation that includes a nextLink that has 10 pages.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> getMultiplePagesLRO() {
+        final String clientRequestId = null;
+        final PagingGetMultiplePagesLroOptions pagingGetMultiplePagesLroOptions = null;
+        return new PagedIterable<>(getMultiplePagesLROAsync(clientRequestId, pagingGetMultiplePagesLroOptions));
     }
 
     /**
@@ -1350,11 +2049,38 @@ public final class Pagings {
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> appendApiVersionAsync() {
+        return new PagedFlux<>(
+                () -> appendApiVersionSinglePageAsync(), nextLink -> appendApiVersionNextSinglePageAsync(nextLink));
+    }
+
+    /**
+     * A paging operation with api version. When calling the next link, you want to append your client's api version to
+     * the next link.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> appendApiVersionSinglePage() {
         return appendApiVersionSinglePageAsync().block();
+    }
+
+    /**
+     * A paging operation with api version. When calling the next link, you want to append your client's api version to
+     * the next link.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> appendApiVersion() {
+        return new PagedIterable<>(appendApiVersionAsync());
     }
 
     /**
@@ -1393,11 +2119,38 @@ public final class Pagings {
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> replaceApiVersionAsync() {
+        return new PagedFlux<>(
+                () -> replaceApiVersionSinglePageAsync(), nextLink -> replaceApiVersionNextSinglePageAsync(nextLink));
+    }
+
+    /**
+     * A paging operation with api version. When calling the next link, you want to reformat it and override the
+     * returned api version with your client's api version.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> replaceApiVersionSinglePage() {
         return replaceApiVersionSinglePageAsync().block();
+    }
+
+    /**
+     * A paging operation with api version. When calling the next link, you want to reformat it and override the
+     * returned api version with your client's api version.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> replaceApiVersion() {
+        return new PagedIterable<>(replaceApiVersionAsync());
     }
 
     /**
@@ -1552,11 +2305,37 @@ public final class Pagings {
      *
      * @throws HttpResponseException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Product> getPagingModelWithItemNameWithXMSClientNameAsync() {
+        return new PagedFlux<>(
+                () -> getPagingModelWithItemNameWithXMSClientNameSinglePageAsync(),
+                nextLink -> getPagingModelWithItemNameWithXMSClientNameNextSinglePageAsync(nextLink));
+    }
+
+    /**
+     * A paging operation that returns a paging model whose item name is is overriden by x-ms-client-name 'indexes'.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Product> getPagingModelWithItemNameWithXMSClientNameSinglePage() {
         return getPagingModelWithItemNameWithXMSClientNameSinglePageAsync().block();
+    }
+
+    /**
+     * A paging operation that returns a paging model whose item name is is overriden by x-ms-client-name 'indexes'.
+     *
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Product> getPagingModelWithItemNameWithXMSClientName() {
+        return new PagedIterable<>(getPagingModelWithItemNameWithXMSClientNameAsync());
     }
 
     /**

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentClientMethodMapper.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentClientMethodMapper.java
@@ -51,6 +51,11 @@ public class FluentClientMethodMapper extends ClientMethodMapper {
                     visibility = NOT_GENERATE;
                     break;
 
+                case PagingSync:
+                case PagingAsync:
+                    visibility = VISIBLE;
+                    break;
+
                 default:
                     visibility = super.methodVisibility(methodType, false, isProtocolMethod);
                     break;

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -841,6 +841,7 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
         if (isProtocolMethod || !responseContainsHeaders) {
             return GenericType.Response(syncReturnType);
         } else if (settings.isGenericResponseTypes()) {
+
             return GenericType.RestResponse(Mappers.getSchemaMapper().map(ClientMapper.parseHeader(operation, settings)),
                 syncReturnType);
         } else {
@@ -1013,6 +1014,12 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                     : NOT_GENERATE;
             }
         } else {
+            // Don't generate PagedFlux or PagedIterable methods without Context.
+            if ((methodType == ClientMethodType.PagingSync || methodType == ClientMethodType.PagingAsync)
+                && !hasContextParameter) {
+                return NOT_GENERATE;
+            }
+
             return VISIBLE;
         }
     }

--- a/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
+++ b/javagen/src/main/java/com/azure/autorest/mapper/ClientMethodMapper.java
@@ -987,7 +987,8 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
      * @return method visibility, null if do not generate.
      */
     protected JavaVisibility methodVisibility(ClientMethodType methodType, boolean hasContextParameter, boolean isProtocolMethod) {
-        if (JavaSettings.getInstance().isDataPlaneClient()) {
+        JavaSettings settings = JavaSettings.getInstance();
+        if (settings.isDataPlaneClient()) {
             if (isProtocolMethod) {
                 /*
                 Rule for DPG protocol method
@@ -1014,9 +1015,9 @@ public class ClientMethodMapper implements IMapper<Operation, List<ClientMethod>
                     : NOT_GENERATE;
             }
         } else {
-            // Don't generate PagedFlux or PagedIterable methods without Context.
+            // Don't generate PagedFlux or PagedIterable methods without Context if Context methods are being generated.
             if ((methodType == ClientMethodType.PagingSync || methodType == ClientMethodType.PagingAsync)
-                && !hasContextParameter) {
+                && !hasContextParameter && settings.isContextClientMethodParameter()) {
                 return NOT_GENERATE;
             }
 

--- a/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientMethod.java
+++ b/javagen/src/main/java/com/azure/autorest/model/clientmodel/ClientMethod.java
@@ -12,11 +12,12 @@ package com.azure.autorest.model.clientmodel;
 
 import com.azure.autorest.extension.base.model.codemodel.RequestParameterLocation;
 import com.azure.autorest.extension.base.plugin.JavaSettings;
-import com.azure.autorest.extension.base.plugin.JavaSettings.SyncMethodsGeneration;
 import com.azure.autorest.model.javamodel.JavaVisibility;
 import com.azure.autorest.util.CodeNamer;
 import com.azure.autorest.util.MethodUtil;
+import com.azure.core.http.rest.Response;
 import com.azure.core.http.rest.SimpleResponse;
+import com.azure.core.util.CoreUtils;
 import com.azure.core.util.DateTimeRfc1123;
 
 import java.time.OffsetDateTime;
@@ -348,6 +349,7 @@ public class ClientMethod {
 
         imports.add("java.util.Objects");
         imports.add("java.util.stream.Collectors");
+        imports.add(Response.class.getName());
         imports.add(SimpleResponse.class.getName());
 
         getReturnValue().addImportsTo(imports, includeImplementationImports);
@@ -380,12 +382,11 @@ public class ClientMethod {
                 imports.add("java.util.Iterator");
             }
 
-            if (settings.getAddContextParameter()
-                    && !(!settings.getRequiredParameterClientMethods() && settings.isContextClientMethodParameter()
-                    && SyncMethodsGeneration.NONE.equals(settings.getSyncMethods()))
-                    && (this.getType() == ClientMethodType.SimpleAsyncRestResponse
-                    || this.getType() == ClientMethodType.PagingAsyncSinglePage
-                    || this.getType() == ClientMethodType.LongRunningAsync)) {
+            // Add FluxUtil as an import if this is an asynchronous method and the last parameter isn't the Context
+            // parameter.
+            if (proxyMethod != null && !proxyMethod.isSync()
+                && (CoreUtils.isNullOrEmpty(parameters)
+                    || parameters.get(parameters.size() - 1) != ClientMethodParameter.CONTEXT_PARAMETER)) {
                 imports.add("com.azure.core.util.FluxUtil");
             }
 

--- a/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
@@ -766,7 +766,10 @@ public class ClientMethodTemplate extends ClientMethodTemplateBase {
             function.line("return %s(%s)", clientMethod.getProxyMethod().getSimpleAsyncRestResponseMethodName(), clientMethod.getArgumentList());
             function.indent(() -> {
                 if (GenericType.Flux(ClassType.ByteBuffer).equals(clientMethod.getReturnValue().getType())) {
-                    function.text(".flatMapMany(StreamResponse::getValue);");
+                    // Previously this used StreamResponse::getValue, but it isn't guaranteed that the return is
+                    // StreamResponse, instead use Response::getValue as StreamResponse is just a fancier
+                    // Response<Flux<ByteBuffer>>.
+                    function.text(".flatMapMany(Response::getValue);");
                 } else if (!GenericType.Mono(ClassType.Void).equals(clientMethod.getReturnValue().getType()) &&
                     !GenericType.Flux(ClassType.Void).equals(clientMethod.getReturnValue().getType())) {
                     function.text(".flatMap(res -> Mono.justOrEmpty(res.getValue()));");

--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -854,7 +854,8 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
 
     private static void generateHeaderDeserializationFunction(ClientModelProperty property, JavaBlock javaBlock) {
         IType wireType = property.getWireType();
-        boolean needsNullGuarding = wireType.deserializationNeedsNullGuarding() && wireType != ClassType.String;
+        boolean needsNullGuarding = (wireType instanceof ClassType && wireType != ClassType.String)
+            || wireType instanceof ArrayType;
 
         // No matter the wire type the rawHeaders will need to be accessed.
         String rawHeaderAccess = String.format("rawHeaders.getValue(\"%s\")", property.getSerializedName());

--- a/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ModelTemplate.java
@@ -460,10 +460,38 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                 continue;
             }
 
-            classBlock.blockComment(settings.getMaximumJavadocCommentWidth(),
-                comment -> comment.line(property.getDescription()));
+            String xmlWrapperClassName = getPropertyXmlWrapperClassName(property);
+            if (settings.shouldGenerateXmlSerialization() && property.getIsXmlWrapper()) {
+                // While using a wrapping class for XML elements that are wrapped may seem inconvenient it is required.
+                // There has been previous attempts to remove this by using JacksonXmlElementWrapper, which based on its
+                // documentation should cover this exact scenario, but it doesn't. Jackson unfortunately doesn't always
+                // respect the JacksonXmlRootName, or JsonRootName, value when handling types wrapped by an enumeration,
+                // such as List<CorsRule> or Iterable<CorsRule>. Instead, it uses the JacksonXmlProperty local name as the
+                // root XML node name for each element in the enumeration. There are configurations for ObjectMapper, and
+                // XmlMapper, that always forces Jackson to use the root name but those also add the class name as a root
+                // XML node name if the class doesn't have a root name annotation which results in an addition XML level
+                // resulting in invalid service XML. There is also one last work around to use JacksonXmlElementWrapper
+                // and JacksonXmlProperty together as the wrapper will configure the wrapper name and property will configure
+                // the element name but this breaks down in cases where the same element name is used in two different
+                // wrappers, a case being Storage BlockList which uses two block elements for its committed and uncommitted
+                // block lists.
+                classBlock.privateStaticFinalClass(xmlWrapperClassName, innerClass -> {
+                    IType propertyClientType = property.getWireType().getClientType();
 
-            addFieldAnnotations(property, classBlock, settings);
+                    String listElementName = property.getXmlListElementName();
+                    String jacksonAnnotation = CoreUtils.isNullOrEmpty(property.getXmlNamespace())
+                        ? "JacksonXmlProperty(localName = \"" + listElementName + "\")"
+                        : "JacksonXmlProperty(localName = \"" + listElementName + "\", namespace = \"" + property.getXmlNamespace() + "\")";
+
+                    innerClass.annotation(jacksonAnnotation);
+                    innerClass.privateFinalMemberVariable(propertyClientType.toString(), "items");
+
+                    innerClass.annotation("JsonCreator");
+                    innerClass.privateConstructor(
+                        xmlWrapperClassName + "(@" + jacksonAnnotation + " " + propertyClientType + " items)",
+                        constructor -> constructor.line("this.items = items;"));
+                });
+            }
 
             String propertyName = property.getName();
             IType propertyType = property.getWireType();
@@ -471,7 +499,6 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
             String fieldSignature;
             if (settings.shouldGenerateXmlSerialization()) {
                 if (property.getIsXmlWrapper()) {
-                    String xmlWrapperClassName = getPropertyXmlWrapperClassName(property);
                     fieldSignature = xmlWrapperClassName + " " + propertyName;
                 } else if (propertyType instanceof ListType) {
                     fieldSignature = propertyType + " " + propertyName + " = new ArrayList<>()";
@@ -493,6 +520,11 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
                 }
             }
 
+            classBlock.blockComment(settings.getMaximumJavadocCommentWidth(),
+                comment -> comment.line(property.getDescription()));
+
+            addFieldAnnotations(property, classBlock, settings);
+
             if (property.isRequired() && settings.isRequiredFieldsAsConstructorArgs()
                 && settings.isStreamStyleSerialization()) {
                 classBlock.privateFinalMemberVariable(fieldSignature);
@@ -510,40 +542,6 @@ public class ModelTemplate implements IJavaTemplate<ClientModel, JavaFile> {
      * @param settings Autorest generation settings.
      */
     protected void addFieldAnnotations(ClientModelProperty property, JavaClass classBlock, JavaSettings settings) {
-        String xmlWrapperClassName = getPropertyXmlWrapperClassName(property);
-
-        if (settings.shouldGenerateXmlSerialization() && property.getIsXmlWrapper()) {
-            // While using a wrapping class for XML elements that are wrapped may seem inconvenient it is required.
-            // There has been previous attempts to remove this by using JacksonXmlElementWrapper, which based on its
-            // documentation should cover this exact scenario, but it doesn't. Jackson unfortunately doesn't always
-            // respect the JacksonXmlRootName, or JsonRootName, value when handling types wrapped by an enumeration,
-            // such as List<CorsRule> or Iterable<CorsRule>. Instead, it uses the JacksonXmlProperty local name as the
-            // root XML node name for each element in the enumeration. There are configurations for ObjectMapper, and
-            // XmlMapper, that always forces Jackson to use the root name but those also add the class name as a root
-            // XML node name if the class doesn't have a root name annotation which results in an addition XML level
-            // resulting in invalid service XML. There is also one last work around to use JacksonXmlElementWrapper
-            // and JacksonXmlProperty together as the wrapper will configure the wrapper name and property will configure
-            // the element name but this breaks down in cases where the same element name is used in two different
-            // wrappers, a case being Storage BlockList which uses two block elements for its committed and uncommitted
-            // block lists.
-            classBlock.privateStaticFinalClass(xmlWrapperClassName, innerClass -> {
-                IType propertyClientType = property.getWireType().getClientType();
-
-                String listElementName = property.getXmlListElementName();
-                String jacksonAnnotation = CoreUtils.isNullOrEmpty(property.getXmlNamespace())
-                    ? "JacksonXmlProperty(localName = \"" + listElementName + "\")"
-                    : "JacksonXmlProperty(localName = \"" + listElementName + "\", namespace = \"" + property.getXmlNamespace() + "\")";
-
-                innerClass.annotation(jacksonAnnotation);
-                innerClass.privateFinalMemberVariable(propertyClientType.toString(), "items");
-
-                innerClass.annotation("JsonCreator");
-                innerClass.privateConstructor(
-                    xmlWrapperClassName + "(@" + jacksonAnnotation + " " + propertyClientType + " items)",
-                    constructor -> constructor.line("this.items = items;"));
-            });
-        }
-
         if (settings.getClientFlattenAnnotationTarget() == JavaSettings.ClientFlattenAnnotationTarget.FIELD && property.getNeedsFlatten()) {
             classBlock.annotation("JsonFlatten");
         }

--- a/vanilla-tests/src/main/java/fixtures/bodyfile/Files.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyfile/Files.java
@@ -118,7 +118,7 @@ public final class Files {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Flux<ByteBuffer> getFileAsync() {
-        return getFileWithResponseAsync().flatMapMany(StreamResponse::getValue);
+        return getFileWithResponseAsync().flatMapMany(Response::getValue);
     }
 
     /**
@@ -132,7 +132,7 @@ public final class Files {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Flux<ByteBuffer> getFileAsync(Context context) {
-        return getFileWithResponseAsync(context).flatMapMany(StreamResponse::getValue);
+        return getFileWithResponseAsync(context).flatMapMany(Response::getValue);
     }
 
     /**
@@ -278,7 +278,7 @@ public final class Files {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Flux<ByteBuffer> getFileLargeAsync() {
-        return getFileLargeWithResponseAsync().flatMapMany(StreamResponse::getValue);
+        return getFileLargeWithResponseAsync().flatMapMany(Response::getValue);
     }
 
     /**
@@ -292,7 +292,7 @@ public final class Files {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Flux<ByteBuffer> getFileLargeAsync(Context context) {
-        return getFileLargeWithResponseAsync(context).flatMapMany(StreamResponse::getValue);
+        return getFileLargeWithResponseAsync(context).flatMapMany(Response::getValue);
     }
 
     /**
@@ -438,7 +438,7 @@ public final class Files {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Flux<ByteBuffer> getEmptyFileAsync() {
-        return getEmptyFileWithResponseAsync().flatMapMany(StreamResponse::getValue);
+        return getEmptyFileWithResponseAsync().flatMapMany(Response::getValue);
     }
 
     /**
@@ -452,7 +452,7 @@ public final class Files {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Flux<ByteBuffer> getEmptyFileAsync(Context context) {
-        return getEmptyFileWithResponseAsync(context).flatMapMany(StreamResponse::getValue);
+        return getEmptyFileWithResponseAsync(context).flatMapMany(Response::getValue);
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/header/models/HeadersResponseBoolHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/header/models/HeadersResponseBoolHeaders.java
@@ -24,7 +24,10 @@ public final class HeadersResponseBoolHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public HeadersResponseBoolHeaders(HttpHeaders rawHeaders) {
-        this.value = Boolean.parseBoolean(rawHeaders.getValue("value"));
+        String value = rawHeaders.getValue("value");
+        if (value != null) {
+            this.value = Boolean.parseBoolean(value);
+        }
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/header/models/HeadersResponseDoubleHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/header/models/HeadersResponseDoubleHeaders.java
@@ -24,7 +24,10 @@ public final class HeadersResponseDoubleHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public HeadersResponseDoubleHeaders(HttpHeaders rawHeaders) {
-        this.value = Double.parseDouble(rawHeaders.getValue("value"));
+        String value = rawHeaders.getValue("value");
+        if (value != null) {
+            this.value = Double.parseDouble(value);
+        }
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/header/models/HeadersResponseFloatHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/header/models/HeadersResponseFloatHeaders.java
@@ -24,7 +24,10 @@ public final class HeadersResponseFloatHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public HeadersResponseFloatHeaders(HttpHeaders rawHeaders) {
-        this.value = Float.parseFloat(rawHeaders.getValue("value"));
+        String value = rawHeaders.getValue("value");
+        if (value != null) {
+            this.value = Float.parseFloat(value);
+        }
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/header/models/HeadersResponseIntegerHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/header/models/HeadersResponseIntegerHeaders.java
@@ -24,7 +24,10 @@ public final class HeadersResponseIntegerHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public HeadersResponseIntegerHeaders(HttpHeaders rawHeaders) {
-        this.value = Integer.parseInt(rawHeaders.getValue("value"));
+        String value = rawHeaders.getValue("value");
+        if (value != null) {
+            this.value = Integer.parseInt(value);
+        }
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/header/models/HeadersResponseLongHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/header/models/HeadersResponseLongHeaders.java
@@ -24,7 +24,10 @@ public final class HeadersResponseLongHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public HeadersResponseLongHeaders(HttpHeaders rawHeaders) {
-        this.value = Long.parseLong(rawHeaders.getValue("value"));
+        String value = rawHeaders.getValue("value");
+        if (value != null) {
+            this.value = Long.parseLong(value);
+        }
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LRORetrysDelete202Retry200Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LRORetrysDelete202Retry200Headers.java
@@ -30,7 +30,10 @@ public final class LRORetrysDelete202Retry200Headers {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LRORetrysDelete202Retry200Headers(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.location = rawHeaders.getValue("Location");
     }
 

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LRORetrysDeleteAsyncRelativeRetrySucceededHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LRORetrysDeleteAsyncRelativeRetrySucceededHeaders.java
@@ -36,7 +36,10 @@ public final class LRORetrysDeleteAsyncRelativeRetrySucceededHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LRORetrysDeleteAsyncRelativeRetrySucceededHeaders(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.azureAsyncOperation = rawHeaders.getValue("Azure-AsyncOperation");
         this.location = rawHeaders.getValue("Location");
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LRORetrysDeleteProvisioning202Accepted200SucceededHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LRORetrysDeleteProvisioning202Accepted200SucceededHeaders.java
@@ -30,7 +30,10 @@ public final class LRORetrysDeleteProvisioning202Accepted200SucceededHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LRORetrysDeleteProvisioning202Accepted200SucceededHeaders(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.location = rawHeaders.getValue("Location");
     }
 

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LRORetrysPost202Retry200Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LRORetrysPost202Retry200Headers.java
@@ -30,7 +30,10 @@ public final class LRORetrysPost202Retry200Headers {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LRORetrysPost202Retry200Headers(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.location = rawHeaders.getValue("Location");
     }
 

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LRORetrysPostAsyncRelativeRetrySucceededHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LRORetrysPostAsyncRelativeRetrySucceededHeaders.java
@@ -36,7 +36,10 @@ public final class LRORetrysPostAsyncRelativeRetrySucceededHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LRORetrysPostAsyncRelativeRetrySucceededHeaders(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.azureAsyncOperation = rawHeaders.getValue("Azure-AsyncOperation");
         this.location = rawHeaders.getValue("Location");
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LRORetrysPutAsyncRelativeRetrySucceededHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LRORetrysPutAsyncRelativeRetrySucceededHeaders.java
@@ -36,7 +36,10 @@ public final class LRORetrysPutAsyncRelativeRetrySucceededHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LRORetrysPutAsyncRelativeRetrySucceededHeaders(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.azureAsyncOperation = rawHeaders.getValue("Azure-AsyncOperation");
         this.location = rawHeaders.getValue("Location");
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsCustomHeadersPost202Retry200Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsCustomHeadersPost202Retry200Headers.java
@@ -30,7 +30,10 @@ public final class LROsCustomHeadersPost202Retry200Headers {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LROsCustomHeadersPost202Retry200Headers(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.location = rawHeaders.getValue("Location");
     }
 

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsCustomHeadersPostAsyncRetrySucceededHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsCustomHeadersPostAsyncRetrySucceededHeaders.java
@@ -36,7 +36,10 @@ public final class LROsCustomHeadersPostAsyncRetrySucceededHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LROsCustomHeadersPostAsyncRetrySucceededHeaders(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.azureAsyncOperation = rawHeaders.getValue("Azure-AsyncOperation");
         this.location = rawHeaders.getValue("Location");
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsCustomHeadersPutAsyncRetrySucceededHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsCustomHeadersPutAsyncRetrySucceededHeaders.java
@@ -36,7 +36,10 @@ public final class LROsCustomHeadersPutAsyncRetrySucceededHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LROsCustomHeadersPutAsyncRetrySucceededHeaders(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.azureAsyncOperation = rawHeaders.getValue("Azure-AsyncOperation");
         this.location = rawHeaders.getValue("Location");
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsDelete202NoRetry204Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsDelete202NoRetry204Headers.java
@@ -30,7 +30,10 @@ public final class LROsDelete202NoRetry204Headers {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LROsDelete202NoRetry204Headers(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.location = rawHeaders.getValue("Location");
     }
 

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsDelete202Retry200Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsDelete202Retry200Headers.java
@@ -30,7 +30,10 @@ public final class LROsDelete202Retry200Headers {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LROsDelete202Retry200Headers(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.location = rawHeaders.getValue("Location");
     }
 

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsDeleteAsyncNoRetrySucceededHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsDeleteAsyncNoRetrySucceededHeaders.java
@@ -36,7 +36,10 @@ public final class LROsDeleteAsyncNoRetrySucceededHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LROsDeleteAsyncNoRetrySucceededHeaders(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.azureAsyncOperation = rawHeaders.getValue("Azure-AsyncOperation");
         this.location = rawHeaders.getValue("Location");
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsDeleteAsyncRetryFailedHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsDeleteAsyncRetryFailedHeaders.java
@@ -36,7 +36,10 @@ public final class LROsDeleteAsyncRetryFailedHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LROsDeleteAsyncRetryFailedHeaders(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.azureAsyncOperation = rawHeaders.getValue("Azure-AsyncOperation");
         this.location = rawHeaders.getValue("Location");
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsDeleteAsyncRetrySucceededHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsDeleteAsyncRetrySucceededHeaders.java
@@ -36,7 +36,10 @@ public final class LROsDeleteAsyncRetrySucceededHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LROsDeleteAsyncRetrySucceededHeaders(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.azureAsyncOperation = rawHeaders.getValue("Azure-AsyncOperation");
         this.location = rawHeaders.getValue("Location");
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsDeleteAsyncRetrycanceledHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsDeleteAsyncRetrycanceledHeaders.java
@@ -36,7 +36,10 @@ public final class LROsDeleteAsyncRetrycanceledHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LROsDeleteAsyncRetrycanceledHeaders(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.azureAsyncOperation = rawHeaders.getValue("Azure-AsyncOperation");
         this.location = rawHeaders.getValue("Location");
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsDeleteProvisioning202Accepted200SucceededHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsDeleteProvisioning202Accepted200SucceededHeaders.java
@@ -30,7 +30,10 @@ public final class LROsDeleteProvisioning202Accepted200SucceededHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LROsDeleteProvisioning202Accepted200SucceededHeaders(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.location = rawHeaders.getValue("Location");
     }
 

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsDeleteProvisioning202DeletingFailed200Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsDeleteProvisioning202DeletingFailed200Headers.java
@@ -30,7 +30,10 @@ public final class LROsDeleteProvisioning202DeletingFailed200Headers {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LROsDeleteProvisioning202DeletingFailed200Headers(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.location = rawHeaders.getValue("Location");
     }
 

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsDeleteProvisioning202Deletingcanceled200Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsDeleteProvisioning202Deletingcanceled200Headers.java
@@ -30,7 +30,10 @@ public final class LROsDeleteProvisioning202Deletingcanceled200Headers {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LROsDeleteProvisioning202Deletingcanceled200Headers(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.location = rawHeaders.getValue("Location");
     }
 

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsPost202NoRetry204Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsPost202NoRetry204Headers.java
@@ -30,7 +30,10 @@ public final class LROsPost202NoRetry204Headers {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LROsPost202NoRetry204Headers(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.location = rawHeaders.getValue("Location");
     }
 

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsPost202Retry200Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsPost202Retry200Headers.java
@@ -30,7 +30,10 @@ public final class LROsPost202Retry200Headers {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LROsPost202Retry200Headers(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.location = rawHeaders.getValue("Location");
     }
 

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsPostAsyncNoRetrySucceededHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsPostAsyncNoRetrySucceededHeaders.java
@@ -36,7 +36,10 @@ public final class LROsPostAsyncNoRetrySucceededHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LROsPostAsyncNoRetrySucceededHeaders(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.azureAsyncOperation = rawHeaders.getValue("Azure-AsyncOperation");
         this.location = rawHeaders.getValue("Location");
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsPostAsyncRetryFailedHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsPostAsyncRetryFailedHeaders.java
@@ -36,7 +36,10 @@ public final class LROsPostAsyncRetryFailedHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LROsPostAsyncRetryFailedHeaders(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.azureAsyncOperation = rawHeaders.getValue("Azure-AsyncOperation");
         this.location = rawHeaders.getValue("Location");
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsPostAsyncRetrySucceededHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsPostAsyncRetrySucceededHeaders.java
@@ -36,7 +36,10 @@ public final class LROsPostAsyncRetrySucceededHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LROsPostAsyncRetrySucceededHeaders(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.azureAsyncOperation = rawHeaders.getValue("Azure-AsyncOperation");
         this.location = rawHeaders.getValue("Location");
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsPostAsyncRetrycanceledHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsPostAsyncRetrycanceledHeaders.java
@@ -36,7 +36,10 @@ public final class LROsPostAsyncRetrycanceledHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LROsPostAsyncRetrycanceledHeaders(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.azureAsyncOperation = rawHeaders.getValue("Azure-AsyncOperation");
         this.location = rawHeaders.getValue("Location");
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsPutAsyncRetryFailedHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsPutAsyncRetryFailedHeaders.java
@@ -36,7 +36,10 @@ public final class LROsPutAsyncRetryFailedHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LROsPutAsyncRetryFailedHeaders(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.azureAsyncOperation = rawHeaders.getValue("Azure-AsyncOperation");
         this.location = rawHeaders.getValue("Location");
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LROsPutAsyncRetrySucceededHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LROsPutAsyncRetrySucceededHeaders.java
@@ -36,7 +36,10 @@ public final class LROsPutAsyncRetrySucceededHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LROsPutAsyncRetrySucceededHeaders(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.azureAsyncOperation = rawHeaders.getValue("Azure-AsyncOperation");
         this.location = rawHeaders.getValue("Location");
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsDelete202NonRetry400Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsDelete202NonRetry400Headers.java
@@ -30,7 +30,10 @@ public final class LrosaDsDelete202NonRetry400Headers {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LrosaDsDelete202NonRetry400Headers(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.location = rawHeaders.getValue("Location");
     }
 

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsDelete202RetryInvalidHeaderHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsDelete202RetryInvalidHeaderHeaders.java
@@ -30,7 +30,10 @@ public final class LrosaDsDelete202RetryInvalidHeaderHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LrosaDsDelete202RetryInvalidHeaderHeaders(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.location = rawHeaders.getValue("Location");
     }
 

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsDeleteAsyncRelativeRetry400Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsDeleteAsyncRelativeRetry400Headers.java
@@ -36,7 +36,10 @@ public final class LrosaDsDeleteAsyncRelativeRetry400Headers {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LrosaDsDeleteAsyncRelativeRetry400Headers(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.azureAsyncOperation = rawHeaders.getValue("Azure-AsyncOperation");
         this.location = rawHeaders.getValue("Location");
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsDeleteAsyncRelativeRetryInvalidHeaderHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsDeleteAsyncRelativeRetryInvalidHeaderHeaders.java
@@ -36,7 +36,10 @@ public final class LrosaDsDeleteAsyncRelativeRetryInvalidHeaderHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LrosaDsDeleteAsyncRelativeRetryInvalidHeaderHeaders(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.azureAsyncOperation = rawHeaders.getValue("Azure-AsyncOperation");
         this.location = rawHeaders.getValue("Location");
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders.java
@@ -36,7 +36,10 @@ public final class LrosaDsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LrosaDsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.azureAsyncOperation = rawHeaders.getValue("Azure-AsyncOperation");
         this.location = rawHeaders.getValue("Location");
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsDeleteAsyncRelativeRetryNoStatusHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsDeleteAsyncRelativeRetryNoStatusHeaders.java
@@ -36,7 +36,10 @@ public final class LrosaDsDeleteAsyncRelativeRetryNoStatusHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LrosaDsDeleteAsyncRelativeRetryNoStatusHeaders(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.azureAsyncOperation = rawHeaders.getValue("Azure-AsyncOperation");
         this.location = rawHeaders.getValue("Location");
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsDeleteNonRetry400Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsDeleteNonRetry400Headers.java
@@ -30,7 +30,10 @@ public final class LrosaDsDeleteNonRetry400Headers {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LrosaDsDeleteNonRetry400Headers(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.location = rawHeaders.getValue("Location");
     }
 

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPost202NoLocationHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPost202NoLocationHeaders.java
@@ -30,7 +30,10 @@ public final class LrosaDsPost202NoLocationHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LrosaDsPost202NoLocationHeaders(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.location = rawHeaders.getValue("Location");
     }
 

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPost202NonRetry400Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPost202NonRetry400Headers.java
@@ -30,7 +30,10 @@ public final class LrosaDsPost202NonRetry400Headers {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LrosaDsPost202NonRetry400Headers(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.location = rawHeaders.getValue("Location");
     }
 

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPost202RetryInvalidHeaderHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPost202RetryInvalidHeaderHeaders.java
@@ -30,7 +30,10 @@ public final class LrosaDsPost202RetryInvalidHeaderHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LrosaDsPost202RetryInvalidHeaderHeaders(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.location = rawHeaders.getValue("Location");
     }
 

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPostAsyncRelativeRetry400Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPostAsyncRelativeRetry400Headers.java
@@ -36,7 +36,10 @@ public final class LrosaDsPostAsyncRelativeRetry400Headers {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LrosaDsPostAsyncRelativeRetry400Headers(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.azureAsyncOperation = rawHeaders.getValue("Azure-AsyncOperation");
         this.location = rawHeaders.getValue("Location");
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPostAsyncRelativeRetryInvalidHeaderHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPostAsyncRelativeRetryInvalidHeaderHeaders.java
@@ -36,7 +36,10 @@ public final class LrosaDsPostAsyncRelativeRetryInvalidHeaderHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LrosaDsPostAsyncRelativeRetryInvalidHeaderHeaders(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.azureAsyncOperation = rawHeaders.getValue("Azure-AsyncOperation");
         this.location = rawHeaders.getValue("Location");
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPostAsyncRelativeRetryInvalidJsonPollingHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPostAsyncRelativeRetryInvalidJsonPollingHeaders.java
@@ -36,7 +36,10 @@ public final class LrosaDsPostAsyncRelativeRetryInvalidJsonPollingHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LrosaDsPostAsyncRelativeRetryInvalidJsonPollingHeaders(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.azureAsyncOperation = rawHeaders.getValue("Azure-AsyncOperation");
         this.location = rawHeaders.getValue("Location");
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPostAsyncRelativeRetryNoPayloadHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPostAsyncRelativeRetryNoPayloadHeaders.java
@@ -36,7 +36,10 @@ public final class LrosaDsPostAsyncRelativeRetryNoPayloadHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LrosaDsPostAsyncRelativeRetryNoPayloadHeaders(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.azureAsyncOperation = rawHeaders.getValue("Azure-AsyncOperation");
         this.location = rawHeaders.getValue("Location");
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPostNonRetry400Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPostNonRetry400Headers.java
@@ -30,7 +30,10 @@ public final class LrosaDsPostNonRetry400Headers {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LrosaDsPostNonRetry400Headers(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.location = rawHeaders.getValue("Location");
     }
 

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPutAsyncRelativeRetry400Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPutAsyncRelativeRetry400Headers.java
@@ -36,7 +36,10 @@ public final class LrosaDsPutAsyncRelativeRetry400Headers {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LrosaDsPutAsyncRelativeRetry400Headers(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.azureAsyncOperation = rawHeaders.getValue("Azure-AsyncOperation");
         this.location = rawHeaders.getValue("Location");
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPutAsyncRelativeRetryInvalidHeaderHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPutAsyncRelativeRetryInvalidHeaderHeaders.java
@@ -36,7 +36,10 @@ public final class LrosaDsPutAsyncRelativeRetryInvalidHeaderHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LrosaDsPutAsyncRelativeRetryInvalidHeaderHeaders(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.azureAsyncOperation = rawHeaders.getValue("Azure-AsyncOperation");
         this.location = rawHeaders.getValue("Location");
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPutAsyncRelativeRetryInvalidJsonPollingHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPutAsyncRelativeRetryInvalidJsonPollingHeaders.java
@@ -36,7 +36,10 @@ public final class LrosaDsPutAsyncRelativeRetryInvalidJsonPollingHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LrosaDsPutAsyncRelativeRetryInvalidJsonPollingHeaders(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.azureAsyncOperation = rawHeaders.getValue("Azure-AsyncOperation");
         this.location = rawHeaders.getValue("Location");
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPutAsyncRelativeRetryNoStatusHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPutAsyncRelativeRetryNoStatusHeaders.java
@@ -36,7 +36,10 @@ public final class LrosaDsPutAsyncRelativeRetryNoStatusHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LrosaDsPutAsyncRelativeRetryNoStatusHeaders(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.azureAsyncOperation = rawHeaders.getValue("Azure-AsyncOperation");
         this.location = rawHeaders.getValue("Location");
     }

--- a/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPutAsyncRelativeRetryNoStatusPayloadHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/lro/models/LrosaDsPutAsyncRelativeRetryNoStatusPayloadHeaders.java
@@ -36,7 +36,10 @@ public final class LrosaDsPutAsyncRelativeRetryNoStatusPayloadHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public LrosaDsPutAsyncRelativeRetryNoStatusPayloadHeaders(HttpHeaders rawHeaders) {
-        this.retryAfter = Integer.parseInt(rawHeaders.getValue("Retry-After"));
+        String retryAfter = rawHeaders.getValue("Retry-After");
+        if (retryAfter != null) {
+            this.retryAfter = Integer.parseInt(retryAfter);
+        }
         this.azureAsyncOperation = rawHeaders.getValue("Azure-AsyncOperation");
         this.location = rawHeaders.getValue("Location");
     }

--- a/vanilla-tests/src/main/java/fixtures/nonamedresponsetypes/models/HeadersResponseBoolHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/nonamedresponsetypes/models/HeadersResponseBoolHeaders.java
@@ -24,7 +24,10 @@ public final class HeadersResponseBoolHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public HeadersResponseBoolHeaders(HttpHeaders rawHeaders) {
-        this.value = Boolean.parseBoolean(rawHeaders.getValue("value"));
+        String value = rawHeaders.getValue("value");
+        if (value != null) {
+            this.value = Boolean.parseBoolean(value);
+        }
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/nonamedresponsetypes/models/HeadersResponseDoubleHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/nonamedresponsetypes/models/HeadersResponseDoubleHeaders.java
@@ -24,7 +24,10 @@ public final class HeadersResponseDoubleHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public HeadersResponseDoubleHeaders(HttpHeaders rawHeaders) {
-        this.value = Double.parseDouble(rawHeaders.getValue("value"));
+        String value = rawHeaders.getValue("value");
+        if (value != null) {
+            this.value = Double.parseDouble(value);
+        }
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/nonamedresponsetypes/models/HeadersResponseFloatHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/nonamedresponsetypes/models/HeadersResponseFloatHeaders.java
@@ -24,7 +24,10 @@ public final class HeadersResponseFloatHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public HeadersResponseFloatHeaders(HttpHeaders rawHeaders) {
-        this.value = Float.parseFloat(rawHeaders.getValue("value"));
+        String value = rawHeaders.getValue("value");
+        if (value != null) {
+            this.value = Float.parseFloat(value);
+        }
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/nonamedresponsetypes/models/HeadersResponseIntegerHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/nonamedresponsetypes/models/HeadersResponseIntegerHeaders.java
@@ -24,7 +24,10 @@ public final class HeadersResponseIntegerHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public HeadersResponseIntegerHeaders(HttpHeaders rawHeaders) {
-        this.value = Integer.parseInt(rawHeaders.getValue("value"));
+        String value = rawHeaders.getValue("value");
+        if (value != null) {
+            this.value = Integer.parseInt(value);
+        }
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/nonamedresponsetypes/models/HeadersResponseLongHeaders.java
+++ b/vanilla-tests/src/main/java/fixtures/nonamedresponsetypes/models/HeadersResponseLongHeaders.java
@@ -24,7 +24,10 @@ public final class HeadersResponseLongHeaders {
      * @param rawHeaders The raw HttpHeaders that will be used to create the property values.
      */
     public HeadersResponseLongHeaders(HttpHeaders rawHeaders) {
-        this.value = Long.parseLong(rawHeaders.getValue("value"));
+        String value = rawHeaders.getValue("value");
+        if (value != null) {
+            this.value = Long.parseLong(value);
+        }
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/specialheader/Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/specialheader/Headers.java
@@ -16,8 +16,6 @@ import com.azure.core.annotation.ReturnType;
 import com.azure.core.annotation.ServiceInterface;
 import com.azure.core.annotation.ServiceMethod;
 import com.azure.core.annotation.UnexpectedResponseExceptionType;
-import com.azure.core.http.rest.PagedFlux;
-import com.azure.core.http.rest.PagedIterable;
 import com.azure.core.http.rest.PagedResponse;
 import com.azure.core.http.rest.PagedResponseBase;
 import com.azure.core.http.rest.Response;
@@ -392,37 +390,11 @@ public final class Headers {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedFlux}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedFlux<Object> paramRepeatabilityRequestPageableAsync() {
-        return new PagedFlux<>(
-                () -> paramRepeatabilityRequestPageableSinglePageAsync(),
-                nextLink -> paramRepeatabilityRequestPageableNextSinglePageAsync(nextLink));
-    }
-
-    /**
-     * Send a post request with header Repeatability-Request-ID and Repeatability-First-Sent.
-     *
-     * @throws ErrorException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Object> paramRepeatabilityRequestPageableSinglePage() {
         return paramRepeatabilityRequestPageableSinglePageAsync().block();
-    }
-
-    /**
-     * Send a post request with header Repeatability-Request-ID and Repeatability-First-Sent.
-     *
-     * @throws ErrorException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the paginated response with {@link PagedIterable}.
-     */
-    @ServiceMethod(returns = ReturnType.COLLECTION)
-    public PagedIterable<Object> paramRepeatabilityRequestPageable() {
-        return new PagedIterable<>(paramRepeatabilityRequestPageableAsync());
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/specialheader/Headers.java
+++ b/vanilla-tests/src/main/java/fixtures/specialheader/Headers.java
@@ -16,6 +16,8 @@ import com.azure.core.annotation.ReturnType;
 import com.azure.core.annotation.ServiceInterface;
 import com.azure.core.annotation.ServiceMethod;
 import com.azure.core.annotation.UnexpectedResponseExceptionType;
+import com.azure.core.http.rest.PagedFlux;
+import com.azure.core.http.rest.PagedIterable;
 import com.azure.core.http.rest.PagedResponse;
 import com.azure.core.http.rest.PagedResponseBase;
 import com.azure.core.http.rest.Response;
@@ -390,11 +392,37 @@ public final class Headers {
      *
      * @throws ErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedFlux}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedFlux<Object> paramRepeatabilityRequestPageableAsync() {
+        return new PagedFlux<>(
+                () -> paramRepeatabilityRequestPageableSinglePageAsync(),
+                nextLink -> paramRepeatabilityRequestPageableNextSinglePageAsync(nextLink));
+    }
+
+    /**
+     * Send a post request with header Repeatability-Request-ID and Repeatability-First-Sent.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
      * @return the response body along with {@link PagedResponse}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public PagedResponse<Object> paramRepeatabilityRequestPageableSinglePage() {
         return paramRepeatabilityRequestPageableSinglePageAsync().block();
+    }
+
+    /**
+     * Send a post request with header Repeatability-Request-ID and Repeatability-First-Sent.
+     *
+     * @throws ErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the paginated response with {@link PagedIterable}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public PagedIterable<Object> paramRepeatabilityRequestPageable() {
+        return new PagedIterable<>(paramRepeatabilityRequestPageableAsync());
     }
 
     /**

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/AppleBarrel.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/AppleBarrel.java
@@ -16,9 +16,6 @@ import java.util.List;
 @JacksonXmlRootElement(localName = "AppleBarrel")
 @Fluent
 public final class AppleBarrel {
-    /*
-     * The GoodApples property.
-     */
     private static final class GoodApplesWrapper {
         @JacksonXmlProperty(localName = "Apple")
         private final List<String> items;
@@ -29,12 +26,12 @@ public final class AppleBarrel {
         }
     }
 
+    /*
+     * The GoodApples property.
+     */
     @JsonProperty(value = "GoodApples")
     private GoodApplesWrapper goodApples;
 
-    /*
-     * The BadApples property.
-     */
     private static final class BadApplesWrapper {
         @JacksonXmlProperty(localName = "Apple")
         private final List<String> items;
@@ -45,6 +42,9 @@ public final class AppleBarrel {
         }
     }
 
+    /*
+     * The BadApples property.
+     */
     @JsonProperty(value = "BadApples")
     private BadApplesWrapper badApples;
 

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/ListContainersResponse.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/ListContainersResponse.java
@@ -40,9 +40,6 @@ public final class ListContainersResponse {
     @JsonProperty(value = "MaxResults", required = true)
     private int maxResults;
 
-    /*
-     * The Containers property.
-     */
     private static final class ContainersWrapper {
         @JacksonXmlProperty(localName = "Container")
         private final List<Container> items;
@@ -53,6 +50,9 @@ public final class ListContainersResponse {
         }
     }
 
+    /*
+     * The Containers property.
+     */
     @JsonProperty(value = "Containers")
     private ContainersWrapper containers;
 

--- a/vanilla-tests/src/main/java/fixtures/xmlservice/models/StorageServiceProperties.java
+++ b/vanilla-tests/src/main/java/fixtures/xmlservice/models/StorageServiceProperties.java
@@ -34,9 +34,6 @@ public final class StorageServiceProperties {
     @JsonProperty(value = "MinuteMetrics")
     private Metrics minuteMetrics;
 
-    /*
-     * The set of CORS rules.
-     */
     private static final class CorsWrapper {
         @JacksonXmlProperty(localName = "CorsRule")
         private final List<CorsRule> items;
@@ -47,6 +44,9 @@ public final class StorageServiceProperties {
         }
     }
 
+    /*
+     * The set of CORS rules.
+     */
     @JsonProperty(value = "Cors")
     private CorsWrapper cors;
 


### PR DESCRIPTION
A few fixes related to `StreamResponse` and other miscellaneous fixes.

- Recently `StreamResponse` APIs with strongly-typed headers began generating as `ResponseBase<HeaderType, InputStream>` where this should have been `Flux<ByteBuffer>` instead of `InputStream`. This has been fixed to generate as `ResponseBase<HeaderType, Flux<ByteBuffer>>`.
- Changed `StreamResponse::getValue` to `Response::getValue` as `Response::getValue` is more generic and will work for `StreamResponse` returns as well as `ResponseBase<HeaderType, Flux<ByteBuffer>>` returns.
- Prevent `PagedFlux` and `PagedIterable` `ClientMethod`s without `Context` being generated.
- Simplified the logic to determine if `FluxUtil` should be included as an import to just checking if the `ClientMethod` is asynchronous and doesn't have a `Context` parameter.
- Moved static inner class creation for XML wrappers to an earlier point in code generation to fix Autorest from commenting the static inner class instead of the class property.