### PR TITLE
Replace Usage of Response::getValue

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
+++ b/javagen/src/main/java/com/azure/autorest/template/ClientMethodTemplate.java
@@ -777,7 +777,7 @@ public class ClientMethodTemplate extends ClientMethodTemplateBase {
                     // Previously this used StreamResponse::getValue, but it isn't guaranteed that the return is
                     // StreamResponse, instead use Response::getValue as StreamResponse is just a fancier
                     // Response<Flux<ByteBuffer>>.
-                    function.text(".flatMapMany(Response::getValue);");
+                    function.text(".flatMapMany(fluxByteBufferResponse -> fluxByteBufferResponse.getValue());");
                 } else if (!GenericType.Mono(ClassType.Void).equals(clientMethod.getReturnValue().getType()) &&
                     !GenericType.Flux(ClassType.Void).equals(clientMethod.getReturnValue().getType())) {
                     function.text(".flatMap(res -> Mono.justOrEmpty(res.getValue()));");

--- a/vanilla-tests/src/main/java/fixtures/bodyfile/Files.java
+++ b/vanilla-tests/src/main/java/fixtures/bodyfile/Files.java
@@ -118,7 +118,7 @@ public final class Files {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Flux<ByteBuffer> getFileAsync() {
-        return getFileWithResponseAsync().flatMapMany(Response::getValue);
+        return getFileWithResponseAsync().flatMapMany(fluxByteBufferResponse -> fluxByteBufferResponse.getValue());
     }
 
     /**
@@ -132,7 +132,8 @@ public final class Files {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Flux<ByteBuffer> getFileAsync(Context context) {
-        return getFileWithResponseAsync(context).flatMapMany(Response::getValue);
+        return getFileWithResponseAsync(context)
+                .flatMapMany(fluxByteBufferResponse -> fluxByteBufferResponse.getValue());
     }
 
     /**
@@ -229,7 +230,7 @@ public final class Files {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Flux<ByteBuffer> getFileLargeAsync() {
-        return getFileLargeWithResponseAsync().flatMapMany(Response::getValue);
+        return getFileLargeWithResponseAsync().flatMapMany(fluxByteBufferResponse -> fluxByteBufferResponse.getValue());
     }
 
     /**
@@ -243,7 +244,8 @@ public final class Files {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Flux<ByteBuffer> getFileLargeAsync(Context context) {
-        return getFileLargeWithResponseAsync(context).flatMapMany(Response::getValue);
+        return getFileLargeWithResponseAsync(context)
+                .flatMapMany(fluxByteBufferResponse -> fluxByteBufferResponse.getValue());
     }
 
     /**
@@ -340,7 +342,7 @@ public final class Files {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Flux<ByteBuffer> getEmptyFileAsync() {
-        return getEmptyFileWithResponseAsync().flatMapMany(Response::getValue);
+        return getEmptyFileWithResponseAsync().flatMapMany(fluxByteBufferResponse -> fluxByteBufferResponse.getValue());
     }
 
     /**
@@ -354,7 +356,8 @@ public final class Files {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Flux<ByteBuffer> getEmptyFileAsync(Context context) {
-        return getEmptyFileWithResponseAsync(context).flatMapMany(Response::getValue);
+        return getEmptyFileWithResponseAsync(context)
+                .flatMapMany(fluxByteBufferResponse -> fluxByteBufferResponse.getValue());
     }
 
     /**


### PR DESCRIPTION
Fixes #1755 

Replaces `.flatMapMany(Response::getValue)` with `.flatMapMany(fluxByteBufferResponse -> fluxByteBufferResponse.getValue())` to fix a compiler warning in generated code.