### PR TITLE
fix credential check error, add 'secret' as key word

### DIFF
--- a/javagen/src/main/java/com/azure/autorest/util/ModelTestCaseUtil.java
+++ b/javagen/src/main/java/com/azure/autorest/util/ModelTestCaseUtil.java
@@ -219,7 +219,8 @@ public class ModelTestCaseUtil {
             "key",
             "code",
             "credential",
-            "token"
+            "token",
+            "secret"
     );
 
     private static void checkCredential(List<String> serializedNames) {


### PR DESCRIPTION
Fix  this build error: https://dev.azure.com/azure-sdk/public/_build/results?buildId=1912619&view=logs&j=2e58d666-b5db-5758-0ec7-32f7d1b2592f&t=846c2b5b-32b8-5a48-6bf5-0ea739aa23f0&l=104 