### PR TITLE
mgmt, improve generated tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,24 +67,27 @@ javagen/*.yaml
 *.log.gz
 *.tgz
 
-# Generated code for tests #
-fluent-tests/src/main/java/com/azure/mgmttest/**
-fluent-tests/src/main/java/com/azure/mgmtlitetest/**
-fluent-tests/src/main/java/module-info.java
-fluent-tests/src/samples/**
-fluent-tests/pom_generated_*.xml
+# Generated code for tests
+/fluent-tests/src/main/java/com/azure/mgmttest/
+/fluent-tests/src/main/java/com/azure/mgmtlitetest/
+/fluent-tests/src/main/java/module-info.java
+/fluent-tests/src/samples/
+/fluent-tests/src/test/java/com/azure/mgmtlitetest/**/generated/
+/fluent-tests/src/test/resources/mockito-extensions/
+/fluent-tests/pom_generated_*.xml
 
-protocol-tests/src/main/java/module-info.java
+/protocol-tests/src/main/java/module-info.java
 
-protocol-sdk-integration-tests/sdk
-!protocol-sdk-integration-tests/sdk/parents
+/protocol-sdk-integration-tests/sdk/
+!/protocol-sdk-integration-tests/sdk/parents/
 
-cadl-tests/cadl-output
-cadl-ranch-coverage.json
+# Cadl output
+/cadl-tests/cadl-output/
+/cadl-tests/cadl-ranch-coverage.json
 /cadl-tests/cadl-ranch-coverage-java.json
 
 # Coverage report
 /coverage/
 
-# language server
-postprocessor/jdt-language-server
+# Language server
+/postprocessor/jdt-language-server/

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentMapper.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/FluentMapper.java
@@ -67,14 +67,15 @@ public class FluentMapper {
             fluentClient.getExamples().addAll(examples);
         }
 
-        // live tests
         if (JavaSettings.getInstance().isGenerateTests()) {
+            // live tests
             fluentClient.getLiveTests().addAll(
                     client.getLiveTests()
                             .stream()
                             .map(liveTests -> FluentLiveTestsMapper.getInstance().map(liveTests, fluentClient, codeModel, fluentJavaSettings))
                             .collect(Collectors.toList()));
 
+            // mock API tests
             UnitTestParser unitTestParser = new UnitTestParser();
             fluentClient.getUnitTests().addAll(
                     fluentClient.getResourceCollections().stream()

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/UnitTestParser.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/mapper/UnitTestParser.java
@@ -4,6 +4,8 @@
 package com.azure.autorest.fluent.mapper;
 
 import com.azure.autorest.extension.base.model.codemodel.RequestParameterLocation;
+import com.azure.autorest.extension.base.plugin.PluginLogger;
+import com.azure.autorest.fluent.FluentGen;
 import com.azure.autorest.fluent.model.clientmodel.FluentCollectionMethod;
 import com.azure.autorest.fluent.model.clientmodel.FluentResourceCollection;
 import com.azure.autorest.fluent.model.clientmodel.MethodParameter;
@@ -20,7 +22,9 @@ import com.azure.autorest.model.clientmodel.ProxyMethodExample;
 import com.azure.autorest.model.clientmodel.examplemodel.ExampleNode;
 import com.azure.autorest.util.ModelExampleUtil;
 import com.azure.autorest.util.ModelTestCaseUtil;
+import com.azure.autorest.util.PossibleCredentialException;
 import com.azure.core.http.HttpMethod;
+import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -29,6 +33,8 @@ import java.util.List;
 import java.util.Map;
 
 public class UnitTestParser extends ExampleParser {
+
+    private static final Logger LOGGER = new PluginLogger(FluentGen.getPluginInstance(), UnitTestParser.class);
 
     public List<FluentMethodUnitTest> parseResourceCollectionForUnitTest(FluentResourceCollection resourceCollection) {
         List<FluentMethodUnitTest> fluentMethodUnitTests = new ArrayList<>();
@@ -51,22 +57,26 @@ public class UnitTestParser extends ExampleParser {
     private static FluentMethodUnitTest parseResourceCreate(FluentResourceCollection collection, ResourceCreate resourceCreate) {
         FluentMethodUnitTest unitTest = null;
 
-        List<FluentCollectionMethod> collectionMethods = resourceCreate.getMethodReferences();
-        for (FluentCollectionMethod collectionMethod : collectionMethods) {
-            ClientMethod clientMethod = collectionMethod.getInnerClientMethod();
-            if (requiresExample(clientMethod)) {
-                List<MethodParameter> methodParameters = getParameters(clientMethod);
-                MethodParameter requestBodyParameter = findRequestBodyParameter(methodParameters);
-                ProxyMethodExample proxyMethodExample = createProxyMethodExample(clientMethod, methodParameters);
-                FluentResourceCreateExample resourceCreateExample =
-                        parseResourceCreate(collection, resourceCreate, proxyMethodExample, methodParameters, requestBodyParameter);
+        try {
+            List<FluentCollectionMethod> collectionMethods = resourceCreate.getMethodReferences();
+            for (FluentCollectionMethod collectionMethod : collectionMethods) {
+                ClientMethod clientMethod = collectionMethod.getInnerClientMethod();
+                if (requiresExample(clientMethod)) {
+                    List<MethodParameter> methodParameters = getParameters(clientMethod);
+                    MethodParameter requestBodyParameter = findRequestBodyParameter(methodParameters);
+                    ProxyMethodExample proxyMethodExample = createProxyMethodExample(clientMethod, methodParameters);
+                    FluentResourceCreateExample resourceCreateExample =
+                            parseResourceCreate(collection, resourceCreate, proxyMethodExample, methodParameters, requestBodyParameter);
 
-                ResponseInfo responseInfo = createProxyMethodExampleResponse(clientMethod);
-                unitTest = new FluentMethodUnitTest(resourceCreateExample, collection, collectionMethod,
-                        responseInfo.responseExample, responseInfo.verificationObjectName, responseInfo.verificationNode);
+                    ResponseInfo responseInfo = createProxyMethodExampleResponse(clientMethod);
+                    unitTest = new FluentMethodUnitTest(resourceCreateExample, collection, collectionMethod,
+                            responseInfo.responseExample, responseInfo.verificationObjectName, responseInfo.verificationNode);
 
-                break;
+                    break;
+                }
             }
+        } catch (PossibleCredentialException e) {
+            LOGGER.warn("Skip unit test for resource '{}', caused by key '{}'", resourceCreate.getResourceModel().getInnerModel().getName(), e.getKeyName());
         }
         return unitTest;
     }
@@ -74,16 +84,20 @@ public class UnitTestParser extends ExampleParser {
     private static FluentMethodUnitTest parseMethod(FluentResourceCollection collection, FluentCollectionMethod collectionMethod) {
         FluentMethodUnitTest unitTest = null;
 
-        ClientMethod clientMethod = collectionMethod.getInnerClientMethod();
-        if (requiresExample(clientMethod)) {
-            List<MethodParameter> methodParameters = getParameters(clientMethod);
-            ProxyMethodExample proxyMethodExample = createProxyMethodExample(clientMethod, methodParameters);
-            FluentCollectionMethodExample collectionMethodExample =
-                    parseMethodForExample(collection, collectionMethod, methodParameters, proxyMethodExample.getName(), proxyMethodExample);
+        try {
+            ClientMethod clientMethod = collectionMethod.getInnerClientMethod();
+            if (requiresExample(clientMethod)) {
+                List<MethodParameter> methodParameters = getParameters(clientMethod);
+                ProxyMethodExample proxyMethodExample = createProxyMethodExample(clientMethod, methodParameters);
+                FluentCollectionMethodExample collectionMethodExample =
+                        parseMethodForExample(collection, collectionMethod, methodParameters, proxyMethodExample.getName(), proxyMethodExample);
 
-            ResponseInfo responseInfo = createProxyMethodExampleResponse(clientMethod);
-            unitTest = new FluentMethodUnitTest(collectionMethodExample, collection, collectionMethod,
-                    responseInfo.responseExample, responseInfo.verificationObjectName, responseInfo.verificationNode);
+                ResponseInfo responseInfo = createProxyMethodExampleResponse(clientMethod);
+                unitTest = new FluentMethodUnitTest(collectionMethodExample, collection, collectionMethod,
+                        responseInfo.responseExample, responseInfo.verificationObjectName, responseInfo.verificationNode);
+            }
+        } catch (PossibleCredentialException e) {
+            LOGGER.warn("Skip unit test for method '{}', caused by key '{}'", collectionMethod.getMethodName(), e.getKeyName());
         }
         return unitTest;
     }

--- a/fluentgen/src/main/java/com/azure/autorest/fluent/model/javamodel/FluentJavaPackage.java
+++ b/fluentgen/src/main/java/com/azure/autorest/fluent/model/javamodel/FluentJavaPackage.java
@@ -114,7 +114,7 @@ public class FluentJavaPackage extends JavaPackage {
 
         String className = unitTest.getResourceCollection().getInterfaceType().getName()
                 + CodeNamer.toPascalCase(unitTest.getCollectionMethod().getMethodName())
-                + "Tests";
+                + "MockTests";
         JavaFile javaFile = getJavaFileFactory().createTestFile(JavaSettings.getInstance().getPackage("generated"), className);
         FluentMethodTestTemplate.ClientMethodInfo info = new FluentMethodTestTemplate.ClientMethodInfo(
                 className, unitTest);

--- a/javagen/src/main/java/com/azure/autorest/model/javamodel/JavaPackage.java
+++ b/javagen/src/main/java/com/azure/autorest/model/javamodel/JavaPackage.java
@@ -33,6 +33,7 @@ import com.azure.autorest.template.ReadmeTemplate;
 import com.azure.autorest.template.ServiceSyncClientTemplate;
 import com.azure.autorest.template.SwaggerReadmeTemplate;
 import com.azure.autorest.template.Templates;
+import com.azure.autorest.util.PossibleCredentialException;
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
@@ -239,11 +240,16 @@ public class JavaPackage {
     }
 
     public void addModelUnitTest(ClientModel model) {
-        String className = model.getName() + "Tests";
-        JavaFile javaFile = javaFileFactory.createTestFile(JavaSettings.getInstance().getPackage("generated"), className);
-        ModelTestTemplate.getInstance().write(model, javaFile);
-        this.checkDuplicateFile(javaFile.getFilePath());
-        javaFiles.add(javaFile);
+        try {
+            String className = model.getName() + "Tests";
+            JavaFile javaFile = javaFileFactory.createTestFile(JavaSettings.getInstance().getPackage("generated"), className);
+            ModelTestTemplate.getInstance().write(model, javaFile);
+            this.checkDuplicateFile(javaFile.getFilePath());
+            javaFiles.add(javaFile);
+        } catch (PossibleCredentialException e) {
+            // skip this test file
+            logger.warn("Skip unit test for model '{}', caused by key '{}'", model.getName(), e.getKeyName());
+        }
     }
 
     public void addReadmeMarkdown(Project project) {

--- a/javagen/src/main/java/com/azure/autorest/util/ModelTestCaseUtil.java
+++ b/javagen/src/main/java/com/azure/autorest/util/ModelTestCaseUtil.java
@@ -17,9 +17,11 @@ import com.azure.core.util.DateTimeRfc1123;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.stream.Collectors;
@@ -192,6 +194,8 @@ public class ModelTestCaseUtil {
 
     @SuppressWarnings("unchecked")
     private static void addToJsonObject(Map<String, Object> jsonObject, List<String> serializedNames, Object value) {
+        checkCredential(serializedNames);
+
         if (serializedNames.size() == 1) {
             jsonObject.put(serializedNames.iterator().next(), value);
         } else {
@@ -207,6 +211,24 @@ public class ModelTestCaseUtil {
                 Map<String, Object> nextJsonObject = new LinkedHashMap<>();
                 jsonObject.put(serializedName, nextJsonObject);
                 addToJsonObject(nextJsonObject, serializedNames, value);
+            }
+        }
+    }
+
+    private static final List<String> POSSIBLE_CREDENTIAL_KEY = Arrays.asList(
+            "key",
+            "code",
+            "credential",
+            "token"
+    );
+
+    private static void checkCredential(List<String> serializedNames) {
+        for (String keyName : serializedNames) {
+            String keyNameLower = keyName.toLowerCase(Locale.ROOT);
+            for (String key : POSSIBLE_CREDENTIAL_KEY) {
+                if (keyNameLower.contains(key)) {
+                    throw new PossibleCredentialException(keyName);
+                }
             }
         }
     }

--- a/javagen/src/main/java/com/azure/autorest/util/PossibleCredentialException.java
+++ b/javagen/src/main/java/com/azure/autorest/util/PossibleCredentialException.java
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.autorest.util;
+
+public class PossibleCredentialException extends RuntimeException {
+
+    private final String keyName;
+
+    public PossibleCredentialException(String keyName) {
+        super("Possible credential in value of key: " + keyName);
+        this.keyName = keyName;
+    }
+
+    public String getKeyName() {
+        return keyName;
+    }
+}


### PR DESCRIPTION
ref https://github.com/Azure/autorest.java/issues/1711

exclude model with JSON object keys that has word "key", "code", "credential", "token".

```
warning | JavaPackage | Skip unit test for model 'AccountInfoSecureInner', caused by key 'apiKey'
warning | JavaPackage | Skip unit test for model 'VMExtensionPayloadInner', caused by key 'ingestionKey'
warning | JavaPackage | Skip unit test for model 'MonitorProperties', caused by key 'ingestionKey'
warning | JavaPackage | Skip unit test for model 'DynatraceEnvironmentProperties', caused by key 'ingestionKey'
warning | JavaPackage | Skip unit test for model 'EnvironmentInfo', caused by key 'ingestionKey'
warning | JavaPackage | Skip unit test for model 'MonitorResourceUpdate', caused by key 'ingestionKey'
```

Though only `AccountInfoSecureInner` triggers CredScan.